### PR TITLE
feat: add w_dec_norm folding

### DIFF
--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -424,6 +424,7 @@ class SAE(HookedRootModule):
         self.d_head = None
         self.hook_z_reshaping_mode = False
 
+
 def get_activation_fn(activation_fn: str) -> Callable[[torch.Tensor], torch.Tensor]:
     if activation_fn == "relu":
         return torch.nn.ReLU()

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -255,6 +255,13 @@ class SAE(HookedRootModule):
 
         return sae_out
 
+    @torch.no_grad()
+    def fold_W_dec_norm(self):
+        W_dec_norms = self.W_dec.norm(dim=-1).unsqueeze(1)
+        self.W_dec.data = self.W_dec.data / W_dec_norms
+        self.W_enc.data = self.W_enc.data * W_dec_norms.T
+        self.b_enc.data = self.b_enc.data * W_dec_norms.squeeze()
+
     def save_model(self, path: str, sparsity: Optional[torch.Tensor] = None):
 
         if not os.path.exists(path):
@@ -416,7 +423,6 @@ class SAE(HookedRootModule):
         self.reshape_fn_out = lambda x, d_head: x
         self.d_head = None
         self.hook_z_reshaping_mode = False
-
 
 def get_activation_fn(activation_fn: str) -> Callable[[torch.Tensor], torch.Tensor]:
     if activation_fn == "relu":


### PR DESCRIPTION
# Description

Implements a simple SAE method for folding W_dec norm weights of Anthropic style SAEs into encoder such that W_dec features are unit norm. See Anthropic update here: https://transformer-circuits.pub/2024/april-update/index.html#training-saes

<img width="708" alt="Screenshot 2024-05-29 at 3 24 26 PM" src="https://github.com/jbloomAus/SAELens/assets/69127271/448ca136-35d8-4a27-99c6-8bfbfb436ef6">

I have tested that the feature activations and sae out are as expected. It's possible we should make this the default when loading from pretrained (so that feature activations are conceptually what you expect them to be). I may submit a PR soon which makes this the case. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility
