### PR TITLE
Added support for Fengyuan Hu's implementation of sparse autoencoder.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "sae_lens"}]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = ">=3.10,<3.12"
 transformer-lens = "^1.14.0"
 transformers = "^4.38.1"
 jupyter = "^1.0.0"
@@ -27,6 +27,7 @@ mkdocs-autorefs = "^1.0.1"
 mkdocs-section-index = "^0.3.8"
 mkdocstrings = "^0.24.1"
 mkdocstrings-python = "^1.9.0"
+sparse-autoencoder = {git = "https://github.com/HuFY-dev/sparse_autoencoder.git", rev = "dev"}
 
 
 [tool.poetry.group.dev.dependencies]

--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -45,6 +45,8 @@ class LanguageModelSAERunnerConfig:
     expansion_factor: int | list[int] = 4
     from_pretrained_path: Optional[str] = None
     d_sae: Optional[int] = None
+    sae_type: str = "sae"
+    noise_scale: float = 0.0
 
     # Training Parameters
     l1_coefficient: float | list[float] = 1e-3

--- a/tutorials/loading_normalized_sae.ipynb
+++ b/tutorials/loading_normalized_sae.ipynb
@@ -1,0 +1,555 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# This is only used for evaluation. Training is not yet supported!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sae_lens.training.sparse_autoencoder import SparseAutoencoder\n",
+    "from sae_lens.training.config import LanguageModelSAERunnerConfig\n",
+    "from sae_lens.training.sae_group import SAEGroup\n",
+    "from huggingface_hub import hf_hub_download\n",
+    "from sparse_autoencoder import SparseAutoencoder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hf_model_id = \"HuFY-dev/normalized_sparse_autoencoder\"\n",
+    "# hf_filename = \"baseline.pt\"\n",
+    "hf_filename = \"normalized.pt\"\n",
+    "model_path = hf_hub_download(hf_model_id, hf_filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sae = SparseAutoencoder.load(model_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n",
+      "Run name: 12288-L1-0.001-LR-0.0003-Tokens-2.000e+06\n",
+      "n_tokens_per_buffer (millions): 0.08192\n",
+      "Lower bound: n_contexts_per_buffer (millions): 0.00064\n",
+      "Total training steps: 488\n",
+      "Total wandb updates: 48\n",
+      "n_tokens_per_feature_sampling_window (millions): 1048.576\n",
+      "n_tokens_per_dead_feature_window (millions): 524.288\n",
+      "We will reset the sparsity calculation 0 times.\n",
+      "Number tokens in sparsity calculation window: 8.19e+06\n"
+     ]
+    }
+   ],
+   "source": [
+    "sae_lens_configs = LanguageModelSAERunnerConfig(\n",
+    "        d_in=sae.config.n_input_features,\n",
+    "        d_sae=sae.config.n_learned_features,\n",
+    "        expansion_factor=sae.config.n_learned_features//sae.config.n_input_features,\n",
+    "        sae_type=sae.config.sae_type,\n",
+    "        noise_scale=sae.config.noise_scale,\n",
+    "        model_name=\"gpt2\",\n",
+    "        hook_point=\"blocks.{layer}.hook_mlp_out\",\n",
+    "        hook_point_layer=list(range(sae.config.n_components)),  # type: ignore\n",
+    "    )\n",
+    "\n",
+    "sae_group = SAEGroup(sae_lens_configs)\n",
+    "\n",
+    "for layer, single_sae in enumerate(sae_group.autoencoders):\n",
+    "    single_sae.W_enc.data = sae.encoder.weight.data[layer].T\n",
+    "    single_sae.b_enc.data = sae.encoder.bias.data[layer]\n",
+    "    single_sae.W_dec.data = sae.decoder.weight.data[layer].T\n",
+    "    single_sae.b_dec.data = sae.tied_bias.data[layer]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<sae_lens.training.sae_group.SAEGroup at 0x7fee5dd405d0>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Now you should be able to use sae_group\n",
+    "sae_group"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Small sanity check"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import TypedDict\n",
+    "from transformer_lens import HookedTransformer\n",
+    "from datasets import load_dataset\n",
+    "import torch\n",
+    "from torch.utils.data import DataLoader"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded pretrained model gpt2 into HookedTransformer\n"
+     ]
+    }
+   ],
+   "source": [
+    "model_name = \"gpt2\"\n",
+    "model = HookedTransformer.from_pretrained(model_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8fe84fba0f2249a7a85c60263ab353a4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Resolving data files:   0%|          | 0/64 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e0218c6b5b754f7ea39beafc34255a8b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Resolving data files:   0%|          | 0/64 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "dataset_path = \"alancooney/sae-monology-pile-uncopyrighted-tokenizer-gpt2\"\n",
+    "torch_dataset = load_dataset(dataset_path, split=\"train\", streaming=True).with_format(\"torch\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TokenizedPrompt = list[int]\n",
+    "\"\"\"A tokenized prompt.\"\"\"\n",
+    "\n",
+    "\n",
+    "class TokenizedPrompts(TypedDict):\n",
+    "    \"\"\"Tokenized prompts.\"\"\"\n",
+    "\n",
+    "    input_ids: list[TokenizedPrompt]\n",
+    "    \n",
+    "class TorchTokenizedPrompts(TypedDict):\n",
+    "    \"\"\"Tokenized prompts prepared for PyTorch.\"\"\"\n",
+    "\n",
+    "    input_ids: torch.Tensor\n",
+    "\n",
+    "dl = DataLoader[TorchTokenizedPrompts](\n",
+    "            torch_dataset,\n",
+    "            batch_size=16,\n",
+    "            # Shuffle is most efficiently done with the `shuffle` method on the dataset itself, not\n",
+    "            # here.\n",
+    "            shuffle=False,\n",
+    "            num_workers=1,\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['blocks.0.hook_mlp_out',\n",
+       " 'blocks.1.hook_mlp_out',\n",
+       " 'blocks.2.hook_mlp_out',\n",
+       " 'blocks.3.hook_mlp_out',\n",
+       " 'blocks.4.hook_mlp_out',\n",
+       " 'blocks.5.hook_mlp_out',\n",
+       " 'blocks.6.hook_mlp_out',\n",
+       " 'blocks.7.hook_mlp_out',\n",
+       " 'blocks.8.hook_mlp_out',\n",
+       " 'blocks.9.hook_mlp_out',\n",
+       " 'blocks.10.hook_mlp_out',\n",
+       " 'blocks.11.hook_mlp_out']"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hooked_layers = [sae_group.cfg.hook_point.format(layer=layer) for layer in sae_group.cfg.hook_point_layer]\n",
+    "hooked_layers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...\n",
+      "To disable this warning, you can either:\n",
+      "\t- Avoid using `tokenizers` before the fork if possible\n",
+      "\t- Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)\n"
+     ]
+    }
+   ],
+   "source": [
+    "residuals = []\n",
+    "for i, batch in enumerate(dl):\n",
+    "    if i >= 1:\n",
+    "        break\n",
+    "    batch_tokens = batch[\"input_ids\"]\n",
+    "    _, cache = model.run_with_cache(batch_tokens, prepend_bos=True, names_filter=hooked_layers)\n",
+    "    residuals = [cache[layer] for layer in hooked_layers]\n",
+    "    del cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Layer 0: L2 loss: 0.04832719266414642, L1 loss: 77.43148803710938\n",
+      "Layer 1: L2 loss: 0.042232636362314224, L1 loss: 172.55780029296875\n",
+      "Layer 2: L2 loss: 0.06555277109146118, L1 loss: 128.61471557617188\n",
+      "Layer 3: L2 loss: 0.049231573939323425, L1 loss: 186.91522216796875\n",
+      "Layer 4: L2 loss: 0.052200037986040115, L1 loss: 207.7947998046875\n",
+      "Layer 5: L2 loss: 0.06075320765376091, L1 loss: 221.3283233642578\n",
+      "Layer 6: L2 loss: 0.07592680305242538, L1 loss: 241.52862548828125\n",
+      "Layer 7: L2 loss: 0.10238073021173477, L1 loss: 245.11529541015625\n",
+      "Layer 8: L2 loss: 0.13369838893413544, L1 loss: 249.97781372070312\n",
+      "Layer 9: L2 loss: 0.2080564647912979, L1 loss: 234.06924438476562\n",
+      "Layer 10: L2 loss: 0.5095118880271912, L1 loss: 141.20864868164062\n",
+      "Layer 11: L2 loss: 0.8912131190299988, L1 loss: 117.58071899414062\n"
+     ]
+    }
+   ],
+   "source": [
+    "sae_hooks = [\"hook_hidden_post\", \"hook_sae_out\"]\n",
+    "for i in range(len(residuals)):\n",
+    "    autoencoder = sae_group.autoencoders[i]\n",
+    "    _, cache = autoencoder.run_with_cache(residuals[i].to(autoencoder.device), names_filter=sae_hooks)\n",
+    "    reconstructed = cache[\"hook_sae_out\"]\n",
+    "    feature_act = cache[\"hook_hidden_post\"]\n",
+    "    l2_loss = torch.nn.functional.mse_loss(residuals[i].to(autoencoder.device), reconstructed)\n",
+    "    l1_loss = torch.nn.functional.l1_loss(feature_act, torch.zeros_like(feature_act)) * autoencoder.d_sae\n",
+    "    print(f\"Layer {i}: L2 loss: {l2_loss}, L1 loss: {l1_loss}\")\n",
+    "    del cache"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pretty similar to the results I got."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Added options in config to use `sae_type="normalized_sae"` and set `noise_scale` for [this implementation of SAE](https://github.com/HuFY-dev/sparse_autoencoder/tree/dev). Default is set to `sae_type="sae"` and `noise_scale=0.0` which should behave exactly the same as the old version.