### PR TITLE
Fix pip install in HookedSAETransformer Demo

### DIFF
--- a/tutorials/Hooked_SAE_Transformer_Demo.ipynb
+++ b/tutorials/Hooked_SAE_Transformer_Demo.ipynb
@@ -44,7 +44,7 @@
     "    import google.colab\n",
     "    IN_COLAB = True\n",
     "    print(\"Running as a Colab notebook\")\n",
-    "    %pip install git+https://github.com/ckkissane/TransformerLens@hooked-sae-transformer\n",
+    "    %pip install git+https://github.com/jbloomAus/SAELens\n",
     "  \n",
     "except:\n",
     "    IN_COLAB = False\n",
@@ -254,31 +254,21 @@
    "source": [
     "In order to use the key features of HookedSAETransformer, we first need to load in SAEs.\n",
     "\n",
-    "HookedSAE is an SAE class we've implemented to have TransformerLens hooks around the SAE activations. While we will use it out of the box, it is designed to be hackable: you can copy and paste the HookedSAE class into a notebook and completely change the architecture / hook names, and as long as it reconstructs the activations, it should still work.\n",
+    "SAE is a class we've implemented to have TransformerLens hooks around the SAE activations. While we will use it out of the box, it is designed to be hackable: you can copy and paste the SAE class into a notebook and completely change the architecture / hook names, and as long as it reconstructs the activations, it should still work.\n",
     "\n",
-    "You can initialize a HookedSAE with a HookedSAEConfig:\n",
-    "```\n",
-    "cfg = HookedSAEConfig(\n",
-    "    d_sae (int): The size of the dictionary.\n",
-    "    d_in (int): The dimension of the input activations for the SAE\n",
-    "    hook_name (str): The hook name of the activation the SAE was trained on (eg. blocks.0.attn.hook_z)\n",
-    ")\n",
-    "hooked_sae = HookedSAE(cfg)\n",
-    "```\n",
-    "\n",
-    "Note you'll likely have to write some basic conversion code to match configs / state dicts to the HookedSAE when loading in an open sourced SAE (eg from HuggingFace). We'll use our GPT-2 Small [Attention SAEs](https://www.alignmentforum.org/posts/FSTRedtjuHa4Gfdbr/attention-saes-scale-to-gpt-2-small) to demonstrate. For convenience, we'll load in all of our attention SAEs from HuggingFace, convert them to HookedSAEs, and store them in a dictionary that maps each hook_name (str) to the corresponding HookedSAE.\n",
+    "You can initialize a SAE with an SAEConfig, but note you'll likely have to write some basic conversion code to match configs / state dicts to the SAE class when loading in an open sourced SAE (eg from HuggingFace). For convenience, we've developed a `SAE.from_pretrained` to automatically load certain open sourced SAEs. We'll use our GPT-2 Small [Attention SAEs](https://www.alignmentforum.org/posts/FSTRedtjuHa4Gfdbr/attention-saes-scale-to-gpt-2-small) to demonstrate. We'll load in all of our attention SAEs with `SAE.from_pretrained`, and store them in a dictionary that maps each hook_name (str) to the corresponding HookedSAE.\n",
     "\n",
     "<details>\n",
     "\n",
-    "Later we'll show how to add HookedSAEs to the HookedSAETransformer (replacing model activations with their SAE reconstructions). When you add a HookedSAE, HookedSAETransformer just treats this a black box that takes some activation as an input, and outputs a tensor of the same shape. \n",
+    "Later we'll show how to add SAEs to the HookedSAETransformer (replacing model activations with their SAE reconstructions). When you add an SAE, HookedSAETransformer just treats this a black box that takes some activation as an input, and outputs a tensor of the same shape. \n",
     "\n",
-    "With this in mind, the HookedSAE is designed to be simple and hackable. Think of it as a convenient default class that you can copy and edit. As long as it takes a TransformerLens activation as input, and outputs a tensor of the same shape, you should be able to add it to your HookedSAETransformer.\n",
+    "With this in mind, the SAE is designed to be simple and hackable. Think of it as a convenient default class that you can copy and edit. As long as it takes a TransformerLens activation as input, and outputs a tensor of the same shape, you should be able to add it to your HookedSAETransformer.\n",
     "\n",
-    "You probably don't even need to use the HookedSAE class, although it's recommended. The sae can be any pytorch module that takes in some activation at hook_name and outputs a tensor of the same shape. The two assumptions that HookedSAETransformer makes when adding SAEs are:\n",
+    "You probably don't even need to use the SAE class, although it's recommended. The sae can be any pytorch module that takes in some activation at hook_name and outputs a tensor of the same shape. The two assumptions that HookedSAETransformer makes when adding SAEs are:\n",
     "1. The SAE class has a cfg attribute, sae.cfg.hook_name (str), for the activation that the SAE was trained to reconstruct (in TransformerLens notation e.g. 'blocks.0.attn.hook_z')\n",
     "2. The SAE takes that activation as input, and outputs a tensor of the same shape.\n",
     "\n",
-    "The main benefit of HookedSAE is that it's a subclass of HookedRootModule, so we can add hooks to SAE activations. This makes it easy to leverage existing TL functionality like run_with_cache and run_with_hooks with SAEs.\n",
+    "The main benefit of HookedSAE is that it's a subclass of HookedRootModule, so we can add hooks to SAE activations. This makes it easy to leverage existing TransformerLens functionality like run_with_cache and run_with_hooks with SAEs.\n",
     "\n",
     "</details>"
    ]
@@ -317,7 +307,7 @@
    "source": [
     "The key feature of HookedSAETransformer is being able to \"splice in\" SAEs, replacing model activations with their SAE reconstructions. \n",
     "\n",
-    "To run a forward pass with SAEs attached use `model.run_with_saes(tokens, saes=saes)`, where saes is a list of HookedSAEs that you want to add for just this forward pass. These will be reset immediately after the forward pass, returning the model to its original state.\n",
+    "To run a forward pass with SAEs attached use `model.run_with_saes(tokens, saes=saes)`, where saes is a list of SAEs that you want to add for just this forward pass. These will be reset immediately after the forward pass, returning the model to its original state.\n",
     "\n",
     "I expect this to be particularly useful for evaluating SAEs (eg [Gurnee](https://www.alignmentforum.org/posts/rZPiuFxESMxCDHe4B/sae-reconstruction-errors-are-empirically-pathological)), including evaluating how SAE reconstructions affect the models ability to perform certain tasks (eg [Makelov et al.](https://openreview.net/forum?id=MHIX9H8aYF&referrer=%5Bthe%20profile%20of%20Neel%20Nanda%5D(%2Fprofile%3Fid%3D~Neel_Nanda1)))\n",
     "\n",
@@ -325,9 +315,9 @@
     "\n",
     "<details>\n",
     "\n",
-    "Under the hood, TransformerLens already wraps activations with a HookPoint object. HookPoint is a dummy pytorch module that acts as an identity function by default, and is only used to access the activation with PyTorch hooks. When you run_with_saes, HookedSAETransformer temporarily replaces these HookPoints with the given HookedSAEs, which take the activation as input and replace it with the HookedSAE output (the reconstructed activation) during the forward pass. \n",
+    "Under the hood, TransformerLens already wraps activations with a HookPoint object. HookPoint is a dummy pytorch module that acts as an identity function by default, and is only used to access the activation with PyTorch hooks. When you run_with_saes, HookedSAETransformer temporarily replaces these HookPoints with the given SAEs, which take the activation as input and replace it with the SAE output (the reconstructed activation) during the forward pass. \n",
     "\n",
-    "Since HookedSAE is a subclass of HookedRootModule, we also are able to add PyTorch hooks to the corresponding SAE activations, as we'll use later.\n",
+    "Since SAE is a subclass of HookedRootModule, we also are able to add PyTorch hooks to the corresponding SAE activations, as we'll use later.\n",
     "\n",
     "</details>"
    ]
@@ -367,9 +357,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We often want to see what SAE features are active on a given prompt. With HookedSAETransformer, you can cache HookedSAE activations (and all the other standard activations) with `logits, cache = model.run_with_cache_with_saes(tokens, saes=saes)`. Just as `run_with_saes` is a wapper around the standard forward pass, `run_with_cache_with_saes` is a wrapper around `run_with_cache`, and will also only add these saes for one forward pass before returning the model to its original state. \n",
+    "We often want to see what SAE features are active on a given prompt. With HookedSAETransformer, you can cache SAE activations (and all the other standard activations) with `logits, cache = model.run_with_cache_with_saes(tokens, saes=saes)`. Just as `run_with_saes` is a wapper around the standard forward pass, `run_with_cache_with_saes` is a wrapper around `run_with_cache`, and will also only add these saes for one forward pass before returning the model to its original state. \n",
     "\n",
-    "To access SAE activations from the cache, the corresponding hook names will generally be the HookedTransformer hook_name (eg blocks.5.attn.hook_z) + the hookedSAE hooked name preceeded by a period (eg .hook_sae_acts_post).\n",
+    "To access SAE activations from the cache, the corresponding hook names will generally be the HookedTransformer hook_name (eg blocks.5.attn.hook_z) + the SAE hooked name preceeded by a period (eg .hook_sae_acts_post).\n",
     "\n",
     "`run_with_cache_with_saes` makes it easy to explore which SAE features are active across any input. Let's explore the active features at the S2 position for our L5 Attention SAE across all of our IOI prompts:"
    ]
@@ -413,7 +403,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "HookedSAETransformer also allows you to intervene on SAE activations with `model.run_with_hooks_with_saes(tokens, saes=saes, fwd_hooks=fwd_hooks)`. This works exactly like the standard TransformerLens `run_with_hooks`, with the added benefit that we can now intervene on SAE activations from the HookedSAEs that we splice in. Along the same lines as `run_with_saes` and `run_with_cache_with_saes`, this will only temporarily add SAEs before returning the model to it's original state. \n",
+    "HookedSAETransformer also allows you to intervene on SAE activations with `model.run_with_hooks_with_saes(tokens, saes=saes, fwd_hooks=fwd_hooks)`. This works exactly like the standard TransformerLens `run_with_hooks`, with the added benefit that we can now intervene on SAE activations from the SAEs that we splice in. Along the same lines as `run_with_saes` and `run_with_cache_with_saes`, this will only temporarily add SAEs before returning the model to it's original state. \n",
     "\n",
     "I expect this to be useful when doing circuit analysis with SAEs. To demonstrate, let's zero ablate individual layer 5 attention SAE features to localize causally important features."
    ]
@@ -477,9 +467,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "While the `run_with_saes` family of methods are great for evaluating SAEs and exploratory analysis, you may want to permanently attach SAEs to your model. You can attach SAEs to any activation with `model.add_sae(sae)`, where sae is a HookedSAE. \n",
+    "While the `run_with_saes` family of methods are great for evaluating SAEs and exploratory analysis, you may want to permanently attach SAEs to your model. You can attach SAEs to any activation with `model.add_sae(sae)`, where sae is an SAE. \n",
     "\n",
-    "When you add an SAE, it gets stored in `model.acts_to_saes`, a dictionary that maps the activation name to the HookedSAE that is attached. The main benefit of permanently adding SAEs is that we can now just run the model like a normal HookedTransformer (with `forward`, `run_with_cache`, `run_with_hooks`), but some activations will be replaced with the reconstructed activations from the corresponding SAEs.\n",
+    "When you add an SAE, it gets stored in `model.acts_to_saes`, a dictionary that maps the activation name to the SAE that is attached. The main benefit of permanently adding SAEs is that we can now just run the model like a normal HookedTransformer (with `forward`, `run_with_cache`, `run_with_hooks`), but some activations will be replaced with the reconstructed activations from the corresponding SAEs.\n",
     "\n",
     "I expect this to be most useful when you've already identified a good set of SAEs that you want to use for interpretability, and don't feel like passing in a massive list of saes for every forward pass."
    ]
@@ -669,7 +659,7 @@
     "\n",
     "Additionally, we can compare interventions on SAE features to the same intervention on the error term to get a better sense of how much the SAE features have actually captured.\n",
     "\n",
-    "To use error terms with HookedSAEs, you can set `hooked_sae.cfg.use_error_term = True`, or initialize it to True in the config. Note HookedSAEConfig sets this to False by default."
+    "To use error terms with SAEs, you can set `sae.use_error_term = True`. Note this is set to False by default."
    ]
   },
   {


### PR DESCRIPTION
# Description

The current HookedSAETransformer demo is broken in [colab](https://colab.research.google.com/github/jbloomAus/SAELens/blob/main/tutorials/Hooked_SAE_Transformer_Demo.ipynb)

It was pip installing from the old TransformerLens branch rather than SAELens. This PR fixes that, and also updates some of the language in the demo to match SAELens (eg HookedSAE -> SAE).

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [ ] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 