### PR TITLE
Change eval batch size

### DIFF
--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -191,12 +191,12 @@ class ActivationsStore:
             self._dataloader = self.get_data_loader()
         return self._dataloader
 
-    def get_batch_tokens(self):
+    def get_batch_tokens(self, batch_size: int | None = None):
         """
         Streams a batch of tokens from a dataset.
         """
-
-        batch_size = self.store_batch_size
+        if not batch_size:
+            batch_size = self.store_batch_size
         context_size = self.context_size
         device = self.device
 

--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -106,6 +106,10 @@ class LanguageModelSAERunnerConfig:
 
     dead_feature_threshold: float = 1e-8
 
+    # Evals
+    n_eval_batches: int = 10
+    n_eval_seqs: int | None = None  # useful if evals cause OOM
+
     # WANDB
     log_to_wandb: bool = True
     log_activations_store_to_wandb: bool = False

--- a/sae_lens/training/evals.py
+++ b/sae_lens/training/evals.py
@@ -28,8 +28,8 @@ def run_evals(
     )
     ### Evals
     eval_tokens = activation_store.get_batch_tokens(n_eval_seqs)
-    print(f'Eval tokens shape: {eval_tokens.shape}')
-    print(f'Normal activation store batch size: {activation_store.store_batch_size}')
+    print(f"Eval tokens shape: {eval_tokens.shape}")
+    print(f"Normal activation store batch size: {activation_store.store_batch_size}")
 
     # Get Reconstruction Score
     losses_df = recons_loss_batched(

--- a/sae_lens/training/evals.py
+++ b/sae_lens/training/evals.py
@@ -28,8 +28,6 @@ def run_evals(
     )
     ### Evals
     eval_tokens = activation_store.get_batch_tokens(n_eval_seqs)
-    print(f"Eval tokens shape: {eval_tokens.shape}")
-    print(f"Normal activation store batch size: {activation_store.store_batch_size}")
 
     # Get Reconstruction Score
     losses_df = recons_loss_batched(

--- a/sae_lens/training/lm_runner.py
+++ b/sae_lens/training/lm_runner.py
@@ -85,6 +85,8 @@ def language_model_sae_runner(cfg: LanguageModelSAERunnerConfig):
         wandb_log_frequency=cfg.wandb_log_frequency,
         eval_every_n_wandb_logs=cfg.eval_every_n_wandb_logs,
         autocast=cfg.autocast,
+        n_eval_batches=cfg.n_eval_batches,
+        n_eval_seqs=cfg.n_eval_seqs,
     ).sae_group
 
     if cfg.log_to_wandb:

--- a/sae_lens/training/train_sae_on_language_model.py
+++ b/sae_lens/training/train_sae_on_language_model.py
@@ -188,6 +188,8 @@ def train_sae_on_language_model(
     wandb_log_frequency: int = 50,
     eval_every_n_wandb_logs: int = 100,
     autocast: bool = False,
+    n_eval_batches: int = 10,
+    n_eval_seqs: int | None = None,
 ) -> SparseAutoencoderDictionary:
     """
     @deprecated Use `train_sae_group_on_language_model` instead. This method is kept for backward compatibility.
@@ -203,6 +205,8 @@ def train_sae_on_language_model(
         wandb_log_frequency=wandb_log_frequency,
         eval_every_n_wandb_logs=eval_every_n_wandb_logs,
         autocast=autocast,
+        n_eval_batches=n_eval_batches,
+        n_eval_seqs=n_eval_seqs,
     ).sae_group
 
 
@@ -223,6 +227,8 @@ def train_sae_group_on_language_model(
     wandb_log_frequency: int = 50,
     eval_every_n_wandb_logs: int = 100,
     autocast: bool = False,
+    n_eval_batches: int = 10,
+    n_eval_seqs: int | None = None,
 ) -> TrainSAEGroupOutput:
     total_training_tokens = get_total_training_tokens(sae_group=sae_group)
     _update_sae_lens_training_version(sae_group)
@@ -325,6 +331,8 @@ def train_sae_group_on_language_model(
                                 model,
                                 training_run_state.n_training_steps,
                                 suffix=wandb_suffix,
+                                n_eval_batches=n_eval_batches,
+                                n_eval_seqs=n_eval_seqs,
                             )
                             sparse_autoencoder.train()
 


### PR DESCRIPTION
# Description

Surfaces extra options for eval step: number of eval batches and number of sequences per eval batch. Adds an optional parameter to activations_store.get_batch_tokens to make this clean: now get_batch_tokens can get a number of sequences that differs from the value defined at init.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

I've checked these locally but not added tests.

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)