### PR TITLE
fix: rename encode_fn to encode and encode to encode_standard

### DIFF
--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -131,10 +131,10 @@ class SAE(HookedRootModule):
 
         if self.cfg.architecture == "standard":
             self.initialize_weights_basic()
-            self.encode_fn = self.encode
+            self.encode = self.encode_standard
         elif self.cfg.architecture == "gated":
             self.initialize_weights_gated()
-            self.encode_fn = self.encode_gated
+            self.encode = self.encode_gated
 
         # handle presence / absence of scaling factor.
         if self.cfg.finetuning_scaling_factor:
@@ -281,7 +281,7 @@ class SAE(HookedRootModule):
         self,
         x: torch.Tensor,
     ) -> torch.Tensor:
-        feature_acts = self.encode_fn(x)
+        feature_acts = self.encode(x)
         sae_out = self.decode(feature_acts)
 
         # TEMP
@@ -366,7 +366,7 @@ class SAE(HookedRootModule):
 
         return active_features * feature_magnitudes
 
-    def encode(
+    def encode_standard(
         self, x: Float[torch.Tensor, "... d_in"]
     ) -> Float[torch.Tensor, "... d_sae"]:
         """

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -182,7 +182,7 @@ class TrainingSAE(SAE):
             ), "Gated SAEs do not support ghost grads"
             assert self.use_error_term is False, "Gated SAEs do not support error terms"
 
-    def encode(
+    def encode_standard(
         self, x: Float[torch.Tensor, "... d_in"]
     ) -> Float[torch.Tensor, "... d_sae"]:
         """


### PR DESCRIPTION
# Description

The gated SAE PR added a new encode method called `encode_gated` which is used by the sae training loop instead of `encode` when training SAEs. However this meant we had this new method called `encode_fn` which needs to be called to get the correct encode. Since this causes issues downstream if people don't know about this, I've renamed `encode_fn` to `encode` (so anyone calling encode gets the correct encode method) and `encode` to `encode_standard` so the code is more explicit about which encode is being used inside the package. 