### PR TITLE
Make load_state_dict use strict=False

### DIFF
--- a/sae_lens/training/sparse_autoencoder.py
+++ b/sae_lens/training/sparse_autoencoder.py
@@ -312,7 +312,13 @@ class SparseAutoencoder(HookedRootModule):
 
         # Create an instance of the class using the loaded configuration
         instance = cls(cfg=state_dict["cfg"])
-        instance.load_state_dict(state_dict["state_dict"], strict=False)
+        new_state_dict = instance.state_dict()
+        if "scaling_factor" not in state_dict["state_dict"]:
+            assert isinstance(instance.cfg.d_sae, int)
+            state_dict["state_dict"]["scaling_factor"] = torch.ones(
+                instance.cfg.d_sae, dtype=instance.cfg.dtype, device=instance.cfg.device
+            )
+        instance.load_state_dict(new_state_dict, strict=True)
 
         return instance
 

--- a/sae_lens/training/sparse_autoencoder.py
+++ b/sae_lens/training/sparse_autoencoder.py
@@ -312,7 +312,7 @@ class SparseAutoencoder(HookedRootModule):
 
         # Create an instance of the class using the loaded configuration
         instance = cls(cfg=state_dict["cfg"])
-        instance.load_state_dict(state_dict["state_dict"])
+        instance.load_state_dict(state_dict["state_dict"], strict=False)
 
         return instance
 

--- a/sae_lens/training/sparse_autoencoder.py
+++ b/sae_lens/training/sparse_autoencoder.py
@@ -312,13 +312,12 @@ class SparseAutoencoder(HookedRootModule):
 
         # Create an instance of the class using the loaded configuration
         instance = cls(cfg=state_dict["cfg"])
-        new_state_dict = instance.state_dict()
         if "scaling_factor" not in state_dict["state_dict"]:
             assert isinstance(instance.cfg.d_sae, int)
             state_dict["state_dict"]["scaling_factor"] = torch.ones(
                 instance.cfg.d_sae, dtype=instance.cfg.dtype, device=instance.cfg.device
             )
-        instance.load_state_dict(new_state_dict, strict=True)
+        instance.load_state_dict(state_dict["state_dict"], strict=True)
 
         return instance
 

--- a/tests/unit/toolkit/test_pretrained_saes.py
+++ b/tests/unit/toolkit/test_pretrained_saes.py
@@ -24,7 +24,7 @@ def test_convert_old_to_modern_saelens_format():
 
     # convert file format
     pretrained_saes.convert_old_to_modern_saelens_format(
-        legacy_out_file, new_out_folder
+        legacy_out_file, new_out_folder, force=True
     )
 
     # Load from new converted file


### PR DESCRIPTION
Your library is too strict, which creates errors if loading state dicts that don't eg contain a scaling factor. I added a quick fix that won't raise errors when loading a state dict that only contains some parameters. This runs the risk that someone may accidentally load a state dict with too few parameters, which is bad? But seems pretty unlikely to me