### PR TITLE
Pin Ansible config example to a specific version, update docs

### DIFF
--- a/scripts/ansible/README.md
+++ b/scripts/ansible/README.md
@@ -84,6 +84,19 @@ Briefly, this example job will (time estimates are for the example above):
    2) Run `util/train_sae.py`, loading the cached activations from your S3 bucket.
    3) You can monitor progress of this by going to WANDB, where it should also have your artifacts.
 
+
+#### Run Cache Acts or Train SAEs Job Separately
+
+Cache Activations only
+```
+ansible-playbook run-configs.yml --tags=cache-acts
+```
+
+Train SAE only
+```
+ansible-playbook run-configs.yml --tags=train-sae
+```
+
 ### TODO
    - document how to monitor running jobs
    - better integration with wandb ("sweep param")

--- a/scripts/ansible/README.md
+++ b/scripts/ansible/README.md
@@ -89,15 +89,19 @@ Briefly, this example job will (time estimates are for the example above):
 
 Cache Activations only
 ```
-ansible-playbook run-configs.yml --tags=cache-acts
+ansible-playbook playbooks/setup.yml
+ansible-playbook playbooks/cache_acts.yml
 ```
 
 Train SAE only
 ```
-ansible-playbook run-configs.yml --tags=train-sae
+ansible-playbook playbooks/setup.yml
+ansible-playbook playbooks/train_sae.yml
 ```
 
 ### TODO
+   - make config scripts that makes the config sweep files automatically
+   - should do async so that canceling ansible doesnt cancel the job
    - document how to monitor running jobs
    - better integration with wandb ("sweep param")
      - should we just use/repurpose wandb stuff instead of manually doing all this?

--- a/scripts/ansible/README.md
+++ b/scripts/ansible/README.md
@@ -11,7 +11,7 @@ This is an Ansible playbook that runs `Cache Activations` and and `Train SAE` in
   - [Increase other quotas (like P instances)](https://us-east-1.console.aws.amazon.com/servicequotas/home/services/ec2/quotas)
   - G and P instances are not enabled by default [docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-resource-limits.html)
   - What GPUs/specs are G and P instance types? [docs](https://docs.aws.amazon.com/dlami/latest/devguide/gpu.html)
-- Wandb API Key
+- Wandb Account (wandb.ai)
 
 ### Local setup
 
@@ -30,6 +30,13 @@ This is an Ansible playbook that runs `Cache Activations` and and `Train SAE` in
 aws_access_key_id=AWS_ACCESS_KEY_ID
 aws_secret_access_key=AWS_SECRET_ACCESS_KEY
 region=us-east-1
+```
+
+#### Load Wandb API Key automatically
+1) Get your Wandb API key here: https://wandb.ai/settings#api
+2) Add the following to your `~/.bash_profile` (or your equivalent shell defaults file)
+```
+export WANDB_API_KEY=[Paste Wandb API Key]
 ```
 
 #### Install Ansible

--- a/scripts/ansible/configs_example/shared.yml
+++ b/scripts/ansible/configs_example/shared.yml
@@ -16,7 +16,7 @@
 s3_bucket_name: johnny.saes.1234
 
 # Change if you need a specific version
-saelens_version_or_branch: automation
+saelens_version_or_branch: v2.1.1
 
 #################### DON'T CHANGE THE FOLLOWING
 

--- a/scripts/ansible/run-configs.yml
+++ b/scripts/ansible/run-configs.yml
@@ -2,7 +2,6 @@
 
 - name: Check that WANDB_API_KEY exists
   hosts: localhost
-  tags: always
   tasks:
     - name: Check that WANDB_API_KEY exists
       ansible.builtin.fail:
@@ -10,16 +9,12 @@
       when: lookup('env', 'WANDB_API_KEY') == ""
 
 - name: Run Setup
-  tags: always
   ansible.builtin.import_playbook: playbooks/setup.yml
 
 - name: Run Cache Acts
-    - cache_acts
   ansible.builtin.import_playbook: playbooks/cache_acts.yml
 
 - name: Run Train SAE
-  tags:
-    - train_sae
   ansible.builtin.import_playbook: playbooks/train_sae.yml
 
 - name: Clear ansible.log

--- a/scripts/ansible/run-configs.yml
+++ b/scripts/ansible/run-configs.yml
@@ -10,6 +10,7 @@
       when: lookup('env', 'WANDB_API_KEY') == ""
 
 - name: Run Setup
+  tags: always
   ansible.builtin.import_playbook: playbooks/setup.yml
 
 - name: Run Cache Acts


### PR DESCRIPTION
# Description

We'll probably delete the `automation` branch at some point, so the Ansible example config should point to a version that has the correct Ansible scripts (could also do `main` but would rather do a known working one)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
