### PR TITLE
Fixed typo in Hooked_SAE_Transformer_Demo.ipynb colab badge

### DIFF
--- a/tutorials/Hooked_SAE_Transformer_Demo.ipynb
+++ b/tutorials/Hooked_SAE_Transformer_Demo.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/TransformerLensOrg/TransformerLens/blob/main/demos/HookedSAETransformerDemo.ipynb\">\n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/TransformerLensOrg/TransformerLens/blob/main/demos/Hooked_SAE_Transformer_Demo.ipynb\">\n",
     "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
     "</a>"
    ]


### PR DESCRIPTION

# Description

A minor typo in the href file name was preventing Hooked_SAE_Transformer_Demo.ipynb "Open in Colab" badge from working.


Fixes # (issue) 

Could not find a relevant logged issue. Didn't create one given the minor scope of the typo.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

I have NOT done any of the above given the limited size and scope of the change. If you want me to do so, I can do so and update the PR.

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [ ] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

I have NOT done any of the above given the limited size and scope of the change. If you want me to do so, I can do so and update the PR.

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 

I have NOT done any of the above since I have not implemented a training change.