### PR TITLE
feat: activation norm scaling factor folding

### DIFF
--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -262,6 +262,12 @@ class SAE(HookedRootModule):
         self.W_enc.data = self.W_enc.data * W_dec_norms.T
         self.b_enc.data = self.b_enc.data * W_dec_norms.squeeze()
 
+    @torch.no_grad()
+    def fold_activation_norm_scaling_factor(
+        self, activation_norm_scaling_factor: float
+    ):
+        self.W_enc.data = self.W_enc.data * activation_norm_scaling_factor
+
     def save_model(self, path: str, sparsity: Optional[torch.Tensor] = None):
 
         if not os.path.exists(path):

--- a/tests/benchmark/test_eval_all_loadable_saes.py
+++ b/tests/benchmark/test_eval_all_loadable_saes.py
@@ -1,13 +1,16 @@
 # import pandas as pd
 # import plotly.express as px
+import numpy as np
 import pytest
 import torch
 from tqdm import tqdm
 
-# from sae_lens.training.activations_store import ActivationsStore
+from sae_lens.evals import run_evals
+
 # from sae_lens.training.evals import run_evals
 from sae_lens.sae import SAE
 from sae_lens.toolkit.pretrained_saes_directory import get_pretrained_saes_directory
+from sae_lens.training.activations_store import ActivationsStore
 from tests.unit.helpers import load_model_cached
 
 # from transformer_lens import HookedTransformer
@@ -46,10 +49,45 @@ def test_eval_all_loadable_saes(release: str, sae_name: str):
         device = "cpu"
 
     sae, _, _ = SAE.from_pretrained(release, sae_name, device=device)
+    sae.fold_W_dec_norm()
 
     model = load_model_cached(sae.cfg.model_name)
     model.to(device)
 
+    activation_store = ActivationsStore.from_sae(
+        model=model,
+        sae=sae,
+        streaming=True,
+        # fairly conservative parameters here so can use same for larger
+        # models without running out of memory.
+        store_batch_size_prompts=8,
+        train_batch_size_tokens=4096,
+        n_batches_in_buffer=4,
+        device=device,
+    )
+
+    if sae.cfg.normalize_activations:
+        norm_scaling_factor = activation_store.estimate_norm_scaling_factor(
+            n_batches_for_norm_estimate=100
+        )
+        sae.fold_activation_norm_scaling_factor(norm_scaling_factor)
+        activation_store.normalize_activations = False
+
+    eval_metrics = run_evals(
+        sae=sae,
+        activation_store=activation_store,
+        model=model,
+        n_eval_batches=10,
+        eval_batch_size_prompts=8,
+    )  #
+    eval_metrics = dict(eval_metrics)
+    eval_metrics["ce_loss_diff"] = (
+        eval_metrics["metrics/ce_loss_with_sae"].item()
+        - eval_metrics["metrics/ce_loss_without_sae"].item()
+    )
+    assert eval_metrics["ce_loss_diff"] < 0.1, "CE Loss Difference is too high"
+
+    # CE Loss Difference
     _, cache = model.run_with_cache(
         example_text, names_filter=[sae.cfg.hook_name], prepend_bos=sae.cfg.prepend_bos
     )
@@ -58,16 +96,16 @@ def test_eval_all_loadable_saes(release: str, sae_name: str):
     sae_in = cache[sae.cfg.hook_name].squeeze()[1:]
 
     feature_acts = sae.encode(sae_in)
-    sae_out = sae.decode(feature_acts)
+    # sae_out = sae.decode(feature_acts)
 
     mean_l0 = (feature_acts[1:] > 0).float().sum(-1).detach().cpu().numpy().mean()
     assert mean_l0 < 1000, f"mean L0 norm is too high: {mean_l0}"
 
-    # get the FVE of teh SAE
-    per_token_l2_loss = (sae_out - sae_in).pow(2).sum(dim=-1).squeeze()
-    total_variance = (sae_in - sae_in.mean(0)).pow(2).sum(-1)
-    explained_variance = 1 - per_token_l2_loss / total_variance
+    # # get the FVE of teh SAE
+    # per_token_l2_loss = (sae_out - sae_in).pow(2).sum(dim=-1).squeeze()
+    # total_variance = (sae_in - sae_in.mean(0)).pow(2).sum(-1)
+    # explained_variance = 1 - per_token_l2_loss / total_variance
 
-    assert (
-        explained_variance.mean().item() > 0.7
-    ), f"Explained variance is too low: {explained_variance.mean().item()}"
+    # assert (
+    #     explained_variance.mean().item() > 0.7
+    # ), f"Explained variance is too low: {explained_variance.mean().item()}"

--- a/tests/benchmark/test_eval_all_loadable_saes.py
+++ b/tests/benchmark/test_eval_all_loadable_saes.py
@@ -1,6 +1,6 @@
 # import pandas as pd
 # import plotly.express as px
-import numpy as np
+# import numpy as np
 import pytest
 import torch
 from tqdm import tqdm

--- a/tests/unit/training/test_activations_store.py
+++ b/tests/unit/training/test_activations_store.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 from math import ceil
 
+import numpy as np
 import pytest
 import torch
 from datasets import Dataset, IterableDataset
@@ -255,3 +256,23 @@ def test_activations_store_moves_with_model(ts_model: HookedTransformer):
     activation_store = ActivationsStore.from_config(ts_model.to("cuda:0"), cfg)  # type: ignore
     activations = activation_store.next_batch()
     assert activations.device == torch.device("cuda:0")
+
+
+def test_activations_store_estimate_norm_scaling_factor(
+    cfg: LanguageModelSAERunnerConfig, model: HookedTransformer
+):
+    # --- first, test initialisation ---
+
+    # config if you want to benchmark this:
+    #
+    # cfg.context_size = 1024
+    # cfg.n_batches_in_buffer = 64
+    # cfg.store_batch_size_prompts = 16
+
+    store = ActivationsStore.from_config(model, cfg)
+
+    factor = store.estimate_norm_scaling_factor(n_batches_for_norm_estimate=10)
+    assert isinstance(factor, float)
+
+    scaled_norm = store._storage_buffer.norm(dim=-1).mean() * factor  # type: ignore
+    assert scaled_norm == pytest.approx(np.sqrt(store.d_in), abs=5)


### PR DESCRIPTION
# Description

Sometimes SAEs are trained on normalized activations. We should really be saving these with the norm scaling factor already folded in, but in the meantime I've written a convenience function to fold the scaling factor in and refactored it's calculation so the method belongs to the activation store. 

I think we're working up to a "processing step" in load from pretrained where we basically have this and similar stuff handled by default. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)