### PR TITLE
fix: pin typing-extensions version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ python-dotenv = "^1.0.1"
 pyyaml = "^6.0.1"
 pytest-profiling = "^1.7.0"
 zstandard = "^0.22.0"
+typing-extensions = "^4.10.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description

We use the `@deprecated` operator, but for old versions of Python (3.10), we need to use the `typing-extensions` package to provide support. It looks like support for `@deprecated` was [added in v4.5.0](https://github.com/python/typing_extensions/blob/main/CHANGELOG.md#release-450-february-14-2023), but we don't actually pin the dependency in pyproject.toml, so it's possible for users to install an outdated version of the dependency and get an error when loading SAELens.

This fixes the issue by pinning the `typing-extensions` dependency to `>=v4.10.0`, which should be recent enough to have everything we depend on.

Fixes #203 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)