### PR TITLE
Enable autocast for LM activation creation

### DIFF
--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -67,6 +67,7 @@ class LanguageModelSAERunnerConfig:
 
     # Performance - see compilation section of lm_runner.py for info
     autocast: bool = False  # autocast to autocast_dtype during training
+    autocast_lm : bool = False  # autocast lm during activation fetching
     compile_llm: bool = False  # use torch.compile on the LLM
     llm_compilation_mode: str | None = None  # which torch.compile mode to use
     compile_sae: bool = False  # use torch.compile on the SAE
@@ -326,6 +327,7 @@ class CacheActivationsRunnerConfig:
     seed: int = 42
     dtype: str | torch.dtype = "float32"
     prepend_bos: bool = True
+    autocast_lm : bool = False  # autocast lm during activation fetching
 
     # Activation caching stuff
     shuffle_every_n_buffers: int = 10

--- a/sae_lens/training/config.py
+++ b/sae_lens/training/config.py
@@ -67,7 +67,7 @@ class LanguageModelSAERunnerConfig:
 
     # Performance - see compilation section of lm_runner.py for info
     autocast: bool = False  # autocast to autocast_dtype during training
-    autocast_lm : bool = False  # autocast lm during activation fetching
+    autocast_lm: bool = False  # autocast lm during activation fetching
     compile_llm: bool = False  # use torch.compile on the LLM
     llm_compilation_mode: str | None = None  # which torch.compile mode to use
     compile_sae: bool = False  # use torch.compile on the SAE
@@ -327,7 +327,7 @@ class CacheActivationsRunnerConfig:
     seed: int = 42
     dtype: str | torch.dtype = "float32"
     prepend_bos: bool = True
-    autocast_lm : bool = False  # autocast lm during activation fetching
+    autocast_lm: bool = False  # autocast lm during activation fetching
 
     # Activation caching stuff
     shuffle_every_n_buffers: int = 10

--- a/scripts/test-autocast-lm.py
+++ b/scripts/test-autocast-lm.py
@@ -18,7 +18,7 @@ else:
 print("Using device:", device)
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
-total_training_steps = 20_000
+total_training_steps = 2000
 batch_size = 4096
 total_training_tokens = total_training_steps * batch_size
 print(f"Total Training Tokens: {total_training_tokens}")
@@ -32,7 +32,7 @@ log_to_wandb = True
 l1_coefficient = 5
 
 for block in [11, 0]:
-    for autocast_lm in [True, False]:
+    for autocast_lm in [False, True]:
         cfg = LanguageModelSAERunnerConfig(
             # Pick a tiny model to make this easier.
             model_name="gpt2",
@@ -81,7 +81,7 @@ for block in [11, 0]:
             adam_beta1=0.9,
             adam_beta2=0.999,
             # Unsure if this is enough
-            n_batches_in_buffer=128,
+            n_batches_in_buffer=64,
             store_batch_size_prompts=16,
             normalize_activations=True,
             # Feature Store
@@ -90,7 +90,7 @@ for block in [11, 0]:
             dead_feature_threshold=1e-4,
             # WANDB
             log_to_wandb=log_to_wandb,
-            wandb_project="gpt-2-sweep-20may24-check-autocast",
+            wandb_project="gpt-2-sweep-20may24-check-autocast-2",
             wandb_log_frequency=50,
             eval_every_n_wandb_logs=10,
             # Misc

--- a/scripts/test-autocast-lm.py
+++ b/scripts/test-autocast-lm.py
@@ -1,0 +1,112 @@
+import os
+import sys
+
+import torch
+
+sys.path.append("..")
+
+from sae_lens.training.config import LanguageModelSAERunnerConfig
+from sae_lens.training.lm_runner import language_model_sae_runner
+
+if torch.cuda.is_available():
+    device = "cuda"
+elif torch.backends.mps.is_available():
+    device = "mps"
+else:
+    device = "cpu"
+
+print("Using device:", device)
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+total_training_steps = 20_000
+batch_size = 4096
+total_training_tokens = total_training_steps * batch_size
+print(f"Total Training Tokens: {total_training_tokens}")
+
+lr_warm_up_steps = 0
+lr_decay_steps = total_training_steps // 5  # 20% of training steps.
+print(f"lr_decay_steps: {lr_decay_steps}")
+l1_warmup_steps = total_training_steps // 20  # 5% of training steps.
+print(f"l1_warmup_steps: {l1_warmup_steps}")
+log_to_wandb = True
+l1_coefficient = 5
+
+for block in [11, 0]:
+    for autocast_lm in [True, False]:
+        cfg = LanguageModelSAERunnerConfig(
+            # Pick a tiny model to make this easier.
+            model_name="gpt2",
+            ## MLP ##
+            hook_point=f"blocks.{block}.hook_mlp_out",
+            hook_point_layer=block,
+            d_in=768,
+            dataset_path="apollo-research/Skylion007-openwebtext-tokenizer-gpt2",
+            streaming=True,
+            context_size=512,
+            is_dataset_tokenized=True,
+            prepend_bos=True,
+            # How big do we want our SAE to be?
+            expansion_factor=64,
+            # Dataset / Activation Store
+            use_cached_activations=False,
+            training_tokens=total_training_tokens,
+            train_batch_size_tokens=4096,
+            # Loss Function
+            ## Reconstruction Coefficient.
+            mse_loss_normalization=None,  # MSE Loss Normalization is not mentioned (so we use stanrd MSE Loss). But not we take an average over the batch.
+            ## Anthropic does not mention using an Lp norm other than L1.
+            l1_coefficient=l1_coefficient,
+            lp_norm=1.0,
+            # Instead, they multiply the L1 loss contribution
+            # from each feature of the activations by the decoder norm of the corresponding feature.
+            scale_sparsity_penalty_by_decoder_norm=True,
+            # Learning Rate
+            lr_scheduler_name="constant",  # we set this independently of warmup and decay steps.
+            l1_warm_up_steps=l1_warmup_steps,
+            lr_warm_up_steps=lr_warm_up_steps,
+            lr_decay_steps=lr_warm_up_steps,
+            ## No ghost grad term.
+            use_ghost_grads=False,
+            # Initialization / Architecture
+            apply_b_dec_to_input=False,
+            # encoder bias zero's. (I'm not sure what it is by default now)
+            # decoder bias zero's.
+            b_dec_init_method="zeros",
+            normalize_sae_decoder=False,
+            decoder_heuristic_init=True,
+            init_encoder_as_decoder_transpose=True,
+            # Optimizer
+            lr=1e-4,
+            ## adam optimizer has no weight decay by default so worry about this.
+            adam_beta1=0.9,
+            adam_beta2=0.999,
+            # Unsure if this is enough
+            n_batches_in_buffer=128,
+            store_batch_size_prompts=16,
+            normalize_activations=True,
+            # Feature Store
+            feature_sampling_window=1000,
+            dead_feature_window=1000,
+            dead_feature_threshold=1e-4,
+            # WANDB
+            log_to_wandb=log_to_wandb,
+            wandb_project="gpt-2-sweep-20may24-check-autocast",
+            wandb_log_frequency=50,
+            eval_every_n_wandb_logs=10,
+            # Misc
+            device=device,
+            seed=42,
+            n_checkpoints=0,
+            checkpoint_path="checkpoints",
+            dtype=torch.float32,
+            eval_batch_size_prompts=2,
+            n_eval_batches=40,
+            autocast=True,
+            autocast_lm=autocast_lm,
+            compile_llm=True,
+            compile_sae=True,
+        )
+
+        language_model_sae_runner(cfg)
+
+        print("=" * 50)


### PR DESCRIPTION
# Description

Torch autocasting can provide a substantial speedup and reduce VRAM consumption for relatively little code complexity. We currently have the option to autocast the SAE but not the LM. Creating activations for SAE training takes up a lot of the training time so adding autocasting to LM activation fetching is a quick win.

This PR enables autocasting of LM activation fetching using a new config option: `autocast_lm`, which is set to False by default buut will caused the LM to be autocast when set to True. This only autocasts activation fetching; evals are left unaffected.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [x] L0: unchanged
- [x] CE Loss: unchanged
- [x] MSE Loss: unchanged
- [] Feature Dashboard Interpretability

This is a throughput improvement: the aim is to maintain existing metrics while accelerating training. This [W&B dashboard](https://wandb.ai/tmcgrath/gpt-2-sweep-20may24-check-autocast-2/workspace) demonstrates that current metrics are maintained but we achieve a  ~17% speedup for GPT-2-S layer 11. This is a best-case for GPT-2-S: gains will diminish when hooking into earlier layers because LM computations make up a smaller portion of the total computation.