### PR TITLE
fix: update automated-interpretability dep to use newly released version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ safetensors = "^0.4.2"
 typer = "^0.12.3"
 mamba-lens = { version = "^0.0.4", optional = true }
 pyzmq = "26.0.0"
-automated-interpretability = "^0.0.3"
+automated-interpretability = ">=0.0.5,<1.0.0"
 python-dotenv = "^1.0.1"
 pyyaml = "^6.0.1"
 pytest-profiling = "^1.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ reportConstantRedefinition = "none"
 reportUnknownLambdaType = "none"
 reportPrivateUsage = "none"
 reportDeprecated = "none"
+reportPrivateImportUsage = "none"
 ignore = [
     "**/wandb/**"
 ]

--- a/sae_lens/training/optim.py
+++ b/sae_lens/training/optim.py
@@ -91,10 +91,10 @@ def _get_main_lr_scheduler(
     if scheduler_name == "constant":
         return lr_scheduler.LambdaLR(optimizer, lr_lambda=lambda steps: 1.0)
     elif scheduler_name == "cosineannealing":
-        return lr_scheduler.CosineAnnealingLR(optimizer, T_max=steps, eta_min=lr_end)
+        return lr_scheduler.CosineAnnealingLR(optimizer, T_max=steps, eta_min=lr_end)  # type: ignore
     elif scheduler_name == "cosineannealingwarmrestarts":
         return lr_scheduler.CosineAnnealingWarmRestarts(
-            optimizer, T_0=steps // num_cycles, eta_min=lr_end
+            optimizer, T_0=steps // num_cycles, eta_min=lr_end  # type: ignore
         )
     else:
         raise ValueError(f"Unsupported scheduler: {scheduler_name}")

--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -365,7 +365,7 @@ class SAETrainer:
     def _build_sparsity_log_dict(self) -> dict[str, Any]:
 
         log_feature_sparsity = _log_feature_sparsity(self.feature_sparsity)
-        wandb_histogram = wandb.Histogram(log_feature_sparsity.numpy())
+        wandb_histogram = wandb.Histogram(log_feature_sparsity.numpy())  # type: ignore
         return {
             "metrics/mean_log10_feature_sparsity": log_feature_sparsity.mean().item(),
             "plots/feature_density_line_chart": wandb_histogram,

--- a/tests/unit/training/test_optim.py
+++ b/tests/unit/training/test_optim.py
@@ -158,7 +158,7 @@ def test_get_scheduler_cosineannealing_with_warmup_and_decay():
 
     # From here on, it should match CosineAnnealingLR
     new_optimizer = Adam([torch.tensor(1.0)], lr=LR)
-    cos_scheduler = CosineAnnealingLR(new_optimizer, T_max=4, eta_min=lr_end)
+    cos_scheduler = CosineAnnealingLR(new_optimizer, T_max=4, eta_min=lr_end)  # type: ignore
 
     step(optimizer, scheduler)
     step(new_optimizer, cos_scheduler)


### PR DESCRIPTION
# Description

This PR updates pyproject.toml to pull in newer versions of the `automated-interpretability` dependency. This dependency was recently updated to relax numpy and scikit-learn dependencies to help make SAELens easier to install, especially on colab. However, since the version number for `automated-interpretability` is `0.0.x`, poetry's `^` dependency operator won't update to new versions automatically. This PR changes the dependency specification for `automated-interpretability` to `>=0.0.5,<1.0.0` to allow minor and patch versions of this library to be automatically installable.

Fixes #246 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)