### PR TITLE
feat:  updating training docs and standardizing pretokenize runner arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please refer to the [documentation](https://jbloomaus.github.io/SAELens/) for in
 
 SAE Lens is the result of many contributors working collectively to improve humanities understanding of neural networks, many of whom are motivated by a desire to [safeguard humanity from risks posed by artificial intelligence](https://80000hours.org/problem-profiles/artificial-intelligence/).
 
-This library is maintained by [Joseph Bloom](https://www.jbloomaus.com/) and [David Channin](https://github.com/chanind).
+This library is maintained by [Joseph Bloom](https://www.jbloomaus.com/) and [David Chanin](https://github.com/chanind).
 
 ## Tutorials
 

--- a/docs/training_saes.md
+++ b/docs/training_saes.md
@@ -1,8 +1,176 @@
 # Training Sparse Autoencoders
 
-Methods development for training SAEs is rapidly evolving, so we're not attempting to maintain detailed up to date documentation.
+Methods development for training SAEs is rapidly evolving, so these docs may change frequently. For all available training options, see [LanguageModelSAERunnerConfig][sae_lens.LanguageModelSAERunnerConfig].
 
-However, are attempting to maintain this [tutorial](tutorials/training_a_sparse_autoencoder.ipynb)
+However, we are attempting to maintain this [tutorial](https://github.com/jbloomAus/SAELens/blob/main/tutorials/training_a_sparse_autoencoder.ipynb)
  [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://githubtocolab.com/jbloomAus/SAELens/blob/main/tutorials/training_a_sparse_autoencoder.ipynb).
 
  We encourage readers to join the [Open Source Mechanistic Interpretability Slack](https://join.slack.com/t/opensourcemechanistic/shared_invite/zt-1qosyh8g3-9bF3gamhLNJiqCL_QqLFrA) for support!
+
+## Basic training setup
+
+ Training a SAE is done using the [SAETrainingRunner][sae_lens.SAETrainingRunner] class. This class is configured using a [LanguageModelSAERunnerConfig][sae_lens.LanguageModelSAERunnerConfig], and has a single method, [run()][sae_lens.SAETrainingRunner.run], which performs training.
+
+ Some of the core config options are below:
+
+ - `model_name`: The base model name to train a SAE on. This must correspond to a [model from TransformerLens](https://neelnanda-io.github.io/TransformerLens/generated/model_properties_table.html).
+ - `hook_name`: This is a TransformerLens hook in the model where our SAE will be trained from. More info on hooks can be found [here](https://neelnanda-io.github.io/TransformerLens/generated/demos/Main_Demo.html#Hook-Points).
+ - `dataset_path`: The path to a dataset on Huggingface for training.
+ - `hook_layer`: This is an int which corresponds to the layer specified in `hook_name`. This must match! e.g. if `hook_name` is `"blocks.3.hook_mlp_out"`, then `layer` must be `3`.
+ - `d_in`: The input size of the SAE. This must match the size of the hook in the model where the SAE is trained.
+ - `expansion_factor`: The hidden layer of the SAE will have size `expansion_factor * d_in`.
+ - `l1_coefficient`: This controls how much sparsity the SAE will have after training.
+ - `training_tokens`: The total tokens used for training.
+ - `train_batch_size_tokens`: The batch size used for training. Adjust this to keep the GPU saturated.
+
+A sample training run from the [tutorial](https://github.com/jbloomAus/SAELens/blob/main/tutorials/training_a_sparse_autoencoder.ipynb) is shown below:
+
+```python
+total_training_steps = 30_000
+batch_size = 4096
+total_training_tokens = total_training_steps * batch_size
+
+lr_warm_up_steps = 0
+lr_decay_steps = total_training_steps // 5  # 20% of training
+l1_warm_up_steps = total_training_steps // 20  # 5% of training
+
+cfg = LanguageModelSAERunnerConfig(
+    # Data Generating Function (Model + Training Distibuion)
+    model_name="tiny-stories-1L-21M",  # our model (more options here: https://neelnanda-io.github.io/TransformerLens/generated/model_properties_table.html)
+    hook_name="blocks.0.hook_mlp_out",  # A valid hook point (see more details here: https://neelnanda-io.github.io/TransformerLens/generated/demos/Main_Demo.html#Hook-Points)
+    hook_layer=0,  # Only one layer in the model.
+    d_in=1024,  # the width of the mlp output.
+    dataset_path="apollo-research/roneneldan-TinyStories-tokenizer-gpt2",  # this is a tokenized language dataset on Huggingface for the Tiny Stories corpus.
+    is_dataset_tokenized=True,
+    streaming=True,  # we could pre-download the token dataset if it was small.
+    # SAE Parameters
+    mse_loss_normalization=None,  # We won't normalize the mse loss,
+    expansion_factor=16,  # the width of the SAE. Larger will result in better stats but slower training.
+    b_dec_init_method="zeros",  # The geometric median can be used to initialize the decoder weights.
+    apply_b_dec_to_input=False,  # We won't apply the decoder weights to the input.
+    normalize_sae_decoder=False,
+    scale_sparsity_penalty_by_decoder_norm=True,
+    decoder_heuristic_init=True,
+    init_encoder_as_decoder_transpose=True,
+    normalize_activations=True,
+    # Training Parameters
+    lr=5e-5,
+    adam_beta1=0.9,  # adam params (default, but once upon a time we experimented with these.)
+    adam_beta2=0.999,
+    lr_scheduler_name="constant",  # constant learning rate with warmup.
+    lr_warm_up_steps=lr_warm_up_steps,  # this can help avoid too many dead features initially.
+    lr_decay_steps=lr_decay_steps,  # this will help us avoid overfitting.
+    l1_coefficient=5,  # will control how sparse the feature activations are
+    l1_warm_up_steps=l1_warm_up_steps,  # this can help avoid too many dead features initially.
+    lp_norm=1.0,  # the L1 penalty (and not a Lp for p < 1)
+    train_batch_size_tokens=batch_size,
+    context_size=256,  # will control the lenght of the prompts we feed to the model. Larger is better but slower. so for the tutorial we'll use a short one.
+    # Activation Store Parameters
+    n_batches_in_buffer=64,  # controls how many activations we store / shuffle.
+    training_tokens=total_training_tokens,  # 100 million tokens is quite a few, but we want to see good stats. Get a coffee, come back.
+    store_batch_size_prompts=16,
+    # Resampling protocol
+    use_ghost_grads=False,  # we don't use ghost grads anymore.
+    feature_sampling_window=1000,  # this controls our reporting of feature sparsity stats
+    dead_feature_window=1000,  # would effect resampling or ghost grads if we were using it.
+    dead_feature_threshold=1e-4,  # would effect resampling or ghost grads if we were using it.
+    # WANDB
+    log_to_wandb=True,  # always use wandb unless you are just testing code.
+    wandb_project="sae_lens_tutorial",
+    wandb_log_frequency=30,
+    eval_every_n_wandb_logs=20,
+    # Misc
+    device=device,
+    seed=42,
+    n_checkpoints=0,
+    checkpoint_path="checkpoints",
+    dtype="float32"
+)
+sparse_autoencoder = SAETrainingRunner(cfg).run()
+```
+
+As you can see, the training setup provides a large number of options to explore. The full list of options can be found in the [LanguageModelSAERunnerConfig][sae_lens.LanguageModelSAERunnerConfig] class.
+
+## Logging to Weights and Biases
+
+For any real training run, you should be logging to Weights and Biases (WandB). This will allow you to track your training progress and compare different runs. To enable WandB, set `log_to_wandb=True`. The `wandb_project` parameter in the config controls the project name in WandB. You can also control the logging frequency with `wandb_log_frequency` and `eval_every_n_wandb_logs`.
+
+A number of helpful metrics are logged to WandB, including the sparsity of the SAE, the mean squared error (MSE) of the SAE, dead features, and explained variance. These metrics can be used to monitor the training progress and adjust the training parameters. Below is a screenshot from one training run. 
+
+![screenshot](dashboard_screenshot.png)
+
+
+## Checkpoints
+
+Checkpoints allow you to save a snapshot of the SAE and sparsitity statistics during training. To enable checkpointing, set `n_checkpoints` to a value larger than 0. If WandB logging is enabled, checkpoints will be uploaded as WandB artifacts. To save checkpoints locally, the `checkpoint_path` parameter can be set to a local directory.
+
+
+## Optimizers and Schedulers
+
+The SAE training runner uses the Adam optimizer with a constant learning rate by default. The optimizer betas can be controlled with the settings `adam_beta1` and `adam_beta2`.
+
+The learning rate scheduler can be controlled with the `lr_scheduler_name` parameter. The available schedulers are: `constant` (default), `consineannealing`, and `cosineannealingwarmrestarts`. All schedulers can be used with linear warmup and linear decay, set via `lr_warm_up_steps` and `lr_decay_steps`.
+
+To avoid dead features, it's often helpful to slowly increase the L1 penalty. This can be done by setting `l1_warm_up_steps` to a value larger than 0. This will linearly increase the L1 penalty over the first `l1_warm_up_steps` training steps.
+
+
+## Datasets, streaming, and context size
+
+SAELens works with datasets hosted on Huggingface. However, these datsets are often very large and take a long time and a lot of disk space to download. To speed this up, you can set `streaming=True` in the config. This will stream the dataset from Huggingface during training, which will allow training to start immediately and save disk space.
+
+The `context_size` parameter controls the length of the prompts fed to the model. Larger context sizes will result in better SAE performance, but will also slow down training. Each training batch will be tokens of size `train_batch_size_tokens x context_size`.
+
+It's also possible to use pre-tokenized datasets to speed up training, since tokenization can be a bottleneck. To use a pre-tokenized dataset on Huggingface, update the `dataset_path` parameter and set `is_dataset_tokenized=True` in the config.
+
+## Pretokenizing datasets
+
+We also provider a runner, [PretokenizeRunner][sae_lens.PretokenizeRunner], which can be used to pre-tokenize a dataset and upload it to Huggingface. See [PretokenizeRunnerConfig][sae_lens.PretokenizeRunnerConfig] for all available options. We also provide a [pretokenizing datasets tutorial](https://github.com/jbloomAus/SAELens/blob/main/tutorials/pretokenizing_datasets.ipynb) with more details.
+
+A sample run from the tutorial for GPT2 and the NeelNanda/c4-10k dataset is shown below.
+
+```python
+from sae_lens import PretokenizeRunner, PretokenizeRunnerConfig
+
+cfg = PretokenizeRunnerConfig(
+    tokenizer_name="gpt2",
+    dataset_path="NeelNanda/c4-10k", # this is just a tiny test dataset
+    shuffle=True,
+    num_proc=4, # increase this number depending on how many CPUs you have
+
+    # tweak these settings depending on the model
+    context_size=128,
+    begin_batch_token="bos",
+    begin_sequence_token=None,
+    sequence_separator_token="eos",
+
+    # uncomment to upload to huggingface
+    # hf_repo_id="your-username/c4-10k-tokenized-gpt2"
+
+    # uncomment to save the dataset locally
+    # save_path="./c4-10k-tokenized-gpt2"
+)
+
+dataset = PretokenizeRunner(cfg).run()
+```
+
+## Caching activations
+
+The next step in improving performance beyond pre-tokenizing datasets is to cache model activations. This allows you to pre-calculate all the training activations for your SAE in advance so the model does not need to be run during training to generate activations. This allows rapid training of SAEs and is especially helpful for experimenting with training hyperparameters. However, pre-calculating activations can take a very large amount of disk space, so it may not always be possible.
+
+SAELens provides a [CacheActivationsRunner][sae_lens.CacheActivationsRunner] class to help with pre-calculating activations. See [CacheActivationsRunnerConfig][sae_lens.CacheActivationsRunnerConfig] for all available options. This runner intentionally shares a lot of options with [LanguageModelSAERunnerConfig][sae_lens.LanguageModelSAERunnerConfig]. These options should be set identically when using the cached activations in training. The CacheActivationsRunner can be used as below:
+
+```python
+from sae_lens import CacheActivationsRunner, CacheActivationsRunnerConfig
+
+cfg = CacheActivationsRunnerConfig(
+    model_name="tiny-stories-1L-21M",
+    hook_name="blocks.0.hook_mlp_out",
+    dataset_path="apollo-research/roneneldan-TinyStories-tokenizer-gpt2",
+    # ... 
+    new_cached_activations_path="./tiny-stories-1L-21M-cache"
+)
+
+CacheActivationsRunner(cfg).run()
+```
+
+To use the cached activations during training, set `use_cached_activations=True` and `cached_activations_path` to match the `new_cached_activations_path` above option in training configuration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ pytest-cov = "^4.1.0"
 pre-commit = "^3.6.2"
 flake8 = "7.0.0"
 isort = "5.13.2"
-pyright = "^1.1.351"
+pyright = "1.1.365"
 mamba-lens = "^0.0.4"
 ansible-lint = { version = "^24.2.3", markers = "platform_system != 'Windows'" }
 botocore = "^1.34.101"
@@ -69,6 +69,7 @@ reportUnnecessaryComparison = "none"
 reportConstantRedefinition = "none"
 reportUnknownLambdaType = "none"
 reportPrivateUsage = "none"
+reportDeprecated = "none"
 
 
 [build-system]

--- a/sae_lens/__init__.py
+++ b/sae_lens/__init__.py
@@ -9,7 +9,7 @@ from .config import (
     PretokenizeRunnerConfig,
 )
 from .evals import run_evals
-from .pretokenize_runner import pretokenize_runner
+from .pretokenize_runner import PretokenizeRunner, pretokenize_runner
 from .sae import SAE, SAEConfig
 from .sae_training_runner import SAETrainingRunner
 from .training.activations_store import ActivationsStore
@@ -27,6 +27,7 @@ __all__ = [
     "CacheActivationsRunnerConfig",
     "CacheActivationsRunner",
     "PretokenizeRunnerConfig",
+    "PretokenizeRunner",
     "pretokenize_runner",
     "run_evals",
 ]

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -93,7 +93,9 @@ class SAEConfig:
 
 
 class SAE(HookedRootModule):
-    """ """
+    """
+    Core Sparse Autoencoder (SAE) class used for inference. For training, see `TrainingSAE`.
+    """
 
     cfg: SAEConfig
     dtype: torch.dtype
@@ -225,6 +227,9 @@ class SAE(HookedRootModule):
     def encode(
         self, x: Float[torch.Tensor, "... d_in"]
     ) -> Float[torch.Tensor, "... d_sae"]:
+        """
+        Calcuate SAE features from inputs
+        """
 
         # move x to correct dtype
         x = x.to(self.dtype)

--- a/sae_lens/sae_training_runner.py
+++ b/sae_lens/sae_training_runner.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 import torch
 import wandb
 from safetensors.torch import save_file
+from transformer_lens.hook_points import HookedRootModule
 
 from sae_lens.config import LanguageModelSAERunnerConfig
 from sae_lens.load_model import load_model
@@ -25,9 +26,12 @@ def interrupt_callback(sig_num: Any, stack_frame: Any):
 
 
 class SAETrainingRunner:
+    """
+    Class to run the training of a Sparse Autoencoder (SAE) on a TransformerLens model.
+    """
 
     cfg: LanguageModelSAERunnerConfig
-    model: torch.nn.Module
+    model: HookedRootModule
     sae: TrainingSAE
     activations_store: ActivationsStore
 
@@ -48,7 +52,7 @@ class SAETrainingRunner:
 
         if self.cfg.from_pretrained_path is not None:
             self.sae = TrainingSAE.load_from_pretrained(
-                self.cfg.from_pretrained_path, self.cfg.device  # type: ignore
+                self.cfg.from_pretrained_path, self.cfg.device
             )
         else:
             self.sae = TrainingSAE(
@@ -59,7 +63,9 @@ class SAETrainingRunner:
             self._init_sae_group_b_decs()
 
     def run(self):
-        """ """
+        """
+        Run the training of the SAE.
+        """
 
         if self.cfg.log_to_wandb:
             wandb.init(
@@ -70,10 +76,10 @@ class SAETrainingRunner:
             )
 
         trainer = SAETrainer(
-            model=self.model,  # type: ignore
-            sae=self.sae,  # type: ignore
+            model=self.model,
+            sae=self.sae,
             activation_store=self.activations_store,
-            save_checkpoint_fn=self.save_checkpoint,  # type: ignore
+            save_checkpoint_fn=self.save_checkpoint,
             cfg=self.cfg,
         )
 
@@ -154,7 +160,7 @@ class SAETrainingRunner:
 
     def save_checkpoint(
         self,
-        trainer,  # type: ignore
+        trainer: SAETrainer,
         checkpoint_name: int | str,
         wandb_aliases: list[str] | None = None,
     ) -> str:

--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -44,6 +44,9 @@ class TrainSAEOutput:
 
 
 class SAETrainer:
+    """
+    Core SAE class used for inference. For training, see TrainingSAE.
+    """
 
     def __init__(
         self,
@@ -95,8 +98,8 @@ class SAETrainer:
             sae.parameters(),
             lr=cfg.lr,
             betas=(
-                cfg.adam_beta1,  # type: ignore
-                cfg.adam_beta2,  # type: ignore
+                cfg.adam_beta1,
+                cfg.adam_beta2,
             ),
         )
         assert cfg.lr_end is not None  # this is set in config post-init

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -124,8 +124,12 @@ class TrainingSAEConfig(SAEConfig):
 
 
 class TrainingSAE(SAE):
+    """
+    A SAE used for training. This class provides a `training_forward_pass` method which calculates
+    losses used for training.
+    """
 
-    cfg: TrainingSAEConfig  # type: ignore
+    cfg: TrainingSAEConfig
     use_error_term: bool
     dtype: torch.dtype
     device: torch.device
@@ -152,6 +156,9 @@ class TrainingSAE(SAE):
     def encode(
         self, x: Float[torch.Tensor, "... d_in"]
     ) -> Float[torch.Tensor, "... d_sae"]:
+        """
+        Calcuate SAE features from inputs
+        """
         feature_acts, _ = self.encode_with_hidden_pre(x)
         return feature_acts
 
@@ -192,7 +199,7 @@ class TrainingSAE(SAE):
         sae_in: torch.Tensor,
         current_l1_coefficient: float,
         dead_neuron_mask: Optional[torch.Tensor] = None,
-    ) -> TrainStepOutput:  # type: ignore
+    ) -> TrainStepOutput:
 
         # do a forward pass to get SAE out, but we also need the
         # hidden pre.
@@ -305,7 +312,7 @@ class TrainingSAE(SAE):
             return standard_mse_loss_fn
 
     @classmethod
-    def load_from_pretrained(  # type: ignore
+    def load_from_pretrained(
         cls,
         path: str,
         device: str = "cpu",

--- a/tutorials/pretokenizing_datasets.ipynb
+++ b/tutorials/pretokenizing_datasets.ipynb
@@ -48,7 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sae_lens import pretokenize_runner, PretokenizeRunnerConfig\n",
+    "from sae_lens import PretokenizeRunner, PretokenizeRunnerConfig\n",
     "\n",
     "cfg = PretokenizeRunnerConfig(\n",
     "    tokenizer_name=\"gpt2\",\n",
@@ -69,7 +69,7 @@
     "    # save_path=\"./c4-10k-tokenized-gpt2\"\n",
     ")\n",
     "\n",
-    "dataset = pretokenize_runner(cfg)"
+    "dataset = PretokenizeRunner(cfg).run()"
    ]
   },
   {
@@ -121,7 +121,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Description

This PR fills out more of the training docs, including basic docs on the following topics:
- basic training setup
- logging to WandB
- checkpoints
- optimizers / schedulers
- dataset streaming / context size
- pretokenizing datasets
- activation caching

As part of this, this PR also standardizes and documents the pretokenization runner with as a class called `PretokenizeRunner`, and deprecated the previous `pretokenize_runner()` function. This commit is thus labeled a `feat` due to this new class.

A screenshot of the SAE training docs page is shown below:

![localhost_8000_training_saes_](https://github.com/jbloomAus/SAELens/assets/200725/d5467b59-315a-4533-bcf9-13a5dd54b3a0)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)