### PR TITLE
breaks up SAE.forward() into encode() and decode()

### DIFF
--- a/sae_lens/training/sparse_autoencoder.py
+++ b/sae_lens/training/sparse_autoencoder.py
@@ -10,6 +10,7 @@ from typing import Callable, NamedTuple, Optional
 
 import einops
 import torch
+from jaxtyping import Float
 from safetensors import safe_open
 from safetensors.torch import save_file
 from torch import nn
@@ -118,7 +119,13 @@ class SparseAutoencoder(HookedRootModule):
 
         self.setup()  # Required for `HookedRootModule`s
 
-    def forward(self, x: torch.Tensor, dead_neuron_mask: torch.Tensor | None = None):
+    def encode(
+        self, x: Float[torch.Tensor, "... d_in"], return_hidden_pre: bool = False
+    ) -> (
+        Float[torch.Tensor, "... d_sae"]
+        | tuple[Float[torch.Tensor, "... d_sae"], Float[torch.Tensor, "... d_sae"]]
+    ):
+        """Encodes input activation tensor x into an SAE feature activation tensor."""
         # move x to correct dtype
         x = x.to(self.dtype)
         sae_in = self.hook_sae_in(
@@ -138,7 +145,15 @@ class SparseAutoencoder(HookedRootModule):
             noise = torch.randn_like(hidden_pre) * self.noise_scale
             noisy_hidden_pre = hidden_pre + noise
         feature_acts = self.hook_hidden_post(self.activation_fn(noisy_hidden_pre))
+        if return_hidden_pre:
+            return feature_acts, hidden_pre
+        else:
+            return feature_acts
 
+    def decode(
+        self, feature_acts: Float[torch.Tensor, "... d_sae"]
+    ) -> Float[torch.Tensor, "... d_in"]:
+        """Decodes SAE feature activation tensor into a reconstructed input activation tensor."""
         sae_out = self.hook_sae_out(
             einops.einsum(
                 feature_acts
@@ -148,6 +163,14 @@ class SparseAutoencoder(HookedRootModule):
             )
             + self.b_dec
         )
+        return sae_out
+
+    def forward(
+        self, x: torch.Tensor, dead_neuron_mask: torch.Tensor | None = None
+    ) -> ForwardOutput:
+
+        feature_acts, hidden_pre = self.encode(x, return_hidden_pre=True)
+        sae_out = self.decode(feature_acts)
 
         # add config for whether l2 is normalized:
         per_item_mse_loss = _per_item_mse_loss_with_target_norm(

--- a/tests/unit/training/test_sparse_autoencoder.py
+++ b/tests/unit/training/test_sparse_autoencoder.py
@@ -149,6 +149,50 @@ def test_SparseAutoencoder_save_and_load_from_pretrained_lacks_scaling_factor(
             )
 
 
+def test_sparse_autoencoder_encode(sparse_autoencoder: SparseAutoencoder):
+    batch_size = 32
+    d_in = sparse_autoencoder.d_in
+    d_sae = sparse_autoencoder.d_sae
+
+    x = torch.randn(batch_size, d_in)
+    feature_acts1: torch.Tensor = sparse_autoencoder.encode(x)  # type: ignore
+    feature_acts2, hidden_pre = sparse_autoencoder.encode(x, return_hidden_pre=True)
+
+    # Check shape
+    assert feature_acts1.shape == (batch_size, d_sae)
+    assert hidden_pre.shape == (batch_size, d_sae)
+
+    # Check values
+    assert torch.allclose(feature_acts1, feature_acts2)
+    if sparse_autoencoder.cfg.noise_scale == 0:
+        assert torch.allclose(
+            sparse_autoencoder.activation_fn(hidden_pre), feature_acts2
+        )
+
+
+def test_sparse_autoencoder_decode(sparse_autoencoder: SparseAutoencoder):
+    batch_size = 32
+    d_in = sparse_autoencoder.d_in
+
+    x = torch.randn(batch_size, d_in)
+    feature_acts: torch.Tensor = sparse_autoencoder.encode(x)  # type: ignore
+    sae_out1 = sparse_autoencoder.decode(feature_acts)
+
+    (
+        sae_out2,
+        _,
+        _,
+        _,
+        _,
+        _,
+    ) = sparse_autoencoder.forward(
+        x,
+    )
+
+    assert sae_out1.shape == x.shape
+    assert torch.allclose(sae_out1, sae_out2)
+
+
 def test_sparse_autoencoder_forward(sparse_autoencoder: SparseAutoencoder):
     batch_size = 32
     d_in = sparse_autoencoder.d_in

--- a/tests/unit/training/test_sparse_autoencoder.py
+++ b/tests/unit/training/test_sparse_autoencoder.py
@@ -155,19 +155,23 @@ def test_sparse_autoencoder_encode(sparse_autoencoder: SparseAutoencoder):
     d_sae = sparse_autoencoder.d_sae
 
     x = torch.randn(batch_size, d_in)
-    feature_acts1: torch.Tensor = sparse_autoencoder.encode(x)  # type: ignore
-    feature_acts2, hidden_pre = sparse_autoencoder.encode(x, return_hidden_pre=True)
+    feature_acts1 = sparse_autoencoder.encode(x)
+    (
+        _,
+        feature_acts2,
+        _,
+        _,
+        _,
+        _,
+    ) = sparse_autoencoder.forward(
+        x,
+    )
 
     # Check shape
     assert feature_acts1.shape == (batch_size, d_sae)
-    assert hidden_pre.shape == (batch_size, d_sae)
 
     # Check values
     assert torch.allclose(feature_acts1, feature_acts2)
-    if sparse_autoencoder.cfg.noise_scale == 0:
-        assert torch.allclose(
-            sparse_autoencoder.activation_fn(hidden_pre), feature_acts2
-        )
 
 
 def test_sparse_autoencoder_decode(sparse_autoencoder: SparseAutoencoder):
@@ -175,7 +179,7 @@ def test_sparse_autoencoder_decode(sparse_autoencoder: SparseAutoencoder):
     d_in = sparse_autoencoder.d_in
 
     x = torch.randn(batch_size, d_in)
-    feature_acts: torch.Tensor = sparse_autoencoder.encode(x)  # type: ignore
+    feature_acts = sparse_autoencoder.encode(x)
     sae_out1 = sparse_autoencoder.decode(feature_acts)
 
     (


### PR DESCRIPTION
# Description

This PR breaks up the forward() pass of the sparse autoencoder into separate encode() and decode() functions, so that users can e.g., just run the encoder or just run the decoder on input or SAE activations.

I'm not 100% sure I have the 'right' unit tests for these functions, so happy to iterate on those.

# Checklist:

- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [ x ] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)