### PR TITLE
prevent context size mismatch error in training turorial

### DIFF
--- a/tutorials/training_a_sparse_autoencoder.ipynb
+++ b/tutorials/training_a_sparse_autoencoder.ipynb
@@ -805,7 +805,7 @@
         "    l1_warm_up_steps=l1_warm_up_steps,  # this can help avoid too many dead features initially.\n",
         "    lp_norm=1.0,  # the L1 penalty (and not a Lp for p < 1)\n",
         "    train_batch_size_tokens=batch_size,\n",
-        "    context_size=256,  # will control the lenght of the prompts we feed to the model. Larger is better but slower. so for the tutorial we'll use a short one.\n",
+        "    context_size=512,  # will control the lenght of the prompts we feed to the model. Larger is better but slower. so for the tutorial we'll use a short one.\n",
         "    # Activation Store Parameters\n",
         "    n_batches_in_buffer=64,  # controls how many activations we store / shuffle.\n",
         "    training_tokens=total_training_tokens,  # 100 million tokens is quite a few, but we want to see good stats. Get a coffee, come back.\n",


### PR DESCRIPTION
# Description

When running the original `tutorials/training_a_sparse_autoencoder.ipynb` code I get an error informing me that there is a mismatch between the input length (512) and the given context length (256). 

```
ValueError: pretokenized dataset has context_size 512, but the provided context_size is 256.
```

The given dataset `apollo-research/roneneldan-TinyStories-tokenizer-gpt2` does in fact have 512 input ids per sample. Presumably the error was added after the tutorial was last updated. The check seems eminently reasonable to me so I don't think we should remove the check.

I have confirmed that `tiny-stories-1L-21M` has a context length of 2048 so this change is sensical, and I can confirm that the changed code works (I'm running it right now in fact)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Printout before error is encountered

```
Run name: 16384-L1-5-LR-5e-05-Tokens-1.229e+08
n_tokens_per_buffer (millions): 0.262144
Lower bound: n_contexts_per_buffer (millions): 0.001024
Total training steps: 30000
Total wandb updates: 1000
n_tokens_per_feature_sampling_window (millions): 1048.576
n_tokens_per_dead_feature_window (millions): 1048.576
We will reset the sparsity calculation 30 times.
Number tokens in sparsity calculation window: 4.10e+06
Loaded pretrained model tiny-stories-1L-21M into HookedTransformer
```

### Error trace 

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[3], [line 62](vscode-notebook-cell:?execution_count=3&line=62)
      [9](vscode-notebook-cell:?execution_count=3&line=9) cfg = LanguageModelSAERunnerConfig(
     [10](vscode-notebook-cell:?execution_count=3&line=10)     # Data Generating Function (Model + Training Distibuion)
     [11](vscode-notebook-cell:?execution_count=3&line=11)     model_name="tiny-stories-1L-21M",  # our model (more options here: https://neelnanda-io.github.io/TransformerLens/generated/model_properties_table.html)
   (...)
     [59](vscode-notebook-cell:?execution_count=3&line=59)     dtype="float32"
     [60](vscode-notebook-cell:?execution_count=3&line=60) )
     [61](vscode-notebook-cell:?execution_count=3&line=61) # look at the next cell to see some instruction for what to do while this is running.
---> [62](vscode-notebook-cell:?execution_count=3&line=62) sparse_autoencoder = SAETrainingRunner(cfg).run()

File [~/code/SAELens/sae_lens/sae_training_runner.py:48](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/sae_training_runner.py:48), in SAETrainingRunner.__init__(self, cfg)
     [39](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/sae_training_runner.py:39) self.cfg = cfg
     [41](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/sae_training_runner.py:41) self.model = load_model(
     [42](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/sae_training_runner.py:42)     self.cfg.model_class_name,
     [43](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/sae_training_runner.py:43)     self.cfg.model_name,
     [44](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/sae_training_runner.py:44)     device=self.cfg.device,
     [45](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/sae_training_runner.py:45)     model_from_pretrained_kwargs=self.cfg.model_from_pretrained_kwargs,
     [46](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/sae_training_runner.py:46) )
---> [48](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/sae_training_runner.py:48) self.activations_store = ActivationsStore.from_config(
     [49](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/sae_training_runner.py:49)     self.model,
     [50](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/sae_training_runner.py:50)     self.cfg,
     [51](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/sae_training_runner.py:51) )
     [53](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/sae_training_runner.py:53) if self.cfg.from_pretrained_path is not None:
     [54](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/sae_training_runner.py:54)     self.sae = TrainingSAE.load_from_pretrained(
     [55](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/sae_training_runner.py:55)         self.cfg.from_pretrained_path, self.cfg.device
     [56](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/sae_training_runner.py:56)     )

File [~/code/SAELens/sae_lens/training/activations_store.py:65](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:65), in ActivationsStore.from_config(cls, model, cfg, dataset)
     [60](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:60) if (
     [61](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:61)     isinstance(cfg, LanguageModelSAERunnerConfig)
     [62](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:62)     and not cfg.use_cached_activations
     [63](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:63) ):
     [64](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:64)     cached_activations_path = None
---> [65](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:65) return cls(
     [66](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:66)     model=model,
     [67](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:67)     dataset=dataset or cfg.dataset_path,
     [68](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:68)     streaming=cfg.streaming,
     [69](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:69)     hook_name=cfg.hook_name,
     [70](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:70)     hook_layer=cfg.hook_layer,
     [71](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:71)     hook_head_index=cfg.hook_head_index,
     [72](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:72)     context_size=cfg.context_size,
     [73](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:73)     d_in=cfg.d_in,
     [74](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:74)     n_batches_in_buffer=cfg.n_batches_in_buffer,
     [75](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:75)     total_training_tokens=cfg.training_tokens,
     [76](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:76)     store_batch_size_prompts=cfg.store_batch_size_prompts,
     [77](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:77)     train_batch_size_tokens=cfg.train_batch_size_tokens,
     [78](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:78)     prepend_bos=cfg.prepend_bos,
     [79](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:79)     normalize_activations=cfg.normalize_activations,
     [80](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:80)     device=torch.device(cfg.act_store_device),
     [81](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:81)     dtype=cfg.dtype,
     [82](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:82)     cached_activations_path=cached_activations_path,
     [83](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:83)     model_kwargs=cfg.model_kwargs,
     [84](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:84)     autocast_lm=cfg.autocast_lm,
     [85](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:85)     dataset_trust_remote_code=cfg.dataset_trust_remote_code,
     [86](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:86) )

File [~/code/SAELens/sae_lens/training/activations_store.py:198](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:198), in ActivationsStore.__init__(self, model, dataset, streaming, hook_name, hook_layer, hook_head_index, context_size, d_in, n_batches_in_buffer, total_training_tokens, store_batch_size_prompts, train_batch_size_tokens, prepend_bos, normalize_activations, device, dtype, cached_activations_path, model_kwargs, autocast_lm, dataset_trust_remote_code)
    [196](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:196) ds_context_size = len(dataset_sample[self.tokens_column])
    [197](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:197) if ds_context_size != self.context_size:
--> [198](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:198)     raise ValueError(
    [199](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:199)         f"pretokenized dataset has context_size {ds_context_size}, but the provided context_size is {self.context_size}."
    [200](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:200)     )
    [201](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:201) # TODO: investigate if this can work for iterable datasets, or if this is even worthwhile as a perf improvement
    [202](https://file+.vscode-resource.vscode-cdn.net/Users/plato/code/SAELens/tutorials/~/code/SAELens/sae_lens/training/activations_store.py:202) if hasattr(self.dataset, "set_format"):

ValueError: pretokenized dataset has context_size 512, but the provided context_size is 256.
```