### PR TITLE
Gpt 2 sweep

### DIFF
--- a/scripts/sweep-gpt2.py
+++ b/scripts/sweep-gpt2.py
@@ -45,7 +45,7 @@ for l1_coefficient in [0.1, 1, 2, 4, 10]:
         cfg = LanguageModelSAERunnerConfig(
             # Pick a tiny model to make this easier.
             model_name="gpt2",
-            ## MLP Layer 0 ##
+            ## MLP ##
             hook_point=f"blocks.{block}.hook_mlp_out",
             hook_point_layer=block,
             d_in=768,
@@ -57,11 +57,8 @@ for l1_coefficient in [0.1, 1, 2, 4, 10]:
             # How big do we want our SAE to be?
             expansion_factor=64,
             # Dataset / Activation Store
-            # When we do a proper test
-            # training_tokens= 820_000_000, # 200k steps * 4096 batch size ~ 820M tokens (doable overnight on an A100)
-            # For now.
             use_cached_activations=False,
-            training_tokens=total_training_tokens,  # For initial testing I think this is a good number.
+            training_tokens=total_training_tokens,
             train_batch_size_tokens=4096,
             # Loss Function
             ## Reconstruction Coefficient.
@@ -92,7 +89,7 @@ for l1_coefficient in [0.1, 1, 2, 4, 10]:
             ## adam optimizer has no weight decay by default so worry about this.
             adam_beta1=0.9,
             adam_beta2=0.999,
-            # Buffer details won't matter in we cache / shuffle our activations ahead of time.
+            # Unsure if this is enough
             n_batches_in_buffer=64,
             store_batch_size_prompts=16,
             normalize_activations=False,
@@ -101,7 +98,7 @@ for l1_coefficient in [0.1, 1, 2, 4, 10]:
             dead_feature_window=1000,
             dead_feature_threshold=1e-4,
             # WANDB
-            log_to_wandb=log_to_wandb,  # always use wandb unless you are just testing code.
+            log_to_wandb=log_to_wandb,
             wandb_project="gpt-2-sweep-12may24",
             wandb_log_frequency=50,
             eval_every_n_wandb_logs=10,
@@ -117,7 +114,6 @@ for l1_coefficient in [0.1, 1, 2, 4, 10]:
             compile_sae=True,
         )
 
-        # look at the next cell to see some instruction for what to do while this is running.
-        sparse_autoencoder_dictionary = language_model_sae_runner(cfg)
+        language_model_sae_runner(cfg)
 
         print("=" * 50)

--- a/scripts/sweep-gpt2.py
+++ b/scripts/sweep-gpt2.py
@@ -1,0 +1,123 @@
+import os
+import sys
+
+import torch
+
+sys.path.append("..")
+
+from sae_lens.training.config import LanguageModelSAERunnerConfig
+from sae_lens.training.lm_runner import language_model_sae_runner
+
+if torch.cuda.is_available():
+    device = "cuda"
+elif torch.backends.mps.is_available():
+    device = "mps"
+else:
+    device = "cpu"
+
+print("Using device:", device)
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+block = 6
+
+total_training_steps = 200_00
+batch_size = 4096
+total_training_tokens = total_training_steps * batch_size
+print(f"Total Training Tokens: {total_training_tokens}")
+
+# change these configs
+model_name = "gelu-1l"
+dataset_path = "NeelNanda/c4-tokenized-2b"
+new_cached_activations_path = (
+    f"./cached_activations/{model_name}/{dataset_path}/{total_training_steps}"
+)
+
+lr_warm_up_steps = 0
+lr_decay_steps = total_training_steps // 5  # 20% of training steps.
+print(f"lr_decay_steps: {lr_decay_steps}")
+l1_warmup_steps = total_training_steps // 20  # 5% of training steps.
+print(f"l1_warmup_steps: {l1_warmup_steps}")
+log_to_wandb = True
+
+for l1_coefficient in [0.1, 1, 2, 4, 10]:
+    for lr in [1e-5, 5e-5, 1e-4, 4e-4,]:
+
+        cfg = LanguageModelSAERunnerConfig(
+            # Pick a tiny model to make this easier.
+            model_name="gpt-2",
+            ## MLP Layer 0 ##
+            hook_point=f"blocks.{block}.hook_mlp_out",
+            hook_point_layer=block,
+            d_in=768,
+            dataset_path="NeelNanda/c4-tokenized-2b",
+            streaming=False,
+            context_size=512,
+            is_dataset_tokenized=True,
+            prepend_bos=True,
+            # How big do we want our SAE to be?
+            expansion_factor=64,
+            # Dataset / Activation Store
+            # When we do a proper test
+            # training_tokens= 820_000_000, # 200k steps * 4096 batch size ~ 820M tokens (doable overnight on an A100)
+            # For now.
+            use_cached_activations=False,
+            training_tokens=total_training_tokens,  # For initial testing I think this is a good number.
+            train_batch_size_tokens=4096,
+            # Loss Function
+            ## Reconstruction Coefficient.
+            mse_loss_normalization=None,  # MSE Loss Normalization is not mentioned (so we use stanrd MSE Loss). But not we take an average over the batch.
+            ## Anthropic does not mention using an Lp norm other than L1.
+            l1_coefficient=l1_coefficient,
+            lp_norm=1.0,
+            # Instead, they multiply the L1 loss contribution
+            # from each feature of the activations by the decoder norm of the corresponding feature.
+            scale_sparsity_penalty_by_decoder_norm=True,
+            # Learning Rate
+            lr_scheduler_name="constant",  # we set this independently of warmup and decay steps.
+            l1_warm_up_steps=l1_warmup_steps,
+            lr_warm_up_steps=lr_warm_up_steps,
+            lr_decay_steps=lr_warm_up_steps,
+            ## No ghost grad term.
+            use_ghost_grads=False,
+            # Initialization / Architecture
+            apply_b_dec_to_input=False,
+            # encoder bias zero's. (I'm not sure what it is by default now)
+            # decoder bias zero's.
+            b_dec_init_method="zeros",
+            normalize_sae_decoder=False,
+            decoder_heuristic_init=True,
+            init_encoder_as_decoder_transpose=True,
+            # Optimizer
+            lr=lr,
+            ## adam optimizer has no weight decay by default so worry about this.
+            adam_beta1=0.9,
+            adam_beta2=0.999,
+            # Buffer details won't matter in we cache / shuffle our activations ahead of time.
+            n_batches_in_buffer=64,
+            store_batch_size_prompts=16,
+            normalize_activations=False,
+            # Feature Store
+            feature_sampling_window=1000,
+            dead_feature_window=1000,
+            dead_feature_threshold=1e-4,
+            # WANDB
+            log_to_wandb=log_to_wandb,  # always use wandb unless you are just testing code.
+            wandb_project="gpt-2-sweep-12may24",
+            wandb_log_frequency=50,
+            eval_every_n_wandb_logs=10,
+            # Misc
+            device=device,
+            seed=42,
+            n_checkpoints=0,
+            checkpoint_path="checkpoints",
+            dtype=torch.float32,
+            eval_batch_size_prompts=2,
+            autocast=True,
+            compile_llm=True,
+            compile_sae=True,
+        )
+
+        # look at the next cell to see some instruction for what to do while this is running.
+        sparse_autoencoder_dictionary = language_model_sae_runner(cfg)
+
+        print("=" * 50)

--- a/scripts/sweep-gpt2.py
+++ b/scripts/sweep-gpt2.py
@@ -40,7 +40,12 @@ print(f"l1_warmup_steps: {l1_warmup_steps}")
 log_to_wandb = True
 
 for l1_coefficient in [0.1, 1, 2, 4, 10]:
-    for lr in [1e-5, 5e-5, 1e-4, 4e-4,]:
+    for lr in [
+        1e-5,
+        5e-5,
+        1e-4,
+        4e-4,
+    ]:
 
         cfg = LanguageModelSAERunnerConfig(
             # Pick a tiny model to make this easier.

--- a/scripts/sweep-gpt2.py
+++ b/scripts/sweep-gpt2.py
@@ -44,7 +44,7 @@ for l1_coefficient in [0.1, 1, 2, 4, 10]:
 
         cfg = LanguageModelSAERunnerConfig(
             # Pick a tiny model to make this easier.
-            model_name="gpt-2",
+            model_name="gpt2",
             ## MLP Layer 0 ##
             hook_point=f"blocks.{block}.hook_mlp_out",
             hook_point_layer=block,


### PR DESCRIPTION
# Description

Adds base sweep settings for gpt-2-small. Sweeps are intentionally relatively short: most of the action that tells us whether a sweep will be obviously bad seems to happen relatively quickly. Based on Anthropic SAE replication.

[W&B dashboard for this run](https://wandb.ai/tmcgrath/gpt-2-sweep-12may24/workspace).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)