### PR TITLE
chore: enabling python 3.12 checks for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -167,10 +167,10 @@ class LanguageModelSAERunnerConfig:
             n_tokens_per_buffer = (
                 self.store_batch_size * self.context_size * self.n_batches_in_buffer
             )
-            print(f"n_tokens_per_buffer (millions): {n_tokens_per_buffer / 10 **6}")
+            print(f"n_tokens_per_buffer (millions): {n_tokens_per_buffer / 10 ** 6}")
             n_contexts_per_buffer = self.store_batch_size * self.n_batches_in_buffer
             print(
-                f"Lower bound: n_contexts_per_buffer (millions): {n_contexts_per_buffer / 10 **6}"
+                f"Lower bound: n_contexts_per_buffer (millions): {n_contexts_per_buffer / 10 ** 6}"
             )
 
             total_training_steps = (
@@ -187,10 +187,10 @@ class LanguageModelSAERunnerConfig:
                 total_training_steps // self.feature_sampling_window
             )
             print(
-                f"n_tokens_per_feature_sampling_window (millions): {(self.feature_sampling_window * self.context_size * self.train_batch_size) / 10 **6}"
+                f"n_tokens_per_feature_sampling_window (millions): {(self.feature_sampling_window * self.context_size * self.train_batch_size) / 10 ** 6}"
             )
             print(
-                f"n_tokens_per_dead_feature_window (millions): {(self.dead_feature_window * self.context_size * self.train_batch_size) / 10 **6}"
+                f"n_tokens_per_dead_feature_window (millions): {(self.dead_feature_window * self.context_size * self.train_batch_size) / 10 ** 6}"
             )
             print(
                 f"We will reset the sparsity calculation {n_feature_window_samples} times."


### PR DESCRIPTION
This PR adds python 3.12 checks for CI, since it turns out that flake8 on 3.12 runs checks inside of f-strings, but on 3.11 and 3.10 it doesn't