### PR TITLE
bugfix - minimum viable updates to tutorial notebook

### DIFF
--- a/tutorials/evaluating_your_sae.ipynb
+++ b/tutorials/evaluating_your_sae.ipynb
@@ -35,7 +35,8 @@
         "sys.path.append(\"..\")\n",
         "\n",
         "from sae_lens.training.session_loader import LMSparseAutoencoderSessionloader\n",
-        "from sae_lens.analysis.visualizer.data_fns import get_feature_data, FeatureData\n",
+        "from sae_vis.data_fetching_fns import get_feature_data, FeatureData\n",
+        "from sae_vis.data_config_classes import SaeVisConfig\n",
         "\n",
         "if torch.backends.mps.is_available():\n",
         "    device = \"mps\"\n",
@@ -104,7 +105,7 @@
       "outputs": [],
       "source": [
         "# pick which sae you wnat to evaluate. Default is 0\n",
-        "sparse_autoencoder = sparse_autoencoders[0]"
+        "sparse_autoencoder = list(sparse_autoencoders)[0]"
       ]
     },
     {
@@ -298,37 +299,39 @@
         "# Currently, don't think much more time can be squeezed out of it. Maybe the best saving would be to\n",
         "# make the entire sequence indexing parallelized, but that's possibly not worth it right now.\n",
         "\n",
-        "max_batch_size = 512\n",
         "total_batch_size = 4096 * 5\n",
         "feature_idx = list(inds.flatten().cpu().numpy())\n",
         "# max_batch_size = 512\n",
         "# total_batch_size = 16384\n",
         "# feature_idx = list(range(1000))\n",
         "\n",
-        "tokens = all_tokens[:total_batch_size]\n",
         "\n",
-        "feature_data: Dict[int, FeatureData] = get_feature_data(\n",
-        "    encoder=sparse_autoencoder,\n",
-        "    # encoder_B=sparse_autoencoder,\n",
-        "    model=model,\n",
+        "feature_vis_params = SaeVisConfig(\n",
         "    hook_point=sparse_autoencoder.cfg.hook_point,\n",
-        "    hook_point_layer=sparse_autoencoder.cfg.hook_point_layer,\n",
-        "    tokens=tokens,\n",
-        "    feature_idx=feature_idx,\n",
-        "    max_batch_size=max_batch_size,\n",
-        "    left_hand_k=3,\n",
-        "    buffer=(5, 5),\n",
-        "    n_groups=10,\n",
-        "    first_group_size=20,\n",
-        "    other_groups_size=5,\n",
-        "    verbose=True,\n",
+        "    minibatch_size_features=256,\n",
+        "    minibatch_size_tokens=64,\n",
+        "    features=feature_idx,\n",
+        "    verbose=True\n",
         ")\n",
         "\n",
         "\n",
+        "\n",
+        "tokens = all_tokens[:total_batch_size]                           \n",
+        "\n",
+        "feature_data: Dict[int, FeatureData] = get_feature_data(\n",
+        "    encoder=sparse_autoencoder,\n",
+        "    model=model,\n",
+        "    tokens=tokens,\n",
+        "    cfg=feature_vis_params\n",
+        ")\n",
+        "\n",
+        "feature_data.model = model\n",
+        "\n",
         "for test_idx in list(inds.flatten().cpu().numpy()):\n",
-        "    html_str = feature_data[test_idx].get_all_html()\n",
-        "    with open(f\"data_{test_idx:04}.html\", \"w\") as f:\n",
-        "        f.write(html_str)"
+        "    feature_data.save_feature_centric_vis(\n",
+        "        f\"data_{test_idx:04}.html\",\n",
+        "        feature_idx=test_idx\n",
+        "    )"
       ]
     },
     {
@@ -337,13 +340,6 @@
       "source": [
         "This will produce a number of html files which each contain a dashboard showing feature activation on the sample data. It currently doesn't process that much data so it isn't that useful. "
       ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": []
     }
   ],
   "metadata": {


### PR DESCRIPTION
While running through the tutorial notebook I encountered a couple of runtime errors - these are the smallest set of updates that get you something runnable, and generate html that looks like:

![image](https://github.com/jbloomAus/SAELens/assets/14338351/f4506198-52f3-49bb-be73-6a94d8890e24)


I'm sure given the dev speed this'll be out of date again soon, but this hopefully this suffices in the interim.