### PR TITLE
Use latest versions for packages in colab tutorials

### DIFF
--- a/tutorials/basic_loading_and_analysing.ipynb
+++ b/tutorials/basic_loading_and_analysing.ipynb
@@ -30,7 +30,7 @@
         "    import google.colab # type: ignore\n",
         "    from google.colab import output\n",
         "    COLAB = True\n",
-        "    %pip install sae-lens==1.3.0 transformer-lens==1.17.0\n",
+        "    %pip install sae-lens transformer-lens\n",
         "except:\n",
         "    COLAB = False\n",
         "    from IPython import get_ipython # type: ignore\n",

--- a/tutorials/logits_lens_with_features.ipynb
+++ b/tutorials/logits_lens_with_features.ipynb
@@ -53,7 +53,7 @@
         "    # For Google Colab, a high RAM instance is needed\n",
         "    import google.colab # type: ignore\n",
         "    from google.colab import output\n",
-        "    %pip install sae-lens==1.3.0 transformer-lens==1.17.0\n",
+        "    %pip install sae-lens transformer-lens\n",
         "except:\n",
         "    from IPython import get_ipython # type: ignore\n",
         "    ipython = get_ipython(); assert ipython is not None\n",

--- a/tutorials/training_a_sparse_autoencoder.ipynb
+++ b/tutorials/training_a_sparse_autoencoder.ipynb
@@ -31,7 +31,7 @@
         "try:\n",
         "    import google.colab # type: ignore\n",
         "    from google.colab import output\n",
-        "    %pip install sae-lens==1.3.0 transformer-lens==1.17.0 circuitsvis==1.43.2\n",
+        "    %pip install sae-lens transformer-lens circuitsvis\n",
         "except:\n",
         "    from IPython import get_ipython # type: ignore\n",
         "    ipython = get_ipython(); assert ipython is not None\n",


### PR DESCRIPTION
# Description

The package versions were fixed to a specific version in the colab notebooks. This was giving users an import error due to recent version changes. I have removed the fixed version so that it now uses the latest version of each package.

I have run a fresh notebook in colab for basic_loading_and_analysing.ipynb with the change and there is no longer an import error.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
