### PR TITLE
Fix issues with resumption testing

### DIFF
--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -93,7 +93,7 @@ class LanguageModelSAERunnerConfig:
     lr_scheduler_name: str | list[str] = (
         "constant"  # constant, cosineannealing, cosineannealingwarmrestarts
     )
-    lr_warm_up_steps: int | list[int] = 500
+    lr_warm_up_steps: int | list[int] = 0
     lr_end: float | list[float] | None = (
         None  # only used for cosine annealing, default is lr / 10
     )

--- a/sae_lens/training/optim.py
+++ b/sae_lens/training/optim.py
@@ -109,7 +109,6 @@ class L1Scheduler:
         sparse_autoencoder: SparseAutoencoder,
     ):
 
-        self.type = type
         self.l1_warmup_steps = l1_warm_up_steps
         self.total_steps = total_steps
         self.sparse_autoencoder = sparse_autoencoder

--- a/tests/unit/training/test_train_sae_on_language_model.py
+++ b/tests/unit/training/test_train_sae_on_language_model.py
@@ -49,6 +49,7 @@ def build_train_ctx(
     n_forward_passes_since_fired: Tensor | None = None,
     n_frac_active_tokens: int = 0,
 ) -> SAETrainContext:
+    """Builds a training context. We need to have this version so we can override some attributes."""
     # Build train context
     ctx = _build_train_context(sae, sae.cfg.training_tokens)
     # Override attributes if required for testing
@@ -56,11 +57,11 @@ def build_train_ctx(
     if n_forward_passes_since_fired is not None:
         ctx.n_forward_passes_since_fired = n_forward_passes_since_fired
     else:
-        ctx.n_forward_passes_since_fired = torch.zeros(sae.cfg.d_sae) # type: ignore
+        ctx.n_forward_passes_since_fired = torch.zeros(sae.cfg.d_sae)  # type: ignore
     if act_freq_scores is not None:
         ctx.act_freq_scores = act_freq_scores
     else:
-        ctx.act_freq_scores = torch.zeros(sae.cfg.d_sae) # type: ignore
+        ctx.act_freq_scores = torch.zeros(sae.cfg.d_sae)  # type: ignore
     return ctx
 
 

--- a/tests/unit/training/test_train_sae_on_language_model.py
+++ b/tests/unit/training/test_train_sae_on_language_model.py
@@ -411,7 +411,7 @@ def test_save_load_and_resume_checkpoint(tmp_path: Path) -> None:
     assert train_contexts_2.keys() == train_contexts.keys()
     for k in train_contexts.keys():
         ctx1 = train_contexts[k]
-        ctx2 = train_contexts[k]
+        ctx2 = train_contexts_2[k]
         sd1 = ctx1.state_dict()
         sd2 = ctx2.state_dict()
         assert_close(sd1, sd2)


### PR DESCRIPTION
# Description

The test `test_save_load_and_resume_checkpoint` was erroneously passing because of an incorrect comparion. Fixing this comparison exposed a further error in the test: the train context defined by `build_train_ctx` defined in the test file didn't conform to the behaviour of `_build_train_context` and was generating incorrect results which caused the fixed test to fail.

This PR fixes the incorrect comparison, changes the testing train context builder to use the real context builder plus some minor overrides to enable testing, and removes an unused attribute from L1Scheduler that was causing comparisons to fail.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)