### PR TITLE
fix sae to method

### DIFF
--- a/tests/unit/training/test_sae_basic.py
+++ b/tests/unit/training/test_sae_basic.py
@@ -268,3 +268,22 @@ def test_sae_get_name_returns_correct_name_from_cfg_vals() -> None:
     cfg = build_sae_cfg(model_name="test_model", hook_name="test_hook_name", d_sae=128)
     sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
     assert sae.get_name() == "sae_test_model_test_hook_name_128"
+
+
+def test_sae_move_between_devices() -> None:
+    cfg = build_sae_cfg(device="cpu")
+    sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
+
+    sae.to("meta")
+    assert sae.device == torch.device("meta")
+    assert sae.cfg.device == "meta"
+    assert sae.W_enc.device == torch.device("meta")
+
+
+def test_sae_change_dtype() -> None:
+    cfg = build_sae_cfg(device="cpu", dtype="float64")
+    sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
+
+    sae.to(dtype=torch.float16)
+    assert sae.dtype == torch.float16
+    assert sae.cfg.dtype == "torch.float16"


### PR DESCRIPTION
# Description

Previously it was easy to call .to on the SAE and have the sae.cfg.dtype or sae.cfg.device not change. This is bad as it can lead to confusing results. 

Fixes #233 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
