### PR TITLE
Hooked toy model

### DIFF
--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -340,6 +340,59 @@ class CacheActivationsRunnerConfig:
             )
 
 
+@dataclass
+class ToyModelSAERunnerConfig:
+    # ReLu Model Parameters
+    n_features: int = 5
+    n_hidden: int = 2
+    n_correlated_pairs: int = 0
+    n_anticorrelated_pairs: int = 0
+    feature_probability: float = 0.025
+    model_training_steps: int = 10_000
+
+    # SAE Parameters
+    d_sae: int = 5
+
+    # Training Parameters
+    l1_coefficient: float = 1e-3
+    lr: float = 3e-4
+    train_batch_size: int = 1024
+    b_dec_init_method: str = "geometric_median"
+
+    # Sparsity / Dead Feature Handling
+    use_ghost_grads: bool = (
+        False  # not currently implemented, but SAE class expects it.
+    )
+    feature_sampling_window: int = 100
+    dead_feature_window: int = 100  # unless this window is larger feature sampling,
+    dead_feature_threshold: float = 1e-8
+
+    # Activation Store Parameters
+    total_training_tokens: int = 25_000
+
+    # WANDB
+    log_to_wandb: bool = True
+    wandb_project: str = "mats_sae_training_toy_model"
+    wandb_entity: str | None = None
+    wandb_log_frequency: int = 50
+
+    # Misc
+    device: str | torch.device = "cuda" if torch.cuda.is_available() else "cpu"
+    seed: int = 42
+    checkpoint_path: str = "checkpoints"
+    dtype: str | torch.dtype = "float32"
+
+    def __post_init__(self):
+        self.d_in = self.n_hidden  # hidden for the ReLu model is the input for the SAE
+
+        if isinstance(self.dtype, str) and self.dtype not in DTYPE_MAP:
+            raise ValueError(
+                f"dtype must be one of {list(DTYPE_MAP.keys())}. Got {self.dtype}"
+            )
+        elif isinstance(self.dtype, str):
+            self.dtype = DTYPE_MAP[self.dtype]
+
+
 def _default_cached_activations_path(
     dataset_path: str,
     model_name: str,

--- a/sae_lens/training/toy_model_runner.py
+++ b/sae_lens/training/toy_model_runner.py
@@ -63,7 +63,6 @@ def toy_model_sae_runner(cfg: SAEToyModelRunnerConfig):
     """
     # Toy Model Config
     toy_model_cfg = ToyConfig(
-        n_instances=1,  # Not set up to train > 1 SAE so shouldn't do > 1 model.
         n_features=cfg.n_features,
         n_hidden=cfg.n_hidden,
         n_correlated_pairs=cfg.n_correlated_pairs,
@@ -85,7 +84,7 @@ def toy_model_sae_runner(cfg: SAEToyModelRunnerConfig):
     hidden = einops.einsum(
         batch,
         model.W,
-        "batch_size instances features, instances hidden features -> batch_size instances hidden",
+        "batch_size features, hidden features -> batch_size hidden",
     )
 
     sparse_autoencoder = SparseAutoencoder(

--- a/sae_lens/training/toy_model_runner.py
+++ b/sae_lens/training/toy_model_runner.py
@@ -1,63 +1,17 @@
-from dataclasses import dataclass
 from typing import Any, cast
 
 import einops
 import torch
 import wandb
 
+from sae_lens.training.config import ToyModelSAERunnerConfig
 from sae_lens.training.sparse_autoencoder import SparseAutoencoder
 from sae_lens.training.toy_models import ReluOutputModel as ToyModel
 from sae_lens.training.toy_models import ToyConfig
 from sae_lens.training.train_sae_on_toy_model import train_toy_sae
 
 
-@dataclass
-class SAEToyModelRunnerConfig:
-    # ReLu Model Parameters
-    n_features: int = 5
-    n_hidden: int = 2
-    n_correlated_pairs: int = 0
-    n_anticorrelated_pairs: int = 0
-    feature_probability: float = 0.025
-    model_training_steps: int = 10_000
-
-    # SAE Parameters
-    d_sae: int = 5
-
-    # Training Parameters
-    l1_coefficient: float = 1e-3
-    lr: float = 3e-4
-    train_batch_size: int = 1024
-    b_dec_init_method: str = "geometric_median"
-
-    # Sparsity / Dead Feature Handling
-    use_ghost_grads: bool = (
-        False  # not currently implemented, but SAE class expects it.
-    )
-    feature_sampling_window: int = 100
-    dead_feature_window: int = 100  # unless this window is larger feature sampling,
-    dead_feature_threshold: float = 1e-8
-
-    # Activation Store Parameters
-    total_training_tokens: int = 25_000
-
-    # WANDB
-    log_to_wandb: bool = True
-    wandb_project: str = "mats_sae_training_toy_model"
-    wandb_entity: str | None = None
-    wandb_log_frequency: int = 50
-
-    # Misc
-    device: torch.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    seed: int = 42
-    checkpoint_path: str = "checkpoints"
-    dtype: torch.dtype = torch.float32
-
-    def __post_init__(self):
-        self.d_in = self.n_hidden  # hidden for the ReLu model is the input for the SAE
-
-
-def toy_model_sae_runner(cfg: SAEToyModelRunnerConfig):
+def toy_model_sae_runner(cfg: ToyModelSAERunnerConfig):
     """
     A runner for training an SAE on a toy model.
     """
@@ -73,7 +27,7 @@ def toy_model_sae_runner(cfg: SAEToyModelRunnerConfig):
     # Initialize Toy Model
     model = ToyModel(
         cfg=toy_model_cfg,
-        device=cfg.device,
+        device=torch.device(cfg.device),
     )
 
     # Train the Toy Model

--- a/sae_lens/training/toy_model_runner.py
+++ b/sae_lens/training/toy_model_runner.py
@@ -6,8 +6,8 @@ import torch
 import wandb
 
 from sae_lens.training.sparse_autoencoder import SparseAutoencoder
-from sae_lens.training.toy_models import Config as ToyConfig
-from sae_lens.training.toy_models import Model as ToyModel
+from sae_lens.training.toy_models import ReluOutputModel as ToyModel
+from sae_lens.training.toy_models import ToyConfig
 from sae_lens.training.train_sae_on_toy_model import train_toy_sae
 
 
@@ -48,7 +48,7 @@ class SAEToyModelRunnerConfig:
     wandb_log_frequency: int = 50
 
     # Misc
-    device: str = "cpu"
+    device: torch.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     seed: int = 42
     checkpoint_path: str = "checkpoints"
     dtype: torch.dtype = torch.float32
@@ -68,13 +68,13 @@ def toy_model_sae_runner(cfg: SAEToyModelRunnerConfig):
         n_hidden=cfg.n_hidden,
         n_correlated_pairs=cfg.n_correlated_pairs,
         n_anticorrelated_pairs=cfg.n_anticorrelated_pairs,
+        feature_probability=cfg.feature_probability,
     )
 
     # Initialize Toy Model
     model = ToyModel(
         cfg=toy_model_cfg,
         device=cfg.device,
-        feature_probability=cfg.feature_probability,
     )
 
     # Train the Toy Model

--- a/sae_lens/training/toy_models.py
+++ b/sae_lens/training/toy_models.py
@@ -5,6 +5,7 @@ https://github.com/callummcdougall/sae-exercises-mats?fbclid=IwAR3qYAELbyD_x5IAY
 
 """
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, List, Optional, Tuple, Union, cast
 
@@ -20,6 +21,7 @@ from matplotlib.widgets import Slider  # , Button
 from torch import Tensor, nn
 from torch.nn import functional as F
 from tqdm import tqdm
+from transformer_lens.hook_points import HookedRootModule, HookPoint
 
 device = "cpu"
 
@@ -37,7 +39,7 @@ def cosine_decay_lr(step: int, steps: int):
 
 
 @dataclass
-class Config:
+class ToyConfig:
     # We optimize n_instances models in a single training loop to let us sweep over
     # sparsity or importance curves  efficiently. You should treat `n_instances` as
     # kinda like a batch dimension, but one which is built into our training setup.
@@ -46,23 +48,18 @@ class Config:
     n_hidden: int = 2
     n_correlated_pairs: int = 0
     n_anticorrelated_pairs: int = 0
+    feature_probability: Optional[Union[float, Tensor]] = None
+    importance: Optional[Union[float, Tensor]] = None
+    device: str | torch.device = device
 
 
-class Model(nn.Module):
-    W: Float[Tensor, "n_instances n_hidden n_features"]
-    b_final: Float[Tensor, "n_instances n_features"]
-    # Our linear map is x -> ReLU(W.T @ W @ x + b_final)
+class HookedToyModel(HookedRootModule, ABC):
 
-    def __init__(
-        self,
-        cfg: Config,
-        feature_probability: Optional[Union[float, Tensor]] = None,
-        importance: Optional[Union[float, Tensor]] = None,
-        device: str | torch.device = device,
-    ):
+    def __init__(self, cfg: ToyConfig, device: torch.device = torch.device("cpu")):
         super().__init__()
         self.cfg = cfg
 
+        feature_probability = cfg.feature_probability
         if feature_probability is None:
             feature_probability = t.ones(())
         if isinstance(feature_probability, float):
@@ -73,6 +70,8 @@ class Model(nn.Module):
         self.feature_probability = feature_probability.to(device).broadcast_to(
             (cfg.n_instances, cfg.n_features)
         )
+
+        importance = cfg.importance
         if importance is None:
             importance = t.ones(())
         if isinstance(importance, float):
@@ -82,42 +81,13 @@ class Model(nn.Module):
             (cfg.n_instances, cfg.n_features)
         )
 
-        self.W = nn.Parameter(
-            nn.init.xavier_normal_(
-                t.empty((cfg.n_instances, cfg.n_hidden, cfg.n_features))
-            )
-        )
-        self.b_final = nn.Parameter(t.zeros((cfg.n_instances, cfg.n_features)))
-        self.to(device)
+    @abstractmethod
+    def forward(self, features: Tensor, return_type: str | None = None) -> Tensor:
+        """Forward pass, to be implemented by subclasses"""
 
-    def forward(
-        self, features: Float[Tensor, "... instances features"]
-    ) -> Float[Tensor, "... instances features"]:
-        hidden = einops.einsum(
-            features,
-            self.W,
-            "... instances features, instances hidden features -> ... instances hidden",
-        )
-        out = einops.einsum(
-            hidden,
-            self.W,
-            "... instances hidden, instances hidden features -> ... instances features",
-        )
-        return F.relu(out + self.b_final)
-
-    # def generate_batch(self, batch_size) -> Float[Tensor, "batch_size instances features"]:
-    #     '''
-    #     Generates a batch of data. We'll return to this function later when we apply correlations.
-    #     '''
-    #     feat = t.rand((batch_size, self.cfg.n_instances, self.cfg.n_features), device=self.W.device)
-    #     feat_seeds = t.rand((batch_size, self.cfg.n_instances, self.cfg.n_features), device=self.W.device)
-    #     feat_is_present = feat_seeds <= self.feature_probability
-    #     batch = t.where(
-    #         feat_is_present,
-    #         feat,
-    #         t.zeros((), device=self.W.device),
-    #     )
-    #     return batch
+    @abstractmethod
+    def calculate_loss(self, out: Tensor, batch: Tensor) -> Tensor:
+        """Loss calculation, to be implemented by subclasses"""
 
     def generate_correlated_features(
         self, batch_size: int, n_correlated_pairs: int
@@ -222,24 +192,6 @@ class Model(nn.Module):
         batch = t.cat(data, dim=-1)
         return batch
 
-    def calculate_loss(
-        self,
-        out: Float[Tensor, "batch instances features"],
-        batch: Float[Tensor, "batch instances features"],
-    ) -> Float[Tensor, ""]:
-        """
-        Calculates the loss for a given batch, using this loss described in the Toy Models paper:
-
-            https://transformer-circuits.pub/2022/toy_model/index.html#demonstrating-setup-loss
-
-        Note, `model.importance` is guaranteed to broadcast with the shape of `out` and `batch`.
-        """
-        error = self.importance * ((batch - out) ** 2)
-        loss = einops.reduce(
-            error, "batch instances features -> instances", "mean"
-        ).sum()
-        return loss
-
     def optimize(
         self,
         batch_size: int = 1024,
@@ -274,6 +226,137 @@ class Model(nn.Module):
                 progress_bar.set_postfix(
                     loss=loss.item() / self.cfg.n_instances, lr=step_lr
                 )
+
+
+class ReluOutputModel(HookedToyModel):
+    """
+    Anthropic's ReLU Output Model as described in the Toy Models paper:
+            https://transformer-circuits.pub/2022/toy_model/index.html#demonstrating-setup-model
+    """
+
+    W: Float[Tensor, "n_instances n_hidden n_features"]
+    b_final: Float[Tensor, "n_instances n_features"]
+    # Our linear map is x -> ReLU(W.T @ W @ x + b_final)
+
+    def __init__(self, cfg: ToyConfig, device: torch.device = torch.device("cpu")):
+        super().__init__(cfg)
+
+        self.W = nn.Parameter(
+            nn.init.xavier_normal_(
+                t.empty((cfg.n_instances, cfg.n_hidden, cfg.n_features))
+            )
+        )
+        self.b_final = nn.Parameter(t.zeros((cfg.n_instances, cfg.n_features)))
+        self.to(device)
+
+        # Add and setup hookpoints.
+        self.hook_hidden = HookPoint()
+        self.hook_out_prebias = HookPoint()
+        self.setup()
+
+    def forward(
+        self,
+        features: Float[Tensor, "... instances features"],
+        return_type: str | None = None,
+    ) -> Float[Tensor, "... instances features"]:
+        hidden = self.hook_hidden(
+            einops.einsum(
+                features,
+                self.W,
+                "... instances features, instances hidden features -> ... instances hidden",
+            )
+        )
+        out = self.hook_out_prebias(
+            einops.einsum(
+                hidden,
+                self.W,
+                "... instances hidden, instances hidden features -> ... instances features",
+            )
+        )
+        reconstructed = F.relu(out + self.b_final)
+
+        if return_type == "loss":
+            return self.calculate_loss(reconstructed, features)
+        else:
+            return reconstructed
+
+    def calculate_loss(
+        self,
+        out: Float[Tensor, "batch instances features"],
+        batch: Float[Tensor, "batch instances features"],
+    ) -> Float[Tensor, ""]:
+        """
+        Calculates the loss for a given batch, using this loss described in the Toy Models paper:
+
+            https://transformer-circuits.pub/2022/toy_model/index.html#demonstrating-setup-loss
+
+        Note, `model.importance` is guaranteed to broadcast with the shape of `out` and `batch`.
+        """
+        error = self.importance * ((batch - out) ** 2)
+        loss = einops.reduce(
+            error, "batch instances features -> instances", "mean"
+        ).sum()
+        return loss
+
+
+class ReluOutputModelCE(ReluOutputModel):
+    """
+    A variant of Anthropic's ReLU Output Model.
+    This model is trained with a Cross Entropy loss instead of MSE loss.
+    The model task is to identify which feature has the largest magnitude activation in the input.
+    The model has an extra feature dimension which is set to a constant nonzero value,
+    which allows for proper classification when all features are zero.
+    """
+
+    W: Float[Tensor, "n_instances n_hidden n_features"]
+    b_final: Float[Tensor, "n_instances n_features"]
+    # Our linear map is x -> ReLU(W.T @ W @ x + b_final)
+
+    def __init__(
+        self,
+        cfg: ToyConfig,
+        device: torch.device = torch.device("cpu"),
+        extra_feature_value: float = 1e-6,
+    ):
+        super().__init__(cfg)
+        self.extra_feature_value = extra_feature_value
+
+        self.W = nn.Parameter(
+            nn.init.xavier_normal_(
+                t.empty((cfg.n_instances, cfg.n_hidden, cfg.n_features + 1))
+            )
+        )
+        self.b_final = nn.Parameter(t.zeros((cfg.n_instances, cfg.n_features + 1)))
+        self.to(device)
+
+    def generate_batch(
+        self, batch_size: int
+    ) -> Float[Tensor, "batch_size instances features"]:
+        """Adds an extra feature to the batch, which is set to a constant nonzero value."""
+        batch = super().generate_batch(batch_size)
+        extra_feature = self.extra_feature_value * t.ones(
+            (batch_size, self.cfg.n_instances, 1)
+        ).to(batch.device)
+        return t.cat((batch, extra_feature), dim=-1)
+
+    def calculate_loss(
+        self,
+        out: Float[Tensor, "batch instances features"],
+        batch: Float[Tensor, "batch instances features"],
+    ) -> Float[Tensor, ""]:
+        """
+        Calculates the loss for a given batch.
+        Loss is calculated using Cross Entropy loss, where the true probability distribution
+        is a one-hot encoding of the feature with the largest magnitude activation in the input.
+        Model outputs (raw logits) are weighted by importance before being passed through CE loss.
+
+        Note, `model.importance` is guaranteed to broadcast with the shape of `out` and `batch`.
+        """
+        max_feat_indices = t.argmax(batch, dim=-1)
+        loss = F.cross_entropy(
+            (self.importance * out).squeeze(), max_feat_indices.squeeze()
+        )
+        return loss
 
 
 Arr = np.ndarray

--- a/tests/benchmark/test_toy_model_sae_runner.py
+++ b/tests/benchmark/test_toy_model_sae_runner.py
@@ -1,7 +1,7 @@
 import torch
 
 from sae_lens.training.toy_model_runner import (
-    SAEToyModelRunnerConfig,
+    ToyModelSAERunnerConfig,
     toy_model_sae_runner,
 )
 
@@ -15,7 +15,7 @@ def test_toy_model_sae_runner():
     else:
         device = "cpu"
 
-    cfg = SAEToyModelRunnerConfig(
+    cfg = ToyModelSAERunnerConfig(
         # Model Details
         n_features=100,
         n_hidden=10,

--- a/tests/benchmark/test_toy_model_sae_runner.py
+++ b/tests/benchmark/test_toy_model_sae_runner.py
@@ -38,7 +38,7 @@ def test_toy_model_sae_runner():
         log_to_wandb=True,
         wandb_project="mats_sae_training_benchmarks_toy",
         wandb_log_frequency=5,
-        device=device,
+        device=torch.device(device),
     )
 
     trained_sae = toy_model_sae_runner(cfg)

--- a/tests/unit/training/test_toy_models.py
+++ b/tests/unit/training/test_toy_models.py
@@ -1,0 +1,106 @@
+import pytest
+import torch
+
+from sae_lens.training.toy_models import ReluOutputModel, ReluOutputModelCE, ToyConfig
+
+
+def test_toy_sparsity_limits():
+    cfg = ToyConfig(n_instances=1, feature_probability=0.0)
+    model = ReluOutputModel(cfg)
+    batch = model.generate_batch(10)
+    assert (batch == 0).all()
+
+    cfg.feature_probability = 1.0
+    model = ReluOutputModel(cfg)
+    batch = model.generate_batch(10)
+    assert (batch > 0).all()  # technically rand() can return 0...is this ok?
+
+
+@pytest.mark.parametrize("n_correlated_pairs", [1, 2, 3])
+def test_toy_correlated_features(n_correlated_pairs: int):
+    cfg = ToyConfig(
+        n_instances=1,
+        n_features=6,
+        n_hidden=2,
+        n_correlated_pairs=n_correlated_pairs,
+        feature_probability=0.5,
+    )
+    model = ReluOutputModel(cfg)
+
+    batch = model.generate_batch(100)
+    for i in range(n_correlated_pairs):
+        assert torch.eq(batch[:, 0, i * 2] > 0, batch[:, 0, i * 2 + 1] > 0).all()
+
+
+@pytest.mark.parametrize("n_anticorrelated_pairs", [1, 2, 3])
+def test_toy_anticorrelated_features(n_anticorrelated_pairs: int):
+    cfg = ToyConfig(
+        n_instances=1,
+        n_features=6,
+        n_hidden=2,
+        n_anticorrelated_pairs=n_anticorrelated_pairs,
+        feature_probability=0.5,
+    )
+    model = ReluOutputModel(cfg)
+
+    batch = model.generate_batch(100)
+    for i in range(n_anticorrelated_pairs):
+        assert torch.eq(batch[:, 0, i * 2] > 0, batch[:, 0, i * 2 + 1] == 0).all()
+        assert torch.eq(batch[:, 0, i * 2] == 0, batch[:, 0, i * 2 + 1] > 0).all()
+
+
+@pytest.mark.parametrize("n_correlated_pairs", [1, 2, 3])
+@pytest.mark.parametrize("n_anticorrelated_pairs", [1, 2, 3])
+def test_toy_anti_and_corr_features(
+    n_correlated_pairs: int, n_anticorrelated_pairs: int
+):
+    cfg = ToyConfig(
+        n_instances=1,
+        n_features=12,
+        n_hidden=2,
+        n_correlated_pairs=n_correlated_pairs,
+        n_anticorrelated_pairs=n_anticorrelated_pairs,
+        feature_probability=0.5,
+    )
+    model = ReluOutputModel(cfg)
+
+    batch = model.generate_batch(100)
+    for i in range(n_correlated_pairs):
+        assert torch.eq(batch[:, 0, i * 2] > 0, batch[:, 0, i * 2 + 1] > 0).all()
+    for i in range(n_anticorrelated_pairs):
+        assert torch.eq(
+            batch[:, 0, n_correlated_pairs * 2 + i * 2] > 0,
+            batch[:, 0, n_correlated_pairs * 2 + i * 2 + 1] == 0,
+        ).all()
+        assert torch.eq(
+            batch[:, 0, n_correlated_pairs * 2 + i * 2] == 0,
+            batch[:, 0, n_correlated_pairs * 2 + i * 2 + 1] > 0,
+        ).all()
+
+
+def test_reluoutput_forward():
+    cfg = ToyConfig(n_instances=1, n_features=6, n_hidden=2, feature_probability=0.5)
+    model = ReluOutputModel(cfg)
+    with torch.inference_mode():
+        model.W[0, 0, :] = torch.tensor([1, 0, 0, 0, 0, 0])
+        model.W[0, 1, :] = torch.tensor([0, 1, 0, 0, 0, 0])
+        model.W[0, 2:, :] = 0
+        model.b_final[:] = 0
+
+    batch = model.generate_batch(100)
+    expected = batch.clone()
+    expected[:, :, 2:] = 0
+    expected_hidden = torch.zeros((batch.shape[0], batch.shape[1], cfg.n_hidden))
+    expected_hidden[:, :, 0] = batch[:, :, 0]
+    expected_hidden[:, :, 1] = batch[:, :, 1]
+    output, cache = model.run_with_cache(batch)
+    assert torch.allclose(output, expected)
+    assert torch.allclose(cache["hook_out_prebias"], expected)
+    assert torch.allclose(cache["hook_hidden"], expected_hidden)
+
+
+def test_reluoutputce_batch_shape():
+    cfg = ToyConfig(n_instances=1, n_features=5, n_hidden=2, feature_probability=0.5)
+    model = ReluOutputModelCE(cfg)
+    batch = model.generate_batch(100)
+    assert batch.shape == (100, cfg.n_instances, cfg.n_features + 1)

--- a/tests/unit/training/test_toy_models.py
+++ b/tests/unit/training/test_toy_models.py
@@ -5,7 +5,7 @@ from sae_lens.training.toy_models import ReluOutputModel, ReluOutputModelCE, Toy
 
 
 def test_toy_sparsity_limits():
-    cfg = ToyConfig(n_instances=1, feature_probability=0.0)
+    cfg = ToyConfig(feature_probability=0.0)
     model = ReluOutputModel(cfg)
     batch = model.generate_batch(10)
     assert (batch == 0).all()
@@ -19,7 +19,6 @@ def test_toy_sparsity_limits():
 @pytest.mark.parametrize("n_correlated_pairs", [1, 2, 3])
 def test_toy_correlated_features(n_correlated_pairs: int):
     cfg = ToyConfig(
-        n_instances=1,
         n_features=6,
         n_hidden=2,
         n_correlated_pairs=n_correlated_pairs,
@@ -29,13 +28,12 @@ def test_toy_correlated_features(n_correlated_pairs: int):
 
     batch = model.generate_batch(100)
     for i in range(n_correlated_pairs):
-        assert torch.eq(batch[:, 0, i * 2] > 0, batch[:, 0, i * 2 + 1] > 0).all()
+        assert torch.eq(batch[:, i * 2] > 0, batch[:, i * 2 + 1] > 0).all()
 
 
 @pytest.mark.parametrize("n_anticorrelated_pairs", [1, 2, 3])
 def test_toy_anticorrelated_features(n_anticorrelated_pairs: int):
     cfg = ToyConfig(
-        n_instances=1,
         n_features=6,
         n_hidden=2,
         n_anticorrelated_pairs=n_anticorrelated_pairs,
@@ -45,8 +43,8 @@ def test_toy_anticorrelated_features(n_anticorrelated_pairs: int):
 
     batch = model.generate_batch(100)
     for i in range(n_anticorrelated_pairs):
-        assert torch.eq(batch[:, 0, i * 2] > 0, batch[:, 0, i * 2 + 1] == 0).all()
-        assert torch.eq(batch[:, 0, i * 2] == 0, batch[:, 0, i * 2 + 1] > 0).all()
+        assert torch.eq(batch[:, i * 2] > 0, batch[:, i * 2 + 1] == 0).all()
+        assert torch.eq(batch[:, i * 2] == 0, batch[:, i * 2 + 1] > 0).all()
 
 
 @pytest.mark.parametrize("n_correlated_pairs", [1, 2, 3])
@@ -55,7 +53,6 @@ def test_toy_anti_and_corr_features(
     n_correlated_pairs: int, n_anticorrelated_pairs: int
 ):
     cfg = ToyConfig(
-        n_instances=1,
         n_features=12,
         n_hidden=2,
         n_correlated_pairs=n_correlated_pairs,
@@ -66,33 +63,33 @@ def test_toy_anti_and_corr_features(
 
     batch = model.generate_batch(100)
     for i in range(n_correlated_pairs):
-        assert torch.eq(batch[:, 0, i * 2] > 0, batch[:, 0, i * 2 + 1] > 0).all()
+        assert torch.eq(batch[:, i * 2] > 0, batch[:, i * 2 + 1] > 0).all()
     for i in range(n_anticorrelated_pairs):
         assert torch.eq(
-            batch[:, 0, n_correlated_pairs * 2 + i * 2] > 0,
-            batch[:, 0, n_correlated_pairs * 2 + i * 2 + 1] == 0,
+            batch[:, n_correlated_pairs * 2 + i * 2] > 0,
+            batch[:, n_correlated_pairs * 2 + i * 2 + 1] == 0,
         ).all()
         assert torch.eq(
-            batch[:, 0, n_correlated_pairs * 2 + i * 2] == 0,
-            batch[:, 0, n_correlated_pairs * 2 + i * 2 + 1] > 0,
+            batch[:, n_correlated_pairs * 2 + i * 2] == 0,
+            batch[:, n_correlated_pairs * 2 + i * 2 + 1] > 0,
         ).all()
 
 
 def test_reluoutput_forward():
-    cfg = ToyConfig(n_instances=1, n_features=6, n_hidden=2, feature_probability=0.5)
+    cfg = ToyConfig(n_features=6, n_hidden=2, feature_probability=0.5)
     model = ReluOutputModel(cfg)
     with torch.inference_mode():
-        model.W[0, 0, :] = torch.tensor([1, 0, 0, 0, 0, 0])
-        model.W[0, 1, :] = torch.tensor([0, 1, 0, 0, 0, 0])
-        model.W[0, 2:, :] = 0
+        model.W[0, :] = torch.tensor([1, 0, 0, 0, 0, 0])
+        model.W[1, :] = torch.tensor([0, 1, 0, 0, 0, 0])
+        model.W[2:, :] = 0
         model.b_final[:] = 0
 
     batch = model.generate_batch(100)
     expected = batch.clone()
-    expected[:, :, 2:] = 0
-    expected_hidden = torch.zeros((batch.shape[0], batch.shape[1], cfg.n_hidden))
-    expected_hidden[:, :, 0] = batch[:, :, 0]
-    expected_hidden[:, :, 1] = batch[:, :, 1]
+    expected[:, 2:] = 0
+    expected_hidden = torch.zeros((batch.shape[0], cfg.n_hidden))
+    expected_hidden[:, 0] = batch[:, 0]
+    expected_hidden[:, 1] = batch[:, 1]
     output, cache = model.run_with_cache(batch)
     assert torch.allclose(output, expected)
     assert torch.allclose(cache["hook_out_prebias"], expected)
@@ -100,7 +97,7 @@ def test_reluoutput_forward():
 
 
 def test_reluoutputce_batch_shape():
-    cfg = ToyConfig(n_instances=1, n_features=5, n_hidden=2, feature_probability=0.5)
+    cfg = ToyConfig(n_features=5, n_hidden=2, feature_probability=0.5)
     model = ReluOutputModelCE(cfg)
     batch = model.generate_batch(100)
-    assert batch.shape == (100, cfg.n_instances, cfg.n_features + 1)
+    assert batch.shape == (100, cfg.n_features + 1)


### PR DESCRIPTION
# Description

Re-implements toy models as child classes of HookedRootModule. Most toy model functionality now lives in an abstract class, which specific toy models inherit from. Also adds some basic unit tests to toy models. Two toy models currently live in the toy model file:

- Anthropic's ReLU output model
- A model which trains using cross-entropy loss on a classification task with the same architecture as the ReLU output model

Fixes #85  (though there's still more toy model work to be done integrating with runners)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ I'm not sure how to do this ] I have made corresponding changes to the documentation
- [ I think they don't? ] My changes generate no new warnings 
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [ x ] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)