### PR TITLE
fix: ensure that load_from_pretrained config typing is correct

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ automated-interpretability = "^0.0.3"
 python-dotenv = "^1.0.1"
 pyyaml = "^6.0.1"
 pytest-profiling = "^1.7.0"
+typeguard = "^2.13.3"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/sae_lens/training/sparse_autoencoder.py
+++ b/sae_lens/training/sparse_autoencoder.py
@@ -6,7 +6,8 @@ import gzip
 import json
 import os
 import pickle
-from typing import Callable, NamedTuple, Optional
+from dataclasses import fields
+from typing import Any, Callable, NamedTuple, Optional
 
 import einops
 import torch


### PR DESCRIPTION
# Description

This PR makes use of the type information on the `LanguageModelSAERunnerConfig` dataclass, along with the `typeguard` package to ensure that when loading an existing config from JSON, that all fields in the config have types which match the types specified in the config. Fields which don't match are removed. This PR also adds a test to ensure that all fields in the config loaded from pretrained in the session loader have types which match what is specified in the config.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 