### PR TITLE
fix: hardcoded mps device in ckrk attn saes

### DIFF
--- a/sae_lens/toolkit/pretrained_saes.py
+++ b/sae_lens/toolkit/pretrained_saes.py
@@ -173,18 +173,26 @@ def get_gpt2_small_ckrk_attn_out_saes() -> dict[str, SparseAutoencoder]:
     saes_weights = {}
     sae_configs = {}
     repo_files = list_repo_tree(REPO_ID)
+
+    device = "cpu"
+    if torch.cuda.is_available():
+        device = "cuda"
+    elif torch.backends.mps.is_available():
+        device = "mps"
+
     for i in tqdm(repo_files):
         file_name = i.path
         if file_name.endswith(".pt"):
             # print(f"Downloading {file_name}")
             path = hf_hub_download(REPO_ID, file_name)
             name = path.split("/")[-1].split(".pt")[0]
-            saes_weights[name] = torch.load(path, map_location="mps")
+            saes_weights[name] = torch.load(path, map_location=device)
         elif file_name.endswith(".json"):
             # print(f"Downloading {file_name}")
             config_path = hf_hub_download(REPO_ID, file_name)
             name = config_path.split("/")[-1].split("_cfg.json")[0]
             sae_configs[name] = json.load(open(config_path, "r"))
+            sae_configs[name].device = device
 
     saes = {}
     for name, config in sae_configs.items():


### PR DESCRIPTION
# Description

Fixes a hardcoded device when loading pretrained attention-out SAEs

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [ ] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 