### PR TITLE
Simple L1 normalization hack to mitigate feature suppression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ pyzmq = "26.0.0"
 automated-interpretability = "^0.0.3"
 python-dotenv = "^1.0.1"
 pyyaml = "^6.0.1"
+huggingface_hub = "0.22.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/sae_lens/training/activation_functions.py
+++ b/sae_lens/training/activation_functions.py
@@ -8,6 +8,10 @@ def get_activation_fn(activation_fn: str) -> Callable[[torch.Tensor], torch.Tens
         return torch.nn.ReLU()
     elif activation_fn == "tanh-relu":
         return tanh_relu
+    elif activation_fn == "tanh":
+        return torch.tanh
+    elif activation_fn == "identity":
+        return identity
     else:
         raise ValueError(f"Unknown activation function: {activation_fn}")
 
@@ -15,4 +19,7 @@ def get_activation_fn(activation_fn: str) -> Callable[[torch.Tensor], torch.Tens
 def tanh_relu(input: torch.Tensor) -> torch.Tensor:
     input = torch.relu(input)
     input = torch.tanh(input)
+    return input
+
+def identity(input: torch.Tensor) -> torch.Tensor:
     return input

--- a/sae_lens/training/activation_functions.py
+++ b/sae_lens/training/activation_functions.py
@@ -21,5 +21,6 @@ def tanh_relu(input: torch.Tensor) -> torch.Tensor:
     input = torch.tanh(input)
     return input
 
+
 def identity(input: torch.Tensor) -> torch.Tensor:
     return input

--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -73,7 +73,10 @@ class LanguageModelSAERunnerConfig:
     mse_loss_normalization: Optional[str] = None
     l1_coefficient: float | list[float] = 1e-3
     lp_norm: float | list[float] = 1
-    l1_normalization_fn: str = "identity"
+    # Normalize the L1 norm of the feature activations. Default is do nothing.
+    # This aims to mitigate the feature suppression problem.
+    # You can observe the effect of this by looking at the `l2_ratio` metric.
+    l1_normalization_fn: str = "identity" # identity, tanh
 
     ## Learning Rate Schedule
     lr: float | list[float] = 3e-4

--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -73,6 +73,7 @@ class LanguageModelSAERunnerConfig:
     mse_loss_normalization: Optional[str] = None
     l1_coefficient: float | list[float] = 1e-3
     lp_norm: float | list[float] = 1
+    l1_normalization_fn: str = "identity"
 
     ## Learning Rate Schedule
     lr: float | list[float] = 3e-4

--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -76,7 +76,7 @@ class LanguageModelSAERunnerConfig:
     # Normalize the L1 norm of the feature activations. Default is do nothing.
     # This aims to mitigate the feature suppression problem.
     # You can observe the effect of this by looking at the `l2_ratio` metric.
-    l1_normalization_fn: str = "identity" # identity, tanh
+    l1_normalization_fn: str = "identity"  # identity, tanh
 
     ## Learning Rate Schedule
     lr: float | list[float] = 3e-4

--- a/sae_lens/training/sparse_autoencoder.py
+++ b/sae_lens/training/sparse_autoencoder.py
@@ -82,6 +82,7 @@ class SparseAutoencoder(HookedRootModule):
         self.hook_point_layer = cfg.hook_point_layer
         self.noise_scale = cfg.noise_scale
         self.activation_fn = get_activation_fn(cfg.activation_fn)
+        self.l1_normalization_fn = get_activation_fn(cfg.l1_normalization_fn)
 
         # NOTE: if using resampling neurons method, you must ensure that we initialise the weights in the order W_enc, b_enc, W_dec, b_dec
         self.W_enc = nn.Parameter(
@@ -198,6 +199,7 @@ class SparseAutoencoder(HookedRootModule):
             )
 
         mse_loss = per_item_mse_loss.mean()
+        feature_acts = self.l1_normalization_fn(feature_acts)
         sparsity = feature_acts.norm(p=self.lp_norm, dim=1).mean(dim=(0,))
         l1_loss = self.l1_coefficient * sparsity
         loss = mse_loss + l1_loss + ghost_grad_loss

--- a/sae_lens/training/sparse_autoencoder.py
+++ b/sae_lens/training/sparse_autoencoder.py
@@ -199,6 +199,8 @@ class SparseAutoencoder(HookedRootModule):
             )
 
         mse_loss = per_item_mse_loss.mean()
+        # Normalize the L1 norm of the feature activations. Default is do nothing.
+        # See config for more info.
         feature_acts = self.l1_normalization_fn(feature_acts)
         sparsity = feature_acts.norm(p=self.lp_norm, dim=1).mean(dim=(0,))
         l1_loss = self.l1_coefficient * sparsity


### PR DESCRIPTION
# Description

Performs a simple tanh normalization before calculating the sparsity loss to bound the sparsity to (-1,1) and hence mitigate feature suppression.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [x] L0: increased a bit, but probably due to L1 coefficient
- [x] CE Loss: better CE_loss_score
- [x] MSE Loss: lower, but probably due to higher L0.
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. [Link](https://api.wandb.ai/links/hufy-dev/zphuq7pd)