### PR TITLE
Fixed hooks for single head SAEs

### DIFF
--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -203,7 +203,7 @@ def get_recons_loss(
         if activation_store.normalize_activations == "expected_average_only_in":
             activations = activation_store.apply_norm_scaling_factor(activations)
 
-        new_activations = sae.decoder(sae.encode(activations[:, :, head_index])).to(
+        new_activations = sae.decode(sae.encode(activations[:, :, head_index])).to(
             activations.dtype
         )
         activations[:, :, head_index] = new_activations

--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -213,10 +213,16 @@ def get_recons_loss(
             activations = activation_store.unscale(activations)
         return activations.to(original_device)
 
-    def zero_ablate_hook(activations: torch.Tensor, hook: Any):
+    def standard_zero_ablate_hook(activations: torch.Tensor, hook: Any):
         original_device = activations.device
         activations = activations.to(sae.device)
         activations = torch.zeros_like(activations)
+        return activations.to(original_device)
+
+    def single_head_zero_ablate_hook(activations: torch.Tensor, hook: Any):
+        original_device = activations.device
+        activations = activations.to(sae.device)
+        activations[:, :, head_index] = torch.zeros_like(activations[:, :, head_index])
         return activations.to(original_device)
 
     # we would include hook z, except that we now have base SAE's
@@ -225,10 +231,13 @@ def get_recons_loss(
     if any(substring in hook_name for substring in has_head_dim_key_substrings):
         if head_index is None:
             replacement_hook = all_head_replacement_hook
+            zero_ablate_hook = standard_zero_ablate_hook
         else:
             replacement_hook = single_head_replacement_hook
+            zero_ablate_hook = single_head_zero_ablate_hook
     else:
         replacement_hook = standard_replacement_hook
+        zero_ablate_hook = standard_zero_ablate_hook
 
     recons_loss = model.run_with_hooks(
         batch_tokens,


### PR DESCRIPTION
# Description

As mentioned in #163 , zero-ablation hooks for single-head SAEs had a bug. I resolve that issue in this pull request.

I also noticed and fixed a typo in `single_head_replacement_hook`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)


Please links to wandb dashboards with a control and test group. 