### PR TITLE
fix: replace list_files_info with list_repo_tree

### DIFF
--- a/sae_lens/toolkit/pretrained_saes.py
+++ b/sae_lens/toolkit/pretrained_saes.py
@@ -4,7 +4,7 @@ import pathlib
 from typing import Optional, Tuple
 
 import torch
-from huggingface_hub import hf_hub_download, list_files_info
+from huggingface_hub import hf_hub_download, list_repo_tree
 from safetensors import safe_open
 from tqdm import tqdm
 
@@ -172,7 +172,7 @@ def get_gpt2_small_ckrk_attn_out_saes() -> dict[str, SparseAutoencoder]:
     # list all files in repo
     saes_weights = {}
     sae_configs = {}
-    repo_files = list_files_info(REPO_ID)
+    repo_files = list_repo_tree(REPO_ID)
     for i in tqdm(repo_files):
         file_name = i.path
         if file_name.endswith(".pt"):


### PR DESCRIPTION
# Description

Currently CI is broken, because the most recent version of huggingface_hub removed the `list_files_info` function. The correct function to use moving forward appears to be `list_repo_tree` ([more info here](https://github.com/huggingface/huggingface_hub/pull/2156)). This PR replaces this function so the library can build again.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)