### PR TITLE
feat: make a neuronpedia list with features via api call

### DIFF
--- a/sae_lens/analysis/neuronpedia_integration.py
+++ b/sae_lens/analysis/neuronpedia_integration.py
@@ -1,6 +1,7 @@
 import json
 import urllib.parse
 import webbrowser
+from typing import Optional
 
 import requests
 
@@ -42,3 +43,59 @@ def get_neuronpedia_feature(
     result["index"] = int(result["index"])
 
     return result
+
+
+class NeuronpediaListFeature(object):
+    modelId = ""
+    layer = 0
+    dataset = ""
+    index = 0
+    description = ""
+
+    def __init__(
+        self,
+        modelId: str,
+        layer: int,
+        dataset: str,
+        feature: int,
+        description: str = "",
+    ):
+        self.modelId = modelId
+        self.layer = layer
+        self.dataset = dataset
+        self.feature = feature
+        self.description = description
+
+
+def make_neuronpedia_list_with_features(
+    api_key: str,
+    list_name: str,
+    features: list[NeuronpediaListFeature],
+    list_description: Optional[str] = None,
+    open_browser: bool = True,
+):
+    url = "https://neuronpedia.org/api/list/new-with-features"
+
+    # make POST json request with body
+    body = {
+        "apiKey": api_key,
+        "name": list_name,
+        "description": list_description,
+        "features": [
+            {
+                "modelId": feature.modelId,
+                "layer": f"{feature.layer}-{feature.dataset}",
+                "index": feature.feature,
+                "description": feature.description,
+            }
+            for feature in features
+        ],
+    }
+    response = requests.post(url, json=body)
+    result = response.json()
+
+    if "url" in result and open_browser:
+        webbrowser.open(result["url"])
+        return result["url"]
+    else:
+        raise Exception("Error in creating list: " + result["message"])

--- a/tests/unit/analysis/test_neuronpedia_integration.py
+++ b/tests/unit/analysis/test_neuronpedia_integration.py
@@ -1,4 +1,10 @@
-from sae_lens.analysis.neuronpedia_integration import get_neuronpedia_feature
+import pytest
+
+from sae_lens.analysis.neuronpedia_integration import (
+    NeuronpediaListFeature,
+    get_neuronpedia_feature,
+    make_neuronpedia_list_with_features,
+)
 
 
 def test_get_neuronpedia_feature():
@@ -9,3 +15,30 @@ def test_get_neuronpedia_feature():
     assert result["modelId"] == "gpt2-small"
     assert result["layer"] == "0-res-jb"
     assert result["index"] == 0
+
+
+@pytest.mark.skip(
+    reason="Need a way to test with an API key - maybe test to dev environment?"
+)
+def test_make_neuronpedia_list_with_features():
+    make_neuronpedia_list_with_features(
+        api_key="test_api_key",
+        list_name="test_api",
+        list_description="List descriptions are optional",
+        features=[
+            NeuronpediaListFeature(
+                modelId="gpt2-small",
+                layer=0,
+                dataset="att-kk",
+                feature=11,
+                description="List feature descriptions are optional as well.",
+            ),
+            NeuronpediaListFeature(
+                modelId="gpt2-small",
+                layer=6,
+                dataset="res_scefr-ajt",
+                feature=7,
+                description="You can add features from any model or SAE in one list.",
+            ),
+        ],
+    )


### PR DESCRIPTION
# Description

This adds a `make_neuronpedia_list_with_features` method that creates a list on neuronpedia with specified features via new neuronpedia API call.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
