### PR TITLE
remove resuming ability, keep resume config but complain if true

### DIFF
--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -62,7 +62,7 @@ class LanguageModelSAERunnerConfig:
     # Misc
     device: str | torch.device = "cpu"
     seed: int = 42
-    dtype: str | torch.dtype = "float32"  # type: ignore #
+    dtype: str | torch.dtype = "torch.float32"  # type: ignore #
     prepend_bos: bool = True
 
     # Performance - see compilation section of lm_runner.py for info
@@ -134,6 +134,13 @@ class LanguageModelSAERunnerConfig:
     sae_lens_training_version: str = field(default_factory=lambda: __version__)
 
     def __post_init__(self):
+
+        if self.resume:
+            raise ValueError(
+                "Resuming is no longer supported. You can finetune a trained SAE using cfg.from_pretrained path."
+                + "If you want to load an SAE with resume=True in the config, please manually set resume=False in that config."
+            )
+
         if self.use_cached_activations and self.cached_activations_path is None:
             self.cached_activations_path = _default_cached_activations_path(
                 self.dataset_path,
@@ -318,7 +325,7 @@ class CacheActivationsRunnerConfig:
     # Misc
     device: str | torch.device = "cpu"
     seed: int = 42
-    dtype: str | torch.dtype = "float32"
+    dtype: str | torch.dtype = "torch.float32"
     prepend_bos: bool = True
 
     # Activation caching stuff

--- a/tests/unit/training/test_config.py
+++ b/tests/unit/training/test_config.py
@@ -1,0 +1,26 @@
+import pytest
+
+from sae_lens.training.config import LanguageModelSAERunnerConfig
+
+TINYSTORIES_MODEL = "tiny-stories-1M"
+TINYSTORIES_DATASET = "roneneldan/TinyStories"
+
+
+def test_sae_training_runner_config_runs_with_defaults():
+    """
+    Helper to create a mock instance of LanguageModelSAERunnerConfig.
+    """
+    # Create a mock object with the necessary attributes
+    _ = LanguageModelSAERunnerConfig()
+
+    assert True
+
+
+def test_sae_training_runner_config_raises_error_if_resume_true():
+    """
+    Helper to create a mock instance of LanguageModelSAERunnerConfig.
+    """
+    # Create a mock object with the necessary attributes
+    with pytest.raises(ValueError):
+        _ = LanguageModelSAERunnerConfig(resume=True)
+    assert True

--- a/tests/unit/training/test_train_sae_on_language_model.py
+++ b/tests/unit/training/test_train_sae_on_language_model.py
@@ -1,45 +1,27 @@
-import os
-from collections import OrderedDict
-from dataclasses import fields
 from pathlib import Path
 from typing import Any, Callable
 from unittest.mock import patch
 
-import numpy as np
 import pytest
 import torch
-import wandb
 from datasets import Dataset
 from torch import Tensor
 from transformer_lens import HookedTransformer
 
 from sae_lens import __version__
 from sae_lens.training.activations_store import ActivationsStore
-from sae_lens.training.optim import L1Scheduler
-from sae_lens.training.sparse_autoencoder import (
-    SAE_CFG_PATH,
-    SAE_WEIGHTS_PATH,
-    SPARSITY_PATH,
-    ForwardOutput,
-    SparseAutoencoder,
-)
+from sae_lens.training.sparse_autoencoder import ForwardOutput, SparseAutoencoder
 from sae_lens.training.train_sae_on_language_model import (
-    ACTIVATION_STORE_PATH,
-    SAE_CONTEXT_PATH,
-    TRAINING_RUN_STATE_PATH,
     SAETrainContext,
-    SAETrainingRunState,
     TrainStepOutput,
     _build_train_context,
     _build_train_step_log_dict,
     _log_feature_sparsity,
-    _save_checkpoint,
     _train_step,
     _update_sae_lens_training_version,
-    load_checkpoint,
     train_sae_group_on_language_model,
 )
-from tests.unit.helpers import build_sae_cfg, load_model_cached
+from tests.unit.helpers import build_sae_cfg
 
 
 def build_train_ctx(
@@ -265,129 +247,6 @@ def test_build_train_step_log_dict() -> None:
         "details/current_l1_coefficient-wandbftw": 0.01,
         "details/n_training_tokens": 123,
     }
-
-
-def test_save_load_and_resume_checkpoint(tmp_path: Path) -> None:
-
-    # set wandb mode to offline
-    os.environ["WANDB_MODE"] = "offline"
-
-    wandb.init()
-    checkpoint_dir = tmp_path / "checkpoint"
-    cfg = build_sae_cfg(
-        checkpoint_path=str(checkpoint_dir),
-        d_in=64,
-        d_sae=128,
-        log_to_wandb=True,
-        training_tokens=256,
-    )
-    sae = SparseAutoencoder(cfg)
-    ctx = build_train_ctx(
-        sae,
-        act_freq_scores=torch.rand((128,)),
-        n_forward_passes_since_fired=torch.randint(0, 128, (128,)),
-        n_frac_active_tokens=123,
-    )
-
-    dataset = Dataset.from_list(
-        [
-            {"text": "hello world1"},
-            {"text": "hello world2"},
-            {"text": "hello world3"},
-        ]
-        * 5000
-    )
-    model = load_model_cached(cfg.model_name)
-    activation_store = ActivationsStore.from_config(model, cfg, dataset=dataset)
-
-    training_run_state = SAETrainingRunState("hi", 1, 2, True)
-
-    _ = activation_store.get_batch_tokens()
-    _ = activation_store.get_batch_tokens()
-    _ = activation_store.get_batch_tokens()
-
-    res = _save_checkpoint(
-        sae=sae,
-        activation_store=activation_store,
-        train_context=ctx,
-        training_run_state=training_run_state,
-        checkpoint_name="test_checkpoint",
-    )
-    assert res == str(checkpoint_dir / "test_checkpoint")
-
-    contents = os.listdir(f"{res}")
-    assert len(contents) == 6
-    assert ACTIVATION_STORE_PATH in contents
-    assert TRAINING_RUN_STATE_PATH in contents
-    contents.remove(ACTIVATION_STORE_PATH)
-    contents.remove(TRAINING_RUN_STATE_PATH)
-
-    assert SAE_CONTEXT_PATH in contents
-    assert SAE_CFG_PATH in contents
-    assert SPARSITY_PATH in contents
-    assert SAE_WEIGHTS_PATH in contents
-    # stuff not tied to a single sae
-
-    training_run_state_2, activation_store_2, sae_2, train_context_2 = load_checkpoint(
-        checkpoint_path=res,
-        cfg=cfg,
-        model=model,
-        batch_size=cfg.train_batch_size_tokens,
-    )
-
-    # recursive handle lots of types
-    def assert_close(sd1: Any, sd2: Any):
-        assert type(sd1) == type(sd2)
-        if type(sd1) is torch.Tensor:
-            assert torch.allclose(sd1, sd2)
-        elif type(sd1) is np.ndarray:
-            assert np.allclose(sd1, sd2)
-        elif type(sd1) in [dict, OrderedDict]:
-            assert sd1.keys() == sd2.keys()
-            for k in sd1.keys():
-                assert_close(sd1[k], sd2[k])
-        elif type(sd1) is list or type(sd1) is tuple:
-            assert len(sd1) == len(sd2)
-            for v1, v2 in zip(sd1, sd2):
-                assert_close(v1, v2)
-        elif type(sd1) in [str, int, bool, float]:
-            assert sd1 == sd2
-        elif sd1 is None:
-            assert sd1 == sd2
-        else:
-            if type(sd1) != L1Scheduler:
-                raise ValueError(f"didn't handle {sd1} of type {type(sd1)}")
-
-    # compare training run states
-    for attr in fields(training_run_state):
-        f1 = getattr(training_run_state, attr.name)
-        f2 = getattr(training_run_state_2, attr.name)
-        assert_close(f1, f2)
-
-    # compare sae groups and ctxs
-    assert_close(sae.state_dict(), sae_2.state_dict())
-
-    # compare activation stores
-    assert_close(activation_store.state_dict(), activation_store_2.state_dict())
-
-    # compare loaded train context
-    sd1 = ctx.state_dict()
-    sd2 = train_context_2.state_dict()
-    assert_close(sd1, sd2)
-
-    res = train_sae_group_on_language_model(
-        model=model,
-        sae=sae,
-        activation_store=activation_store,
-        train_context=train_context_2,
-        training_run_state=training_run_state_2,
-        batch_size=cfg.train_batch_size_tokens,
-    )
-    assert res.checkpoint_path == str(checkpoint_dir / "final_258")
-    assert len(res.log_feature_sparsities) == 128
-
-    assert res.log_feature_sparsities.shape == (cfg.d_sae,)
-    assert isinstance(res.sae, SparseAutoencoder)
 
 
 def test_train_sae_group_on_language_model__runs(


### PR DESCRIPTION
# Description

I'm removing the ability to resume a previous run, but keeping the "save SAE on ctrl c" functionality which came with that features. As with SAE dictionaries, this is about cleaning up the code and making room for cleaner code. I realise that this regression might make it hard to work with compute that may be revoked mid-job. However, this is not a use case we intend to support in the short - medium term. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check. (not relevant)

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability
