### PR TITLE
add gemma-2b bootleg saes

### DIFF
--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -30,3 +30,12 @@ SAE_LOOKUP:
         path: "blocks.11.hook_resid_pre"
       - id: "blocks.11.hook_resid_post"
         path: "blocks.11.hook_resid_post"
+  gemma-2b-res-jb:
+    repo_id: "jbloom/Gemma-2b-Residual-Stream-SAEs"
+    model: "gemma-2b"
+    conversion_func: null
+    saes:
+      - id: "blocks.0.hook_resid_post"
+        path: "gemma_2b_blocks.0.hook_resid_post_16384_anthropic"
+      - id: "blocks.0.hook_resid_post"
+        path: "gemma_2b_blocks.6.hook_resid_post_16384_anthropic_fast_lr"


### PR DESCRIPTION
- New SAEs in from pretrained. 

See HF repo here: https://huggingface.co/jbloom/Gemma-2b-Residual-Stream-SAEs
Load using from pretrained method here.


```python
import torch
from transformer_lens import HookedTransformer
from sae_lens import SparseAutoencoder, ActivationsStore

torch.set_grad_enabled(False)
model = HookedTransformer.from_pretrained("gemma-2b")
sparse_autoencoder = SparseAutoencoder.from_pretrained(
  "gemma-2b-res-jb", # to see the list of available releases, go to: https://github.com/jbloomAus/SAELens/blob/main/sae_lens/pretrained_saes.yaml
  "blocks.0.hook_resid_post" # change this to another specific SAE ID in the release if desired. 
)
activation_store = ActivationsStore.from_config(model, sparse_autoencoder.cfg)
```