### PR TITLE
add expected perf for pretrained

### DIFF
--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -6,30 +6,56 @@ SAE_LOOKUP:
     saes:
       - id: "blocks.0.hook_resid_pre"
         path: "blocks.0.hook_resid_pre"
+        variance_explained: 0.999
+        l0: 10.0
       - id: "blocks.1.hook_resid_pre"
         path: "blocks.1.hook_resid_pre"
+        variance_explained: 0.999
+        l0: 10.0
       - id: "blocks.2.hook_resid_pre"
         path: "blocks.2.hook_resid_pre"
+        variance_explained: 0.999
+        l0: 18.0
       - id: "blocks.3.hook_resid_pre"
         path: "blocks.3.hook_resid_pre"
+        variance_explained: 0.999
+        l0: 23.0
       - id: "blocks.4.hook_resid_pre"
         path: "blocks.4.hook_resid_pre"
+        variance_explained: 0.900
+        l0: 31.0
       - id: "blocks.5.hook_resid_pre"
         path: "blocks.5.hook_resid_pre"
+        variance_explained: 0.900
+        l0: 41.0
       - id: "blocks.6.hook_resid_pre"
         path: "blocks.6.hook_resid_pre"
+        variance_explained: 0.900
+        l0: 51.0
       - id: "blocks.7.hook_resid_pre"
         path: "blocks.7.hook_resid_pre"
+        variance_explained: 0.900
+        l0: 54.0
       - id: "blocks.8.hook_resid_pre"
         path: "blocks.8.hook_resid_pre"
+        variance_explained: 0.900
+        l0: 60.0
       - id: "blocks.9.hook_resid_pre"
         path: "blocks.9.hook_resid_pre"
+        variance_explained: 0.77
+        l0: 70.0
       - id: "blocks.10.hook_resid_pre"
         path: "blocks.10.hook_resid_pre"
+        variance_explained: 0.77
+        l0: 52.0
       - id: "blocks.11.hook_resid_pre"
         path: "blocks.11.hook_resid_pre"
+        variance_explained: 0.77
+        l0: 56.0
       - id: "blocks.11.hook_resid_post"
         path: "blocks.11.hook_resid_post"
+        variance_explained: 0.77
+        l0: 70.0
   gpt2-small-hook-z-kk:
     repo_id: "ckkissane/attn-saes-gpt2-small-all-layers"
     model: "gpt2-small"
@@ -37,28 +63,52 @@ SAE_LOOKUP:
     saes:
       - id: "blocks.0.hook_z"
         path: "gpt2-small_L0_Hcat_z_lr1.20e-03_l11.80e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt"
+        variance_explained: 0.13
+        l0: 3.0
       - id: "blocks.1.hook_z"
         path: "gpt2-small_L1_Hcat_z_lr1.20e-03_l18.00e-01_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v5.pt"
+        variance_explained: 0.42
+        l0: 23.0
       - id: "blocks.2.hook_z"
         path: "gpt2-small_L2_Hcat_z_lr1.20e-03_l11.00e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v4.pt"
+        variance_explained: 0.40
+        l0: 16.0
       - id: "blocks.3.hook_z"
         path: "gpt2-small_L3_Hcat_z_lr1.20e-03_l19.00e-01_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt"
+        variance_explained: 0.43
+        l0: 15.0
       - id: "blocks.4.hook_z"
         path: "gpt2-small_L4_Hcat_z_lr1.20e-03_l11.10e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v7.pt"
+        variance_explained: 0.27
+        l0: 14.0
       - id: "blocks.5.hook_z"
         path: "gpt2-small_L5_Hcat_z_lr1.20e-03_l11.00e+00_ds49152_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt"
+        variance_explained: 0.13
+        l0: 17.0
       - id: "blocks.6.hook_z"
         path: "gpt2-small_L6_Hcat_z_lr1.20e-03_l11.10e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt"
+        variance_explained: 0.0
+        l0: 17.0
       - id: "blocks.7.hook_z"
         path: "gpt2-small_L7_Hcat_z_lr1.20e-03_l11.10e+00_ds49152_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt"
+        variance_explained: -7.55
+        l0: 19.0
       - id: "blocks.8.hook_z"
         path: "gpt2-small_L8_Hcat_z_lr1.20e-03_l11.30e+00_ds24576_bs4096_dc1.00e-05_rsanthropic_rie25000_nr4_v6.pt"
+        variance_explained: -0.22
+        l0: 23.0
       - id: "blocks.9.hook_z"
         path: "gpt2-small_L9_Hcat_z_lr1.20e-03_l11.20e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt"
+        variance_explained: -0.54
+        l0: 23.0
       - id: "blocks.10.hook_z"
         path: "gpt2-small_L10_Hcat_z_lr1.20e-03_l11.30e+00_ds24576_bs4096_dc1.00e-05_rsanthropic_rie25000_nr4_v9.pt"
+        variance_explained: -0.27
+        l0: 14.0
       - id: "blocks.11.hook_z"
         path: "gpt2-small_L11_Hcat_z_lr1.20e-03_l13.00e+00_ds24576_bs4096_dc3.16e-06_rsanthropic_rie25000_nr4_v9.pt"
+        variance_explained: -0.7
+        l0: 9.4
   gpt2-small-mlp-tm:
     repo_id: "tommmcgrath/gpt2-small-mlp-out-saes"
     model: "gpt2-small"
@@ -66,28 +116,52 @@ SAE_LOOKUP:
     saes:
       - id: "blocks.0.hook_mlp_out"
         path: "sae_group_gpt2_blocks.0.hook_mlp_out_24576:v1"
+        variance_explained: 0.999
+        l0: 15.0
       - id: "blocks.1.hook_mlp_out"
         path: "sae_group_gpt2_blocks.1.hook_mlp_out_24576:v0"
+        variance_explained: -0.20
+        l0: 21.0
       - id: "blocks.2.hook_mlp_out"
         path: "sae_group_gpt2_blocks.2.hook_mlp_out_24576:v0"
+        variance_explained: 0.55
+        l0: 137.0
       - id: "blocks.3.hook_mlp_out"
         path: "sae_group_gpt2_blocks.3.hook_mlp_out_24576:v0"
+        variance_explained: 0.41
+        l0: 54.0
       - id: "blocks.4.hook_mlp_out"
         path: "sae_group_gpt2_blocks.4.hook_mlp_out_24576:v0"
+        variance_explained: 0.44
+        l0: 74.0
       - id: "blocks.5.hook_mlp_out"
         path: "sae_group_gpt2_blocks.5.hook_mlp_out_24576:v0"
+        variance_explained: 0.52
+        l0: 76.0
       - id: "blocks.6.hook_mlp_out"
         path: "sae_group_gpt2_blocks.6.hook_mlp_out_24576:v0"
+        variance_explained: 0.508
+        l0: 40.0
       - id: "blocks.7.hook_mlp_out"
         path: "sae_group_gpt2_blocks.7.hook_mlp_out_24576:v0"
+        variance_explained: 0.53
+        l0: 52.0
       - id: "blocks.8.hook_mlp_out"
         path: "sae_group_gpt2_blocks.8.hook_mlp_out_24576:v1"
+        variance_explained: 0.46
+        l0: 36.0
       - id: "blocks.9.hook_mlp_out"
         path: "sae_group_gpt2_blocks.9.hook_mlp_out_24576:v0"
+        variance_explained: 0.37
+        l0: 49.0
       - id: "blocks.10.hook_mlp_out"
         path: "sae_group_gpt2_blocks.10.hook_mlp_out_24576:v0"
+        variance_explained: -0.44
+        l0: 167.0
       - id: "blocks.11.hook_mlp_out"
         path: "sae_group_gpt2_blocks.11.hook_mlp_out_24576:v2"
+        variance_explained: 0.05
+        l0: 170.0
   gemma-2b-res-jb:
     repo_id: "jbloom/Gemma-2b-Residual-Stream-SAEs"
     model: "gemma-2b"
@@ -95,7 +169,13 @@ SAE_LOOKUP:
     saes:
       - id: "blocks.0.hook_resid_post"
         path: "gemma_2b_blocks.0.hook_resid_post_16384_anthropic"
+        variance_explained: 0.999
+        l0: 47.0
       - id: "blocks.6.hook_resid_post"
         path: "gemma_2b_blocks.6.hook_resid_post_16384_anthropic_fast_lr"
+        variance_explained: 0.71
+        l0: 56.0
       - id: "blocks.12.hook_resid_post"
         path: "gemma_2b_blocks.12.hook_resid_post_16384"
+        variance_explained: -3.6
+        l0: 62.0

--- a/sae_lens/toolkit/pretrained_saes_directory.py
+++ b/sae_lens/toolkit/pretrained_saes_directory.py
@@ -12,6 +12,8 @@ class PretrainedSAELookup:
     model: str
     conversion_func: str | None
     saes_map: dict[str, str]  # id -> path
+    expected_var_explained: dict[str, float]
+    expected_l0: dict[str, float]
 
 
 @cache
@@ -24,13 +26,21 @@ def get_pretrained_saes_directory() -> dict[str, PretrainedSAELookup]:
         data = yaml.safe_load(file)
         for release, value in data["SAE_LOOKUP"].items():
             saes_map: dict[str, str] = {}
+            var_explained_map: dict[str, float] = {}
+            l0_map: dict[str, float] = {}
             for hook_info in value["saes"]:
                 saes_map[hook_info["id"]] = hook_info["path"]
+                var_explained_map[hook_info["id"]] = hook_info.get(
+                    "variance_explained", 1.00
+                )
+                l0_map[hook_info["id"]] = hook_info.get("l0", 0.00)
             directory[release] = PretrainedSAELookup(
                 release=release,
                 repo_id=value["repo_id"],
                 model=value["model"],
                 conversion_func=value.get("conversion_func"),
                 saes_map=saes_map,
+                expected_var_explained=var_explained_map,
+                expected_l0=l0_map,
             )
     return directory

--- a/tests/benchmark/test_eval_all_loadable_saes.py
+++ b/tests/benchmark/test_eval_all_loadable_saes.py
@@ -5,16 +5,18 @@ import pytest
 import torch
 from tqdm import tqdm
 
-from sae_lens.evals import run_evals
-
 # from sae_lens.training.evals import run_evals
 from sae_lens.sae import SAE
 from sae_lens.toolkit.pretrained_saes_directory import get_pretrained_saes_directory
 from sae_lens.training.activations_store import ActivationsStore
 from tests.unit.helpers import load_model_cached
 
+# from sae_lens.evals import run_evals
+
+
 # from transformer_lens import HookedTransformer
 
+torch.set_grad_enabled(False)
 
 example_text = """
 Mr. and Mrs. Dursley, of number four, Privet Drive, were proud to say
@@ -30,13 +32,21 @@ def all_loadable_saes() -> list[tuple[str, str]]:
     saes_directory = get_pretrained_saes_directory()
     for release, lookup in tqdm(saes_directory.items()):
         for sae_name in lookup.saes_map.keys():
-            all_loadable_saes.append((release, sae_name))
+            expected_var_explained = lookup.expected_var_explained[sae_name]
+            expected_l0 = lookup.expected_l0[sae_name]
+            all_loadable_saes.append(
+                (release, sae_name, expected_var_explained, expected_l0)
+            )
 
     return all_loadable_saes
 
 
-@pytest.mark.parametrize("release, sae_name", all_loadable_saes())
-def test_loading_pretrained_saes(release: str, sae_name: str):
+@pytest.mark.parametrize(
+    "release, sae_name, expected_var_explained, expected_l0", all_loadable_saes()
+)
+def test_loading_pretrained_saes(
+    release: str, sae_name: str, expected_var_explained: float, expected_l0: float
+):
     if torch.cuda.is_available():
         device = "cuda"
     elif torch.backends.mps.is_available():
@@ -48,8 +58,12 @@ def test_loading_pretrained_saes(release: str, sae_name: str):
     assert isinstance(sae, SAE)
 
 
-@pytest.mark.parametrize("release, sae_name", all_loadable_saes())
-def test_eval_all_loadable_saes(release: str, sae_name: str):
+@pytest.mark.parametrize(
+    "release, sae_name, expected_var_explained, expected_l0", all_loadable_saes()
+)
+def test_eval_all_loadable_saes(
+    release: str, sae_name: str, expected_var_explained: float, expected_l0: float
+):
     """This test is currently only passing for a subset of SAEs because we need to
     have the normalization factors on hand to normalize the activations. We should
     really fold these into SAEs so this test is easy to do."""
@@ -86,19 +100,20 @@ def test_eval_all_loadable_saes(release: str, sae_name: str):
         sae.fold_activation_norm_scaling_factor(norm_scaling_factor)
         activation_store.normalize_activations = False
 
-    eval_metrics = run_evals(
-        sae=sae,
-        activation_store=activation_store,
-        model=model,
-        n_eval_batches=10,
-        eval_batch_size_prompts=8,
-    )  #
-    eval_metrics = dict(eval_metrics)
-    eval_metrics["ce_loss_diff"] = (
-        eval_metrics["metrics/ce_loss_with_sae"].item()
-        - eval_metrics["metrics/ce_loss_without_sae"].item()
-    )
-    assert eval_metrics["ce_loss_diff"] < 0.1, "CE Loss Difference is too high"
+    metrics = {}
+    # eval_metrics = run_evals(
+    #     sae=sae,
+    #     activation_store=activation_store,
+    #     model=model,
+    #     n_eval_batches=10,
+    #     eval_batch_size_prompts=8,
+    # )  #
+    # eval_metrics = dict(eval_metrics)
+    # eval_metrics["ce_loss_diff"] = (
+    #     eval_metrics["metrics/ce_loss_with_sae"].item()
+    #     - eval_metrics["metrics/ce_loss_without_sae"].item()
+    # )
+    # assert eval_metrics["ce_loss_diff"] < 0.1, "CE Loss Difference is too high"
 
     # CE Loss Difference
     _, cache = model.run_with_cache(
@@ -109,16 +124,24 @@ def test_eval_all_loadable_saes(release: str, sae_name: str):
     sae_in = cache[sae.cfg.hook_name].squeeze()[1:]
 
     feature_acts = sae.encode(sae_in)
-    # sae_out = sae.decode(feature_acts)
+    sae_out = sae.decode(feature_acts)
 
     mean_l0 = (feature_acts[1:] > 0).float().sum(-1).detach().cpu().numpy().mean()
-    assert mean_l0 < 1000, f"mean L0 norm is too high: {mean_l0}"
 
     # # get the FVE of teh SAE
-    # per_token_l2_loss = (sae_out - sae_in).pow(2).sum(dim=-1).squeeze()
-    # total_variance = (sae_in - sae_in.mean(0)).pow(2).sum(-1)
-    # explained_variance = 1 - per_token_l2_loss / total_variance
+    per_token_l2_loss = (sae_out - sae_in).pow(2).sum(dim=-1).squeeze()
+    total_variance = (sae_in - sae_in.mean(0)).pow(2).sum(-1)
+    explained_variance = 1 - per_token_l2_loss / total_variance
 
-    # assert (
-    #     explained_variance.mean().item() > 0.7
-    # ), f"Explained variance is too low: {explained_variance.mean().item()}"
+    metrics["l0"] = mean_l0
+    metrics["var_explained"] = explained_variance.mean().cpu().item()
+
+    assert metrics == {
+        "l0": pytest.approx(expected_l0, abs=5),
+        "var_explained": pytest.approx(expected_var_explained, abs=0.1),
+    }
+
+    # assert mean_l0 == pytest.approx(expected_l0, abs=5)
+    # assert explained_variance.mean().cpu() == pytest.approx(
+    #     expected_var_explained, abs=0.1
+    # )

--- a/tests/unit/toolkit/test_pretrained_saes_directory.py
+++ b/tests/unit/toolkit/test_pretrained_saes_directory.py
@@ -7,7 +7,7 @@ from sae_lens.toolkit.pretrained_saes_directory import (
 def test_get_pretrained_saes_directory():
     sae_directory = get_pretrained_saes_directory()
     assert isinstance(sae_directory, dict)
-    assert sae_directory["gpt2-small-res-jb"] == PretrainedSAELookup(
+    expected_result = PretrainedSAELookup(
         release="gpt2-small-res-jb",
         repo_id="jbloom/GPT2-Small-SAEs-Reformatted",
         model="gpt2-small",
@@ -27,4 +27,36 @@ def test_get_pretrained_saes_directory():
             "blocks.11.hook_resid_pre": "blocks.11.hook_resid_pre",
             "blocks.11.hook_resid_post": "blocks.11.hook_resid_post",
         },
+        expected_var_explained={
+            "blocks.0.hook_resid_pre": 0.999,
+            "blocks.1.hook_resid_pre": 0.999,
+            "blocks.2.hook_resid_pre": 0.999,
+            "blocks.3.hook_resid_pre": 0.999,
+            "blocks.4.hook_resid_pre": 0.9,
+            "blocks.5.hook_resid_pre": 0.9,
+            "blocks.6.hook_resid_pre": 0.9,
+            "blocks.7.hook_resid_pre": 0.9,
+            "blocks.8.hook_resid_pre": 0.9,
+            "blocks.9.hook_resid_pre": 0.77,
+            "blocks.10.hook_resid_pre": 0.77,
+            "blocks.11.hook_resid_pre": 0.77,
+            "blocks.11.hook_resid_post": 0.77,
+        },
+        expected_l0={
+            "blocks.0.hook_resid_pre": 10.0,
+            "blocks.1.hook_resid_pre": 10.0,
+            "blocks.2.hook_resid_pre": 18.0,
+            "blocks.3.hook_resid_pre": 23.0,
+            "blocks.4.hook_resid_pre": 31.0,
+            "blocks.5.hook_resid_pre": 41.0,
+            "blocks.6.hook_resid_pre": 51.0,
+            "blocks.7.hook_resid_pre": 54.0,
+            "blocks.8.hook_resid_pre": 60.0,
+            "blocks.9.hook_resid_pre": 70.0,
+            "blocks.10.hook_resid_pre": 52.0,
+            "blocks.11.hook_resid_pre": 56.0,
+            "blocks.11.hook_resid_post": 70.0,
+        },
     )
+
+    assert sae_directory["gpt2-small-res-jb"] == expected_result


### PR DESCRIPTION
# Description

From pretrained.yaml now stores the expected L0 / variance explained on a test example in tests/benchmark. This is a first step towards having pre-trained model loading in CI. We'll likely need a GPU runner that can cache downloaded SAEs to do this properly. 
