### PR TITLE
fix: fixing cache_activations_runner and adding a test

### DIFF
--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -50,6 +50,9 @@ class ActivationsStore:
             and not cfg.use_cached_activations
         ):
             cached_activations_path = None
+        # don't try to load from the cache for the cache runner, since we're building a new cache
+        if isinstance(cfg, CacheActivationsRunnerConfig):
+            cached_activations_path = None
         return cls(
             model=model,
             dataset=dataset or cfg.dataset_path,
@@ -132,8 +135,7 @@ class ActivationsStore:
             )
         self.iterable_dataset = iter(self.dataset)  # Reset iterator after checking
 
-        if cached_activations_path is not None:  # EDIT: load from multi-layer acts
-            assert self.cached_activations_path is not None  # keep pyright happy
+        if self.cached_activations_path is not None:  # EDIT: load from multi-layer acts
             # Sanity check: does the cache directory exist?
             assert os.path.exists(
                 self.cached_activations_path

--- a/sae_lens/training/cache_activations_runner.py
+++ b/sae_lens/training/cache_activations_runner.py
@@ -16,30 +16,26 @@ def cache_activations_runner(cfg: CacheActivationsRunnerConfig):
         model_name=cfg.model_name,
         device=cfg.device,
     )
-    activations_store = ActivationsStore.from_config(
-        model,
-        cfg,
-    )
+    activations_store = ActivationsStore.from_config(model, cfg)
 
     # if the activations directory exists and has files in it, raise an exception
-    assert activations_store.cached_activations_path is not None
-    if os.path.exists(activations_store.cached_activations_path):
-        if len(os.listdir(activations_store.cached_activations_path)) > 0:
+    assert cfg.cached_activations_path is not None
+    if os.path.exists(cfg.cached_activations_path):
+        if len(os.listdir(cfg.cached_activations_path)) > 0:
             raise Exception(
-                f"Activations directory ({activations_store.cached_activations_path}) is not empty. Please delete it or specify a different path. Exiting the script to prevent accidental deletion of files."
+                f"Activations directory ({cfg.cached_activations_path}) is not empty. Please delete it or specify a different path. Exiting the script to prevent accidental deletion of files."
             )
     else:
-        os.makedirs(activations_store.cached_activations_path)
+        os.makedirs(cfg.cached_activations_path)
 
     print(f"Started caching {cfg.training_tokens} activations")
     tokens_per_buffer = (
         cfg.store_batch_size * cfg.context_size * cfg.n_batches_in_buffer
     )
     n_buffers = math.ceil(cfg.training_tokens / tokens_per_buffer)
-    # for i in tqdm(range(n_buffers), desc="Caching activations"):
     for i in range(n_buffers):
         buffer = activations_store.get_buffer(cfg.n_batches_in_buffer)
-        torch.save(buffer, f"{activations_store.cached_activations_path}/{i}.pt")
+        torch.save(buffer, f"{cfg.cached_activations_path}/{i}.pt")
         del buffer
 
         if i % cfg.shuffle_every_n_buffers == 0 and i > 0:
@@ -48,14 +44,14 @@ def cache_activations_runner(cfg: CacheActivationsRunnerConfig):
             # Do random pairwise shuffling between the last shuffle_every_n_buffers buffers
             for _ in range(cfg.n_shuffles_with_last_section):
                 shuffle_activations_pairwise(
-                    activations_store.cached_activations_path,
+                    cfg.cached_activations_path,
                     buffer_idx_range=(i - cfg.shuffle_every_n_buffers, i),
                 )
 
             # Do more random pairwise shuffling between all the buffers
             for _ in range(cfg.n_shuffles_in_entire_dir):
                 shuffle_activations_pairwise(
-                    activations_store.cached_activations_path,
+                    cfg.cached_activations_path,
                     buffer_idx_range=(0, i),
                 )
 
@@ -63,6 +59,6 @@ def cache_activations_runner(cfg: CacheActivationsRunnerConfig):
     if n_buffers > 1:
         for _ in tqdm(range(cfg.n_shuffles_final), desc="Final shuffling"):
             shuffle_activations_pairwise(
-                activations_store.cached_activations_path,
+                cfg.cached_activations_path,
                 buffer_idx_range=(0, n_buffers),
             )

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -3,7 +3,10 @@ from typing import Any
 import torch
 from transformer_lens import HookedTransformer
 
-from sae_lens.training.config import LanguageModelSAERunnerConfig
+from sae_lens.training.config import (
+    CacheActivationsRunnerConfig,
+    LanguageModelSAERunnerConfig,
+)
 
 TINYSTORIES_MODEL = "tiny-stories-1M"
 TINYSTORIES_DATASET = "roneneldan/TinyStories"
@@ -41,6 +44,36 @@ def build_sae_cfg(**kwargs: Any) -> LanguageModelSAERunnerConfig:
         device=torch.device("cpu"),
         seed=24,
         checkpoint_path="test/checkpoints",
+        dtype=torch.float32,
+        prepend_bos=True,
+    )
+
+    for key, val in kwargs.items():
+        setattr(mock_config, key, val)
+
+    return mock_config
+
+
+def build_cache_runner_cfg(**kwargs: Any) -> CacheActivationsRunnerConfig:
+    """
+    Helper to create a mock instance of CacheActivationsRunnerConfig.
+    """
+    # Create a mock object with the necessary attributes
+    mock_config = CacheActivationsRunnerConfig(
+        model_name=TINYSTORIES_MODEL,
+        hook_point="blocks.0.hook_mlp_out",
+        hook_point_layer=0,
+        hook_point_head_index=None,
+        dataset_path=TINYSTORIES_DATASET,
+        is_dataset_tokenized=False,
+        d_in=64,
+        train_batch_size=4,
+        context_size=6,
+        n_batches_in_buffer=2,
+        training_tokens=1_000_000,
+        store_batch_size=4,
+        device=torch.device("cpu"),
+        seed=24,
         dtype=torch.float32,
         prepend_bos=True,
     )

--- a/tests/unit/training/test_cache_activations_runner.py
+++ b/tests/unit/training/test_cache_activations_runner.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pytest
+import torch
+
+from sae_lens.training.cache_activations_runner import cache_activations_runner
+from tests.unit.helpers import TINYSTORIES_MODEL, build_cache_runner_cfg
+
+
+def test_cache_activations_runner_outputs_look_correct(tmp_path: Path):
+    target_dir = tmp_path / "activations"
+    cfg = build_cache_runner_cfg(
+        model_name=TINYSTORIES_MODEL,
+        cached_activations_path=target_dir,
+        d_in=64,  # tinystories has a 64-dim residual stream
+        batch_size=4,
+        context_size=6,
+        n_batches_in_buffer=2,
+        training_tokens=1_000,
+    )
+    cache_activations_runner(cfg)
+
+    expected_tokens_per_buffer = 48  # 4 * 6 * 2
+    expected_num_buffers = 21  # 1000 / 48
+    saved_buffers = list(target_dir.glob("*.pt"))
+    assert len(saved_buffers) == expected_num_buffers
+    for buffer_path in saved_buffers:
+        buffer = torch.load(buffer_path)
+        assert buffer.shape == (expected_tokens_per_buffer, 1, 64)  # 64 is d_in
+
+
+def test_cache_activations_runner_errors_if_cache_dir_is_nonempty(tmp_path: Path):
+    target_dir = tmp_path / "activations"
+    cfg = build_cache_runner_cfg(cached_activations_path=target_dir)
+    target_dir.mkdir()
+    (target_dir / "some_file.txt").touch()
+    with pytest.raises(Exception):
+        cache_activations_runner(cfg)


### PR DESCRIPTION
# Description

This PR fixes an issue in `cache_activations_runner` where the runner will always error since it requires a `cached_activations_path` to be set, but the `ActivationsStore` will error if an empty `cached_activations_path` is passed to it. This PR adds a basic test case to the `cache_activations_runner()` function as well.

This PR doesn't change any other implementation of `cache_activations_runner()`, but a followup PR will investigate saving a huggingface datasest consisting of activations to disk instead of using `torch.save()`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
