### PR TITLE
tools to make tests more deterministic

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,29 @@
+import random
+
+import numpy as np
 import pytest
+import torch
 
 from tests.unit.helpers import TINYSTORIES_MODEL, load_model_cached
+
+
+@pytest.fixture(autouse=True)
+def reproducibility():
+    """Apply various mechanisms to try to prevent nondeterminism in test runs."""
+    # I have not in general attempted to verify that the below are necessary
+    # for reproducibility, only that they are likely to help and unlikely to
+    # hurt.
+    # https://pytorch.org/docs/stable/notes/randomness.html#reproducibility
+    seed = 0x1234_5678_9ABC_DEF0
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    torch.use_deterministic_algorithms(True)
+    torch.backends.cudnn.benchmark = False
+    # Python native RNG; docs don't give any limitations on seed range
+    random.seed(seed)
+    # this is a "legacy" method that operates on a global RandomState
+    # sounds like the argument must be in [0, 2**32)
+    np.random.seed(seed & 0xFFFF_FFFF)
 
 
 @pytest.fixture


### PR DESCRIPTION
# Description

Pretty simple test change to add a pytest fixture that is run for every test, and use it to seed the RNG.

I don't strongly have evidence that not doing this caused test failures, or that doing it fixes them, but the principled case for doing this is pretty strong IMO and I can't think of any real downsides.

I think it's quite likely that there are other sources of non-determinism not fixed here (e.g. any non-global RNGs that are used in code), but incremental progress helps.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
    - none necessary
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
    - This is *possible* (e.g. by testing the output of `torch.get_rng_state`) but it's hard to imagine a version of this test that catches actual bugs.
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 