### PR TITLE
fix: avoid bfloat16 errors in training gated saes

### DIFF
--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -354,7 +354,7 @@ class SAE(HookedRootModule):
 
         # Gating path
         gating_pre_activation = sae_in @ self.W_enc + self.b_gate
-        active_features = (gating_pre_activation > 0).float()
+        active_features = (gating_pre_activation > 0).to(self.dtype)
 
         # Magnitude path with weight sharing
         magnitude_pre_activation = self.hook_sae_acts_pre(

--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -318,16 +318,16 @@ class SAETrainer:
                 model_kwargs=self.cfg.model_kwargs,
             )
 
-            W_dec_norm_dist = self.sae.W_dec.norm(dim=1).detach().cpu().numpy()
+            W_dec_norm_dist = self.sae.W_dec.detach().float().norm(dim=1).cpu().numpy()
             eval_metrics["weights/W_dec_norms"] = wandb.Histogram(W_dec_norm_dist)  # type: ignore
 
             if self.sae.cfg.architecture == "standard":
-                b_e_dist = self.sae.b_enc.detach().cpu().numpy()
+                b_e_dist = self.sae.b_enc.detach().float().cpu().numpy()
                 eval_metrics["weights/b_e"] = wandb.Histogram(b_e_dist)  # type: ignore
             elif self.sae.cfg.architecture == "gated":
-                b_gate_dist = self.sae.b_gate.detach().cpu().numpy()
+                b_gate_dist = self.sae.b_gate.detach().float().cpu().numpy()
                 eval_metrics["weights/b_gate"] = wandb.Histogram(b_gate_dist)  # type: ignore
-                b_mag_dist = self.sae.b_mag.detach().cpu().numpy()
+                b_mag_dist = self.sae.b_mag.detach().float().cpu().numpy()
                 eval_metrics["weights/b_mag"] = wandb.Histogram(b_mag_dist)  # type: ignore
 
             wandb.log(

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -231,7 +231,7 @@ class TrainingSAE(SAE):
 
         # Gating path with Heaviside step function
         gating_pre_activation = sae_in @ self.W_enc + self.b_gate
-        active_features = (gating_pre_activation > 0).float()
+        active_features = (gating_pre_activation > 0).to(self.dtype)
 
         # Magnitude path with weight sharing
         magnitude_pre_activation = sae_in @ (self.W_enc * self.r_mag.exp()) + self.b_mag


### PR DESCRIPTION
# Description

- Convert to `sae.cfg.dtype` for consistency of dtype (not to float) to avoid errors associated with that.
- Convert to `float` when logging during evals to avoid `bfloat16` errors on cpu. 

Fixes (not raised yet)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility


### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
