### PR TITLE
feat: make pretrained sae directory docs page

### DIFF
--- a/docs/generate_sae_table.py
+++ b/docs/generate_sae_table.py
@@ -1,0 +1,128 @@
+# type: ignore
+import json
+from pathlib import Path
+
+import pandas as pd
+import yaml
+from huggingface_hub import hf_hub_download
+from tqdm import tqdm
+
+from sae_lens import SAEConfig
+from sae_lens.toolkit.pretrained_sae_loaders import (
+    get_sae_config_from_hf,
+    handle_config_defaulting,
+)
+
+INCLUDED_CFG = [
+    # "id",
+    # "architecture",
+    # "model_name",
+    "hook_name",
+    "hook_layer",
+    "d_sae",
+    "context_size",
+    "dataset_path",
+    "normalize_activations",
+]
+
+
+def on_pre_build(config):
+    print("Generating SAE table...")
+    generate_sae_table()
+    print("SAE table generation complete.")
+
+
+def generate_sae_table():
+    # Read the YAML file
+    yaml_path = Path("sae_lens/pretrained_saes.yaml")
+    with open(yaml_path, "r") as file:
+        data = yaml.safe_load(file)
+
+    # Start the Markdown content
+    markdown_content = "# Pretrained SAEs\n\n"
+    markdown_content += "This is a list of SAEs importable from the SAELens package. Click on each link for more details.\n\n"  # Added newline
+    markdown_content += "*This file contains the contents of `sae_lens/pretrained_saes.yaml` in Markdown*\n\n"
+
+    # Generate content for each model
+    for model_name, model_info in tqdm(data["SAE_LOOKUP"].items()):
+        repo_link = f"https://huggingface.co/{model_info['repo_id']}"
+        markdown_content += f"## [{model_name}]({repo_link})\n\n"
+        markdown_content += f"- **Huggingface Repo**: {model_info['repo_id']}\n"
+        markdown_content += f"- **model**: {model_info['model']}\n"
+
+        if "links" in model_info:
+            markdown_content += "- **Additional Links**:\n"
+            for link_type, url in model_info["links"].items():
+                markdown_content += f"    - [{link_type.capitalize()}]({url})\n"
+
+        markdown_content += "\n"
+
+        # get the config
+
+        # for sae_info in model_info["saes"]:
+        #     sae_cfg = get_sae_config_from_hf(
+        #         model_info["repo_id"],
+        #         sae_info["path"],
+        #     )
+
+        for info in tqdm(model_info["saes"]):
+
+            # can remove this by explicitly overriding config in yaml. Do this later.
+            if model_info["conversion_func"] == "connor_rob_hook_z":
+                repo_id = model_info["repo_id"]
+                folder_name = info["path"]
+                config_path = folder_name.split(".pt")[0] + "_cfg.json"
+                config_path = hf_hub_download(repo_id, config_path)
+                old_cfg_dict = json.load(open(config_path, "r"))
+
+                cfg = {
+                    "architecture": "standard",
+                    "d_in": old_cfg_dict["act_size"],
+                    "d_sae": old_cfg_dict["dict_size"],
+                    "dtype": "float32",
+                    "device": "cpu",
+                    "model_name": "gpt2-small",
+                    "hook_name": old_cfg_dict["act_name"],
+                    "hook_layer": old_cfg_dict["layer"],
+                    "hook_head_index": None,
+                    "activation_fn_str": "relu",
+                    "apply_b_dec_to_input": True,
+                    "finetuning_scaling_factor": False,
+                    "sae_lens_training_version": None,
+                    "prepend_bos": True,
+                    "dataset_path": "Skylion007/openwebtext",
+                    "context_size": 128,
+                    "normalize_activations": "none",
+                    "dataset_trust_remote_code": True,
+                }
+                cfg = handle_config_defaulting(cfg)
+                cfg = SAEConfig.from_dict(cfg).to_dict()
+                info.update(cfg)
+            else:
+                cfg = get_sae_config_from_hf(
+                    model_info["repo_id"],
+                    info["path"],
+                )
+                cfg = handle_config_defaulting(cfg)
+                cfg = SAEConfig.from_dict(cfg).to_dict()
+            info.update(cfg)
+
+        # cfg_to_in
+        # Create DataFrame for SAEs
+        df = pd.DataFrame(model_info["saes"])
+
+        # Keep only 'id' and 'path' columns
+        df = df[INCLUDED_CFG]
+
+        # Generate Markdown table
+        table = df.to_markdown(index=False)
+        markdown_content += table + "\n\n"
+
+    # Write the content to a Markdown file
+    output_path = Path("docs/sae_table.md")
+    with open(output_path, "w") as file:
+        file.write(markdown_content)
+
+
+if __name__ == "__main__":
+    generate_sae_table()

--- a/docs/sae_table.md
+++ b/docs/sae_table.md
@@ -1,0 +1,173 @@
+# Pretrained SAEs
+
+This is a list of SAEs importable from the SAELens package. Click on each link for more details.
+
+*This file contains the contents of `sae_lens/pretrained_saes.yaml` in Markdown*
+
+## [gpt2-small-res-jb](https://huggingface.co/jbloom/GPT2-Small-SAEs-Reformatted)
+
+- **Huggingface Repo**: jbloom/GPT2-Small-SAEs-Reformatted
+- **model**: gpt2-small
+- **Additional Links**:
+    - [Model](https://huggingface.co/gpt2)
+    - [Dashboards](https://www.neuronpedia.org/gpt2sm-res-jb)
+    - [Publication](https://www.lesswrong.com/posts/f9EgfLSurAiqRJySD/open-source-sparse-autoencoders-for-all-residual-stream)
+
+| hook_name                 |   hook_layer |   d_sae |   context_size | normalize_activations   |
+|:--------------------------|-------------:|--------:|---------------:|:------------------------|
+| blocks.0.hook_resid_pre   |            0 |   24576 |            128 | none                    |
+| blocks.1.hook_resid_pre   |            1 |   24576 |            128 | none                    |
+| blocks.2.hook_resid_pre   |            2 |   24576 |            128 | none                    |
+| blocks.3.hook_resid_pre   |            3 |   24576 |            128 | none                    |
+| blocks.4.hook_resid_pre   |            4 |   24576 |            128 | none                    |
+| blocks.5.hook_resid_pre   |            5 |   24576 |            128 | none                    |
+| blocks.6.hook_resid_pre   |            6 |   24576 |            128 | none                    |
+| blocks.7.hook_resid_pre   |            7 |   24576 |            128 | none                    |
+| blocks.8.hook_resid_pre   |            8 |   24576 |            128 | none                    |
+| blocks.9.hook_resid_pre   |            9 |   24576 |            128 | none                    |
+| blocks.10.hook_resid_pre  |           10 |   24576 |            128 | none                    |
+| blocks.11.hook_resid_pre  |           11 |   24576 |            128 | none                    |
+| blocks.11.hook_resid_post |           11 |   24576 |            128 | none                    |
+
+## [gpt2-small-hook-z-kk](https://huggingface.co/ckkissane/attn-saes-gpt2-small-all-layers)
+
+- **Huggingface Repo**: ckkissane/attn-saes-gpt2-small-all-layers
+- **model**: gpt2-small
+- **Additional Links**:
+    - [Model](https://huggingface.co/gpt2)
+    - [Dashboards](https://www.neuronpedia.org/gpt2sm-kk)
+    - [Publication](https://www.lesswrong.com/posts/FSTRedtjuHa4Gfdbr/attention-saes-scale-to-gpt-2-small)
+
+| hook_name             |   hook_layer |   d_sae |   context_size | normalize_activations   |
+|:----------------------|-------------:|--------:|---------------:|:------------------------|
+| blocks.0.attn.hook_z  |            0 |   24576 |            128 | none                    |
+| blocks.1.attn.hook_z  |            1 |   24576 |            128 | none                    |
+| blocks.2.attn.hook_z  |            2 |   24576 |            128 | none                    |
+| blocks.3.attn.hook_z  |            3 |   24576 |            128 | none                    |
+| blocks.4.attn.hook_z  |            4 |   24576 |            128 | none                    |
+| blocks.5.attn.hook_z  |            5 |   49152 |            128 | none                    |
+| blocks.6.attn.hook_z  |            6 |   24576 |            128 | none                    |
+| blocks.7.attn.hook_z  |            7 |   49152 |            128 | none                    |
+| blocks.8.attn.hook_z  |            8 |   24576 |            128 | none                    |
+| blocks.9.attn.hook_z  |            9 |   24576 |            128 | none                    |
+| blocks.10.attn.hook_z |           10 |   24576 |            128 | none                    |
+| blocks.11.attn.hook_z |           11 |   24576 |            128 | none                    |
+
+## [gpt2-small-mlp-tm](https://huggingface.co/tommmcgrath/gpt2-small-mlp-out-saes)
+
+- **Huggingface Repo**: tommmcgrath/gpt2-small-mlp-out-saes
+- **model**: gpt2-small
+- **Additional Links**:
+    - [Model](https://huggingface.co/gpt2)
+
+| hook_name              |   hook_layer |   d_sae |   context_size | normalize_activations    |
+|:-----------------------|-------------:|--------:|---------------:|:-------------------------|
+| blocks.0.hook_mlp_out  |            0 |   24576 |            512 | expected_average_only_in |
+| blocks.1.hook_mlp_out  |            1 |   24576 |            512 | expected_average_only_in |
+| blocks.2.hook_mlp_out  |            2 |   24576 |            512 | expected_average_only_in |
+| blocks.3.hook_mlp_out  |            3 |   24576 |            512 | expected_average_only_in |
+| blocks.4.hook_mlp_out  |            4 |   24576 |            512 | expected_average_only_in |
+| blocks.5.hook_mlp_out  |            5 |   24576 |            512 | expected_average_only_in |
+| blocks.6.hook_mlp_out  |            6 |   24576 |            512 | expected_average_only_in |
+| blocks.7.hook_mlp_out  |            7 |   24576 |            512 | expected_average_only_in |
+| blocks.8.hook_mlp_out  |            8 |   24576 |            512 | expected_average_only_in |
+| blocks.9.hook_mlp_out  |            9 |   24576 |            512 | expected_average_only_in |
+| blocks.10.hook_mlp_out |           10 |   24576 |            512 | expected_average_only_in |
+| blocks.11.hook_mlp_out |           11 |   24576 |            512 | expected_average_only_in |
+
+## [gpt2-small-res-jb-feature-splitting](https://huggingface.co/jbloom/GPT2-Small-Feature-Splitting-Experiment-Layer-8)
+
+- **Huggingface Repo**: jbloom/GPT2-Small-Feature-Splitting-Experiment-Layer-8
+- **model**: gpt2-small
+- **Additional Links**:
+    - [Model](https://huggingface.co/gpt2)
+    - [Dashboards](https://www.neuronpedia.org/gpt2sm-rfs-jb)
+
+| hook_name               |   hook_layer |   d_sae |   context_size | normalize_activations   |
+|:------------------------|-------------:|--------:|---------------:|:------------------------|
+| blocks.8.hook_resid_pre |            8 |     768 |            128 | none                    |
+| blocks.8.hook_resid_pre |            8 |    1536 |            128 | none                    |
+| blocks.8.hook_resid_pre |            8 |    3072 |            128 | none                    |
+| blocks.8.hook_resid_pre |            8 |    6144 |            128 | none                    |
+| blocks.8.hook_resid_pre |            8 |   12288 |            128 | none                    |
+| blocks.8.hook_resid_pre |            8 |   24576 |            128 | none                    |
+| blocks.8.hook_resid_pre |            8 |   49152 |            128 | none                    |
+| blocks.8.hook_resid_pre |            8 |   98304 |            128 | none                    |
+
+## [gpt2-small-resid-post-v5-32k](https://huggingface.co/jbloom/GPT2-Small-OAI-v5-32k-resid-post-SAEs)
+
+- **Huggingface Repo**: jbloom/GPT2-Small-OAI-v5-32k-resid-post-SAEs
+- **model**: gpt2-small
+
+| hook_name                 |   hook_layer |   d_sae |   context_size | normalize_activations   |
+|:--------------------------|-------------:|--------:|---------------:|:------------------------|
+| blocks.0.hook_resid_post  |            0 |   32768 |             64 | layer_norm              |
+| blocks.1.hook_resid_post  |            1 |   32768 |             64 | layer_norm              |
+| blocks.2.hook_resid_post  |            2 |   32768 |             64 | layer_norm              |
+| blocks.3.hook_resid_post  |            3 |   32768 |             64 | layer_norm              |
+| blocks.4.hook_resid_post  |            4 |   32768 |             64 | layer_norm              |
+| blocks.5.hook_resid_post  |            5 |   32768 |             64 | layer_norm              |
+| blocks.6.hook_resid_post  |            6 |   32768 |             64 | layer_norm              |
+| blocks.7.hook_resid_post  |            7 |   32768 |             64 | layer_norm              |
+| blocks.8.hook_resid_post  |            8 |   32768 |             64 | layer_norm              |
+| blocks.9.hook_resid_post  |            9 |   32768 |             64 | layer_norm              |
+| blocks.10.hook_resid_post |           10 |   32768 |             64 | layer_norm              |
+| blocks.11.hook_resid_post |           11 |   32768 |             64 | layer_norm              |
+
+## [gpt2-small-resid-post-v5-128k](https://huggingface.co/jbloom/GPT2-Small-OAI-v5-128k-resid-post-SAEs)
+
+- **Huggingface Repo**: jbloom/GPT2-Small-OAI-v5-128k-resid-post-SAEs
+- **model**: gpt2-small
+
+| hook_name                 |   hook_layer |   d_sae |   context_size | normalize_activations   |
+|:--------------------------|-------------:|--------:|---------------:|:------------------------|
+| blocks.0.hook_resid_post  |            0 |  131072 |             64 | layer_norm              |
+| blocks.1.hook_resid_post  |            1 |  131072 |             64 | layer_norm              |
+| blocks.2.hook_resid_post  |            2 |  131072 |             64 | layer_norm              |
+| blocks.3.hook_resid_post  |            3 |  131072 |             64 | layer_norm              |
+| blocks.4.hook_resid_post  |            4 |  131072 |             64 | layer_norm              |
+| blocks.5.hook_resid_post  |            5 |  131072 |             64 | layer_norm              |
+| blocks.6.hook_resid_post  |            6 |  131072 |             64 | layer_norm              |
+| blocks.7.hook_resid_post  |            7 |  131072 |             64 | layer_norm              |
+| blocks.8.hook_resid_post  |            8 |  131072 |             64 | layer_norm              |
+| blocks.9.hook_resid_post  |            9 |  131072 |             64 | layer_norm              |
+| blocks.10.hook_resid_post |           10 |  131072 |             64 | layer_norm              |
+| blocks.11.hook_resid_post |           11 |  131072 |             64 | layer_norm              |
+
+## [gemma-2b-res-jb](https://huggingface.co/jbloom/Gemma-2b-Residual-Stream-SAEs)
+
+- **Huggingface Repo**: jbloom/Gemma-2b-Residual-Stream-SAEs
+- **model**: gemma-2b
+- **Additional Links**:
+    - [Model](https://huggingface.co/google/gemma-2b)
+    - [Dashboards](https://www.neuronpedia.org/gemma2b-res-jb)
+
+| hook_name                 |   hook_layer |   d_sae |   context_size | normalize_activations    |
+|:--------------------------|-------------:|--------:|---------------:|:-------------------------|
+| blocks.0.hook_resid_post  |            0 |   16384 |           1024 | none                     |
+| blocks.6.hook_resid_post  |            6 |   16384 |           1024 | none                     |
+| blocks.12.hook_resid_post |           12 |   16384 |           1024 | expected_average_only_in |
+
+## [gemma-2b-it-res-jb](https://huggingface.co/jbloom/Gemma-2b-IT-Residual-Stream-SAEs)
+
+- **Huggingface Repo**: jbloom/Gemma-2b-IT-Residual-Stream-SAEs
+- **model**: gemma-2b-it
+- **Additional Links**:
+    - [Model](https://huggingface.co/google/gemma-2b-it)
+    - [Dashboards](https://www.neuronpedia.org/gemma2bit-res-jb)
+
+| hook_name                 |   hook_layer |   d_sae |   context_size | normalize_activations   |
+|:--------------------------|-------------:|--------:|---------------:|:------------------------|
+| blocks.12.hook_resid_post |           12 |   16384 |           1024 | none                    |
+
+## [mistral-7b-res-wg](https://huggingface.co/JoshEngels/Mistral-7B-Residual-Stream-SAEs)
+
+- **Huggingface Repo**: JoshEngels/Mistral-7B-Residual-Stream-SAEs
+- **model**: mistral-7b
+
+| hook_name                |   hook_layer |   d_sae |   context_size | normalize_activations   |
+|:-------------------------|-------------:|--------:|---------------:|:------------------------|
+| blocks.8.hook_resid_pre  |            8 |   65536 |            256 | none                    |
+| blocks.16.hook_resid_pre |           16 |   65536 |            256 | none                    |
+| blocks.24.hook_resid_pre |           24 |   65536 |            256 | none                    |
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,8 +48,8 @@ nav:
   - Training SAEs: training_saes.md
   - Citation: citation.md
   - Contributing: contributing.md
-  # - Analysis: usage/examples.md
   - API: api.md
+  - Supported SAEs: sae_table.md
 
 plugins:
   - search
@@ -60,6 +60,8 @@ plugins:
       watch:
         - sae_lens/  # Replace with the path to your Python code
 
+hooks:
+  - docs/generate_sae_table.py
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ mkdocs-autorefs = "^1.0.1"
 mkdocs-section-index = "^0.3.8"
 mkdocstrings = "^0.24.1"
 mkdocstrings-python = "^1.9.0"
+tabulate = "^0.9.0"
 
 [tool.poetry.extras]
 mamba = ["mamba-lens"]

--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -3,6 +3,10 @@ SAE_LOOKUP:
     repo_id: "jbloom/GPT2-Small-SAEs-Reformatted"
     model: "gpt2-small"
     conversion_func: null
+    links:
+      model: "https://huggingface.co/gpt2"
+      dashboards: "https://www.neuronpedia.org/gpt2sm-res-jb"
+      publication: "https://www.lesswrong.com/posts/f9EgfLSurAiqRJySD/open-source-sparse-autoencoders-for-all-residual-stream"
     saes:
       - id: "blocks.0.hook_resid_pre"
         path: "blocks.0.hook_resid_pre"
@@ -60,6 +64,10 @@ SAE_LOOKUP:
     repo_id: "ckkissane/attn-saes-gpt2-small-all-layers"
     model: "gpt2-small"
     conversion_func: "connor_rob_hook_z"
+    links:
+      model: "https://huggingface.co/gpt2"
+      dashboards: "https://www.neuronpedia.org/gpt2sm-kk"
+      publication: "https://www.lesswrong.com/posts/FSTRedtjuHa4Gfdbr/attention-saes-scale-to-gpt-2-small"
     saes:
       - id: "blocks.0.hook_z"
         path: "gpt2-small_L0_Hcat_z_lr1.20e-03_l11.80e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt"
@@ -112,6 +120,8 @@ SAE_LOOKUP:
   gpt2-small-mlp-tm:
     repo_id: "tommmcgrath/gpt2-small-mlp-out-saes"
     model: "gpt2-small"
+    links:
+      model: "https://huggingface.co/gpt2"
     conversion_func: null
     config_overrides:
       dataset_path: "Skylion007/openwebtext"
@@ -167,6 +177,9 @@ SAE_LOOKUP:
   gpt2-small-res-jb-feature-splitting:
     repo_id: "jbloom/GPT2-Small-Feature-Splitting-Experiment-Layer-8"
     model: "gpt2-small"
+    links:
+      model: "https://huggingface.co/gpt2"
+      dashboards: "https://www.neuronpedia.org/gpt2sm-rfs-jb"
     conversion_func: null
     saes:
       - id: "blocks.8.hook_resid_pre_768"
@@ -315,6 +328,9 @@ SAE_LOOKUP:
     repo_id: "jbloom/Gemma-2b-Residual-Stream-SAEs"
     model: "gemma-2b"
     conversion_func: null
+    links:
+      model: https://huggingface.co/google/gemma-2b
+      dashboards: https://www.neuronpedia.org/gemma2b-res-jb
     saes:
       - id: "blocks.0.hook_resid_post"
         path: "gemma_2b_blocks.0.hook_resid_post_16384_anthropic"
@@ -332,6 +348,9 @@ SAE_LOOKUP:
     repo_id: "jbloom/Gemma-2b-IT-Residual-Stream-SAEs"
     model: "gemma-2b-it"
     conversion_func: null
+    links:
+      model: https://huggingface.co/google/gemma-2b-it
+      dashboards: https://www.neuronpedia.org/gemma2bit-res-jb
     saes:
       - id: "blocks.12.hook_resid_post"
         path: "gemma_2b_it_blocks.12.hook_resid_post_16384"
@@ -340,7 +359,9 @@ SAE_LOOKUP:
   mistral-7b-res-wg:
     repo_id: "JoshEngels/Mistral-7B-Residual-Stream-SAEs"
     model: "mistral-7b"
-    conversion_func: "mistral_7b_josh_engels_loader"
+    conversion_func: null
+    config_overrides:
+      normalize_activations: "constant_norm_rescale"
     saes:
       - id: "blocks.8.hook_resid_pre"
         path: "mistral_7b_layer_8"

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -17,7 +17,8 @@ from transformer_lens.hook_points import HookedRootModule, HookPoint
 from sae_lens.config import DTYPE_MAP
 from sae_lens.toolkit.pretrained_sae_loaders import (
     NAMED_PRETRAINED_SAE_LOADERS,
-    load_pretrained_sae_lens_sae_components,
+    handle_config_defaulting,
+    read_sae_from_disk,
 )
 from sae_lens.toolkit.pretrained_saes_directory import get_pretrained_saes_directory
 
@@ -454,11 +455,18 @@ class SAE(HookedRootModule):
         cls, path: str, device: str = "cpu", dtype: str = "float32"
     ) -> "SAE":
 
-        config_path = os.path.join(path, "cfg.json")
-        weight_path = os.path.join(path, "sae_weights.safetensors")
+        # get the config
+        config_path = os.path.join(path, SAE_CFG_PATH)
+        with open(config_path, "r") as f:
+            cfg_dict = json.load(f)
+        cfg_dict = handle_config_defaulting(cfg_dict)
 
-        cfg_dict, state_dict, _ = load_pretrained_sae_lens_sae_components(
-            config_path, weight_path, device, dtype
+        weight_path = os.path.join(path, SAE_WEIGHTS_PATH)
+        cfg_dict, state_dict = read_sae_from_disk(
+            cfg_dict=cfg_dict,
+            weight_path=weight_path,
+            device=device,
+            dtype=DTYPE_MAP[dtype],
         )
 
         sae_cfg = SAEConfig.from_dict(cfg_dict)

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional, Protocol
+from typing import Any, Dict, Optional, Protocol
 
 import torch
 from huggingface_hub import hf_hub_download
@@ -23,14 +23,24 @@ class PretrainedSaeLoader(Protocol):
 def sae_lens_loader(
     repo_id: str,
     folder_name: str,
-    device: Optional[str] = None,
+    device: str = "cpu",
     force_download: bool = False,
     cfg_overrides: Optional[dict[str, Any]] = None,
 ) -> tuple[dict[str, Any], dict[str, torch.Tensor], Optional[torch.Tensor]]:
-    cfg_filename = f"{folder_name}/cfg.json"
-    cfg_path = hf_hub_download(
-        repo_id=repo_id, filename=cfg_filename, force_download=force_download
+    """
+    Get's SAEs from HF, loads them.
+    """
+    # Get the config
+    cfg_dict = get_sae_config_from_hf(
+        repo_id,
+        folder_name,
+        force_download,
     )
+    # Apply overrides if provided
+    if cfg_overrides is not None:
+        cfg_dict.update(cfg_overrides)
+    cfg_dict["device"] = device
+    cfg_dict = handle_config_defaulting(cfg_dict)
 
     weights_filename = f"{folder_name}/sae_weights.safetensors"
     sae_path = hf_hub_download(
@@ -46,17 +56,74 @@ def sae_lens_loader(
     except EntryNotFoundError:
         log_sparsity_path = None  # no sparsity file
 
-    if device is None:
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-
-    # TODO: don't call a function at the end of another like this. Poor form.
-    return load_pretrained_sae_lens_sae_components(
-        cfg_path,
-        sae_path,
-        device,
-        log_sparsity_path=log_sparsity_path,
-        cfg_overrides=cfg_overrides,
+    cfg_dict, state_dict = read_sae_from_disk(
+        cfg_dict=cfg_dict,
+        weight_path=sae_path,
+        device=device,
     )
+
+    # get sparsity tensor if it exists
+    if log_sparsity_path is not None:
+        with safe_open(log_sparsity_path, framework="pt", device=device) as f:  # type: ignore
+            log_sparsity = f.get_tensor("sparsity")
+    else:
+        log_sparsity = None
+
+    return cfg_dict, state_dict, log_sparsity
+
+
+def get_sae_config_from_hf(
+    repo_id: str,
+    folder_name: str,
+    force_download: bool = False,
+) -> Dict[str, Any]:
+    """
+    Retrieve the configuration for a Sparse Autoencoder (SAE) from a Hugging Face repository.
+
+    Args:
+        repo_id (str): The repository ID on Hugging Face.
+        folder_name (str): The folder name within the repository containing the config file.
+        force_download (bool, optional): Whether to force download the config file. Defaults to False.
+        cfg_overrides (Optional[Dict[str, Any]], optional): Overrides for the config. Defaults to None.
+
+    Returns:
+        Dict[str, Any]: The configuration dictionary for the SAE.
+    """
+    cfg_filename = f"{folder_name}/cfg.json"
+    cfg_path = hf_hub_download(
+        repo_id=repo_id, filename=cfg_filename, force_download=force_download
+    )
+
+    with open(cfg_path, "r") as f:
+        cfg_dict = json.load(f)
+
+    return cfg_dict
+
+
+def handle_config_defaulting(cfg_dict: dict[str, Any]) -> dict[str, Any]:
+
+    # Set default values for backwards compatibility
+    cfg_dict.setdefault("prepend_bos", True)
+    cfg_dict.setdefault("dataset_trust_remote_code", True)
+    cfg_dict.setdefault("apply_b_dec_to_input", True)
+    cfg_dict.setdefault("finetuning_scaling_factor", False)
+    cfg_dict.setdefault("sae_lens_training_version", None)
+    cfg_dict.setdefault("activation_fn_str", cfg_dict.get("activation_fn", "relu"))
+    cfg_dict.setdefault("architecture", "standard")
+
+    if "normalize_activations" in cfg_dict and isinstance(
+        cfg_dict["normalize_activations"], bool
+    ):
+        # backwards compatibility
+        cfg_dict["normalize_activations"] = (
+            "none"
+            if not cfg_dict["normalize_activations"]
+            else "expected_average_only_in"
+        )
+
+    cfg_dict.setdefault("normalize_activations", "none")
+
+    return cfg_dict
 
 
 def connor_rob_hook_z_loader(
@@ -64,6 +131,7 @@ def connor_rob_hook_z_loader(
     folder_name: str,
     device: Optional[str] = None,
     force_download: bool = False,
+    cfg_overrides: Optional[dict[str, Any]] = None,
 ) -> tuple[dict[str, Any], dict[str, torch.Tensor], None]:
 
     file_path = hf_hub_download(
@@ -153,107 +221,22 @@ def connor_rob_hook_z_loader(
     return cfg_dict, weights, None
 
 
-def mistral_7b_josh_engels_loader(
-    repo_id: str,
-    folder_name: str,
-    device: Optional[str] = None,
-    force_download: bool = False,
-    cfg_overrides: Optional[dict[str, Any]] = None,
-) -> tuple[dict[str, Any], dict[str, torch.Tensor], Optional[torch.Tensor]]:
-
-    cfg_dict, state_dict, log_sparsity = sae_lens_loader(
-        repo_id, folder_name, device, force_download, cfg_overrides
-    )
-
-    # this is redundant now but can remove later. We should just use the config overrides.
-    cfg_dict["normalize_activations"] = "constant_norm_rescale"
-    return cfg_dict, state_dict, log_sparsity
-
-
-def load_pretrained_sae_lens_sae_components(
-    cfg_path: str,
+def read_sae_from_disk(
+    cfg_dict: dict[str, Any],
     weight_path: str,
     device: str = "cpu",
-    dtype: str = "float32",
-    log_sparsity_path: Optional[str] = None,
-    cfg_overrides: Optional[dict[str, Any]] = None,
-) -> tuple[dict[str, Any], dict[str, torch.Tensor], Optional[torch.Tensor]]:
-    with open(cfg_path, "r") as f:
-        cfg_dict = json.load(f)
-
-    # apply overrides
-    if cfg_overrides is not None:
-        cfg_dict.update(cfg_overrides)
-
-    if "architecture" not in cfg_dict:
-        cfg_dict["architecture"] = (
-            "standard"  # TODO: modify this when we add support for loading more architectures
-        )
-
-    # filter config for varnames
-    cfg_dict["device"] = device
-    cfg_dict["dtype"] = dtype
-
-    # # # Removing this since we should add it during instantiation of the SAE, not the SAE config.
-    # # TODO: if we change our SAE implementation such that old versions need conversion to be
-    # # loaded, we can inspect the original "sae_lens_version" and apply a conversion function here.
-    # config["sae_lens_version"] = __version__
-
-    # check that the config is valid
-    for key in ["d_sae", "d_in", "dtype"]:
-        assert key in cfg_dict, f"config missing key {key}"
+    dtype: torch.dtype = torch.float32,
+) -> tuple[dict[str, Any], dict[str, torch.Tensor]]:
+    """
+    Given a loaded dictionary and a path to a weight file, load the weights and return the state_dict.
+    """
 
     state_dict = {}
     with safe_open(weight_path, framework="pt", device=device) as f:  # type: ignore
         for k in f.keys():
-            state_dict[k] = f.get_tensor(k)
+            state_dict[k] = f.get_tensor(k).to(dtype=dtype)
 
-    # get sparsity tensor if it exists
-    if log_sparsity_path is not None:
-        with safe_open(log_sparsity_path, framework="pt", device=device) as f:  # type: ignore
-            log_sparsity = f.get_tensor("sparsity")
-    else:
-        log_sparsity = None
-
-    if "prepend_bos" not in cfg_dict:
-        # default to True for backwards compatibility
-        cfg_dict["prepend_bos"] = True
-
-    if "dataset_trust_remote_code" not in cfg_dict:
-        # default to True for backwards compatibility
-        cfg_dict["dataset_trust_remote_code"] = True
-
-    if "apply_b_dec_to_input" not in cfg_dict:
-        # default to True for backwards compatibility
-        cfg_dict["apply_b_dec_to_input"] = True
-
-    if "finetuning_scaling_factor" not in cfg_dict:
-        # default to False for backwards compatibility
-        cfg_dict["finetuning_scaling_factor"] = False
-
-    if "sae_lens_training_version" not in cfg_dict:
-        cfg_dict["sae_lens_training_version"] = None
-
-    if "activation_fn_str" not in cfg_dict:
-        if "activation_fn" in cfg_dict:  # older config might call it activation fn
-            cfg_dict["activation_fn_str"] = cfg_dict["activation_fn"]
-        else:
-            cfg_dict["activation_fn_str"] = "relu"
-
-    # if missing then none.
-    if "normalize_activations" not in cfg_dict:
-        cfg_dict["normalize_activations"] = "none"
     # if bool and True, then it's the April update method of normalizing activations and hasn't been folded in.
-    if "normalize_activations" in cfg_dict and isinstance(
-        cfg_dict["normalize_activations"], bool
-    ):
-        # backwards compatibility
-        cfg_dict["normalize_activations"] = (
-            "none"
-            if not cfg_dict["normalize_activations"]
-            else "expected_average_only_in"
-        )
-
     if "scaling_factor" in state_dict:
         # we were adding it anyway for a period of time but are no longer doing so.
         # so we should delete it if
@@ -273,7 +256,7 @@ def load_pretrained_sae_lens_sae_components(
         # it's there and it's not all 1's, we should use it.
         cfg_dict["finetuning_scaling_factor"] = False
 
-    return cfg_dict, state_dict, log_sparsity
+    return cfg_dict, state_dict
 
 
 # TODO: add more loaders for other SAEs not trained by us
@@ -281,5 +264,4 @@ def load_pretrained_sae_lens_sae_components(
 NAMED_PRETRAINED_SAE_LOADERS: dict[str, PretrainedSaeLoader] = {
     "sae_lens": sae_lens_loader,  # type: ignore
     "connor_rob_hook_z": connor_rob_hook_z_loader,  # type: ignore
-    "mistral_7b_josh_engels_loader": mistral_7b_josh_engels_loader,  # type: ignore
 }

--- a/sae_lens/training/toy_models.py
+++ b/sae_lens/training/toy_models.py
@@ -435,7 +435,7 @@ def plot_features_in_2d(
         if title:
             fig.suptitle(title[t], fontsize=15)
         if subplot_titles:
-            ax.set_title(subplot_titles[t], fontsize=12)  # type: ignore
+            ax.set_title(subplot_titles[t], fontsize=12)
         fig.canvas.draw_idle()
 
     def play(event: Any):

--- a/sae_lens/training/toy_models.py
+++ b/sae_lens/training/toy_models.py
@@ -435,7 +435,7 @@ def plot_features_in_2d(
         if title:
             fig.suptitle(title[t], fontsize=15)
         if subplot_titles:
-            ax.set_title(subplot_titles[t], fontsize=12)
+            ax.set_title(subplot_titles[t], fontsize=12)  # type: ignore
         fig.canvas.draw_idle()
 
     def play(event: Any):

--- a/sae_lens/training/toy_models.py
+++ b/sae_lens/training/toy_models.py
@@ -350,7 +350,7 @@ def plot_features_in_2d(
     values: Float[Tensor, "timesteps d_hidden feats"],
     colors: Optional[list[Any]] = None,  # shape [timesteps feats]
     title: Optional[str | list[str]] = None,
-    subplot_titles: Optional[list[str] | list[list[str]]] = None,
+    subplot_titles: Optional[list[str] | list[list[str]]] = None,  # type: ignore
     save: Optional[str] = None,
     colab: bool = False,
 ):

--- a/tests/benchmark/test_eval_all_loadable_saes.py
+++ b/tests/benchmark/test_eval_all_loadable_saes.py
@@ -7,6 +7,7 @@ from tqdm import tqdm
 
 # from sae_lens.training.evals import run_evals
 from sae_lens.sae import SAE
+from sae_lens.toolkit.pretrained_sae_loaders import get_sae_config_from_hf
 from sae_lens.toolkit.pretrained_saes_directory import get_pretrained_saes_directory
 from sae_lens.training.activations_store import ActivationsStore
 from tests.unit.helpers import load_model_cached
@@ -39,6 +40,15 @@ def all_loadable_saes() -> list[tuple[str, str]]:
             )
 
     return all_loadable_saes
+
+
+def test_get_sae_config():
+    repo_id = "jbloom/GPT2-Small-SAEs-Reformatted"
+    cfg = get_sae_config_from_hf(
+        repo_id=repo_id,
+        folder_name="blocks.0.hook_resid_pre",
+    )
+    assert cfg is not None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

I made a docs page which will load SAE Configs for all SAEs which can be loaded with `from_pretrained`. Had to do some refactoring which was a bit annoying but probably healthy. 

<img width="1194" alt="Screenshot 2024-07-04 at 1 47 08 PM" src="https://github.com/jbloomAus/SAELens/assets/69127271/9f70e15e-19f6-40fa-a577-33e7f29b7f50">

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)