### PR TITLE
Fix checkpointing of training state that includes a compiled SAE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 
 
+## v2.1.2 (2024-05-13)
+
+### Fix
+
+* fix: Fix issues with resumption testing (#144)
+
+* fix always-true comparison in train context testing
+
+* set default warmup steps to zero
+
+* remove unused type attribute from L1Scheduler
+
+* update training tests to use real context builder
+
+* add docstring for build_train_ctx ([`085d04f`](https://github.com/jbloomAus/SAELens/commit/085d04f7e57e3819810b18e12b011adc8c7f2ba1))
+
+
 ## v2.1.1 (2024-05-13)
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sae-lens"
-version = "2.1.1"
+version = "2.1.2"
 description = "Training and Analyzing Sparse Autoencoders (SAEs)"
 authors = ["Joseph Bloom"]
 readme = "README.md"

--- a/sae_lens/__init__.py
+++ b/sae_lens/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.1"
+__version__ = "2.1.2"
 
 from .training.activations_store import ActivationsStore
 from .training.cache_activations_runner import CacheActivationsRunner

--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -93,7 +93,7 @@ class LanguageModelSAERunnerConfig:
     lr_scheduler_name: str | list[str] = (
         "constant"  # constant, cosineannealing, cosineannealingwarmrestarts
     )
-    lr_warm_up_steps: int | list[int] = 500
+    lr_warm_up_steps: int | list[int] = 0
     lr_end: float | list[float] | None = (
         None  # only used for cosine annealing, default is lr / 10
     )

--- a/sae_lens/training/optim.py
+++ b/sae_lens/training/optim.py
@@ -109,7 +109,6 @@ class L1Scheduler:
         sparse_autoencoder: SparseAutoencoder,
     ):
 
-        self.type = type
         self.l1_warmup_steps = l1_warm_up_steps
         self.total_steps = total_steps
         self.sparse_autoencoder = sparse_autoencoder

--- a/sae_lens/training/optim.py
+++ b/sae_lens/training/optim.py
@@ -2,6 +2,8 @@
 Took the LR scheduler from my previous work: https://github.com/jbloomAus/DecisionTransformerInterpretability/blob/ee55df35cdb92e81d689c72fb9dd5a7252893363/src/decision_transformer/utils.py#L425
 """
 
+from typing import Any
+
 import torch.optim as optim
 import torch.optim.lr_scheduler as lr_scheduler
 
@@ -140,3 +142,18 @@ class L1Scheduler:
             self.sparse_autoencoder.l1_coefficient = self.final_l1_value  # type: ignore
 
         self.current_step += 1
+
+    def state_dict(self):
+        """State dict for serializing as part of an SAETrainContext."""
+        return {
+            "type": self.type,
+            "l1_warmup_steps": self.l1_warmup_steps,
+            "total_steps": self.total_steps,
+            "final_l1_value": self.final_l1_value,
+            "current_step": self.current_step,
+        }
+
+    def load_state_dict(self, state_dict: dict[str, Any]):
+        """Loads all state apart from attached SAE."""
+        for k in state_dict:
+            setattr(self, k, state_dict[k])

--- a/sae_lens/training/optim.py
+++ b/sae_lens/training/optim.py
@@ -146,7 +146,6 @@ class L1Scheduler:
     def state_dict(self):
         """State dict for serializing as part of an SAETrainContext."""
         return {
-            "type": self.type,
             "l1_warmup_steps": self.l1_warmup_steps,
             "total_steps": self.total_steps,
             "final_l1_value": self.final_l1_value,

--- a/tests/unit/training/test_train_sae_on_language_model.py
+++ b/tests/unit/training/test_train_sae_on_language_model.py
@@ -15,7 +15,7 @@ from transformer_lens import HookedTransformer
 
 from sae_lens import __version__
 from sae_lens.training.activations_store import ActivationsStore
-from sae_lens.training.optim import L1Scheduler, get_lr_scheduler
+from sae_lens.training.optim import L1Scheduler
 from sae_lens.training.sae_group import SparseAutoencoderDictionary
 from sae_lens.training.sparse_autoencoder import (
     SAE_CFG_PATH,
@@ -31,6 +31,7 @@ from sae_lens.training.train_sae_on_language_model import (
     SAETrainContext,
     SAETrainingRunState,
     TrainStepOutput,
+    _build_train_context,
     _build_train_step_log_dict,
     _log_feature_sparsity,
     _save_checkpoint,
@@ -42,46 +43,26 @@ from sae_lens.training.train_sae_on_language_model import (
 from tests.unit.helpers import build_sae_cfg, load_model_cached
 
 
-# TODO: Address why we have this code here rather than importing it.
 def build_train_ctx(
     sae: SparseAutoencoder,
     act_freq_scores: Tensor | None = None,
     n_forward_passes_since_fired: Tensor | None = None,
     n_frac_active_tokens: int = 0,
 ) -> SAETrainContext:
-    """
-    Factory helper to build a default SAETrainContext object.
-    """
-    assert sae.cfg.d_sae is not None
-    assert not isinstance(sae.cfg.lr, list)
-    optimizer = torch.optim.Adam(sae.parameters(), lr=sae.cfg.lr)
-    return SAETrainContext(
-        act_freq_scores=(
-            torch.zeros(sae.cfg.d_sae) if act_freq_scores is None else act_freq_scores
-        ),
-        n_forward_passes_since_fired=(
-            torch.zeros(sae.cfg.d_sae)
-            if n_forward_passes_since_fired is None
-            else n_forward_passes_since_fired
-        ),
-        n_frac_active_tokens=n_frac_active_tokens,
-        optimizer=optimizer,
-        lr_scheduler=get_lr_scheduler(
-            "constant",
-            lr=sae.cfg.lr,
-            optimizer=optimizer,
-            training_steps=1000,
-            lr_end=0,
-            warm_up_steps=0,
-            decay_steps=0,
-            num_cycles=1,
-        ),
-        l1_scheduler=L1Scheduler(
-            l1_warm_up_steps=0,
-            total_steps=sae.cfg.training_tokens,
-            sparse_autoencoder=sae,
-        ),
-    )
+    """Builds a training context. We need to have this version so we can override some attributes."""
+    # Build train context
+    ctx = _build_train_context(sae, sae.cfg.training_tokens)
+    # Override attributes if required for testing
+    ctx.n_frac_active_tokens = n_frac_active_tokens
+    if n_forward_passes_since_fired is not None:
+        ctx.n_forward_passes_since_fired = n_forward_passes_since_fired
+    else:
+        ctx.n_forward_passes_since_fired = torch.zeros(sae.cfg.d_sae)  # type: ignore
+    if act_freq_scores is not None:
+        ctx.act_freq_scores = act_freq_scores
+    else:
+        ctx.act_freq_scores = torch.zeros(sae.cfg.d_sae)  # type: ignore
+    return ctx
 
 
 def modify_sae_output(
@@ -411,7 +392,7 @@ def test_save_load_and_resume_checkpoint(tmp_path: Path) -> None:
     assert train_contexts_2.keys() == train_contexts.keys()
     for k in train_contexts.keys():
         ctx1 = train_contexts[k]
-        ctx2 = train_contexts[k]
+        ctx2 = train_contexts_2[k]
         sd1 = ctx1.state_dict()
         sd2 = ctx2.state_dict()
         assert_close(sd1, sd2)


### PR DESCRIPTION
# Description

Compiled SAEs currently break checkpointing. The root cause of this is that compiled models cannot be saved with torch.save(compiled_model), but should instead be saved using their state dict (see [PyTorch ref](https://pytorch.org/get-started/pytorch-2.0/#serialization)). 

The model checkpointing code serializes the compiled model using its state_dict, but `SAETrainContext.save` does not. The issue comes from `L1Scheduler` having a reference to the SAE, which has been compiled. When `SAETrainContext.save` is called, because `L1Scheduler` has no state_dict, the code attempts to save a compiled model, leading to a crash.

This PR adds a state dict to L1Scheduler, as well as restoring the L1Scheduler from that state dict, which now allows for proper serialisation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [ ] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

Having some issues with `make test` but have run `make format` and run tests inside VSCode.