### PR TITLE
fix: load_from_pretrained should not require a dtype nor default to float32

### DIFF
--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -452,7 +452,7 @@ class SAE(HookedRootModule):
 
     @classmethod
     def load_from_pretrained(
-        cls, path: str, device: str = "cpu", dtype: str = "float32"
+        cls, path: str, device: str = "cpu", dtype: str | None = None
     ) -> "SAE":
 
         # get the config
@@ -461,14 +461,15 @@ class SAE(HookedRootModule):
             cfg_dict = json.load(f)
         cfg_dict = handle_config_defaulting(cfg_dict)
         cfg_dict["device"] = device
-        cfg_dict["dtype"] = dtype
+        if dtype is not None:
+            cfg_dict["dtype"] = dtype
 
         weight_path = os.path.join(path, SAE_WEIGHTS_PATH)
         cfg_dict, state_dict = read_sae_from_disk(
             cfg_dict=cfg_dict,
             weight_path=weight_path,
             device=device,
-            dtype=DTYPE_MAP[dtype],
+            dtype=DTYPE_MAP[cfg_dict["dtype"]],
         )
 
         sae_cfg = SAEConfig.from_dict(cfg_dict)

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -404,7 +404,7 @@ class TrainingSAE(SAE):
         cls,
         path: str,
         device: str = "cpu",
-        dtype: str = "float32",
+        dtype: str | None = None,
     ) -> "TrainingSAE":
 
         # get the config
@@ -412,13 +412,16 @@ class TrainingSAE(SAE):
         with open(config_path, "r") as f:
             cfg_dict = json.load(f)
         cfg_dict = handle_config_defaulting(cfg_dict)
+        cfg_dict["device"] = device
+        if dtype is not None:
+            cfg_dict["dtype"] = dtype
 
         weight_path = os.path.join(path, SAE_WEIGHTS_PATH)
         cfg_dict, state_dict = read_sae_from_disk(
             cfg_dict=cfg_dict,
             weight_path=weight_path,
             device=device,
-            dtype=DTYPE_MAP[dtype],
+            dtype=DTYPE_MAP[cfg_dict["dtype"]],
         )
         sae_cfg = TrainingSAEConfig.from_dict(cfg_dict)
 


### PR DESCRIPTION
# Description

load_from_pretrained currently defaults dtype to float32 if a dtype is not specified. The issue is that we sometimes want to just load the SAE with the SAE's configured dtype, instead of setting one manually or defaulting to float32.

this does the following:
1) make load_from_pretrained default to dtype = None
2) if dtype is None, then use the SAE config's dtype
3) applies the same fix to both SAE and TrainingSAE
4) TrainingSAE's load_from_pretrained now also respects device override

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)