### PR TITLE
Fix dataset naming issue (typo?) in unit test

### DIFF
--- a/tests/unit/training/test_activations_store.py
+++ b/tests/unit/training/test_activations_store.py
@@ -51,7 +51,7 @@ def tokenize_with_bos(model: HookedTransformer, text: str) -> list[int]:
         },
         {
             "model_name": "gpt2",
-            "dataset_path": "apollo-research/sae-monology-pile-uncopyrighted-tokenizer-gpt2",
+            "dataset_path": "apollo-research/monology-pile-uncopyrighted-tokenizer-gpt2",
             "tokenized": True,
             "hook_name": "blocks.1.hook_resid_pre",
             "hook_layer": 1,


### PR DESCRIPTION
# Description

I ran unit tests locally with

`make check-ci`

Nearly all passed, but two failed 
```
==================================================================================== short test summary info =====================================================================================
FAILED tests/unit/training/test_activations_store.py::test_activations_store__shapes_look_correct_with_real_models_and_datasets[gpt2-tokenized] - datasets.exceptions.DatasetNotFoundError: Dataset 'apollo-research/sae-monology-pile-uncopyrighted-tokenizer-gpt2' doesn't exist on the Hub or cannot be accessed.
FAILED tests/unit/training/test_activations_store.py::test_activations_store_estimate_norm_scaling_factor[gpt2-tokenized] - datasets.exceptions.DatasetNotFoundError: Dataset 'apollo-research/sae-monology-pile-uncopyrighted-tokenizer-gpt2' doesn't exist on the Hub or cannot be accessed.
================================================================ 2 failed, 209 passed, 8 skipped, 7 warnings in 782.32s (0:13:02) ================================================================
make[1]: *** [unit-test] Error 1
make: *** [check-ci] Error 2
``` 

On closer inspection both are caused by a parameter set in `tests/unit/training/test_activations_store.py` pointing its `dataset_path` to the huggingface dataset `apollo-research/sae-monology-pile-uncopyrighted-tokenizer-gpt2` which **does not exist** (I confirmed this was not merely a huggingface access/credentials issue, it ain't there).

Luckily the similarly named huggingface dataset `apollo-research/monology-pile-uncopyrighted-tokenizer-gpt2` (no "sae-") does very much exist though, and seems to contain tokenized text, similar to `Skylion007/openwebtext` which is the other dataset associated in these tests with the gpt2 model. The intention of these tests seems to be merely to check that the training script processes standard sorts of input correctly, and `apollo-research/monology-pile-uncopyrighted-tokenizer-gpt2`  seems an appropriate dataset to achieve this.

Having changed the name of the dataset to  `apollo-research/monology-pile-uncopyrighted-tokenizer-gpt2` all 211 tests now pass.

Marvelous repo by the way, thank you all very much

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

