### PR TITLE
Trainer eval config will now respect trainer config params

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sae-lens"
-version = "3.12.1"
+version = "3.12.3"
 description = "Training and Analyzing Sparse Autoencoders (SAEs)"
 authors = ["Joseph Bloom"]
 readme = "README.md"

--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -22,13 +22,6 @@ FINETUNING_PARAMETERS = {
     "unrotated_decoder": ["scaling_factor", "b_dec"],
 }
 
-TRAINER_EVAL_CONFIG = EvalConfig(
-    n_eval_reconstruction_batches=10,
-    compute_ce_loss=True,
-    n_eval_sparsity_variance_batches=1,
-    compute_l2_norms=True,
-)
-
 
 def _log_feature_sparsity(
     feature_sparsity: torch.Tensor, eps: float = 1e-10
@@ -137,6 +130,16 @@ class SAETrainer:
             )
         else:
             self.autocast_if_enabled = contextlib.nullcontext()
+
+        # Set up eval config
+
+        self.trainer_eval_config = EvalConfig(
+            batch_size_prompts=self.cfg.eval_batch_size_prompts,
+            n_eval_reconstruction_batches=self.cfg.n_eval_batches,
+            compute_ce_loss=True,
+            n_eval_sparsity_variance_batches=1,
+            compute_l2_norms=True,
+        )
 
     @property
     def feature_sparsity(self) -> torch.Tensor:
@@ -326,7 +329,7 @@ class SAETrainer:
                 sae=self.sae,
                 activation_store=self.activation_store,
                 model=self.model,
-                eval_config=TRAINER_EVAL_CONFIG,
+                eval_config=self.trainer_eval_config,
                 model_kwargs=self.cfg.model_kwargs,
             )
 

--- a/tests/unit/training/test_evals.py
+++ b/tests/unit/training/test_evals.py
@@ -3,12 +3,18 @@ from datasets import Dataset
 from transformer_lens import HookedTransformer
 
 from sae_lens.config import LanguageModelSAERunnerConfig
-from sae_lens.evals import get_eval_everything_config, run_evals
+from sae_lens.evals import EvalConfig, get_eval_everything_config, run_evals
 from sae_lens.sae import SAE
 from sae_lens.training.activations_store import ActivationsStore
-from sae_lens.training.sae_trainer import TRAINER_EVAL_CONFIG
 from sae_lens.training.training_sae import TrainingSAE
 from tests.unit.helpers import TINYSTORIES_MODEL, build_sae_cfg, load_model_cached
+
+TRAINER_EVAL_CONFIG = EvalConfig(
+    n_eval_reconstruction_batches=10,
+    compute_ce_loss=True,
+    n_eval_sparsity_variance_batches=1,
+    compute_l2_norms=True,
+)
 
 
 @pytest.fixture(

--- a/tutorials/Hooked_SAE_Transformer_Demo.ipynb
+++ b/tutorials/Hooked_SAE_Transformer_Demo.ipynb
@@ -336,7 +336,7 @@
     "\n",
     "for layers in all_layers:\n",
     "    hooked_saes = [hook_name_to_sae[utils.get_act_name('z', layer)] for layer in layers]\n",
-    "    logits_with_saes = model.run_with_saes(tokens, saes=hooked_saes)\n",
+    "    logits_with_saes = model.run_with_saes(tokens, saes=hooked_saes, use_error_term=None)\n",
     "    average_logit_diff_with_saes = logits_to_ave_logit_diff(logits_with_saes, answer_tokens)\n",
     "    per_prompt_diff_with_saes = logits_to_ave_logit_diff(logits_with_saes, answer_tokens, per_prompt=True)\n",
     "    \n",
@@ -900,7 +900,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Description

Corrected issue with eval configs not using the parameters from the trainer config. n_eval_batches and eval_batch_size_prompts will now be respected by the training eval config.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)