### PR TITLE
feat: Add model_from_pretrained_kwargs as config parameter

### DIFF
--- a/sae_lens/training/cache_activations_runner.py
+++ b/sae_lens/training/cache_activations_runner.py
@@ -15,6 +15,7 @@ def cache_activations_runner(cfg: CacheActivationsRunnerConfig):
         model_class_name=cfg.model_class_name,
         model_name=cfg.model_name,
         device=cfg.device,
+        model_from_pretrained_kwargs=cfg.model_from_pretrained_kwargs,
     )
     activations_store = ActivationsStore.from_config(
         model,

--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -115,6 +115,7 @@ class LanguageModelSAERunnerConfig:
     checkpoint_path: str = "checkpoints"
     verbose: bool = True
     model_kwargs: dict[str, Any] = field(default_factory=dict)
+    model_from_pretrained_kwargs: dict[str, Any] = field(default_factory=dict)
     sae_lens_version: str = field(default_factory=lambda: __version__)
     sae_lens_training_version: str = field(default_factory=lambda: __version__)
 
@@ -301,6 +302,7 @@ class CacheActivationsRunnerConfig:
     n_shuffles_in_entire_dir: int = 10
     n_shuffles_final: int = 100
     model_kwargs: dict[str, Any] = field(default_factory=dict)
+    model_from_pretrained_kwargs: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         # Autofill cached_activations_path unless the user overrode it

--- a/sae_lens/training/load_model.py
+++ b/sae_lens/training/load_model.py
@@ -6,10 +6,17 @@ from transformer_lens.hook_points import HookedRootModule
 
 
 def load_model(
-    model_class_name: str, model_name: str, device: str | torch.device | None = None
+    model_class_name: str,
+    model_name: str,
+    device: str | torch.device | None = None,
+    model_from_pretrained_kwargs: dict[str, Any] | None = None,
 ) -> HookedRootModule:
+    model_from_pretrained_kwargs = model_from_pretrained_kwargs or {}
+
     if model_class_name == "HookedTransformer":
-        return HookedTransformer.from_pretrained(model_name=model_name, device=device)
+        return HookedTransformer.from_pretrained(
+            model_name=model_name, device=device, **model_from_pretrained_kwargs
+        )
     elif model_class_name == "HookedMamba":
         try:
             from mamba_lens import HookedMamba
@@ -20,7 +27,9 @@ def load_model(
         # HookedMamba has incorrect typing information, so we need to cast the type here
         return cast(
             HookedRootModule,
-            HookedMamba.from_pretrained(model_name, device=cast(Any, device)),
+            HookedMamba.from_pretrained(
+                model_name, device=cast(Any, device), **model_from_pretrained_kwargs
+            ),
         )
     else:
         raise ValueError(f"Unknown model class: {model_class_name}")

--- a/sae_lens/training/sae_group.py
+++ b/sae_lens/training/sae_group.py
@@ -136,6 +136,8 @@ class SparseAutoencoderDictionary:
                 cfg.sae_lens_version = "0.0.0"
             if not hasattr(cfg, "sae_lens_training_version"):
                 cfg.sae_lens_training_version = "0.0.0"
+            if not hasattr(cfg, "model_from_pretrained_kwargs"):
+                cfg.model_from_pretrained_kwargs = {}
             sparse_autoencoder = SparseAutoencoder(cfg=cfg)
             # add dummy scaling factor to the state dict
             group["state_dict"]["scaling_factor"] = torch.ones(

--- a/sae_lens/training/session_loader.py
+++ b/sae_lens/training/session_loader.py
@@ -67,6 +67,9 @@ class LMSparseAutoencoderSessionloader:
         # Todo: add check that model_name is valid
 
         model = load_model(
-            self.cfg.model_class_name, model_name, device=self.cfg.device
+            self.cfg.model_class_name,
+            model_name,
+            device=self.cfg.device,
+            model_from_pretrained_kwargs=self.cfg.model_from_pretrained_kwargs,
         )
         return model

--- a/tests/unit/training/test_load_model.py
+++ b/tests/unit/training/test_load_model.py
@@ -1,4 +1,5 @@
 from mamba_lens import HookedMamba
+from transformer_lens import HookedTransformer
 
 from sae_lens.training.load_model import load_model
 
@@ -11,3 +12,26 @@ def test_load_model_works_with_mamba():
     )
     assert model is not None
     assert isinstance(model, HookedMamba)
+
+
+def test_load_model_works_without_model_kwargs():
+    model = load_model(
+        model_class_name="HookedTransformer",
+        model_name="pythia-14m",
+        device="cpu",
+    )
+    assert model is not None
+    assert isinstance(model, HookedTransformer)
+    assert model.cfg.checkpoint_index is None
+
+
+def test_load_model_works_with_model_kwargs():
+    model = load_model(
+        model_class_name="HookedTransformer",
+        model_name="pythia-14m",
+        device="cpu",
+        model_from_pretrained_kwargs={"checkpoint_index": 0},
+    )
+    assert model is not None
+    assert isinstance(model, HookedTransformer)
+    assert model.cfg.checkpoint_index == 0

--- a/tests/unit/training/test_session_loader.py
+++ b/tests/unit/training/test_session_loader.py
@@ -19,32 +19,18 @@ TEST_MODEL = "tiny-stories-1M"
 TEST_DATASET = "roneneldan/TinyStories"
 
 
-@pytest.fixture(
-    params=[
-        {
-            "model_name": "tiny-stories-1M",
-            "hook_point": "blocks.0.hook_mlp_out",
-            "hook_point_layer": 0,
-            "dataset_path": "roneneldan/TinyStories",
-            "is_dataset_tokenized": False,
-        },
-        # For testing 'model_from_pretrained_kwargs' parameter
-        {
-            "model_name": "pythia-14m",
-            "hook_point": "blocks.0.hook_mlp_out",
-            "hook_point_layer": 0,
-            "dataset_path": "roneneldan/TinyStories",
-            "is_dataset_tokenized": False,
-            "model_from_pretrained_kwargs": {"checkpoint_index": 0},
-        },
-    ],
-    ids=["tiny-stories-1M", "pythia-14m with model_from_pretrained_kwargs"],
-)
-def cfg(request: pytest.FixtureRequest):
+@pytest.fixture
+def cfg():
     """
     Pytest fixture to create a mock instance of LanguageModelSAERunnerConfig.
     """
-    cfg = build_sae_cfg(**request.param)
+    cfg = build_sae_cfg(
+        model_name=TEST_MODEL,
+        hook_point="blocks.0.hook_mlp_out",
+        hook_point_layer=0,
+        dataset_path=TEST_DATASET,
+        is_dataset_tokenized=False,
+    )
     return cfg
 
 
@@ -62,17 +48,28 @@ def test_LMSparseAutoencoderSessionloader_load_session(
     assert isinstance(model, HookedTransformer)
     assert isinstance(next(iter(sae_group))[1], SparseAutoencoder)
     assert isinstance(activations_loader, ActivationsStore)
+    assert model.cfg.checkpoint_index is None
 
-    if (
-        cfg.model_from_pretrained_kwargs is not None
-        and "checkpoint_index" in cfg.model_from_pretrained_kwargs
-    ):
-        assert (
-            model.cfg.checkpoint_index
-            == cfg.model_from_pretrained_kwargs["checkpoint_index"]
-        )
-    elif cfg.model_from_pretrained_kwargs is None:
-        assert model.cfg.checkpoint_index is None
+
+def test_LMSparseAutoencoderSessionloader_load_session_can_load_model_with_kwargs():
+    cfg = build_sae_cfg(
+        model_name="pythia-14m",
+        hook_point="blocks.0.hook_mlp_out",
+        hook_point_layer=0,
+        dataset_path="roneneldan/TinyStories",
+        is_dataset_tokenized=False,
+        model_from_pretrained_kwargs={"checkpoint_index": 0},
+    )
+    loader = LMSparseAutoencoderSessionloader(cfg)
+    model, sae_group, activations_loader = loader.load_sae_training_group_session()
+
+    assert isinstance(model, HookedTransformer)
+    assert isinstance(next(iter(sae_group))[1], SparseAutoencoder)
+    assert isinstance(activations_loader, ActivationsStore)
+    assert (
+        model.cfg.checkpoint_index
+        == cfg.model_from_pretrained_kwargs["checkpoint_index"]
+    )
 
 
 def test_LMSparseAutoencoderSessionloader_load_sae_session_from_pretrained(


### PR DESCRIPTION
# Description

Adds the `model_from_pretrained_kwargs` config parameter and associated code in order to allow full control over the `HookedTransformer` or `HookedMamba` model used to extract activations from. In my specific case this is required in order to load non-default checkpoints for Pythia models.

## Type of change

Please delete options that are not relevant.

- [ ] ~~Bug fix (non-breaking change which fixes an issue)~~
- [x] New feature (non-breaking change which adds functionality)
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to not work as expected)~~
- [ ] ~~This change requires a documentation update~~



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
  - [x] Not required given existing documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group.

Doesn't affect performance for existing code