### PR TITLE
Fix normalisation

### DIFF
--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -122,7 +122,7 @@ class ActivationsStore:
         self.n_dataset_processed = 0
         self.iterable_dataset = iter(self.dataset)
 
-        self.estimated_norm_scaling_factor = 1.
+        self.estimated_norm_scaling_factor = 1.0
 
         # Check if dataset is tokenized
         dataset_sample = next(self.iterable_dataset)
@@ -176,7 +176,7 @@ class ActivationsStore:
 
     def apply_norm_scaling_factor(self, activations: torch.Tensor) -> torch.Tensor:
         return activations * self.estimated_norm_scaling_factor
-    
+
     def unscale(self, activations: torch.Tensor) -> torch.Tensor:
         return activations / self.estimated_norm_scaling_factor
 
@@ -392,7 +392,7 @@ class ActivationsStore:
         # every buffer should be normalized:
         if self.normalize_activations:
             if self.estimated_norm_scaling_factor == 1:
-                print('WARNING: no normalisation is being applied, scaling factor = 1')
+                print("WARNING: no normalisation is being applied, scaling factor = 1")
             new_buffer = self.apply_norm_scaling_factor(new_buffer)
 
         return new_buffer

--- a/sae_lens/training/train_sae_on_language_model.py
+++ b/sae_lens/training/train_sae_on_language_model.py
@@ -281,7 +281,7 @@ def train_sae_group_on_language_model(
         # Estimate norm scaling factor if necessary
         # TODO(tomMcGrath): this is a bodge and should be moved back inside a class
         if activation_store.normalize_activations:
-            print('Estimating activation norm')
+            print("Estimating activation norm")
             n_batches_for_norm_estimate = int(1e3)
             norms_per_batch = []
             for _ in tqdm(range(n_batches_for_norm_estimate)):

--- a/scripts/sweep-gpt2-blocks.py
+++ b/scripts/sweep-gpt2-blocks.py
@@ -18,8 +18,6 @@ else:
 print("Using device:", device)
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
-block = 6
-
 total_training_steps = 20_000
 batch_size = 4096
 total_training_tokens = total_training_steps * batch_size

--- a/scripts/sweep-gpt2-blocks.py
+++ b/scripts/sweep-gpt2-blocks.py
@@ -1,0 +1,111 @@
+import os
+import sys
+
+import torch
+
+sys.path.append("..")
+
+from sae_lens.training.config import LanguageModelSAERunnerConfig
+from sae_lens.training.lm_runner import language_model_sae_runner
+
+if torch.cuda.is_available():
+    device = "cuda"
+elif torch.backends.mps.is_available():
+    device = "mps"
+else:
+    device = "cpu"
+
+print("Using device:", device)
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+block = 6
+
+total_training_steps = 20_000
+batch_size = 4096
+total_training_tokens = total_training_steps * batch_size
+print(f"Total Training Tokens: {total_training_tokens}")
+
+lr_warm_up_steps = 0
+lr_decay_steps = total_training_steps // 5  # 20% of training steps.
+print(f"lr_decay_steps: {lr_decay_steps}")
+l1_warmup_steps = total_training_steps // 20  # 5% of training steps.
+print(f"l1_warmup_steps: {l1_warmup_steps}")
+log_to_wandb = True
+
+for l1_coefficient in [3, 4, 5, 6, 7]:
+    for block in [1, 3, 5, 6]:
+        cfg = LanguageModelSAERunnerConfig(
+            # Pick a tiny model to make this easier.
+            model_name="gpt2",
+            ## MLP ##
+            hook_point=f"blocks.{block}.hook_mlp_out",
+            hook_point_layer=block,
+            d_in=768,
+            dataset_path="apollo-research/Skylion007-openwebtext-tokenizer-gpt2",
+            streaming=True,
+            context_size=512,
+            is_dataset_tokenized=True,
+            prepend_bos=True,
+            # How big do we want our SAE to be?
+            expansion_factor=64,
+            # Dataset / Activation Store
+            use_cached_activations=False,
+            training_tokens=total_training_tokens,
+            train_batch_size_tokens=4096,
+            # Loss Function
+            ## Reconstruction Coefficient.
+            mse_loss_normalization=None,  # MSE Loss Normalization is not mentioned (so we use stanrd MSE Loss). But not we take an average over the batch.
+            ## Anthropic does not mention using an Lp norm other than L1.
+            l1_coefficient=l1_coefficient,
+            lp_norm=1.0,
+            # Instead, they multiply the L1 loss contribution
+            # from each feature of the activations by the decoder norm of the corresponding feature.
+            scale_sparsity_penalty_by_decoder_norm=True,
+            # Learning Rate
+            lr_scheduler_name="constant",  # we set this independently of warmup and decay steps.
+            l1_warm_up_steps=l1_warmup_steps,
+            lr_warm_up_steps=lr_warm_up_steps,
+            lr_decay_steps=lr_warm_up_steps,
+            ## No ghost grad term.
+            use_ghost_grads=False,
+            # Initialization / Architecture
+            apply_b_dec_to_input=False,
+            # encoder bias zero's. (I'm not sure what it is by default now)
+            # decoder bias zero's.
+            b_dec_init_method="zeros",
+            normalize_sae_decoder=False,
+            decoder_heuristic_init=True,
+            init_encoder_as_decoder_transpose=True,
+            # Optimizer
+            lr=1e-4,
+            ## adam optimizer has no weight decay by default so worry about this.
+            adam_beta1=0.9,
+            adam_beta2=0.999,
+            # Unsure if this is enough
+            n_batches_in_buffer=64,
+            store_batch_size_prompts=16,
+            normalize_activations=True,
+            # Feature Store
+            feature_sampling_window=1000,
+            dead_feature_window=1000,
+            dead_feature_threshold=1e-4,
+            # WANDB
+            log_to_wandb=log_to_wandb,
+            wandb_project="gpt-2-sweep-15may24-try-normalisation",
+            wandb_log_frequency=50,
+            eval_every_n_wandb_logs=10,
+            # Misc
+            device=device,
+            seed=42,
+            n_checkpoints=0,
+            checkpoint_path="checkpoints",
+            dtype=torch.float32,
+            eval_batch_size_prompts=2,
+            autocast=True,
+            compile_llm=True,
+            compile_sae=True,
+        )
+
+        language_model_sae_runner(cfg)
+
+        print("=" * 50)

--- a/scripts/sweep-gpt2-blocks.py
+++ b/scripts/sweep-gpt2-blocks.py
@@ -83,7 +83,7 @@ for l1_coefficient in [3, 4, 5, 6, 7]:
             adam_beta2=0.999,
             # Unsure if this is enough
             n_batches_in_buffer=64,
-            store_batch_size_prompts=16,
+            store_batch_size_prompts=32,
             normalize_activations=True,
             # Feature Store
             feature_sampling_window=1000,
@@ -101,6 +101,7 @@ for l1_coefficient in [3, 4, 5, 6, 7]:
             checkpoint_path="checkpoints",
             dtype=torch.float32,
             eval_batch_size_prompts=2,
+            n_eval_batches=40,
             autocast=True,
             compile_llm=True,
             compile_sae=True,

--- a/scripts/sweep-gpt2.py
+++ b/scripts/sweep-gpt2.py
@@ -20,17 +20,10 @@ os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 block = 6
 
-total_training_steps = 200_00
+total_training_steps = 20_000
 batch_size = 4096
 total_training_tokens = total_training_steps * batch_size
 print(f"Total Training Tokens: {total_training_tokens}")
-
-# change these configs
-model_name = "gelu-1l"
-dataset_path = "NeelNanda/c4-tokenized-2b"
-new_cached_activations_path = (
-    f"./cached_activations/{model_name}/{dataset_path}/{total_training_steps}"
-)
 
 lr_warm_up_steps = 0
 lr_decay_steps = total_training_steps // 5  # 20% of training steps.
@@ -46,7 +39,6 @@ for l1_coefficient in [0.1, 1, 2, 4, 10]:
         1e-4,
         4e-4,
     ]:
-
         cfg = LanguageModelSAERunnerConfig(
             # Pick a tiny model to make this easier.
             model_name="gpt2",
@@ -54,8 +46,8 @@ for l1_coefficient in [0.1, 1, 2, 4, 10]:
             hook_point=f"blocks.{block}.hook_mlp_out",
             hook_point_layer=block,
             d_in=768,
-            dataset_path="NeelNanda/c4-tokenized-2b",
-            streaming=False,
+            dataset_path="apollo-research/Skylion007-openwebtext-tokenizer-gpt2",
+            streaming=True,
             context_size=512,
             is_dataset_tokenized=True,
             prepend_bos=True,
@@ -104,7 +96,7 @@ for l1_coefficient in [0.1, 1, 2, 4, 10]:
             dead_feature_threshold=1e-4,
             # WANDB
             log_to_wandb=log_to_wandb,
-            wandb_project="gpt-2-sweep-12may24",
+            wandb_project="gpt-2-sweep-14may24",
             wandb_log_frequency=50,
             eval_every_n_wandb_logs=10,
             # Misc


### PR DESCRIPTION
# Description

Anthropic's SAE training code normalises activations before they enter the SAE so that their average L2 norm is sqrt(d_model). Although we have normalisation activation in the code, it is not currently applied during evals which both harms the cross-entropy loss and makes hyperparameter transfer across layers impossible as different layers have substantially different mean norms.

This PR changes estimation of the scale factor to occur once, with a larger sample size, before SAE training, and modifies the eval code to up- and downscale activations as part of the hook function as well as correctly estimate the L2 norm of activations that the SAE will actually see during training.

The code in this PR isn't the prettiest and I aim to create a tidier version next week but we need this functionality. I've marked areas for tidying with `TODO(tomMcGrath)` and will open an issue to track this. EDIT: this is now tracked in issue #151.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [x] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

[This W&B dashboard ](https://wandb.ai/tmcgrath/gpt-2-sweep-15may24-try-normalisation/workspace.)shows the effect of the fix:
- `metrics/l2_norm_in` shows the L2 norm of the inputs fluctuating around sqrt(d_model)
- `metrics/CE_loss_score` shows the effects of correctly up- and downsampling, as well as the effects of no normalisation (the state pre-fix) and only upscaling