### PR TITLE
Use error term param

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sae-lens"
-version = "3.12.3"
+version = "3.12.4"
 description = "Training and Analyzing Sparse Autoencoders (SAEs)"
 authors = ["Joseph Bloom"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sae-lens"
-version = "3.12.1"
+version = "3.12.3"
 description = "Training and Analyzing Sparse Autoencoders (SAEs)"
 authors = ["Joseph Bloom"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sae-lens"
-version = "3.12.4"
+version = "3.13.0"
 description = "Training and Analyzing Sparse Autoencoders (SAEs)"
 authors = ["Joseph Bloom"]
 readme = "README.md"

--- a/sae_lens/analysis/hooked_sae_transformer.py
+++ b/sae_lens/analysis/hooked_sae_transformer.py
@@ -75,7 +75,7 @@ class HookedSAETransformer(HookedTransformer):
         super().__init__(*model_args, **model_kwargs)
         self.acts_to_saes: Dict[str, SAE] = {}
 
-    def add_sae(self, sae: SAE):
+    def add_sae(self, sae: SAE, use_error_term: Optional[bool] = None):
         """Attaches an SAE to the model
 
         WARNING: This sae will be permanantly attached until you remove it with reset_saes. This function will also overwrite any existing SAE attached to the same hook point.
@@ -89,6 +89,9 @@ class HookedSAETransformer(HookedTransformer):
                 f"No hook found for {act_name}. Skipping. Check model.hook_dict for available hooks."
             )
             return
+
+        if use_error_term is not None:
+            sae.use_error_term = True
 
         self.acts_to_saes[act_name] = sae
         set_deep_attr(self, act_name, sae)


### PR DESCRIPTION
# Description

Addresses https://github.com/jbloomAus/SAELens/issues/231. use_error_term is now a parameter for add_sae, run_with_saes, and run_with_cache_with_saes, and SAEs will be returned to their former states after the latter two functions execute (even if detached).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
