### PR TITLE
WIP make activations_store re start the dataset when it runs out

### DIFF
--- a/sae_lens/analysis/neuronpedia_runner.py
+++ b/sae_lens/analysis/neuronpedia_runner.py
@@ -128,12 +128,21 @@ class NeuronpediaRunner:
     ):
         all_tokens_list = []
         pbar = tqdm(range(n_batches_to_sample_from))
-        for _ in pbar:
-            batch_tokens = self.activation_store.get_batch_tokens()
-            batch_tokens = batch_tokens[torch.randperm(batch_tokens.shape[0])][
-                : batch_tokens.shape[0]
-            ]
-            all_tokens_list.append(batch_tokens)
+        for i in pbar:
+            try:
+                batch_tokens = self.activation_store.get_batch_tokens(
+                    raise_at_epoch_end=True
+                )
+                batch_tokens = batch_tokens[torch.randperm(batch_tokens.shape[0])][
+                    : batch_tokens.shape[0]
+                ]
+                all_tokens_list.append(batch_tokens)
+            except StopIteration:
+                print(
+                    f"Warning: Ran out of tokens to sample from at batch {i} before reaching {n_batches_to_sample_from} batches."
+                )
+                pbar.close()
+                break
 
         all_tokens = torch.cat(all_tokens_list, dim=0)
         all_tokens = all_tokens[torch.randperm(all_tokens.shape[0])]

--- a/sae_lens/cache_activations_runner.py
+++ b/sae_lens/cache_activations_runner.py
@@ -83,29 +83,37 @@ class CacheActivationsRunner:
         n_buffers = math.ceil(self.cfg.training_tokens / tokens_per_buffer)
 
         for i in tqdm(range(n_buffers), desc="Caching activations"):
-            buffer = self.activations_store.get_buffer(self.cfg.n_batches_in_buffer)
-            self.activations_store.save_buffer(
-                buffer, f"{new_cached_activations_path}/{i}.safetensors"
-            )
+            try:
+                buffer = self.activations_store.get_buffer(self.cfg.n_batches_in_buffer)
 
-            del buffer
+                self.activations_store.save_buffer(
+                    buffer, f"{new_cached_activations_path}/{i}.safetensors"
+                )
 
-            if i % self.cfg.shuffle_every_n_buffers == 0 and i > 0:
-                # Shuffle the buffers on disk
+                del buffer
 
-                # Do random pairwise shuffling between the last shuffle_every_n_buffers buffers
-                for _ in range(self.cfg.n_shuffles_with_last_section):
-                    self.shuffle_activations_pairwise(
-                        new_cached_activations_path,
-                        buffer_idx_range=(i - self.cfg.shuffle_every_n_buffers, i),
-                    )
 
-                # Do more random pairwise shuffling between all the buffers
-                for _ in range(self.cfg.n_shuffles_in_entire_dir):
-                    self.shuffle_activations_pairwise(
-                        new_cached_activations_path,
-                        buffer_idx_range=(0, i),
-                    )
+                if i % self.cfg.shuffle_every_n_buffers == 0 and i > 0:
+                    # Shuffle the buffers on disk
+
+                    # Do random pairwise shuffling between the last shuffle_every_n_buffers buffers
+                    for _ in range(self.cfg.n_shuffles_with_last_section):
+                        self.shuffle_activations_pairwise(
+                            new_cached_activations_path,
+                            buffer_idx_range=(i - self.cfg.shuffle_every_n_buffers, i),
+                        )
+
+                    # Do more random pairwise shuffling between all the buffers
+                    for _ in range(self.cfg.n_shuffles_in_entire_dir):
+                        self.shuffle_activations_pairwise(
+                            new_cached_activations_path,
+                            buffer_idx_range=(0, i),
+                        )
+            except StopIteration:
+                print(
+                    f"Warning: Ran out of samples while filling the buffer at batch {i} before reaching {n_buffers} batches. No more caching will occur."
+                )
+                break
 
         # More final shuffling (mostly in case we didn't end on an i divisible by shuffle_every_n_buffers)
         if n_buffers > 1:

--- a/sae_lens/cache_activations_runner.py
+++ b/sae_lens/cache_activations_runner.py
@@ -92,7 +92,6 @@ class CacheActivationsRunner:
 
                 del buffer
 
-
                 if i % self.cfg.shuffle_every_n_buffers == 0 and i > 0:
                     # Shuffle the buffers on disk
 

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -543,11 +543,15 @@ class ActivationsStore:
                 self.half_buffer_size, raise_on_epoch_end=True
             )
         except StopIteration:
-            print("Warning: All samples in the training dataset have been exhausted, we are now beginning a new epoch with the same samples.")
-            self._storage_buffer = None # dump the current buffer so samples do not leak between epochs
+            print(
+                "Warning: All samples in the training dataset have been exhausted, we are now beginning a new epoch with the same samples."
+            )
+            self._storage_buffer = (
+                None  # dump the current buffer so samples do not leak between epochs
+            )
             try:
                 new_samples = self.get_buffer(self.half_buffer_size)
-            except StopIteration: 
+            except StopIteration:
                 raise ValueError(
                     "We were unable to fill up the buffer directly after starting a new epoch. This could indicate that there are less samples in the dataset than are required to fill up the buffer. Consider reducing batch_size or n_batches_in_buffer. "
                 )

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -343,7 +343,12 @@ class ActivationsStore:
         sequences = []
         # the sequences iterator yields fully formed tokens of size context_size, so we just need to cat these into a batch
         for _ in range(batch_size):
-            sequences.append(next(self.iterable_sequences))
+            try:
+                sequences.append(next(self.iterable_sequences))
+            except StopIteration:
+                self.iterable_sequences = self._iterate_tokenized_sequences()
+                sequences.append(next(self.iterable_sequences))
+
         return torch.stack(sequences, dim=0).to(self.model.W_E.device)
 
     @torch.no_grad()

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -6,13 +6,7 @@ from typing import Any, Generator, Iterator, Literal, cast
 
 import numpy as np
 import torch
-from datasets import (
-    Dataset,
-    DatasetDict,
-    IterableDataset,
-    IterableDatasetDict,
-    load_dataset,
-)
+from datasets import Dataset, DatasetDict, load_dataset
 from safetensors import safe_open
 from safetensors.torch import save_file
 from torch.utils.data import DataLoader
@@ -155,12 +149,23 @@ class ActivationsStore:
             if isinstance(dataset, str)
             else dataset
         )
+
+        if isinstance(dataset, (Dataset, DatasetDict)):
+            self.dataset = cast(Dataset | DatasetDict, self.dataset)
+            n_samples = len(self.dataset)
+
+            if n_samples < total_training_tokens:
+                print(
+                    f"Warning: the training dataset contains fewer samples ({n_samples}) than the number of samples required by your training configuration ({total_training_tokens}). This will result in multiple training epochs and some samples being used more than once."
+                )
+
         self.hook_name = hook_name
         self.hook_layer = hook_layer
         self.hook_head_index = hook_head_index
         self.context_size = context_size
         self.d_in = d_in
         self.n_batches_in_buffer = n_batches_in_buffer
+        self.half_buffer_size = n_batches_in_buffer // 2
         self.total_training_tokens = total_training_tokens
         self.store_batch_size_prompts = store_batch_size_prompts
         self.train_batch_size_tokens = train_batch_size_tokens
@@ -324,7 +329,7 @@ class ActivationsStore:
     @property
     def storage_buffer(self) -> torch.Tensor:
         if self._storage_buffer is None:
-            self._storage_buffer = self.get_buffer(self.n_batches_in_buffer // 2)
+            self._storage_buffer = self.get_buffer(self.half_buffer_size)
 
         return self._storage_buffer
 
@@ -334,9 +339,13 @@ class ActivationsStore:
             self._dataloader = self.get_data_loader()
         return self._dataloader
 
-    def get_batch_tokens(self, batch_size: int | None = None):
+    def get_batch_tokens(
+        self, batch_size: int | None = None, raise_at_epoch_end: bool = False
+    ):
         """
         Streams a batch of tokens from a dataset.
+
+        If raise_at_epoch_end is true we will reset the dataset at the end of each epoch and raise a StopIteration. Otherwise we will reset silently.
         """
         if not batch_size:
             batch_size = self.store_batch_size_prompts
@@ -347,7 +356,12 @@ class ActivationsStore:
                 sequences.append(next(self.iterable_sequences))
             except StopIteration:
                 self.iterable_sequences = self._iterate_tokenized_sequences()
-                sequences.append(next(self.iterable_sequences))
+                if raise_at_epoch_end:
+                    raise StopIteration(
+                        f"Ran out of tokens in dataset after {self.n_dataset_processed} samples, beginning the next epoch."
+                    )
+                else:
+                    sequences.append(next(self.iterable_sequences))
 
         return torch.stack(sequences, dim=0).to(self.model.W_E.device)
 
@@ -398,7 +412,16 @@ class ActivationsStore:
         return stacked_activations
 
     @torch.no_grad()
-    def get_buffer(self, n_batches_in_buffer: int) -> torch.Tensor:
+    def get_buffer(
+        self, n_batches_in_buffer: int, raise_on_epoch_end: bool = False
+    ) -> torch.Tensor:
+        """
+        Loads the next n_batches_in_buffer batches of activations into a tensor and returns half of it.
+
+        The primary purpose here is maintaining a shuffling buffer.
+
+        If raise_on_epoch_end is True, when the dataset it exhausted it will automatically refill the dataset and then raise a StopIteration so that the caller has a chance to react.
+        """
         context_size = self.context_size
         batch_size = self.store_batch_size_prompts
         d_in = self.d_in
@@ -468,7 +491,9 @@ class ActivationsStore:
 
         for refill_batch_idx_start in refill_iterator:
             # move batch toks to gpu for model
-            refill_batch_tokens = self.get_batch_tokens().to(self.model.cfg.device)
+            refill_batch_tokens = self.get_batch_tokens(
+                raise_at_epoch_end=raise_on_epoch_end
+            ).to(self.model.cfg.device)
             refill_activations = self.get_activations(refill_batch_tokens)
             # move acts back to cpu
             refill_activations.to(self.device)
@@ -513,9 +538,23 @@ class ActivationsStore:
 
         batch_size = self.train_batch_size_tokens
 
+        try:
+            new_samples = self.get_buffer(
+                self.half_buffer_size, raise_on_epoch_end=True
+            )
+        except StopIteration:
+            print("Warning: All samples in the training dataset have been exhausted, we are now beginning a new epoch with the same samples.")
+            self._storage_buffer = None # dump the current buffer so samples do not leak between epochs
+            try:
+                new_samples = self.get_buffer(self.half_buffer_size)
+            except StopIteration: 
+                raise ValueError(
+                    "We were unable to fill up the buffer directly after starting a new epoch. This could indicate that there are less samples in the dataset than are required to fill up the buffer. Consider reducing batch_size or n_batches_in_buffer. "
+                )
+
         # 1. # create new buffer by mixing stored and new buffer
         mixing_buffer = torch.cat(
-            [self.get_buffer(self.n_batches_in_buffer // 2), self.storage_buffer],
+            [new_samples, self.storage_buffer],
             dim=0,
         )
 

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -6,7 +6,13 @@ from typing import Any, Generator, Iterator, Literal, cast
 
 import numpy as np
 import torch
-from datasets import Dataset, DatasetDict, load_dataset
+from datasets import (
+    Dataset,
+    DatasetDict,
+    IterableDataset,
+    IterableDatasetDict,
+    load_dataset,
+)
 from safetensors import safe_open
 from safetensors.torch import save_file
 from torch.utils.data import DataLoader

--- a/tests/unit/training/test_cache_activations_runner.py
+++ b/tests/unit/training/test_cache_activations_runner.py
@@ -167,7 +167,7 @@ def test_activations_store_refreshes_dataset_when_it_runs_out():
         os.path.dirname(__file__), "fixtures", "cached_activations"
     )
 
-    total_training_steps = 200  # probably we should do more
+    total_training_steps = 200  
     batch_size = 4
     total_training_tokens = total_training_steps * batch_size
 
@@ -175,28 +175,21 @@ def test_activations_store_refreshes_dataset_when_it_runs_out():
     cfg = LanguageModelSAERunnerConfig(
         cached_activations_path=cached_activations_fixture_path,
         use_cached_activations=True,
-        # Pick a tiny model to make this easier.
         model_name="gelu-1l",
-        ## MLP Layer 0 ##
         hook_name="blocks.0.hook_mlp_out",
         hook_layer=0,
         d_in=512,
-        dataset_path="NeelNanda/c4-10k",
+        dataset_path="",
         context_size=context_size,
         is_dataset_tokenized=True,
-        prepend_bos=True,  # I used to train GPT2 SAEs with a prepended-bos but no longer think we should do this.
-        training_tokens=total_training_tokens,  # For initial testing I think this is a good number.
+        prepend_bos=True, 
+        training_tokens=total_training_tokens, 
         train_batch_size_tokens=4096,
-        # Loss Function
-        ## Reconstruction Coefficient.
-        # Buffer details won't matter in we cache / shuffle our activations ahead of time.
+        
         n_batches_in_buffer=2,
         store_batch_size_prompts=batch_size,
         normalize_activations="none",
-        # shuffle_every_n_buffers=2,
-        # n_shuffles_with_last_section=1,
-        # n_shuffles_in_entire_dir=1,
-        # n_shuffles_final=1,
+        
         # Misc
         device="cpu",
         seed=42,

--- a/tests/unit/training/test_cache_activations_runner.py
+++ b/tests/unit/training/test_cache_activations_runner.py
@@ -167,7 +167,7 @@ def test_activations_store_refreshes_dataset_when_it_runs_out():
         os.path.dirname(__file__), "fixtures", "cached_activations"
     )
 
-    total_training_steps = 200  
+    total_training_steps = 200
     batch_size = 4
     total_training_tokens = total_training_steps * batch_size
 
@@ -182,10 +182,9 @@ def test_activations_store_refreshes_dataset_when_it_runs_out():
         dataset_path="",
         context_size=context_size,
         is_dataset_tokenized=True,
-        prepend_bos=True, 
-        training_tokens=total_training_tokens, 
+        prepend_bos=True,
+        training_tokens=total_training_tokens,
         train_batch_size_tokens=4096,
-        
         n_batches_in_buffer=2,
         store_batch_size_prompts=batch_size,
         normalize_activations="none",

--- a/tests/unit/training/test_cache_activations_runner.py
+++ b/tests/unit/training/test_cache_activations_runner.py
@@ -2,8 +2,8 @@ import os
 from pathlib import Path
 from typing import Any, Tuple
 
-import torch
 import pytest
+import torch
 from datasets import Dataset
 from safetensors import safe_open
 from transformer_lens import HookedTransformer
@@ -216,12 +216,13 @@ def test_activations_store_refreshes_dataset_when_it_runs_out():
 
     # assert a stop iteration is raised when we do one more get_batch_tokens
 
-    pytest.raises(StopIteration, activations_store.get_batch_tokens, batch_size, raise_at_epoch_end=True)
+    pytest.raises(
+        StopIteration,
+        activations_store.get_batch_tokens,
+        batch_size,
+        raise_at_epoch_end=True,
+    )
 
     # no errors are ever raised if we do not ask for raise_at_epoch_end
     for _ in range(32):
         _ = activations_store.get_batch_tokens(batch_size, raise_at_epoch_end=False)
-
-    
-    
-

--- a/tests/unit/training/test_cache_activations_runner.py
+++ b/tests/unit/training/test_cache_activations_runner.py
@@ -1,10 +1,9 @@
 import os
-
-# import pytest
-# import shutil
 from pathlib import Path
+from typing import Any, Tuple
 
 import torch
+from datasets import Dataset
 from safetensors import safe_open
 from transformer_lens import HookedTransformer
 
@@ -160,3 +159,67 @@ def test_load_cached_activations():
 
     # assert sparse_autoencoder_dictionary is not None
     # know whether or not this works by looking at the dashboard!
+
+
+def test_activations_store_refreshes_dataset_when_it_runs_out():
+
+    cached_activations_fixture_path = os.path.join(
+        os.path.dirname(__file__), "fixtures", "cached_activations"
+    )
+
+    total_training_steps = 200  # probably we should do more
+    batch_size = 4
+    total_training_tokens = total_training_steps * batch_size
+
+    context_size = 256
+    cfg = LanguageModelSAERunnerConfig(
+        cached_activations_path=cached_activations_fixture_path,
+        use_cached_activations=True,
+        # Pick a tiny model to make this easier.
+        model_name="gelu-1l",
+        ## MLP Layer 0 ##
+        hook_name="blocks.0.hook_mlp_out",
+        hook_layer=0,
+        d_in=512,
+        dataset_path="NeelNanda/c4-10k",
+        context_size=context_size,
+        is_dataset_tokenized=True,
+        prepend_bos=True,  # I used to train GPT2 SAEs with a prepended-bos but no longer think we should do this.
+        training_tokens=total_training_tokens,  # For initial testing I think this is a good number.
+        train_batch_size_tokens=4096,
+        # Loss Function
+        ## Reconstruction Coefficient.
+        # Buffer details won't matter in we cache / shuffle our activations ahead of time.
+        n_batches_in_buffer=2,
+        store_batch_size_prompts=batch_size,
+        normalize_activations="none",
+        # shuffle_every_n_buffers=2,
+        # n_shuffles_with_last_section=1,
+        # n_shuffles_in_entire_dir=1,
+        # n_shuffles_final=1,
+        # Misc
+        device="cpu",
+        seed=42,
+        dtype="float16",
+    )
+
+    class MockModel:
+        def to_tokens(self, *args: Tuple[Any, ...], **kwargs: Any) -> torch.Tensor:
+            return torch.ones(context_size)
+
+        @property
+        def W_E(self) -> torch.Tensor:
+            return torch.ones(16, 16)
+
+    dataset = Dataset.from_list(
+        [
+            {"text": "hello world1"},
+        ]
+        * 64
+    )
+
+    model = MockModel()
+    activations_store = ActivationsStore.from_config(model, cfg, override_dataset=dataset)  # type: ignore
+    for _ in range(17):
+        _ = activations_store.get_batch_tokens(batch_size)
+        # we iterate 17 times, 17 * 4 (batch_size) = 68, more than we have samples


### PR DESCRIPTION
I ran into an error after almost 3 hours of training which was 

```
  File "/root/SAELens/sae_lens/training/activations_store.py", line 466, in get_buffer                                                                   
    refill_activations = self.get_activations(refill_batch_tokens)                                                                                       
  File "/root/SAELens/sae_lens/training/activations_store.py", line 346, in get_batch_tokens                                                                                                                                                                                                                       
    return torch.stack(sequences, dim=0).to(self.model.W_E.device)                                                                                       
StopIteration      
```

Ultimately I traced this back to a line 

```python
        self.iterable_sequences = self._iterate_tokenized_sequences()
```

in the `__init__` of `ActivationsStore`. This ultimately assigns this class variables to a dataset iterator, which looks like


```python
    def _iterate_raw_dataset(
        self,
    ) -> Generator[torch.Tensor | list[int] | str, None, None]:
        """
        Helper to iterate over the dataset while incrementing n_dataset_processed
        """
        for row in self.dataset:
            # typing datasets is difficult
            yield row[self.tokens_column]  # type: ignore
            self.n_dataset_processed += 1
```

All well and good, happy times, but it turns out our friend `self.iterable_sequences` never gets re-assigned, so when we reach the dataset runs out and `_iterate_raw_dataset` throws `StopIteration` all future calls to `next(self.iterable_sequences)` will also throw a `StopIteration`, which eventually stops being caught. 

Luckily `next(self.iterable_sequences)` is only called in once place so we just add a try/except block which reassigns `self.iterable_sequences` to a fresh iterator and we start back at the beginning of the dataset. 




```
all last):                                                                                                                                                                                                                                                                                                         
  File "/root/SAELens/sae_lens/training/activations_store.py", line 541, in next_batch                                                                                                                                                                                                                             
    except StopIteration:                                                                                                                                                                                                                                                                                          
  File "/root/.cache/pypoetry/virtualenvs/sae-lens--vdHUHSD-py3.10/lib/python3.10/site-packages/torch/utils/data/dataloader.py", line 631, in __next__                                                                                                                                                             
    data = self._next_data()                                                                                                                                                                                                                                                                                       
  File "/root/.cache/pypoetry/virtualenvs/sae-lens--vdHUHSD-py3.10/lib/python3.10/site-packages/torch/utils/data/dataloader.py", line 674, in _next_data                                                                                                                                                           
    index = self._next_index()  # may raise StopIteration                                                                                                                                                                                                                                                          
  File "/root/.cache/pypoetry/virtualenvs/sae-lens--vdHUHSD-py3.10/lib/python3.10/site-packages/torch/utils/data/dataloader.py", line 621, in _next_index                                                                                                                                                          
    return next(self._sampler_iter)  # may raise StopIteration                                                                                                                                                                                                                                                     
StopIteration                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                   
During handling of the above exception, another exception occurred:                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                   
Traceback (most recent call last):                                                                                                                                                                                                                                                                                 
  File "/root/SAELens/pad.py", line 84, in <module>                                                                                                                                                                                                                                                                
  File "/root/SAELens/sae_lens/sae_training_runner.py", line 87, in run                                                                                                                                                                                                                                            
    )                                                                                                                                                                                                                                                                                                              
  File "/root/SAELens/sae_lens/sae_training_runner.py", line 130, in run_trainer_with_interruption_handling                                                                                                                                                                                                        
    signal.signal(signal.SIGTERM, interrupt_callback)                                                                                                                                                                                                                                                              
  File "/root/SAELens/sae_lens/training/sae_trainer.py", line 159, in fit                                                                                                                                                                                                                                          
    layer_acts = self.activation_store.next_batch()[:, 0, :].to(self.sae.device)                                                                                                                                                                                                                                   
  File "/root/SAELens/sae_lens/training/activations_store.py", line 544, in next_batch                                                                                                                                                                                                                             
    return next(self.dataloader)                                                                                                                                                                                                                                                                                   
  File "/root/SAELens/sae_lens/training/activations_store.py", line 513, in get_data_loader                                                                                                                                                                                                                        
    dim=0,                                                                                                                                                                                                                                                                                                         
  File "/root/.cache/pypoetry/virtualenvs/sae-lens--vdHUHSD-py3.10/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context                                                                                                                                                         
    return func(*args, **kwargs)                                                                                                                                                                                                                                                                                   
  File "/root/SAELens/sae_lens/training/activations_store.py", line 466, in get_buffer                                                                                                                                                                                                                             
    refill_activations = self.get_activations(refill_batch_tokens)                                                                                                                
  File "/root/SAELens/sae_lens/training/activations_store.py", line 346, in get_batch_tokens                                                                                                                                                                                                                       
    return torch.stack(sequences, dim=0).to(self.model.W_E.device)                                                                                       
StopIteration                                                               
Traceback (most recent call last):                                          
  File "/root/SAELens/sae_lens/training/activations_store.py", line 541, in next_batch                                                                   
    except StopIteration:                                                   
  File "/root/.cache/pypoetry/virtualenvs/sae-lens--vdHUHSD-py3.10/lib/python3.10/site-packages/torch/utils/data/dataloader.py", line 631, in __next__                                                                                                                                                             
    data = self._next_data()                                                
  File "/root/.cache/pypoetry/virtualenvs/sae-lens--vdHUHSD-py3.10/lib/python3.10/site-packages/torch/utils/data/dataloader.py", line 674, in _next_data                                                                                                                                                           
    index = self._next_index()  # may raise StopIteration                                                                                                
  File "/root/.cache/pypoetry/virtualenvs/sae-lens--vdHUHSD-py3.10/lib/python3.10/site-packages/torch/utils/data/dataloader.py", line 621, in _next_index                                                                                                                                                          
    return next(self._sampler_iter)  # may raise StopIteration                                                                                           
StopIteration                                                               

During handling of the above exception, another exception occurred:                                                                                      

Traceback (most recent call last):                                          
  File "/root/SAELens/pad.py", line 84, in <module>                                                                                                      
  File "/root/SAELens/sae_lens/sae_training_runner.py", line 87, in run                                                                                  
    )                                                                       
  File "/root/SAELens/sae_lens/sae_training_runner.py", line 130, in run_trainer_with_interruption_handling                                                                                                                                                                                                        
    signal.signal(signal.SIGTERM, interrupt_callback)                                                                                                    
  File "/root/SAELens/sae_lens/training/sae_trainer.py", line 159, in fit                                                                                
    layer_acts = self.activation_store.next_batch()[:, 0, :].to(self.sae.device)                                                                         
  File "/root/SAELens/sae_lens/training/activations_store.py", line 544, in next_batch                                                                   
    return next(self.dataloader)                                            
  File "/root/SAELens/sae_lens/training/activations_store.py", line 513, in get_data_loader                                                                                                                                                                                                                        
    dim=0,                                                                  
  File "/root/.cache/pypoetry/virtualenvs/sae-lens--vdHUHSD-py3.10/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context                                                                                                                                                         
    return func(*args, **kwargs)                                            
  File "/root/SAELens/sae_lens/training/activations_store.py", line 466, in get_buffer                                                                   
    refill_activations = self.get_activations(refill_batch_tokens)                                                                                       
  File "/root/SAELens/sae_lens/training/activations_store.py", line 346, in get_batch_tokens                                                                                                                                                                                                                       
    return torch.stack(sequences, dim=0).to(self.model.W_E.device)                                                                                       
StopIteration      
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [ ] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 