### PR TITLE
fix: allow setting trust_remote_code for new huggingface version

### DIFF
--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -33,6 +33,7 @@ class LanguageModelSAERunnerConfig:
         hook_layer (int): The index of the layer to hook. Used to stop forward passes early and speed up processing.
         hook_head_index (int, optional): When the hook if for an activatio with a head index, we can specify a specific head to use here.
         dataset_path (str): A Hugging Face dataset path.
+        dataset_trust_remote_code (bool): Whether to trust remote code when loading datasets from Huggingface.
         streaming (bool): Whether to stream the dataset. Streaming large datasets is usually practical.
         is_dataset_tokenized (bool): NOT IN USE. We used to use this but now automatically detect if the dataset is tokenized.
         context_size (int): The context size to use when generating activations on which to train the SAE.
@@ -113,6 +114,7 @@ class LanguageModelSAERunnerConfig:
     hook_layer: int = 0
     hook_head_index: Optional[int] = None
     dataset_path: str = "NeelNanda/c4-tokenized-2b"
+    dataset_trust_remote_code: bool | None = None
     streaming: bool = True
     is_dataset_tokenized: bool = True
     context_size: int = 128
@@ -360,6 +362,7 @@ class LanguageModelSAERunnerConfig:
             "context_size": self.context_size,
             "prepend_bos": self.prepend_bos,
             "dataset_path": self.dataset_path,
+            "dataset_trust_remote_code": self.dataset_trust_remote_code,
             "finetuning_scaling_factor": self.finetuning_method is not None,
             "sae_lens_training_version": self.sae_lens_training_version,
             "normalize_activations": self.normalize_activations,
@@ -420,6 +423,7 @@ class CacheActivationsRunnerConfig:
     hook_layer: int = 0
     hook_head_index: Optional[int] = None
     dataset_path: str = "NeelNanda/c4-tokenized-2b"
+    dataset_trust_remote_code: bool | None = None
     streaming: bool = True
     is_dataset_tokenized: bool = True
     context_size: int = 128
@@ -552,6 +556,7 @@ def _default_cached_activations_path(
 class PretokenizeRunnerConfig:
     tokenizer_name: str = "gpt2"
     dataset_path: str = "NeelNanda/c4-10k"
+    dataset_trust_remote_code: bool | None = None
     split: str | None = "train"
     data_files: list[str] | None = None
     data_dir: str | None = None

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -44,6 +44,7 @@ class SAEConfig:
     hook_head_index: Optional[int]
     prepend_bos: bool
     dataset_path: str
+    dataset_trust_remote_code: bool
     normalize_activations: str
 
     # misc
@@ -89,6 +90,7 @@ class SAEConfig:
             "sae_lens_training_version": self.sae_lens_training_version,
             "prepend_bos": self.prepend_bos,
             "dataset_path": self.dataset_path,
+            "dataset_trust_remote_code": self.dataset_trust_remote_code,
             "context_size": self.context_size,
             "normalize_activations": self.normalize_activations,
         }

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -198,6 +198,10 @@ def load_pretrained_sae_lens_sae_components(
         # default to True for backwards compatibility
         cfg_dict["prepend_bos"] = True
 
+    if "dataset_trust_remote_code" not in cfg_dict:
+        # default to True for backwards compatibility
+        cfg_dict["dataset_trust_remote_code"] = True
+
     if "apply_b_dec_to_input" not in cfg_dict:
         # default to True for backwards compatibility
         cfg_dict["apply_b_dec_to_input"] = True

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -111,6 +111,7 @@ class ActivationsStore:
             n_batches_in_buffer=n_batches_in_buffer,
             total_training_tokens=total_tokens,
             normalize_activations=sae.cfg.normalize_activations,
+            dataset_trust_remote_code=sae.cfg.dataset_trust_remote_code,
             dtype=sae.cfg.dtype,
             device=torch.device(device),
         )
@@ -136,13 +137,19 @@ class ActivationsStore:
         cached_activations_path: str | None = None,
         model_kwargs: dict[str, Any] | None = None,
         autocast_lm: bool = False,
+        dataset_trust_remote_code: bool | None = None,
     ):
         self.model = model
         if model_kwargs is None:
             model_kwargs = {}
         self.model_kwargs = model_kwargs
         self.dataset = (
-            load_dataset(dataset, split="train", streaming=streaming)
+            load_dataset(
+                dataset,
+                split="train",
+                streaming=streaming,
+                trust_remote_code=dataset_trust_remote_code,  # type: ignore
+            )
             if isinstance(dataset, str)
             else dataset
         )

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -119,6 +119,7 @@ class TrainingSAEConfig(SAEConfig):
             "finetuning_scaling_factor": self.finetuning_scaling_factor,
             "normalize_activations": self.normalize_activations,
             "dataset_path": self.dataset_path,
+            "dataset_trust_remote_code": self.dataset_trust_remote_code,
             "sae_lens_training_version": self.sae_lens_training_version,
         }
 

--- a/tests/unit/analysis/test_hooked_sae.py
+++ b/tests/unit/analysis/test_hooked_sae.py
@@ -54,6 +54,7 @@ def get_hooked_sae(model: HookedTransformer, act_name: str) -> SAE:
         prepend_bos=True,
         context_size=128,
         dataset_path="test",
+        dataset_trust_remote_code=True,
         apply_b_dec_to_input=False,
         finetuning_scaling_factor=False,
         sae_lens_training_version=None,

--- a/tests/unit/analysis/test_hooked_sae_transformer.py
+++ b/tests/unit/analysis/test_hooked_sae_transformer.py
@@ -54,6 +54,7 @@ def get_hooked_sae(model: HookedTransformer, act_name: str) -> SAE:
         prepend_bos=True,
         context_size=128,
         dataset_path="test",
+        dataset_trust_remote_code=True,
         apply_b_dec_to_input=False,
         finetuning_scaling_factor=False,
         sae_lens_training_version=None,

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -20,6 +20,7 @@ def build_sae_cfg(**kwargs: Any) -> LanguageModelSAERunnerConfig:
         hook_layer=0,
         hook_head_index=None,
         dataset_path=TINYSTORIES_DATASET,
+        dataset_trust_remote_code=True,
         is_dataset_tokenized=False,
         use_cached_activations=False,
         d_in=64,

--- a/tests/unit/training/test_config.py
+++ b/tests/unit/training/test_config.py
@@ -59,6 +59,7 @@ def test_sae_training_runner_config_get_sae_base_parameters():
         "prepend_bos": True,
         "finetuning_scaling_factor": False,
         "dataset_path": "NeelNanda/c4-tokenized-2b",
+        "dataset_trust_remote_code": None,
         "sae_lens_training_version": str(__version__),
         "normalize_activations": "none",
     }


### PR DESCRIPTION
# Description

The newest version of Huggingface transformers won't allow loading old datasets that require allowing code execution without explicitly setting `trust_remote_code=True`. This PR adds an option `dataset_trust_remote_code` which the user can set to allow this remote code execution so old datasets can be loaded in new versions of transformers.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)