### PR TITLE
Fix/allow device override

### DIFF
--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -460,6 +460,8 @@ class SAE(HookedRootModule):
         with open(config_path, "r") as f:
             cfg_dict = json.load(f)
         cfg_dict = handle_config_defaulting(cfg_dict)
+        cfg_dict["device"] = device
+        cfg_dict["dtype"] = dtype
 
         weight_path = os.path.join(path, SAE_WEIGHTS_PATH)
         cfg_dict, state_dict = read_sae_from_disk(

--- a/test.py
+++ b/test.py
@@ -1,9 +1,0 @@
-# %%
-from sae_lens.sae import SAE
-
-sae = SAE.load_from_pretrained(
-    path="/media/curttigges/project-files/projects/Mistral-7B-Residual-Stream-SAEs/mistral_7b_layer_8",
-    device="cuda:0",
-)
-print(sae.device)
-# %%

--- a/test.py
+++ b/test.py
@@ -1,0 +1,9 @@
+# %%
+from sae_lens.sae import SAE
+
+sae = SAE.load_from_pretrained(
+    path="/media/curttigges/project-files/projects/Mistral-7B-Residual-Stream-SAEs/mistral_7b_layer_8",
+    device="cuda:0",
+)
+print(sae.device)
+# %%


### PR DESCRIPTION
# Description

Fix for https://github.com/jbloomAus/SAELens/issues/220. Forces load_from_pretrained to use the specified device for the whole SAE, as well as the specified dtype.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)