### PR TITLE
Remove cuda cache emptying in evals.py

### DIFF
--- a/sae_lens/training/evals.py
+++ b/sae_lens/training/evals.py
@@ -62,9 +62,6 @@ def run_evals(
     sae_out, _, _, _, _, _ = sparse_autoencoder(original_act)
     del cache
 
-    if "cuda" in str(model.cfg.device):
-        torch.cuda.empty_cache()
-
     l2_norm_in = torch.norm(original_act, dim=-1)
     l2_norm_out = torch.norm(sae_out, dim=-1)
     l2_norm_in_for_div = l2_norm_in.clone()


### PR DESCRIPTION
# Description

Currently evals.py includes a call to `torch.cuda.empty_cache()`. This causes inconsistent memory usage across runs, which makes OOMs unpredictable and might cause extra recompilation (though I'm not sure on this). `torch.cuda.empty_cache` doesn't actually free up additional memory for pytorch - it simply releases it from the pytorch allocator (I was surprised by this, discussion [here](https://pytorch.org/docs/stable/notes/cuda.html#memory-management) and [here](https://discuss.pytorch.org/t/about-torch-cuda-empty-cache/34232)). It's also not recommended for use by end-users except in edge cases, so I propose we remove it.

I've tested this change with and without compilation on GPT-2-S SAEs. All unit tests continue to pass.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas (n/a: code removal)
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 