### PR TITLE
chore: setting up precommit to be consistent with CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,21 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
-    -   id: end-of-file-fixer
-    -   id: check-yaml
-    -   id: check-added-large-files
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
         args: [--maxkb=250000]
--   repo: https://github.com/psf/black
+  - repo: https://github.com/psf/black
     rev: 24.3.0
     hooks:
-    -   id: black
--   repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
     hooks:
-    -   id: flake8
-        args: ['--config=.flake8']
-        additional_dependencies: [
-            'flake8-blind-except',
-            # 'flake8-docstrings',
-            'flake8-bugbear',
-            'flake8-comprehensions',
-            'flake8-implicit-str-concat',
-            'pydocstyle>=5.0.0',
-        ]
+      - id: isort
+        name: isort (python)
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,11 @@ pyzmq = "26.0.0"
 
 
 [tool.poetry.group.dev.dependencies]
-black = "^24.2.0"
+black = "24.4.0"
 pytest = "^8.0.2"
 pytest-cov = "^4.1.0"
 pre-commit = "^3.6.2"
-flake8 = "^7.0.0"
+flake8 = "7.0.0"
 isort = "5.13.2"
 pyright = "^1.1.351"
 mamba-lens = "^0.0.4"


### PR DESCRIPTION
This PR pins all version of the pre-commit checks with the same version as used by CI, and removes extra flake8 checks