### PR TITLE
fix: share config defaulting between hf and local loading

### DIFF
--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -345,46 +345,6 @@ class SAE(HookedRootModule):
             force_download=False,
         )
 
-        if "prepend_bos" not in cfg_dict:
-            # default to True for backwards compatibility
-            cfg_dict["prepend_bos"] = True
-
-        if "apply_b_dec_to_input" not in cfg_dict:
-            # default to True for backwards compatibility
-            cfg_dict["apply_b_dec_to_input"] = True
-
-        if "finetuning_scaling_factor" not in cfg_dict:
-            # default to False for backwards compatibility
-            cfg_dict["finetuning_scaling_factor"] = False
-
-        if "sae_lens_training_version" not in cfg_dict:
-            cfg_dict["sae_lens_training_version"] = None
-
-        if "activation_fn" not in cfg_dict:
-            cfg_dict["activation_fn_str"] = "relu"
-
-        if "normalize_activations" not in cfg_dict:
-            cfg_dict["normalize_activations"] = False
-
-        if "scaling_factor" in state_dict:
-            # we were adding it anyway for a period of time but are no longer doing so.
-            # so we should delete it if
-            if torch.allclose(
-                state_dict["scaling_factor"],
-                torch.ones_like(state_dict["scaling_factor"]),
-            ):
-                del state_dict["scaling_factor"]
-                cfg_dict["finetuning_scaling_factor"] = False
-            else:
-                assert cfg_dict[
-                    "finetuning_scaling_factor"
-                ], "Scaling factor is present but finetuning_scaling_factor is False."
-                state_dict["finetuning_scaling_factor"] = state_dict["scaling_factor"]
-                del state_dict["scaling_factor"]
-        else:
-            # it's there and it's not all 1's, we should use it.
-            cfg_dict["finetuning_scaling_factor"] = False
-
         sae = cls(SAEConfig.from_dict(cfg_dict))
         sae.load_state_dict(state_dict)
 

--- a/tests/benchmark/test_eval_all_loadable_saes.py
+++ b/tests/benchmark/test_eval_all_loadable_saes.py
@@ -33,6 +33,19 @@ def all_loadable_saes() -> list[tuple[str, str]]:
 
 
 @pytest.mark.parametrize("release, sae_name", all_loadable_saes())
+def test_loading_pretrained_saes(release: str, sae_name: str):
+    if torch.cuda.is_available():
+        device = "cuda"
+    elif torch.backends.mps.is_available():
+        device = "mps"
+    else:
+        device = "cpu"
+
+    sae, _, _ = SAE.from_pretrained(release, sae_name, device=device)
+    assert isinstance(sae, SAE)
+
+
+@pytest.mark.parametrize("release, sae_name", all_loadable_saes())
 def test_eval_all_loadable_saes(release: str, sae_name: str):
     """This test is currently only passing for a subset of SAEs because we need to
     have the normalization factors on hand to normalize the activations. We should

--- a/tests/unit/training/test_sae_training_runner.py
+++ b/tests/unit/training/test_sae_training_runner.py
@@ -1,0 +1,82 @@
+import os
+from pathlib import Path
+
+import pytest
+from datasets import Dataset
+from transformer_lens import HookedTransformer
+
+from sae_lens.config import LanguageModelSAERunnerConfig
+from sae_lens.sae import SAE
+from sae_lens.sae_training_runner import SAETrainingRunner
+from sae_lens.training.activations_store import ActivationsStore
+from sae_lens.training.sae_trainer import SAETrainer
+from sae_lens.training.training_sae import TrainingSAE
+from tests.unit.helpers import TINYSTORIES_MODEL, build_sae_cfg, load_model_cached
+
+
+@pytest.fixture
+def cfg(tmp_path: Path):
+    cfg = build_sae_cfg(d_in=64, d_sae=128, hook_layer=0, checkpoint_path=str(tmp_path))
+    return cfg
+
+
+@pytest.fixture
+def model():
+    return load_model_cached(TINYSTORIES_MODEL)
+
+
+@pytest.fixture
+def activation_store(model: HookedTransformer, cfg: LanguageModelSAERunnerConfig):
+    return ActivationsStore.from_config(
+        model, cfg, dataset=Dataset.from_list([{"text": "hello world"}] * 2000)
+    )
+
+
+@pytest.fixture
+def training_sae(cfg: LanguageModelSAERunnerConfig):
+    return TrainingSAE.from_dict(cfg.get_training_sae_cfg_dict())
+
+
+@pytest.fixture
+def trainer(
+    cfg: LanguageModelSAERunnerConfig,
+    training_sae: TrainingSAE,
+    model: HookedTransformer,
+    activation_store: ActivationsStore,
+):
+
+    trainer = SAETrainer(
+        model=model,
+        sae=training_sae,
+        activation_store=activation_store,
+        save_checkpoint_fn=lambda *args, **kwargs: None,
+        cfg=cfg,
+    )
+
+    return trainer
+
+
+@pytest.fixture
+def training_runner(
+    cfg: LanguageModelSAERunnerConfig,
+):
+    runner = SAETrainingRunner(cfg)
+    return runner
+
+
+def test_save_checkpoint(training_runner: SAETrainingRunner, trainer: SAETrainer):
+
+    training_runner.save_checkpoint(
+        trainer=trainer,
+        checkpoint_name="test",
+    )
+
+    contents = os.listdir(training_runner.cfg.checkpoint_path + "/test")
+
+    assert "sae_weights.safetensors" in contents
+    assert "sparsity.safetensors" in contents
+    assert "cfg.json" in contents
+
+    sae = SAE.load_from_pretrained(training_runner.cfg.checkpoint_path + "/test")
+
+    assert isinstance(sae, SAE)


### PR DESCRIPTION
# Description

We temporarily had a situation where `SAE.load_from_pretrained` wasn't using the defaulting system we've got for `from_pretrained` (saes on HuggingFace). This refactor just moves the defaults (temporary hack) to a common function).

Fixes #168 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
