### PR TITLE
chore: remove use_deterministic_algorithms=True since it causes cuda errors

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -17,7 +17,6 @@ def reproducibility():
     seed = 0x1234_5678_9ABC_DEF0
     torch.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
-    torch.use_deterministic_algorithms(True)
     torch.backends.cudnn.benchmark = False
     # Python native RNG; docs don't give any limitations on seed range
     random.seed(seed)


### PR DESCRIPTION
# Description

It looks like setting `torch.use_deterministic_algorithms(True)` in tests causes errors on CUDA >= 10.2. This setting isn't actually necessary for our tests, so this PR removes that option from the reproducability fixture.

Fixes #136

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)