### PR TITLE
Pretokenize runner

### DIFF
--- a/sae_lens/__init__.py
+++ b/sae_lens/__init__.py
@@ -2,9 +2,14 @@ __version__ = "2.1.2"
 
 from .training.activations_store import ActivationsStore
 from .training.cache_activations_runner import CacheActivationsRunner
-from .training.config import CacheActivationsRunnerConfig, LanguageModelSAERunnerConfig
+from .training.config import (
+    CacheActivationsRunnerConfig,
+    LanguageModelSAERunnerConfig,
+    PretokenizeRunnerConfig,
+)
 from .training.evals import run_evals
 from .training.lm_runner import language_model_sae_runner
+from .training.pretokenize_runner import pretokenize_runner
 from .training.sae_group import SparseAutoencoderDictionary
 from .training.session_loader import LMSparseAutoencoderSessionloader
 from .training.sparse_autoencoder import SparseAutoencoder
@@ -14,10 +19,12 @@ __all__ = [
     "LanguageModelSAERunnerConfig",
     "CacheActivationsRunnerConfig",
     "LMSparseAutoencoderSessionloader",
+    "PretokenizeRunnerConfig",
     "SparseAutoencoder",
     "SparseAutoencoderDictionary",
     "run_evals",
     "language_model_sae_runner",
+    "pretokenize_runner",
     "CacheActivationsRunner",
     "ActivationsStore",
     "train_sae_group_on_language_model",

--- a/sae_lens/training/batching.py
+++ b/sae_lens/training/batching.py
@@ -1,0 +1,92 @@
+from typing import Generator, Iterator
+
+import torch
+
+
+def _add_tokens_to_batch(
+    batch: torch.Tensor | None,
+    tokens: torch.Tensor,
+    context_size: int,
+    is_start_of_sequence: bool,
+    begin_batch_token_id: int | None = None,
+    begin_sequence_token_id: int | None = None,
+    sequence_separator_token_id: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    original_tokens = tokens
+    # prepend the start of sequence token if needed
+    if is_start_of_sequence and begin_sequence_token_id is not None:
+        begin_sequence_token_id_tensor = torch.tensor(
+            [begin_sequence_token_id], dtype=torch.long, device=tokens.device
+        )
+        if tokens[0] != begin_sequence_token_id_tensor:
+            tokens = torch.concat([begin_sequence_token_id_tensor, tokens], dim=0)
+    # We're at the start of a new batch
+    if batch is None:
+        # add the BOS token to the start if needed
+        if begin_batch_token_id is not None:
+            begin_batch_token_id_tensor = torch.tensor(
+                [begin_batch_token_id], dtype=torch.long, device=tokens.device
+            )
+            if tokens[0] != begin_batch_token_id_tensor:
+                tokens = torch.concat([begin_batch_token_id_tensor, tokens], dim=0)
+            batch = tokens[:context_size]
+        return tokens[:context_size], tokens[context_size:]
+    # if we're concatting batches, add the separator token as needed
+    if sequence_separator_token_id is not None:
+        sequence_separator_token_id_tensor = torch.tensor(
+            [sequence_separator_token_id], dtype=torch.long, device=tokens.device
+        )
+        if tokens[0] != sequence_separator_token_id_tensor:
+            tokens = torch.concat([sequence_separator_token_id_tensor, tokens], dim=0)
+    tokens_needed = context_size - batch.shape[0]
+    batch = torch.concat([batch, tokens[:tokens_needed]])
+
+    remaining_tokens = tokens[tokens_needed:]
+    # it's possible we've prepending 2 tokens to original_tokens, but only removed 1
+    # if so, we should only return the original tokens
+    if len(remaining_tokens) > len(original_tokens):
+        remaining_tokens = original_tokens
+    return batch, remaining_tokens
+
+
+@torch.no_grad()
+def concat_and_batch_sequences(
+    tokens_iterator: Iterator[torch.Tensor],
+    context_size: int,
+    begin_batch_token_id: int | None = None,
+    begin_sequence_token_id: int | None = None,
+    sequence_separator_token_id: int | None = None,
+) -> Generator[torch.Tensor, None, None]:
+    """
+    Generator to concat token sequences together from the tokens_interator, yielding
+    batches of size `context_size`.
+
+    Args:
+        tokens_iterator: An iterator which returns a 1D tensors of tokens
+        context_size: Each batch will have this many tokens
+        begin_batch_token_id: If provided, this token will be at position 0 of each batch
+        begin_sequence_token_id: If provided, this token will be the first token of each sequence
+        sequence_separator_token_id: If provided, this token will be inserted between concatenated sequences
+        max_batches: If not provided, the iterator will be run to completion.
+    """
+    batch: torch.Tensor | None = None
+    for tokens in tokens_iterator:
+        assert (
+            len(tokens.shape) == 1
+        ), f"tokens.shape should be 1D but was {tokens.shape}"
+        remaining_tokens = tokens
+        is_start_of_sequence = True
+        while len(remaining_tokens) > 0:
+            batch, remaining_tokens = _add_tokens_to_batch(
+                batch=batch,
+                tokens=remaining_tokens,
+                context_size=context_size,
+                is_start_of_sequence=is_start_of_sequence,
+                begin_batch_token_id=begin_batch_token_id,
+                begin_sequence_token_id=begin_sequence_token_id,
+                sequence_separator_token_id=sequence_separator_token_id,
+            )
+            is_start_of_sequence = False
+            if batch.shape[0] == context_size:
+                yield batch
+                batch = None

--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -409,3 +409,27 @@ def _default_cached_activations_path(
     if hook_point_head_index is not None:
         path += f"_{hook_point_head_index}"
     return path
+
+
+@dataclass
+class PretokenizeRunnerConfig:
+    tokenizer_name: str = "gpt2"
+    dataset_path: str = "NeelNanda/c4-10k"
+    split: str | None = "train"
+    data_files: list[str] | None = None
+    data_dir: str | None = None
+    num_proc: int = 4
+    context_size: int = 123
+    column_name: str = "text"
+    shuffle: bool = True
+    seed: int | None = None
+    streaming: bool = False
+
+    # if saving locally, set save_path
+    save_path: str | None = None
+
+    # if saving to huggingface, set hf_repo_id
+    hf_repo_id: str | None = None
+    hf_num_shards: int = 64
+    hf_revision: str = "main"
+    hf_is_private_repo: bool = False

--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import dataclass, field
-from typing import Any, Optional, cast
+from typing import Any, Literal, Optional, cast
 
 import torch
 import wandb
@@ -419,11 +419,16 @@ class PretokenizeRunnerConfig:
     data_files: list[str] | None = None
     data_dir: str | None = None
     num_proc: int = 4
-    context_size: int = 123
+    context_size: int = 128
     column_name: str = "text"
     shuffle: bool = True
     seed: int | None = None
     streaming: bool = False
+
+    # special tokens
+    begin_batch_token: int | Literal["bos", "eos", "sep"] | None = "bos"
+    begin_sequence_token: int | Literal["bos", "eos", "sep"] | None = None
+    sequence_separator_token: int | Literal["bos", "eos", "sep"] | None = "eos"
 
     # if saving locally, set save_path
     save_path: str | None = None

--- a/sae_lens/training/pretokenize_runner.py
+++ b/sae_lens/training/pretokenize_runner.py
@@ -1,0 +1,64 @@
+import sys
+from typing import cast
+
+from datasets import Dataset, DatasetDict, load_dataset
+from transformer_lens.utils import tokenize_and_concatenate
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
+
+from sae_lens.training.config import PretokenizeRunnerConfig
+
+
+def pretokenize_dataset(
+    dataset: Dataset,
+    tokenizer: PreTrainedTokenizerBase,
+    cfg: PretokenizeRunnerConfig,
+):
+    tokenized_dataset = tokenize_and_concatenate(
+        dataset,
+        cast(AutoTokenizer, tokenizer),
+        streaming=False,
+        max_length=cfg.context_size,
+        add_bos_token=False,
+        num_proc=cfg.num_proc,
+    )
+    if cfg.shuffle:
+        tokenized_dataset = tokenized_dataset.shuffle(seed=cfg.seed)
+    return tokenized_dataset.rename_column("tokens", "input_ids")
+
+
+def push_to_hugging_face_hub(
+    dataset: Dataset,
+    cfg: PretokenizeRunnerConfig,
+):
+    assert cfg.hf_repo_id is not None
+    return dataset.push_to_hub(
+        repo_id=cfg.hf_repo_id,
+        num_shards=cfg.hf_num_shards,
+        private=cfg.hf_is_private_repo,
+        revision=cfg.hf_revision,
+    )
+
+
+def pretokenize_runner(
+    cfg: PretokenizeRunnerConfig,
+):
+    dataset = load_dataset(
+        cfg.dataset_path,
+        data_dir=cfg.data_dir,
+        data_files=cfg.data_files,
+        split=cfg.split,
+        streaming=cfg.streaming,
+    )
+    if isinstance(dataset, DatasetDict):
+        raise ValueError("Dataset has multiple splits. Must provide a 'split' param.")
+    tokenizer = AutoTokenizer.from_pretrained(cfg.tokenizer_name)
+    tokenizer.model_max_length = sys.maxsize
+    tokenized_dataset = pretokenize_dataset(cast(Dataset, dataset), tokenizer, cfg)
+
+    if cfg.save_path is not None:
+        tokenized_dataset.save_to_disk(cfg.save_path)
+
+    if cfg.hf_repo_id is not None:
+        push_to_hugging_face_hub(tokenized_dataset, cfg)
+
+    return tokenized_dataset

--- a/tests/unit/training/test_batching.py
+++ b/tests/unit/training/test_batching.py
@@ -1,0 +1,291 @@
+import torch
+
+from sae_lens.training.batching import _add_tokens_to_batch, concat_and_batch_sequences
+
+
+def test_add_tokens_to_batch_can_start_a_new_batch():
+    tokens = torch.arange(10)
+    new_batch, remaining_tokens = _add_tokens_to_batch(
+        batch=None, tokens=tokens, context_size=5, is_start_of_sequence=True
+    )
+    assert torch.all(new_batch == tokens[:5])
+    assert torch.all(remaining_tokens == tokens[5:])
+
+
+def test_add_tokens_to_batch_adds_bos_if_new_batch():
+    tokens = torch.arange(10)
+    new_batch, remaining_tokens = _add_tokens_to_batch(
+        batch=None,
+        tokens=tokens,
+        context_size=5,
+        is_start_of_sequence=True,
+        begin_batch_token_id=999,
+        sequence_separator_token_id=998,
+    )
+    assert new_batch.tolist() == [999] + tokens[:4].tolist()
+    assert torch.all(remaining_tokens == tokens[4:])
+
+
+def test_add_tokens_to_batch_does_not_adds_bos_if_the_bos_is_already_there():
+    tokens = torch.tensor([999, 1, 2, 3])
+    new_batch, remaining_tokens = _add_tokens_to_batch(
+        batch=None,
+        tokens=tokens,
+        context_size=5,
+        is_start_of_sequence=True,
+        begin_batch_token_id=999,
+    )
+    assert new_batch.tolist() == tokens.tolist()
+    assert len(remaining_tokens) == 0
+
+
+def test_add_tokens_to_batch_uses_all_tokens_if_less_than_context_size():
+    tokens = torch.arange(3)
+    new_batch, remaining_tokens = _add_tokens_to_batch(
+        batch=None,
+        tokens=tokens,
+        context_size=5,
+        is_start_of_sequence=False,
+    )
+    assert torch.all(new_batch == tokens)
+    assert remaining_tokens.shape == (0,)
+
+
+def test_add_tokens_to_batch_can_append_both_the_bos_and_start_of_sequence_token():
+    tokens = torch.arange(10)
+    new_batch, remaining_tokens = _add_tokens_to_batch(
+        batch=None,
+        tokens=tokens,
+        context_size=5,
+        is_start_of_sequence=True,
+        begin_batch_token_id=999,
+        begin_sequence_token_id=998,
+    )
+    assert new_batch.tolist() == [999, 998] + tokens[:3].tolist()
+    assert torch.all(remaining_tokens == tokens[3:])
+
+
+def test_add_tokens_to_batch_appends_to_the_existing_batch():
+    batch = torch.arange(4)
+    tokens = torch.arange(10)
+    new_batch, remaining_tokens = _add_tokens_to_batch(
+        batch=batch,
+        tokens=tokens,
+        context_size=5,
+        is_start_of_sequence=True,
+    )
+    assert new_batch.tolist() == batch.tolist() + tokens[:1].tolist()
+    assert torch.all(remaining_tokens == tokens[1:])
+
+
+def test_add_tokens_to_batch_can_separate_sequences():
+    batch = torch.arange(3)
+    tokens = torch.arange(10)
+    new_batch, remaining_tokens = _add_tokens_to_batch(
+        batch=batch,
+        tokens=tokens,
+        context_size=5,
+        is_start_of_sequence=True,
+        sequence_separator_token_id=997,
+        begin_batch_token_id=999,
+    )
+    assert new_batch.tolist() == batch.tolist() + [997] + tokens[:1].tolist()
+    assert torch.all(remaining_tokens == tokens[1:])
+
+
+def test_add_tokens_to_batch_can_both_separate_sequences_and_add_seq_start_token():
+    batch = torch.arange(2)
+    tokens = torch.arange(10)
+    new_batch, remaining_tokens = _add_tokens_to_batch(
+        batch=batch,
+        tokens=tokens,
+        context_size=5,
+        is_start_of_sequence=True,
+        sequence_separator_token_id=997,
+        begin_sequence_token_id=998,
+        begin_batch_token_id=999,
+    )
+    assert new_batch.tolist() == batch.tolist() + [997, 998] + tokens[:1].tolist()
+    assert torch.all(remaining_tokens == tokens[1:])
+
+
+def test_add_tokens_to_batch_wont_return_more_remaining_tokens_than_the_original():
+    batch = torch.arange(4)
+    tokens = torch.arange(10)
+    new_batch, remaining_tokens = _add_tokens_to_batch(
+        batch=batch,
+        tokens=tokens,
+        context_size=5,
+        is_start_of_sequence=True,
+        sequence_separator_token_id=997,
+        begin_sequence_token_id=998,
+        begin_batch_token_id=999,
+    )
+    assert new_batch.tolist() == batch.tolist() + [997]
+    assert torch.all(remaining_tokens == tokens)
+
+
+def test_add_tokens_to_batch_collapses_separate_sequences_and_add_seq_start_token_if_identical():
+    batch = torch.arange(2)
+    tokens = torch.arange(10)
+    new_batch, remaining_tokens = _add_tokens_to_batch(
+        batch=batch,
+        tokens=tokens,
+        context_size=5,
+        is_start_of_sequence=True,
+        sequence_separator_token_id=998,
+        begin_sequence_token_id=998,
+        begin_batch_token_id=999,
+    )
+    assert new_batch.tolist() == batch.tolist() + [998] + tokens[:2].tolist()
+    assert torch.all(remaining_tokens == tokens[2:])
+
+
+def test_add_tokens_to_batch_skips_add_seq_start_token_if_not_start_of_seq():
+    batch = torch.arange(2)
+    tokens = torch.arange(10)
+    new_batch, remaining_tokens = _add_tokens_to_batch(
+        batch=batch,
+        tokens=tokens,
+        context_size=5,
+        is_start_of_sequence=False,
+        sequence_separator_token_id=997,
+        begin_sequence_token_id=998,
+    )
+    assert new_batch.tolist() == batch.tolist() + [997] + tokens[:2].tolist()
+    assert torch.all(remaining_tokens == tokens[2:])
+
+
+def test_concat_and_batch_sequences_generates_context_size_sequences():
+    all_toks = torch.arange(20)
+    seqs = [all_toks[:3], all_toks[3:10], all_toks[10:17], all_toks[17:]]
+    batches_list = list(
+        concat_and_batch_sequences(
+            tokens_iterator=iter(seqs),
+            context_size=5,
+        )
+    )
+    batches = torch.stack(batches_list)
+    assert batches.shape == (4, 5)
+    assert torch.all(batches == all_toks.reshape(4, 5))
+
+
+def test_concat_and_batch_sequences_drops_the_final_batch_if_too_small():
+    all_toks = torch.arange(19)
+    seqs = [all_toks[:3], all_toks[3:10], all_toks[10:17], all_toks[17:]]
+    batches_list = list(
+        concat_and_batch_sequences(
+            tokens_iterator=iter(seqs),
+            context_size=5,
+        )
+    )
+    batches = torch.stack(batches_list)
+    assert batches.shape == (3, 5)
+    assert torch.all(batches == all_toks[:15].reshape(3, 5))
+
+
+def test_concat_and_batch_sequences_can_ensure_everything_starts_with_bos():
+    all_toks = torch.arange(19)
+    seqs = [all_toks[:3], all_toks[3:10], all_toks[10:17], all_toks[17:]]
+    batches_list = list(
+        concat_and_batch_sequences(
+            tokens_iterator=iter(seqs),
+            context_size=5,
+            begin_batch_token_id=999,
+        )
+    )
+    batches = torch.stack(batches_list)
+    expected = [
+        [999, 0, 1, 2, 3],
+        [999, 4, 5, 6, 7],
+        [999, 8, 9, 10, 11],
+        [999, 12, 13, 14, 15],
+    ]
+    assert batches.tolist() == expected
+
+
+def test_concat_and_batch_sequences_can_ensure_each_seq_starts_with_a_token():
+    all_toks = torch.arange(19)
+    seqs = [all_toks[:3], all_toks[3:10], all_toks[10:17], all_toks[17:]]
+    batches_list = list(
+        concat_and_batch_sequences(
+            tokens_iterator=iter(seqs),
+            context_size=5,
+            begin_sequence_token_id=998,
+        )
+    )
+    batches = torch.stack(batches_list)
+    expected = [
+        [998, 0, 1, 2, 998],
+        [3, 4, 5, 6, 7],
+        [8, 9, 998, 10, 11],
+        [12, 13, 14, 15, 16],
+    ]
+    assert batches.tolist() == expected
+
+
+def test_concat_and_batch_sequences_can_ensure_each_seq_is_separated_with_a_token():
+    all_toks = torch.arange(19)
+    seqs = [all_toks[:3], all_toks[3:10], all_toks[10:17], all_toks[17:]]
+    batches_list = list(
+        concat_and_batch_sequences(
+            tokens_iterator=iter(seqs),
+            context_size=5,
+            sequence_separator_token_id=997,
+        )
+    )
+    batches = torch.stack(batches_list)
+    expected = [
+        [0, 1, 2, 997, 3],
+        [4, 5, 6, 7, 8],
+        [9, 997, 10, 11, 12],
+        [13, 14, 15, 16, 997],
+    ]
+    assert batches.tolist() == expected
+
+
+def test_concat_and_batch_sequences_can_use_all_token_types():
+    all_toks = torch.arange(19)
+    seqs = [all_toks[:3], all_toks[3:8], all_toks[8:11], all_toks[11:17], all_toks[17:]]
+    batches_list = list(
+        concat_and_batch_sequences(
+            tokens_iterator=iter(seqs),
+            context_size=5,
+            sequence_separator_token_id=997,
+            begin_sequence_token_id=998,
+            begin_batch_token_id=999,
+        )
+    )
+    batches = torch.stack(batches_list)
+    expected = [
+        [999, 998, 0, 1, 2],
+        [999, 998, 3, 4, 5],
+        [999, 6, 7, 997, 998],
+        [999, 8, 9, 10, 997],
+        [999, 11, 12, 13, 14],
+        [999, 15, 16, 997, 998],
+    ]
+    assert batches.tolist() == expected
+
+
+def test_concat_and_batch_collapses_identical_special_tokens():
+    all_toks = torch.arange(19)
+    seqs = [all_toks[:3], all_toks[3:8], all_toks[8:11], all_toks[11:17], all_toks[17:]]
+    batches_list = list(
+        concat_and_batch_sequences(
+            tokens_iterator=iter(seqs),
+            context_size=5,
+            sequence_separator_token_id=999,
+            begin_sequence_token_id=999,
+            begin_batch_token_id=999,
+        )
+    )
+    batches = torch.stack(batches_list)
+    expected = [
+        [999, 0, 1, 2, 999],
+        [999, 3, 4, 5, 6],
+        [999, 7, 999, 8, 9],
+        [999, 10, 999, 11, 12],
+        [999, 13, 14, 15, 16],
+    ]
+    assert batches.tolist() == expected

--- a/tests/unit/training/test_pretokenize_runner.py
+++ b/tests/unit/training/test_pretokenize_runner.py
@@ -1,59 +1,129 @@
+import json
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
 from datasets import Dataset
-from transformer_lens import HookedTransformer
-from transformer_lens.utils import tokenize_and_concatenate
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
+from sae_lens import __version__
 from sae_lens.training.config import PretokenizeRunnerConfig
 from sae_lens.training.pretokenize_runner import pretokenize_dataset, pretokenize_runner
 
 
-def test_pretokenize_dataset_concatenates_text_until_context_size(
-    ts_model: HookedTransformer,
-):
-    dataset = Dataset.from_list([{"text": "hello world"}] * 100)
-    cfg = PretokenizeRunnerConfig(context_size=10, num_proc=1, shuffle=False)
+@pytest.fixture
+def ts_tokenizer() -> PreTrainedTokenizerBase:
+    return AutoTokenizer.from_pretrained("roneneldan/TinyStories-1M")
 
-    assert ts_model.tokenizer is not None
-    tokenized_dataset = cast(Any, pretokenize_dataset(dataset, ts_model.tokenizer, cfg))
+
+def test_pretokenize_dataset_concatenates_text_until_context_size(
+    ts_tokenizer: PreTrainedTokenizerBase,
+):
+    dataset = Dataset.from_list([{"text": "hello world"}] * 30)
+    cfg = PretokenizeRunnerConfig(
+        context_size=10,
+        num_proc=1,
+        shuffle=False,
+        begin_batch_token=None,
+        sequence_separator_token=None,
+        begin_sequence_token=None,
+    )
+
+    tokenized_dataset = cast(Any, pretokenize_dataset(dataset, ts_tokenizer, cfg))
     assert tokenized_dataset["input_ids"].shape[1] == cfg.context_size
     assert (
-        ts_model.tokenizer.decode(tokenized_dataset["input_ids"][0])
+        ts_tokenizer.decode(tokenized_dataset["input_ids"][0])
         == "hello worldhello worldhello worldhello worldhello world"
     )
 
 
-def test_pretokenize_dataset_matches_tlens(ts_model: HookedTransformer):
-    dataset = Dataset.from_list(
-        [
-            {"text": "hello world1"},
-            {"text": "hello world2"},
-            {"text": "hello world3"},
-        ]
-        * 5000
-    )
-    cfg = PretokenizeRunnerConfig(context_size=10, num_proc=1, shuffle=False)
-
-    assert ts_model.tokenizer is not None
-    tokenized_dataset = cast(Any, pretokenize_dataset(dataset, ts_model.tokenizer, cfg))
-
-    tl_tokenized_res = cast(
-        Any,
-        tokenize_and_concatenate(
-            dataset,
-            cast(Any, ts_model.tokenizer),
-            max_length=cfg.context_size,
-            add_bos_token=False,
-        ),
+def test_pretokenize_dataset_can_add_bos_tokens_to_the_start_of_each_batch(
+    ts_tokenizer: PreTrainedTokenizerBase,
+):
+    dataset = Dataset.from_list([{"text": "hello world"}] * 30)
+    cfg = PretokenizeRunnerConfig(
+        context_size=10,
+        num_proc=1,
+        shuffle=False,
+        begin_batch_token="bos",
+        sequence_separator_token=None,
+        begin_sequence_token=None,
     )
 
+    tokenized_dataset = cast(Any, pretokenize_dataset(dataset, ts_tokenizer, cfg))
+    assert tokenized_dataset["input_ids"].shape[1] == cfg.context_size
     assert (
-        tokenized_dataset["input_ids"].tolist() == tl_tokenized_res["tokens"].tolist()
+        ts_tokenizer.decode(tokenized_dataset["input_ids"][0])
+        == "<|endoftext|>hello worldhello worldhello worldhello worldhello"
+    )
+    for batch in tokenized_dataset["input_ids"]:
+        assert ts_tokenizer.decode(batch[0]) == "<|endoftext|>"
+
+
+def test_pretokenize_dataset_can_separate_sequences_with_bos(
+    ts_tokenizer: PreTrainedTokenizerBase,
+):
+    dataset = Dataset.from_list([{"text": "hello world"}] * 30)
+    cfg = PretokenizeRunnerConfig(
+        context_size=10,
+        num_proc=1,
+        shuffle=False,
+        begin_batch_token=None,
+        sequence_separator_token="bos",
+        begin_sequence_token=None,
+    )
+
+    tokenized_dataset = cast(Any, pretokenize_dataset(dataset, ts_tokenizer, cfg))
+    assert tokenized_dataset["input_ids"].shape[1] == cfg.context_size
+    assert (
+        ts_tokenizer.decode(tokenized_dataset["input_ids"][0])
+        == "hello world<|endoftext|>hello world<|endoftext|>hello world<|endoftext|>hello"
     )
 
 
-def test_pretokenize_dataset_can_shuffle(ts_model: HookedTransformer):
+def test_pretokenize_dataset_can_begin_sequences_with_bos(
+    ts_tokenizer: PreTrainedTokenizerBase,
+):
+    dataset = Dataset.from_list([{"text": "hello world"}] * 30)
+    cfg = PretokenizeRunnerConfig(
+        context_size=10,
+        num_proc=1,
+        shuffle=False,
+        begin_batch_token=None,
+        sequence_separator_token=None,
+        begin_sequence_token="bos",
+    )
+
+    tokenized_dataset = cast(Any, pretokenize_dataset(dataset, ts_tokenizer, cfg))
+    assert tokenized_dataset["input_ids"].shape[1] == cfg.context_size
+    assert (
+        ts_tokenizer.decode(tokenized_dataset["input_ids"][0])
+        == "<|endoftext|>hello world<|endoftext|>hello world<|endoftext|>hello world<|endoftext|>"
+    )
+
+
+def test_pretokenize_dataset_dedupes_bos(
+    ts_tokenizer: PreTrainedTokenizerBase,
+):
+    dataset = Dataset.from_list([{"text": "hello world"}] * 30)
+    cfg = PretokenizeRunnerConfig(
+        context_size=10,
+        num_proc=1,
+        shuffle=False,
+        begin_batch_token="bos",
+        sequence_separator_token="bos",
+        begin_sequence_token="bos",
+    )
+
+    tokenized_dataset = cast(Any, pretokenize_dataset(dataset, ts_tokenizer, cfg))
+    assert tokenized_dataset["input_ids"].shape[1] == cfg.context_size
+    assert (
+        ts_tokenizer.decode(tokenized_dataset["input_ids"][0])
+        == "<|endoftext|>hello world<|endoftext|>hello world<|endoftext|>hello world<|endoftext|>"
+    )
+
+
+def test_pretokenize_dataset_can_shuffle(ts_tokenizer: PreTrainedTokenizerBase):
     dataset = Dataset.from_list(
         [
             {"text": "hello world1"},
@@ -64,13 +134,9 @@ def test_pretokenize_dataset_can_shuffle(ts_model: HookedTransformer):
     )
     cfg = PretokenizeRunnerConfig(context_size=10, num_proc=1, shuffle=True)
 
-    assert ts_model.tokenizer is not None
-    tokenized_dataset1 = cast(
-        Any, pretokenize_dataset(dataset, ts_model.tokenizer, cfg)
-    )
-    tokenized_dataset2 = cast(
-        Any, pretokenize_dataset(dataset, ts_model.tokenizer, cfg)
-    )
+    # assert ts_model.tokenizer is not None
+    tokenized_dataset1 = cast(Any, pretokenize_dataset(dataset, ts_tokenizer, cfg))
+    tokenized_dataset2 = cast(Any, pretokenize_dataset(dataset, ts_tokenizer, cfg))
     assert len(tokenized_dataset1) == len(tokenized_dataset2)
     assert (
         tokenized_dataset1["input_ids"].tolist()
@@ -94,3 +160,13 @@ def test_pretokenize_runner_save_dataset_locally(tmp_path: Path):
     loaded_dataset = Dataset.load_from_disk(str(save_path))
     assert len(dataset) == len(loaded_dataset)
     assert dataset["input_ids"].tolist() == loaded_dataset["input_ids"].tolist()  # type: ignore
+    with open(save_path / "sae_lens.json") as f:
+        metadata_dict = json.load(f)
+    assert metadata_dict["original_dataset"] == "NeelNanda/c4-10k"
+    assert metadata_dict["original_split"] == "train[:20]"
+    assert metadata_dict["context_size"] == 10
+    assert metadata_dict["shuffled"] is True
+    assert metadata_dict["begin_batch_token"] == "bos"
+    assert metadata_dict["begin_sequence_token"] is None
+    assert metadata_dict["sequence_separator_token"] == "eos"
+    assert metadata_dict["sae_lens_version"] == __version__

--- a/tests/unit/training/test_pretokenize_runner.py
+++ b/tests/unit/training/test_pretokenize_runner.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+from typing import Any, cast
+
+from datasets import Dataset
+from transformer_lens import HookedTransformer
+from transformer_lens.utils import tokenize_and_concatenate
+
+from sae_lens.training.config import PretokenizeRunnerConfig
+from sae_lens.training.pretokenize_runner import pretokenize_dataset, pretokenize_runner
+
+
+def test_pretokenize_dataset_concatenates_text_until_context_size(
+    ts_model: HookedTransformer,
+):
+    dataset = Dataset.from_list([{"text": "hello world"}] * 100)
+    cfg = PretokenizeRunnerConfig(context_size=10, num_proc=1, shuffle=False)
+
+    assert ts_model.tokenizer is not None
+    tokenized_dataset = cast(Any, pretokenize_dataset(dataset, ts_model.tokenizer, cfg))
+    assert tokenized_dataset["input_ids"].shape[1] == cfg.context_size
+    assert (
+        ts_model.tokenizer.decode(tokenized_dataset["input_ids"][0])
+        == "hello worldhello worldhello worldhello worldhello world"
+    )
+
+
+def test_pretokenize_dataset_matches_tlens(ts_model: HookedTransformer):
+    dataset = Dataset.from_list(
+        [
+            {"text": "hello world1"},
+            {"text": "hello world2"},
+            {"text": "hello world3"},
+        ]
+        * 5000
+    )
+    cfg = PretokenizeRunnerConfig(context_size=10, num_proc=1, shuffle=False)
+
+    assert ts_model.tokenizer is not None
+    tokenized_dataset = cast(Any, pretokenize_dataset(dataset, ts_model.tokenizer, cfg))
+
+    tl_tokenized_res = cast(
+        Any,
+        tokenize_and_concatenate(
+            dataset,
+            cast(Any, ts_model.tokenizer),
+            max_length=cfg.context_size,
+            add_bos_token=False,
+        ),
+    )
+
+    assert (
+        tokenized_dataset["input_ids"].tolist() == tl_tokenized_res["tokens"].tolist()
+    )
+
+
+def test_pretokenize_dataset_can_shuffle(ts_model: HookedTransformer):
+    dataset = Dataset.from_list(
+        [
+            {"text": "hello world1"},
+            {"text": "hello world2"},
+            {"text": "hello world3"},
+        ]
+        * 5000
+    )
+    cfg = PretokenizeRunnerConfig(context_size=10, num_proc=1, shuffle=True)
+
+    assert ts_model.tokenizer is not None
+    tokenized_dataset1 = cast(
+        Any, pretokenize_dataset(dataset, ts_model.tokenizer, cfg)
+    )
+    tokenized_dataset2 = cast(
+        Any, pretokenize_dataset(dataset, ts_model.tokenizer, cfg)
+    )
+    assert len(tokenized_dataset1) == len(tokenized_dataset2)
+    assert (
+        tokenized_dataset1["input_ids"].tolist()
+        != tokenized_dataset2["input_ids"].tolist()
+    )
+
+
+def test_pretokenize_runner_save_dataset_locally(tmp_path: Path):
+    save_path = tmp_path / "ds"
+    cfg = PretokenizeRunnerConfig(
+        tokenizer_name="gpt2",
+        context_size=10,
+        num_proc=2,
+        shuffle=True,
+        save_path=str(save_path),
+        dataset_path="NeelNanda/c4-10k",
+        split="train[:20]",
+    )
+    dataset = pretokenize_runner(cfg)
+    assert save_path.exists()
+    loaded_dataset = Dataset.load_from_disk(str(save_path))
+    assert len(dataset) == len(loaded_dataset)
+    assert dataset["input_ids"].tolist() == loaded_dataset["input_ids"].tolist()  # type: ignore

--- a/tutorials/pretokenizing_datasets.ipynb
+++ b/tutorials/pretokenizing_datasets.ipynb
@@ -1,0 +1,133 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pretokenizing Datasets\n",
+    "\n",
+    "An easy way to speed up SAE training is to pretokenize the training dataset so it's already tokenized and batched for all subsequent training runs. Pretokenized datasets can also be uploaded to Huggingface so they're easily shared between with other researchers experimenting with SAEs.\n",
+    "\n",
+    "This notebook will show how to pretokenize a dataset and upload it to Huggingface using the built-in pretokenize runner in SAELens."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Core hyperparameters and special tokens\n",
+    "\n",
+    "Pretokenizing a dataset will encode each sentence in the dataset into tokens, form these into batches of length `context_size` tokens, and optionally shuffle the batches. This process shares a lot of similarities with language model (LM) training, and indeed we want our SAEs to be trained using datasets that behave similarly to how the original LM was trained.\n",
+    "\n",
+    "Importantly, we want the special tokens used during pretokenization to match the special tokens used by the LM during training. For instance, if the LM was trained with a `<bos>` token at the start of each batch, with each sentence in the batch separated by an `<eos>` token, then our pretokenized dataset should match that behavior.\n",
+    "\n",
+    "In SAELens, we can control this special token behavior with the following 3 options in the config:\n",
+    "- `begin_batch_token`: If not `None`, this token will be prepended to the start of each batch. By default this is the `<bos>` token\n",
+    "- `begin_sequence_token`: If not `None`, this token will be prepended to the start of every sentence, regardless of where in the batch the sentence starts. By default this is `None`\n",
+    "- `sequence_separator_token`: If not `None`, this tokken will be placed between sentences in a batch to act as a separator. By default, this is the `<eos>` token.\n",
+    "\n",
+    "For each of the above options, you can pass the string `\"bos\"`, `\"eos\"`, or `\"sep\"` for the `<bos>`, `<eos>`, or `<sep>` tokens, respectively. You can also pass in a token ID as an int if you need to customize this further.\n",
+    "\n",
+    "The special tokens you should use will vary depending on the LM, so you should check how the original LM was trained and select pretokenization settings that match as closely as possible. For some LMs like GPT2, the `<bos>` and `<eos>` tokens are actually the same token."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Uploading to Huggingface\n",
+    "\n",
+    "If you want to upload your dataset to Huggingface, you just need to set the param `hf_repo_id`. This should be of the form `<huggingface username>/<dataset repo name>`. It's a good idea to name the repo descriptively, including the tokenizer you used and the word `tokenized`. For instance, if you're tokenizing a dataset called `web-text` with `gpt2`, and your username is `hf_user`, you might pass a `hf_repo_id` like `hf_user/web-text-tokenized-gpt2`.\n",
+    "\n",
+    "You can also save the dataset locally by setting `save_path` to a path on your local machine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sae_lens import pretokenize_runner, PretokenizeRunnerConfig\n",
+    "\n",
+    "cfg = PretokenizeRunnerConfig(\n",
+    "    tokenizer_name=\"gpt2\",\n",
+    "    dataset_path=\"NeelNanda/c4-10k\", # this is just a tiny test dataset\n",
+    "    shuffle=True,\n",
+    "    num_proc=4, # increase this number depending on how many CPUs you have\n",
+    "\n",
+    "    # tweak these settings depending on the model\n",
+    "    context_size=128,\n",
+    "    begin_batch_token=\"bos\",\n",
+    "    begin_sequence_token=None,\n",
+    "    sequence_separator_token=\"eos\",\n",
+    "\n",
+    "    # uncomment to upload to huggingface\n",
+    "    # hf_repo_id=\"your-username/c4-10k-tokenized-gpt2\"\n",
+    "\n",
+    "    # uncomment to save the dataset locally\n",
+    "    # save_path=\"./c4-10k-tokenized-gpt2\"\n",
+    ")\n",
+    "\n",
+    "dataset = pretokenize_runner(cfg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspecting our new dataset\n",
+    "\n",
+    "Our dataset now contains a single key `input_ids` with tokenized sentences."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Row has 128 tokens\n",
+      "Decoded: <|endoftext|> railway equipment, telecom and signaling, catenary and traction power, rolling stock, etc.), safety, maintenance and repair, maintenance or operational planning.\n",
+      "Egis can also support public and private client developing and implementing various form of project such as D&B, EPC, PPP and turnkey projects.<|endoftext|>And just like that, Fall has come!\n",
+      "Hello friends. This is my first post since the middle of the summer! I found myself so focused the last two months on 1) enjoying every bit of summer while Madison was home with me and 2) prepare her for school and a new chapter for our family.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from transformers import AutoTokenizer\n",
+    "\n",
+    "tokenizer = AutoTokenizer.from_pretrained(\"gpt2\")\n",
+    "\n",
+    "tokenized_row = dataset['input_ids'][5]\n",
+    "\n",
+    "print(f\"Row has {len(tokenized_row)} tokens\")\n",
+    "print(f\"Decoded: {tokenizer.decode(tokenized_row)}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "sae-lens-CSfAEFdT-py3.11",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
# Description

This PR adds a pretokenize runner which can be used to pre-tokenize / chunk / shuffle datasets and upload them to Huggingface. I plan on adding a follow-up PR in the future to harmonize the `ActivationsStore` to use the same logic for generating batches as is used here, but decided to hold off on that for now to avoid merge conflicts and to keep this PR more easily reviewable.

This PR has several design considerations after discussion in the OSMI slack:
- Support specifying a special token to use only at the beginning of every batch
- Support specifying a special token to use at the begging of each new sequence
- Support specifying a special token to use as a separator between sequences
- It should be possible for these tokens to occur one after another if desired (e.g. `seq 1 <eos> <bos> seq 2`)

The main batching function, `concat_and_batch_sequences()`, is written as a Python Generator, and thus is an iterator, so it can be used directly inside of `ActivationsStore` in the future to generate batches of tokens.

This PR also uploads a `sae_lens.json` metadata file along with the dataset that specifies info about how the dataset was generated, what version of SAELens was used to generate it, special tokens used, context_size, etc... In the future, we can read this data in when loading a pretokenized dataset in `ActivationsStore`.

This PR also includes a tutorial notebook on how to use this runner.

**NOTE**
The special tokens config for this runner differs from the way our other configs work, as our current configs only have a `prepend_bos` token option, but not the option to customize this behavior to the extent in this PR. I'm not sure if the names I used for these special token params is ideal, but definitely open to feedback on this! Longer term, we should use the same special token options for the other configs as well.

A sample pretokenized dataset generated with this script can be found [here](https://huggingface.co/datasets/chanind/c4-10k-tokenized-gpt2), and the corresponding metadata json can be found [here](https://huggingface.co/datasets/chanind/c4-10k-tokenized-gpt2/blob/main/sae_lens.json)

Fixes #34 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)