### PR TITLE
SAETrainingRunner takes optional HFDataset

### DIFF
--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -5,6 +5,7 @@ from typing import Any, Literal, Optional, cast
 
 import torch
 import wandb
+from datasets import Dataset, DatasetDict, IterableDataset, IterableDatasetDict
 
 from sae_lens import __version__
 
@@ -18,6 +19,8 @@ DTYPE_MAP = {
     "torch.float16": torch.float16,
     "torch.bfloat16": torch.bfloat16,
 }
+
+HfDataset = DatasetDict | Dataset | IterableDatasetDict | IterableDataset
 
 
 @dataclass

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -116,7 +116,7 @@ class LanguageModelSAERunnerConfig:
     hook_eval: str = "NOT_IN_USE"
     hook_layer: int = 0
     hook_head_index: Optional[int] = None
-    dataset_path: str = "NeelNanda/c4-tokenized-2b"
+    dataset_path: str = ""
     dataset_trust_remote_code: bool = True
     streaming: bool = True
     is_dataset_tokenized: bool = True
@@ -431,7 +431,7 @@ class CacheActivationsRunnerConfig:
     hook_name: str = "blocks.{layer}.hook_mlp_out"
     hook_layer: int = 0
     hook_head_index: Optional[int] = None
-    dataset_path: str = "NeelNanda/c4-tokenized-2b"
+    dataset_path: str = ""
     dataset_trust_remote_code: bool | None = None
     streaming: bool = True
     is_dataset_tokenized: bool = True
@@ -568,7 +568,7 @@ def _default_cached_activations_path(
 @dataclass
 class PretokenizeRunnerConfig:
     tokenizer_name: str = "gpt2"
-    dataset_path: str = "NeelNanda/c4-10k"
+    dataset_path: str = ""
     dataset_trust_remote_code: bool | None = None
     split: str | None = "train"
     data_files: list[str] | None = None

--- a/sae_lens/sae_training_runner.py
+++ b/sae_lens/sae_training_runner.py
@@ -8,7 +8,7 @@ import wandb
 from safetensors.torch import save_file
 from transformer_lens.hook_points import HookedRootModule
 
-from sae_lens.config import LanguageModelSAERunnerConfig
+from sae_lens.config import HfDataset, LanguageModelSAERunnerConfig
 from sae_lens.load_model import load_model
 from sae_lens.sae import SAE_CFG_PATH, SAE_WEIGHTS_PATH, SPARSITY_PATH
 from sae_lens.training.activations_store import ActivationsStore
@@ -35,7 +35,9 @@ class SAETrainingRunner:
     sae: TrainingSAE
     activations_store: ActivationsStore
 
-    def __init__(self, cfg: LanguageModelSAERunnerConfig):
+    def __init__(
+        self, cfg: LanguageModelSAERunnerConfig, dataset: HfDataset | None = None
+    ):
         self.cfg = cfg
 
         self.model = load_model(
@@ -48,6 +50,7 @@ class SAETrainingRunner:
         self.activations_store = ActivationsStore.from_config(
             self.model,
             self.cfg,
+            dataset=dataset,
         )
 
         if self.cfg.from_pretrained_path is not None:

--- a/sae_lens/sae_training_runner.py
+++ b/sae_lens/sae_training_runner.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import signal
 from typing import Any, cast
@@ -36,8 +37,15 @@ class SAETrainingRunner:
     activations_store: ActivationsStore
 
     def __init__(
-        self, cfg: LanguageModelSAERunnerConfig, dataset: HfDataset | None = None
+        self,
+        cfg: LanguageModelSAERunnerConfig,
+        override_dataset: HfDataset | None = None,
     ):
+        if override_dataset is not None:
+            logging.warning(
+                f"You just passed in a dataset which will override the one specified in your configuration: {cfg.dataset_path}. As a consequence this run will not be reproducable via configuration alone."
+            )
+
         self.cfg = cfg
 
         self.model = load_model(
@@ -50,7 +58,7 @@ class SAETrainingRunner:
         self.activations_store = ActivationsStore.from_config(
             self.model,
             self.cfg,
-            dataset=dataset,
+            override_dataset=override_dataset,
         )
 
         if self.cfg.from_pretrained_path is not None:

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -6,13 +6,7 @@ from typing import Any, Generator, Iterator, Literal, cast
 
 import numpy as np
 import torch
-from datasets import (
-    Dataset,
-    DatasetDict,
-    IterableDataset,
-    IterableDatasetDict,
-    load_dataset,
-)
+from datasets import load_dataset
 from safetensors import safe_open
 from safetensors.torch import save_file
 from torch.utils.data import DataLoader
@@ -22,12 +16,11 @@ from transformer_lens.hook_points import HookedRootModule
 from sae_lens.config import (
     DTYPE_MAP,
     CacheActivationsRunnerConfig,
+    HfDataset,
     LanguageModelSAERunnerConfig,
 )
 from sae_lens.sae import SAE
 from sae_lens.tokenization_and_batching import concat_and_batch_sequences
-
-HfDataset = DatasetDict | Dataset | IterableDatasetDict | IterableDataset
 
 
 # TODO: Make an activation store config class to be consistent with the rest of the code.
@@ -62,6 +55,12 @@ class ActivationsStore:
             and not cfg.use_cached_activations
         ):
             cached_activations_path = None
+
+        if dataset is None and cfg.dataset_path == "":
+            raise ValueError(
+                "You must either pass in a dataset or specify a dataset_path in your configutation."
+            )
+
         return cls(
             model=model,
             dataset=dataset or cfg.dataset_path,

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -46,7 +46,7 @@ class ActivationsStore:
         cls,
         model: HookedRootModule,
         cfg: LanguageModelSAERunnerConfig | CacheActivationsRunnerConfig,
-        dataset: HfDataset | None = None,
+        override_dataset: HfDataset | None = None,
     ) -> "ActivationsStore":
         cached_activations_path = cfg.cached_activations_path
         # set cached_activations_path to None if we're not using cached activations
@@ -56,14 +56,14 @@ class ActivationsStore:
         ):
             cached_activations_path = None
 
-        if dataset is None and cfg.dataset_path == "":
+        if override_dataset is None and cfg.dataset_path == "":
             raise ValueError(
                 "You must either pass in a dataset or specify a dataset_path in your configutation."
             )
 
         return cls(
             model=model,
-            dataset=dataset or cfg.dataset_path,
+            dataset=override_dataset or cfg.dataset_path,
             streaming=cfg.streaming,
             hook_name=cfg.hook_name,
             hook_layer=cfg.hook_layer,

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -342,7 +342,10 @@ class ActivationsStore:
         sequences = []
         # the sequences iterator yields fully formed tokens of size context_size, so we just need to cat these into a batch
         for _ in range(batch_size):
-            sequences.append(next(self.iterable_sequences))
+            try:
+                sequences.append(next(self.iterable_sequences))
+            except StopIteration:
+                raise ValueError(f"the number of tokens in your dataset is less than (batches_in_buffer // 2) * batch_size, {self.n_batches_in_buffer // 2} * {batch_size}. Consider lowering n_batches_in_buffer.")
         return torch.stack(sequences, dim=0).to(self.model.W_E.device)
 
     @torch.no_grad()

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -342,12 +342,7 @@ class ActivationsStore:
         sequences = []
         # the sequences iterator yields fully formed tokens of size context_size, so we just need to cat these into a batch
         for _ in range(batch_size):
-            try:
-                sequences.append(next(self.iterable_sequences))
-            except StopIteration:
-                raise ValueError(
-                    f"the number of tokens in your dataset is less than (batches_in_buffer // 2) * batch_size, {self.n_batches_in_buffer // 2} * {batch_size}. Consider lowering n_batches_in_buffer."
-                )
+            sequences.append(next(self.iterable_sequences))
         return torch.stack(sequences, dim=0).to(self.model.W_E.device)
 
     @torch.no_grad()

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -345,7 +345,9 @@ class ActivationsStore:
             try:
                 sequences.append(next(self.iterable_sequences))
             except StopIteration:
-                raise ValueError(f"the number of tokens in your dataset is less than (batches_in_buffer // 2) * batch_size, {self.n_batches_in_buffer // 2} * {batch_size}. Consider lowering n_batches_in_buffer.")
+                raise ValueError(
+                    f"the number of tokens in your dataset is less than (batches_in_buffer // 2) * batch_size, {self.n_batches_in_buffer // 2} * {batch_size}. Consider lowering n_batches_in_buffer."
+                )
         return torch.stack(sequences, dim=0).to(self.model.W_E.device)
 
     @torch.no_grad()

--- a/tests/benchmark/test_activations_store.py
+++ b/tests/benchmark/test_activations_store.py
@@ -36,9 +36,11 @@ def test_benchmark_activations_store_get_batch_tokens_pretokenized_vs_raw():
         cast(Any, dataset), tokenizer, pretokenize_cfg
     )
 
-    text_dataset_store = ActivationsStore.from_config(model, cfg, dataset=dataset)
+    text_dataset_store = ActivationsStore.from_config(
+        model, cfg, override_dataset=dataset
+    )
     pretokenized_dataset_store = ActivationsStore.from_config(
-        model, cfg, dataset=tokenized_dataset
+        model, cfg, override_dataset=tokenized_dataset
     )
 
     text_start_time = perf_counter()

--- a/tests/unit/training/test_activations_store.py
+++ b/tests/unit/training/test_activations_store.py
@@ -392,3 +392,23 @@ def test_activations_store___iterate_tokenized_sequences__yields_identical_resul
         for seq in tokenized_activation_store._iterate_tokenized_sequences()
     ]
     assert seqs == pretok_seqs
+
+
+def test_activation_store__errors_if_neither_dataset_nor_dataset_path(
+    ts_model: HookedTransformer,
+):
+    cfg = build_sae_cfg(dataset_path="")
+
+    example_ds = Dataset.from_list(
+        [
+            {"text": "hello world1"},
+            {"text": "hello world2"},
+            {"text": "hello world3"},
+        ]
+        * 20
+    )
+
+    ActivationsStore.from_config(ts_model, cfg, dataset=example_ds)
+
+    with pytest.raises(ValueError):
+        ActivationsStore.from_config(ts_model, cfg, dataset=None)

--- a/tests/unit/training/test_activations_store.py
+++ b/tests/unit/training/test_activations_store.py
@@ -199,7 +199,9 @@ def test_activations_store__get_batch_tokens__fills_the_context_separated_by_bos
         context_size=context_size,
     )
 
-    activation_store = ActivationsStore.from_config(ts_model, cfg, dataset=dataset)
+    activation_store = ActivationsStore.from_config(
+        ts_model, cfg, override_dataset=dataset
+    )
     encoded_text = tokenize_with_bos(ts_model, "hello world")
     tokens = activation_store.get_batch_tokens()
     assert tokens.shape == (2, context_size)  # batch_size x context_size
@@ -227,7 +229,9 @@ def test_activations_store__iterate_raw_dataset_tokens__tokenizes_each_example_i
             {"text": "hello world3"},
         ]
     )
-    activation_store = ActivationsStore.from_config(ts_model, cfg, dataset=dataset)
+    activation_store = ActivationsStore.from_config(
+        ts_model, cfg, override_dataset=dataset
+    )
     iterator = activation_store._iterate_raw_dataset_tokens()
 
     assert next(iterator).tolist() == tokenizer.encode("hello world1")
@@ -244,7 +248,9 @@ def test_activations_store__iterate_raw_dataset_tokens__can_handle_long_examples
             {"text": " France" * 3000},
         ]
     )
-    activation_store = ActivationsStore.from_config(ts_model, cfg, dataset=dataset)
+    activation_store = ActivationsStore.from_config(
+        ts_model, cfg, override_dataset=dataset
+    )
     iterator = activation_store._iterate_raw_dataset_tokens()
 
     assert len(next(iterator).tolist()) == 3000
@@ -307,7 +313,9 @@ def test_activations_store___iterate_tokenized_sequences__yields_concat_and_batc
             {"text": "hello world3"},
         ]
     )
-    activation_store = ActivationsStore.from_config(ts_model, cfg, dataset=dataset)
+    activation_store = ActivationsStore.from_config(
+        ts_model, cfg, override_dataset=dataset
+    )
     iterator = activation_store._iterate_tokenized_sequences()
 
     expected = [
@@ -335,7 +343,9 @@ def test_activations_store___iterate_tokenized_sequences__yields_sequences_of_co
         ]
         * 20
     )
-    activation_store = ActivationsStore.from_config(ts_model, cfg, dataset=dataset)
+    activation_store = ActivationsStore.from_config(
+        ts_model, cfg, override_dataset=dataset
+    )
     for toks in activation_store._iterate_tokenized_sequences():
         assert toks.shape == (5,)
 
@@ -357,7 +367,7 @@ def test_activations_store__errors_if_pretokenized_context_size_doesnt_match_cfg
     pretokenize_cfg = PretokenizeRunnerConfig(context_size=10)
     tokenized_dataset = pretokenize_dataset(dataset, tokenizer, cfg=pretokenize_cfg)
     with pytest.raises(ValueError):
-        ActivationsStore.from_config(ts_model, cfg, dataset=tokenized_dataset)
+        ActivationsStore.from_config(ts_model, cfg, override_dataset=tokenized_dataset)
 
 
 def test_activations_store___iterate_tokenized_sequences__yields_identical_results_with_and_without_pretokenizing(
@@ -382,9 +392,11 @@ def test_activations_store___iterate_tokenized_sequences__yields_identical_resul
         sequence_separator_token="bos",
     )
     tokenized_dataset = pretokenize_dataset(dataset, tokenizer, cfg=pretokenize_cfg)
-    activation_store = ActivationsStore.from_config(ts_model, cfg, dataset=dataset)
+    activation_store = ActivationsStore.from_config(
+        ts_model, cfg, override_dataset=dataset
+    )
     tokenized_activation_store = ActivationsStore.from_config(
-        ts_model, cfg, dataset=tokenized_dataset
+        ts_model, cfg, override_dataset=tokenized_dataset
     )
     seqs = [seq.tolist() for seq in activation_store._iterate_tokenized_sequences()]
     pretok_seqs = [
@@ -408,7 +420,7 @@ def test_activation_store__errors_if_neither_dataset_nor_dataset_path(
         * 20
     )
 
-    ActivationsStore.from_config(ts_model, cfg, dataset=example_ds)
+    ActivationsStore.from_config(ts_model, cfg, override_dataset=example_ds)
 
     with pytest.raises(ValueError):
-        ActivationsStore.from_config(ts_model, cfg, dataset=None)
+        ActivationsStore.from_config(ts_model, cfg, override_dataset=None)

--- a/tests/unit/training/test_config.py
+++ b/tests/unit/training/test_config.py
@@ -60,7 +60,7 @@ def test_sae_training_runner_config_get_sae_base_parameters():
         "context_size": 128,
         "prepend_bos": True,
         "finetuning_scaling_factor": False,
-        "dataset_path": "NeelNanda/c4-tokenized-2b",
+        "dataset_path": "",
         "dataset_trust_remote_code": True,
         "sae_lens_training_version": str(__version__),
         "normalize_activations": "none",

--- a/tests/unit/training/test_evals.py
+++ b/tests/unit/training/test_evals.py
@@ -79,7 +79,7 @@ def model():
 @pytest.fixture
 def activation_store(model: HookedTransformer, cfg: LanguageModelSAERunnerConfig):
     return ActivationsStore.from_config(
-        model, cfg, dataset=Dataset.from_list([{"text": "hello world"}] * 2000)
+        model, cfg, override_dataset=Dataset.from_list([{"text": "hello world"}] * 2000)
     )
 
 

--- a/tests/unit/training/test_sae_trainer.py
+++ b/tests/unit/training/test_sae_trainer.py
@@ -33,7 +33,7 @@ def model():
 @pytest.fixture
 def activation_store(model: HookedTransformer, cfg: LanguageModelSAERunnerConfig):
     return ActivationsStore.from_config(
-        model, cfg, dataset=Dataset.from_list([{"text": "hello world"}] * 2000)
+        model, cfg, override_dataset=Dataset.from_list([{"text": "hello world"}] * 2000)
     )
 
 
@@ -211,7 +211,9 @@ def test_train_sae_group_on_language_model__runs(
     )
     # just a tiny datast which will run quickly
     dataset = Dataset.from_list([{"text": "hello world"}] * 2000)
-    activation_store = ActivationsStore.from_config(ts_model, cfg, dataset=dataset)
+    activation_store = ActivationsStore.from_config(
+        ts_model, cfg, override_dataset=dataset
+    )
     sae = TrainingSAE.from_dict(cfg.get_training_sae_cfg_dict())
     sae = SAETrainer(
         model=ts_model,

--- a/tests/unit/training/test_sae_training.py
+++ b/tests/unit/training/test_sae_training.py
@@ -87,7 +87,7 @@ def training_sae(cfg: Any):
 @pytest.fixture
 def activation_store(model: HookedTransformer, cfg: LanguageModelSAERunnerConfig):
     return ActivationsStore.from_config(
-        model, cfg, dataset=Dataset.from_list([{"text": "hello world"}] * 2000)
+        model, cfg, override_dataset=Dataset.from_list([{"text": "hello world"}] * 2000)
     )
 
 

--- a/tests/unit/training/test_sae_training_runner.py
+++ b/tests/unit/training/test_sae_training_runner.py
@@ -28,7 +28,7 @@ def model():
 @pytest.fixture
 def activation_store(model: HookedTransformer, cfg: LanguageModelSAERunnerConfig):
     return ActivationsStore.from_config(
-        model, cfg, dataset=Dataset.from_list([{"text": "hello world"}] * 2000)
+        model, cfg, override_dataset=Dataset.from_list([{"text": "hello world"}] * 2000)
     )
 
 


### PR DESCRIPTION
Allows users to pass in datasets which are not on huggingface when training using the `SAETrainingRunner`

Code of the following kind (which is quite useful imo, especially when testing) now runs:

```python

... 

dataset: IterableDataset = cast(IterableDataset, load_dataset(
    "apollo-research/roneneldan-TinyStories-tokenizer-gpt2",
    split="train",
    streaming=True,
    trust_remote_code=True,
))

dataset = dataset.take(100)

sparse_autoencoder = SAETrainingRunner(cfg, dataset).run()
```

The changes are based on an existing pattern for passing in non-path datasets to the `ActivationStore`

Also added a more explicit error for when the activation buffer size is too large for the dataset passed in.

IMO we should give users the option of passing in `None` to the `dataset_path` across all kinds of config for cases like this as it will lead to less confusion, but I am not familiar enough with the codebase to make such an important change to so many interfaces. 

Another reasonable change would be to make the default `dataset_path` an empty string instead of good old `NeelNanda/c4-tokenized-2b` since users should probably always choose which dataset they are using explicitly.

Very open to feedback on this PR

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
