### PR TITLE
Add bf16 autocast

### DIFF
--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -64,6 +64,7 @@ class LanguageModelSAERunnerConfig:
     seed: int = 42
     dtype: str | torch.dtype = "float32"  # type: ignore #
     prepend_bos: bool = True
+    autocast: bool = False  # autocast to bf16 during training
 
     # Training Parameters
 

--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -64,7 +64,8 @@ class LanguageModelSAERunnerConfig:
     seed: int = 42
     dtype: str | torch.dtype = "float32"  # type: ignore #
     prepend_bos: bool = True
-    autocast: bool = False  # autocast to bf16 during training
+    autocast: bool = False  # autocast to autocast_dtype during training
+    autocast_dtype: torch.dtype = torch.bfloat16  # float16 is typically unstable
 
     # Training Parameters
 

--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -65,7 +65,6 @@ class LanguageModelSAERunnerConfig:
     dtype: str | torch.dtype = "float32"  # type: ignore #
     prepend_bos: bool = True
     autocast: bool = False  # autocast to autocast_dtype during training
-    autocast_dtype: torch.dtype = torch.bfloat16  # float16 is typically unstable
 
     # Training Parameters
 

--- a/sae_lens/training/lm_runner.py
+++ b/sae_lens/training/lm_runner.py
@@ -85,7 +85,6 @@ def language_model_sae_runner(cfg: LanguageModelSAERunnerConfig):
         wandb_log_frequency=cfg.wandb_log_frequency,
         eval_every_n_wandb_logs=cfg.eval_every_n_wandb_logs,
         autocast=cfg.autocast,
-        autocast_dtype=cfg.autocast_dtype,
     ).sae_group
 
     if cfg.log_to_wandb:

--- a/sae_lens/training/lm_runner.py
+++ b/sae_lens/training/lm_runner.py
@@ -84,6 +84,7 @@ def language_model_sae_runner(cfg: LanguageModelSAERunnerConfig):
         use_wandb=cfg.log_to_wandb,
         wandb_log_frequency=cfg.wandb_log_frequency,
         eval_every_n_wandb_logs=cfg.eval_every_n_wandb_logs,
+        autocast=cfg.autocast,
     ).sae_group
 
     if cfg.log_to_wandb:

--- a/sae_lens/training/lm_runner.py
+++ b/sae_lens/training/lm_runner.py
@@ -85,6 +85,7 @@ def language_model_sae_runner(cfg: LanguageModelSAERunnerConfig):
         wandb_log_frequency=cfg.wandb_log_frequency,
         eval_every_n_wandb_logs=cfg.eval_every_n_wandb_logs,
         autocast=cfg.autocast,
+        autocast_dtype=cfg.autocast_dtype,
     ).sae_group
 
     if cfg.log_to_wandb:

--- a/sae_lens/training/train_sae_on_language_model.py
+++ b/sae_lens/training/train_sae_on_language_model.py
@@ -188,6 +188,7 @@ def train_sae_on_language_model(
     wandb_log_frequency: int = 50,
     eval_every_n_wandb_logs: int = 100,
     autocast: bool = False,
+    autocast_dtype: torch.dtype = torch.bfloat16,
 ) -> SparseAutoencoderDictionary:
     """
     @deprecated Use `train_sae_group_on_language_model` instead. This method is kept for backward compatibility.
@@ -203,6 +204,7 @@ def train_sae_on_language_model(
         wandb_log_frequency=wandb_log_frequency,
         eval_every_n_wandb_logs=eval_every_n_wandb_logs,
         autocast=autocast,
+        autocast_dtype=autocast_dtype,
     ).sae_group
 
 
@@ -223,6 +225,7 @@ def train_sae_group_on_language_model(
     wandb_log_frequency: int = 50,
     eval_every_n_wandb_logs: int = 100,
     autocast: bool = False,
+    autocast_dtype: torch.dtype = torch.bfloat16,
 ) -> TrainSAEGroupOutput:
     total_training_tokens = get_total_training_tokens(sae_group=sae_group)
     _update_sae_lens_training_version(sae_group)
@@ -294,6 +297,7 @@ def train_sae_group_on_language_model(
                     batch_size=batch_size,
                     wandb_suffix=wandb_suffix,
                     autocast=autocast,
+                    autocast_dtype=autocast_dtype,
                 )
                 mse_losses.append(step_output.mse_loss)
                 l1_losses.append(step_output.l1_loss)
@@ -545,6 +549,7 @@ def _train_step(
     batch_size: int,
     wandb_suffix: str,
     autocast: bool = True,
+    autocast_dtype: torch.dtype = torch.bfloat16,
 ) -> TrainStepOutput:
     assert sparse_autoencoder.cfg.d_sae is not None  # keep pyright happy
     layer_id = all_layers.index(sparse_autoencoder.hook_point_layer)
@@ -590,7 +595,8 @@ def _train_step(
     if autocast:
         autocast_if_enabled = torch.autocast(
             device_type="cuda",
-            dtype=torch.bfloat16,
+            # dtype=torch.bfloat16,
+            dtype=autocast_dtype,
             enabled=autocast,
             )
     else:

--- a/sae_lens/training/train_sae_on_language_model.py
+++ b/sae_lens/training/train_sae_on_language_model.py
@@ -188,7 +188,6 @@ def train_sae_on_language_model(
     wandb_log_frequency: int = 50,
     eval_every_n_wandb_logs: int = 100,
     autocast: bool = False,
-    autocast_dtype: torch.dtype = torch.bfloat16,
 ) -> SparseAutoencoderDictionary:
     """
     @deprecated Use `train_sae_group_on_language_model` instead. This method is kept for backward compatibility.
@@ -204,7 +203,6 @@ def train_sae_on_language_model(
         wandb_log_frequency=wandb_log_frequency,
         eval_every_n_wandb_logs=eval_every_n_wandb_logs,
         autocast=autocast,
-        autocast_dtype=autocast_dtype,
     ).sae_group
 
 
@@ -225,7 +223,6 @@ def train_sae_group_on_language_model(
     wandb_log_frequency: int = 50,
     eval_every_n_wandb_logs: int = 100,
     autocast: bool = False,
-    autocast_dtype: torch.dtype = torch.bfloat16,
 ) -> TrainSAEGroupOutput:
     total_training_tokens = get_total_training_tokens(sae_group=sae_group)
     _update_sae_lens_training_version(sae_group)
@@ -297,7 +294,6 @@ def train_sae_group_on_language_model(
                     batch_size=batch_size,
                     wandb_suffix=wandb_suffix,
                     autocast=autocast,
-                    autocast_dtype=autocast_dtype,
                 )
                 mse_losses.append(step_output.mse_loss)
                 l1_losses.append(step_output.l1_loss)
@@ -549,7 +545,6 @@ def _train_step(
     batch_size: int,
     wandb_suffix: str,
     autocast: bool = True,
-    autocast_dtype: torch.dtype = torch.bfloat16,
 ) -> TrainStepOutput:
     assert sparse_autoencoder.cfg.d_sae is not None  # keep pyright happy
     layer_id = all_layers.index(sparse_autoencoder.hook_point_layer)
@@ -595,8 +590,7 @@ def _train_step(
     if autocast:
         autocast_if_enabled = torch.autocast(
             device_type="cuda",
-            # dtype=torch.bfloat16,
-            dtype=autocast_dtype,
+            dtype=torch.bfloat16,
             enabled=autocast,
         )
     else:

--- a/sae_lens/training/train_sae_on_language_model.py
+++ b/sae_lens/training/train_sae_on_language_model.py
@@ -598,7 +598,7 @@ def _train_step(
             # dtype=torch.bfloat16,
             dtype=autocast_dtype,
             enabled=autocast,
-            )
+        )
     else:
         autocast_if_enabled = contextlib.nullcontext()
 

--- a/sae_lens/training/train_sae_on_language_model.py
+++ b/sae_lens/training/train_sae_on_language_model.py
@@ -544,7 +544,7 @@ def _train_step(
     all_layers: list[int],
     batch_size: int,
     wandb_suffix: str,
-    autocast: bool = True,  # TODO(tomMcGrath): propagate up to config
+    autocast: bool = True,
 ) -> TrainStepOutput:
     assert sparse_autoencoder.cfg.d_sae is not None  # keep pyright happy
     layer_id = all_layers.index(sparse_autoencoder.hook_point_layer)


### PR DESCRIPTION
# Description

Adds torch autocasting to the SAE train step, improving throughput.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (see W&B dash)
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [x] L0
- [x] CE Loss
- [x] MSE Loss
- [ ] Feature Dashboard Interpretability

W&B dashboard showing no performance regression when autocasting to bf16 and moderate speedup/perf-per-time improvement: https://wandb.ai/tmcgrath/autocast%20testing/workspace

More performance could probably be obtained by compiling and autocasting the LLM and maybe by compiling the SAE. Other hyperparameters are also probably better for performance.