### PR TITLE
fix: Activation store factor unscaling fold fix

### DIFF
--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -64,7 +64,7 @@ def run_evals(
     else:
         original_act = cache[hook_name]
 
-    # normalise if necessary
+    # normalise if necessary (necessary in training only, otherwise we should fold the scaling in)
     if activation_store.normalize_activations == "expected_average_only_in":
         original_act = activation_store.apply_norm_scaling_factor(original_act)
 
@@ -72,6 +72,10 @@ def run_evals(
     sae_out = sae.decode(sae.encode(original_act.to(sae.device))).to(
         original_act.device
     )
+
+    if activation_store.normalize_activations == "expected_average_only_in":
+        sae_out = activation_store.unscale(sae_out)
+
     del cache
 
     l2_norm_in = torch.norm(original_act, dim=-1)

--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -326,7 +326,7 @@ SAE_LOOKUP:
         l0: 56.0
       - id: "blocks.12.hook_resid_post"
         path: "gemma_2b_blocks.12.hook_resid_post_16384"
-        variance_explained: -3.6
+        variance_explained: -0.65
         l0: 62.0
   gemma-2b-it-res-jb:
     repo_id: "jbloom/Gemma-2b-IT-Residual-Stream-SAEs"

--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -113,6 +113,8 @@ SAE_LOOKUP:
     repo_id: "tommmcgrath/gpt2-small-mlp-out-saes"
     model: "gpt2-small"
     conversion_func: null
+    config_overrides:
+      dataset_path: "Skylion007/openwebtext"
     saes:
       - id: "blocks.0.hook_mlp_out"
         path: "sae_group_gpt2_blocks.0.hook_mlp_out_24576:v1"
@@ -120,7 +122,7 @@ SAE_LOOKUP:
         l0: 15.0
       - id: "blocks.1.hook_mlp_out"
         path: "sae_group_gpt2_blocks.1.hook_mlp_out_24576:v0"
-        variance_explained: -0.20
+        variance_explained: 0.57
         l0: 21.0
       - id: "blocks.2.hook_mlp_out"
         path: "sae_group_gpt2_blocks.2.hook_mlp_out_24576:v0"
@@ -128,7 +130,7 @@ SAE_LOOKUP:
         l0: 137.0
       - id: "blocks.3.hook_mlp_out"
         path: "sae_group_gpt2_blocks.3.hook_mlp_out_24576:v0"
-        variance_explained: 0.41
+        variance_explained: 0.57
         l0: 54.0
       - id: "blocks.4.hook_mlp_out"
         path: "sae_group_gpt2_blocks.4.hook_mlp_out_24576:v0"
@@ -152,15 +154,15 @@ SAE_LOOKUP:
         l0: 36.0
       - id: "blocks.9.hook_mlp_out"
         path: "sae_group_gpt2_blocks.9.hook_mlp_out_24576:v0"
-        variance_explained: 0.37
+        variance_explained: 0.49
         l0: 49.0
       - id: "blocks.10.hook_mlp_out"
         path: "sae_group_gpt2_blocks.10.hook_mlp_out_24576:v0"
-        variance_explained: -0.44
+        variance_explained: 0.22
         l0: 167.0
       - id: "blocks.11.hook_mlp_out"
         path: "sae_group_gpt2_blocks.11.hook_mlp_out_24576:v2"
-        variance_explained: 0.05
+        variance_explained: 0.59
         l0: 170.0
   gpt2-small-res-jb-feature-splitting:
     repo_id: "jbloom/GPT2-Small-Feature-Splitting-Experiment-Layer-8"
@@ -203,6 +205,8 @@ SAE_LOOKUP:
     repo_id: "jbloom/GPT2-Small-OAI-v5-32k-resid-post-SAEs"
     model: "gpt2-small"
     conversion_func: null
+    config_overrides:
+      dataset_path: "Skylion007/openwebtext"
     saes:
       - id: "blocks.0.hook_resid_post"
         path: "v5_32k_layer_0.pt"
@@ -256,6 +260,8 @@ SAE_LOOKUP:
     repo_id: "jbloom/GPT2-Small-OAI-v5-128k-resid-post-SAEs"
     model: "gpt2-small"
     conversion_func: null
+    config_overrides:
+      dataset_path: "Skylion007/openwebtext"
     saes:
       - id: "blocks.0.hook_resid_post"
         path: "v5_128k_layer_0"
@@ -338,8 +344,8 @@ SAE_LOOKUP:
     saes:
       - id: "blocks.8.hook_resid_pre"
         path: "mistral_7b_layer_8"
-        variance_explained: 0.74
-        l0: 82
+        variance_explained: 0.94
+        l0: 92
       - id: "blocks.16.hook_resid_pre"
         path: "mistral_7b_layer_16"
         variance_explained: 0.85

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -425,6 +425,11 @@ class SAE(HookedRootModule):
         self, activation_norm_scaling_factor: float
     ):
         self.W_enc.data = self.W_enc.data * activation_norm_scaling_factor
+        # previously weren't doing this.
+        self.W_dec.data = self.W_dec.data / activation_norm_scaling_factor
+
+        # once we normalize, we shouldn't need to scale activations.
+        self.cfg.normalize_activations = "none"
 
     def save_model(self, path: str, sparsity: Optional[torch.Tensor] = None):
 
@@ -507,6 +512,7 @@ class SAE(HookedRootModule):
             folder_name=hf_path,
             device=device,
             force_download=False,
+            cfg_overrides=sae_directory[release].config_overrides,
         )
 
         sae = cls(SAEConfig.from_dict(cfg_dict))

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -16,6 +16,7 @@ class PretrainedSaeLoader(Protocol):
         folder_name: str,
         device: str | torch.device | None = None,
         force_download: bool = False,
+        cfg_overrides: dict[str, Any] | None = None,
     ) -> tuple[dict[str, Any], dict[str, torch.Tensor], Optional[torch.Tensor]]: ...
 
 
@@ -24,6 +25,7 @@ def sae_lens_loader(
     folder_name: str,
     device: Optional[str] = None,
     force_download: bool = False,
+    cfg_overrides: Optional[dict[str, Any]] = None,
 ) -> tuple[dict[str, Any], dict[str, torch.Tensor], Optional[torch.Tensor]]:
     cfg_filename = f"{folder_name}/cfg.json"
     cfg_path = hf_hub_download(
@@ -49,7 +51,11 @@ def sae_lens_loader(
 
     # TODO: don't call a function at the end of another like this. Poor form.
     return load_pretrained_sae_lens_sae_components(
-        cfg_path, sae_path, device, log_sparsity_path=log_sparsity_path
+        cfg_path,
+        sae_path,
+        device,
+        log_sparsity_path=log_sparsity_path,
+        cfg_overrides=cfg_overrides,
     )
 
 
@@ -138,7 +144,7 @@ def connor_rob_hook_z_loader(
         "finetuning_scaling_factor": False,
         "sae_lens_training_version": None,
         "prepend_bos": True,
-        "dataset_path": "apollo-research/Skylion007-openwebtext-tokenizer-gpt2",
+        "dataset_path": "Skylion007/openwebtext",
         "context_size": 128,
         "normalize_activations": "none",
         "dataset_trust_remote_code": True,
@@ -152,11 +158,14 @@ def mistral_7b_josh_engels_loader(
     folder_name: str,
     device: Optional[str] = None,
     force_download: bool = False,
+    cfg_overrides: Optional[dict[str, Any]] = None,
 ) -> tuple[dict[str, Any], dict[str, torch.Tensor], Optional[torch.Tensor]]:
 
     cfg_dict, state_dict, log_sparsity = sae_lens_loader(
-        repo_id, folder_name, device, force_download
+        repo_id, folder_name, device, force_download, cfg_overrides
     )
+
+    # this is redundant now but can remove later. We should just use the config overrides.
     cfg_dict["normalize_activations"] = "constant_norm_rescale"
     return cfg_dict, state_dict, log_sparsity
 
@@ -167,9 +176,14 @@ def load_pretrained_sae_lens_sae_components(
     device: str = "cpu",
     dtype: str = "float32",
     log_sparsity_path: Optional[str] = None,
+    cfg_overrides: Optional[dict[str, Any]] = None,
 ) -> tuple[dict[str, Any], dict[str, torch.Tensor], Optional[torch.Tensor]]:
     with open(cfg_path, "r") as f:
         cfg_dict = json.load(f)
+
+    # apply overrides
+    if cfg_overrides is not None:
+        cfg_dict.update(cfg_overrides)
 
     cfg_dict["architecture"] = (
         "standard"  # TODO: modify this when we add support for loading more architectures

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -185,12 +185,11 @@ def load_pretrained_sae_lens_sae_components(
     if cfg_overrides is not None:
         cfg_dict.update(cfg_overrides)
 
-
     if "architecture" not in cfg_dict:
         cfg_dict["architecture"] = (
             "standard"  # TODO: modify this when we add support for loading more architectures
         )
-        
+
     # filter config for varnames
     cfg_dict["device"] = device
     cfg_dict["dtype"] = dtype

--- a/sae_lens/toolkit/pretrained_saes_directory.py
+++ b/sae_lens/toolkit/pretrained_saes_directory.py
@@ -14,6 +14,7 @@ class PretrainedSAELookup:
     saes_map: dict[str, str]  # id -> path
     expected_var_explained: dict[str, float]
     expected_l0: dict[str, float]
+    config_overrides: dict[str, str] | None
 
 
 @cache
@@ -42,5 +43,6 @@ def get_pretrained_saes_directory() -> dict[str, PretrainedSAELookup]:
                 saes_map=saes_map,
                 expected_var_explained=var_explained_map,
                 expected_l0=l0_map,
+                config_overrides=value.get("config_overrides"),
             )
     return directory

--- a/sae_lens/training/toy_models.py
+++ b/sae_lens/training/toy_models.py
@@ -435,7 +435,7 @@ def plot_features_in_2d(
         if title:
             fig.suptitle(title[t], fontsize=15)
         if subplot_titles:
-            ax.set_title(subplot_titles[t], fontsize=12)
+            ax.set_title(subplot_titles[t], fontsize=12)  # type: ignore
         fig.canvas.draw_idle()
 
     def play(event: Any):

--- a/tests/unit/toolkit/test_pretrained_saes_directory.py
+++ b/tests/unit/toolkit/test_pretrained_saes_directory.py
@@ -57,6 +57,7 @@ def test_get_pretrained_saes_directory():
             "blocks.11.hook_resid_pre": 56.0,
             "blocks.11.hook_resid_post": 70.0,
         },
+        config_overrides=None,
     )
 
     assert sae_directory["gpt2-small-res-jb"] == expected_result

--- a/tests/unit/training/test_sae_basic.py
+++ b/tests/unit/training/test_sae_basic.py
@@ -119,6 +119,8 @@ def test_sae_fold_norm_scaling_factor(cfg: LanguageModelSAERunnerConfig):
     sae2 = deepcopy(sae)
     sae2.fold_activation_norm_scaling_factor(norm_scaling_factor)
 
+    assert sae2.cfg.normalize_activations == "none"
+
     assert torch.allclose(sae2.W_enc.data, sae.W_enc.data * norm_scaling_factor)
 
     # we expect activations of features to differ by W_dec norm weights.
@@ -140,7 +142,7 @@ def test_sae_fold_norm_scaling_factor(cfg: LanguageModelSAERunnerConfig):
     torch.testing.assert_close(feature_activations_2, feature_activations_1)
 
     sae_out_1 = sae.decode(feature_activations_1)
-    sae_out_2 = sae2.decode(feature_activations_2)
+    sae_out_2 = sae2.decode(feature_activations_2 * norm_scaling_factor)
 
     # but actual outputs should be the same
     torch.testing.assert_close(sae_out_1, sae_out_2)


### PR DESCRIPTION
# Description

We had a bug where we weren't scaling the decoder weights when using SAEs that had an activation norm factor scaling factor `normalize_activations = "expected_average_only_in"` which affected the quality of GPT2-Small MLP-Out SAEs (TM ones, not OAI) and the gemma-2b (base) layer 12 resid post SAE. 

Also, in order to have benchmark tests (not yet in CI) not fail due to warnings over dataset size matches, we've switched some SAE configs to tokenizing in real time (which slows them down unfortunately) - but this is solve-able if we make some pre-tokenized datasets with the right lengths. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
