### PR TITLE
feat: support uploading and loading arbitrary huggingface SAEs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ WandB Dashboards provide lots of useful insights while training SAE's. Here's a 
 ```
 @misc{bloom2024saetrainingcodebase,
    title = {SAELens Training
-   author = {Joseph Bloom, David Channin},
+   author = {Joseph Bloom, David Chanin},
    year = {2024},
    howpublished = {\url{}},
 }}

--- a/docs/training_saes.md
+++ b/docs/training_saes.md
@@ -187,3 +187,27 @@ CacheActivationsRunner(cfg).run()
 ```
 
 To use the cached activations during training, set `use_cached_activations=True` and `cached_activations_path` to match the `new_cached_activations_path` above option in training configuration.
+
+
+## Uploading SAEs to Huggingface
+
+Once you have a set of SAEs that you're happy with, your next step is to share them with the world! SAELens has a `upload_saes_to_huggingface()` function which makes this easy to do. We also provide a [uploading saes to huggingface tutorial](https://github.com/jbloomAus/SAELens/blob/main/tutorials/uploading_saes_to_huggingface.ipynb) with more details.
+
+You'll just need to pass a dictionary of SAEs to upload along with the huggingface repo id to upload to. The dictionary keys will become the folders in the repo where each SAE will be located. It's best practice to use the hook point that the SAE was trained on as the key to make it clear to users where in the model to apply the SAE. The values of this dictionary can be either an SAE object, or a path to a saved SAE object on disk from the `sae.save_model()` method.
+
+A sample is shown below:
+
+```python
+from sae_lens import upload_saes_to_huggingface
+
+saes_dict = {
+    "blocks.0.hook_resid_pre": layer_0_sae,
+    "blocks.1.hook_resid_pre": layer_1_sae,
+    # ...
+}
+
+upload_saes_to_huggingface(
+    saes_dict,
+    hf_repo_id="your-username/your-sae-repo",
+)
+```

--- a/sae_lens/__init__.py
+++ b/sae_lens/__init__.py
@@ -14,6 +14,7 @@ from .sae import SAE, SAEConfig
 from .sae_training_runner import SAETrainingRunner
 from .training.activations_store import ActivationsStore
 from .training.training_sae import TrainingSAE, TrainingSAEConfig
+from .training.upload_saes_to_huggingface import upload_saes_to_huggingface
 
 __all__ = [
     "SAE",
@@ -30,4 +31,5 @@ __all__ = [
     "PretokenizeRunner",
     "pretokenize_runner",
     "run_evals",
+    "upload_saes_to_huggingface",
 ]

--- a/sae_lens/training/upload_saes_to_huggingface.py
+++ b/sae_lens/training/upload_saes_to_huggingface.py
@@ -1,0 +1,137 @@
+import io
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from textwrap import dedent
+from typing import Iterable
+
+from huggingface_hub import HfApi, create_repo, get_hf_file_metadata, hf_hub_url
+from huggingface_hub.utils._errors import EntryNotFoundError, RepositoryNotFoundError
+from tqdm.autonotebook import tqdm
+
+from sae_lens.sae import SAE, SAE_CFG_PATH, SAE_WEIGHTS_PATH, SPARSITY_PATH
+
+
+def upload_saes_to_huggingface(
+    saes_dict: dict[str, SAE | Path | str],
+    hf_repo_id: str,
+    hf_revision: str = "main",
+    show_progress: bool = True,
+    add_default_readme: bool = True,
+):
+    api = HfApi()
+    if len(saes_dict) == 0:
+        raise ValueError("No SAEs to upload")
+    # pre-validate that everything is a SAE or a valid path before starting the upload
+    for sae_ref in saes_dict.values():
+        if isinstance(sae_ref, SAE):
+            continue
+        _validate_sae_path(Path(sae_ref))
+
+    if not _repo_exists(api, hf_repo_id):
+        create_repo(hf_repo_id)
+
+    for sae_id, sae_ref in tqdm(
+        saes_dict.items(), desc="Uploading SAEs", disable=not show_progress
+    ):
+        with TemporaryDirectory() as tmp_dir:
+            sae_path = _build_sae_path(sae_ref, tmp_dir)
+            _validate_sae_path(sae_path)
+            _upload_sae(
+                api,
+                sae_path,
+                repo_id=hf_repo_id,
+                sae_id=sae_id,
+                revision=hf_revision,
+            )
+        if add_default_readme:
+            if _repo_file_exists(hf_repo_id, "README.md", hf_revision):
+                print("README.md already exists in the repo, skipping upload")
+            else:
+                readme = _create_default_readme(hf_repo_id, saes_dict)
+                readme_io = io.BytesIO()
+                readme_io.write(readme.encode("utf-8"))
+                readme_io.seek(0)
+                api.upload_file(
+                    path_or_fileobj=readme_io,
+                    path_in_repo="README.md",
+                    repo_id=hf_repo_id,
+                    revision=hf_revision,
+                    commit_message="Add README.md",
+                )
+
+
+def _create_default_readme(repo_id: str, sae_ids: Iterable[str]) -> str:
+    readme = dedent(
+        """
+        ---
+        library_name: saelens
+        ---
+
+        # SAEs for use with the SAELens library
+
+        This repository contains the following SAEs:
+        """
+    )
+    for sae_id in sae_ids:
+        readme += f"- {sae_id}\n"
+
+    readme += dedent(
+        f"""
+        Load these SAEs using SAELens as below:
+        ```python
+        from sae_lens import SAE
+
+        sae, cfg_dict, sparsity = SAE.from_pretrained("{repo_id}", "<sae_id>")
+        ```
+        """
+    )
+    return readme.strip()
+
+
+def _repo_file_exists(repo_id: str, filename: str, revision: str) -> bool:
+    try:
+        url = hf_hub_url(repo_id=repo_id, filename=filename, revision=revision)
+        get_hf_file_metadata(url)
+        return True
+    except EntryNotFoundError:
+        return False
+
+
+def _repo_exists(api: HfApi, repo_id: str) -> bool:
+    try:
+        api.repo_info(repo_id)
+        return True
+    except RepositoryNotFoundError:
+        return False
+
+
+def _upload_sae(api: HfApi, sae_path: Path, repo_id: str, sae_id: str, revision: str):
+    api.upload_folder(
+        folder_path=sae_path,
+        path_in_repo=sae_id,
+        repo_id=repo_id,
+        revision=revision,
+        repo_type="model",
+        commit_message=f"Upload SAE {sae_id}",
+        allow_patterns=[SAE_CFG_PATH, SAE_WEIGHTS_PATH, SPARSITY_PATH],
+    )
+
+
+def _build_sae_path(sae_ref: SAE | Path | str, tmp_dir: str) -> Path:
+    if isinstance(sae_ref, SAE):
+        sae_ref.save_model(tmp_dir)
+        return Path(tmp_dir)
+    elif isinstance(sae_ref, Path):
+        return sae_ref
+    else:
+        return Path(sae_ref)
+
+
+def _validate_sae_path(sae_path: Path):
+    "Validate that the model files exist in the given path."
+    if not (sae_path / SAE_CFG_PATH).exists():
+        raise FileNotFoundError(f"SAE config file not found: {sae_path / SAE_CFG_PATH}")
+    if not (sae_path / SAE_WEIGHTS_PATH).exists():
+        raise FileNotFoundError(
+            f"SAE weights file not found: {sae_path / SAE_WEIGHTS_PATH}"
+        )

--- a/tests/unit/training/test_sae_from_pretrained.py
+++ b/tests/unit/training/test_sae_from_pretrained.py
@@ -39,6 +39,39 @@ def test_SparseAutoencoder_from_pretrained_loads_from_hugginface_using_shorthand
         assert torch.allclose(sae.state_dict()[k], state_dict[k])
 
 
+def test_SparseAutoencoder_from_pretrained_can_load_arbitrary_saes_from_hugginface():
+    sae, original_cfg_dict, sparsity = SAE.from_pretrained(
+        release="jbloom/GPT2-Small-SAEs-Reformatted",
+        sae_id="blocks.0.hook_resid_pre",
+        device="cpu",
+    )
+
+    # it should match what we get when manually loading from hf
+    repo_id = "jbloom/GPT2-Small-SAEs-Reformatted"
+    hook_point = "blocks.0.hook_resid_pre"
+    filename = f"{hook_point}/sae_weights.safetensors"
+    weight_path = hf_hub_download(repo_id=repo_id, filename=filename)
+    state_dict = {}
+    with safe_open(weight_path, framework="pt", device="cpu") as f:  # type: ignore
+        for k in f.keys():
+            state_dict[k] = f.get_tensor(k)
+
+    assert isinstance(sae, SAE)
+    assert sae.cfg.model_name == "gpt2-small"
+    assert sae.cfg.hook_name == "blocks.0.hook_resid_pre"
+
+    assert isinstance(original_cfg_dict, dict)
+
+    assert isinstance(sparsity, torch.Tensor)
+    assert sparsity.shape == (sae.cfg.d_sae,)
+    assert sparsity.max() < 0.0
+
+    for k in sae.state_dict().keys():
+        if k == "finetuning_scaling_factor":
+            continue
+        assert torch.allclose(sae.state_dict()[k], state_dict[k])
+
+
 def test_SparseAutoencoder_from_pretrained_errors_for_invalid_releases():
     with pytest.raises(ValueError):
         SAE.from_pretrained(

--- a/tests/unit/training/test_upload_saes_to_huggingface.py
+++ b/tests/unit/training/test_upload_saes_to_huggingface.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from huggingface_hub import HfApi
+
+from sae_lens.sae import SAE
+from sae_lens.training.upload_saes_to_huggingface import (
+    _build_sae_path,
+    _create_default_readme,
+    _repo_exists,
+    _repo_file_exists,
+    _validate_sae_path,
+)
+from tests.unit.helpers import build_sae_cfg
+
+
+def test_create_default_readme():
+    saes_dict = ["sae1", "sae2"]
+    expected_readme = dedent(
+        """
+        ---
+        library_name: saelens
+        ---
+
+        # SAEs for use with the SAELens library
+
+        This repository contains the following SAEs:
+        - sae1
+        - sae2
+
+        Load these SAEs using SAELens as below:
+        ```python
+        from sae_lens import SAE
+
+        sae, cfg_dict, sparsity = SAE.from_pretrained("jimi/hendrix", "<sae_id>")
+        ```
+        """
+    ).strip()
+    assert _create_default_readme("jimi/hendrix", saes_dict) == expected_readme
+
+
+def test_build_sae_path_saves_live_saes_to_tmpdir(tmp_path: Path):
+    cfg = build_sae_cfg(device="cpu")
+    sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
+    sae_path = _build_sae_path(sae, str(tmp_path))
+    assert sae_path == tmp_path
+    assert (tmp_path / "sae_weights.safetensors").exists()
+    assert (tmp_path / "cfg.json").exists()
+
+
+def test_build_sae_path_directly_passes_through_existing_dirs(tmp_path: Path):
+    assert _build_sae_path("/sae/path", str(tmp_path)) == Path("/sae/path")
+    assert _build_sae_path(Path("/sae/path"), str(tmp_path)) == Path("/sae/path")
+
+
+def test_repo_exists():
+    api = HfApi()
+    assert not _repo_exists(api, "fake/repo")
+    assert _repo_exists(api, "jbloom/Gemma-2b-Residual-Stream-SAEs")
+
+
+def test_repo_file_exists():
+    assert _repo_file_exists(
+        "jbloom/Gemma-2b-Residual-Stream-SAEs", "README.md", "main"
+    )
+    assert not _repo_file_exists(
+        "jbloom/Gemma-2b-Residual-Stream-SAEs", "fake_file.md", "main"
+    )
+
+
+def test_validate_sae_path_errors_if_files_are_missing(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        _validate_sae_path(tmp_path)
+    (tmp_path / "cfg.json").touch()
+    with pytest.raises(FileNotFoundError):
+        _validate_sae_path(tmp_path)
+    (tmp_path / "sae_weights.safetensors").touch()
+    _validate_sae_path(tmp_path)

--- a/tutorials/uploading_saes_to_huggingface.ipynb
+++ b/tutorials/uploading_saes_to_huggingface.ipynb
@@ -1,0 +1,233 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Uploading trained SAEs to Huggingface\n",
+    "\n",
+    "After you've trained a set of SAEs for a model, you'll likely want to upload the SAEs to Huggingface for others to use as well. SAELens provides a helper function `upload_saes_to_huggingface()` which makes this easy to do. This notebook demonstrates how to use this function. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To demonstrate, we're just going to download some of Joseph's GPT2 SAEs and re-upload them. Of course, in practice you'd want to train your own SAEs and upload those instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sae_lens import SAE\n",
+    "\n",
+    "# Load some SAEs from the gpt2-small-res-jb release\n",
+    "# In practice you'll want to train your own SAEs to upload to huggingface\n",
+    "layer_0_sae = SAE.from_pretrained(\n",
+    "    release=\"gpt2-small-res-jb\",\n",
+    "    sae_id=\"blocks.0.hook_resid_pre\",\n",
+    "    device=\"cpu\",\n",
+    ")[0]\n",
+    "layer_1_sae = SAE.from_pretrained(\n",
+    "    release=\"gpt2-small-res-jb\",\n",
+    "    sae_id=\"blocks.1.hook_resid_pre\",\n",
+    "    device=\"cpu\",\n",
+    ")[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Uploading the SAEs\n",
+    "\n",
+    "The upload function takes a dictionary of SAEs, where the keys will become the sae_id of the SAE on Huggingface. It's a good idea to use the hook point of the SAE as the sae_id, so it's clear to users where the SAE should be attached. The values of this dictionary can either be the SAEs themselves, or a path to a directory where the SAEs have been saved using `sae.save_model()`. Below, we'll do both! One of the SAEs will be uploaded directly from the SAE object, and the other will be uploaded from a directory.\n",
+    "\n",
+    "Note that you'll need to be logged in to your huggingface account either by running `huggingface-cli login` in the terminal or by setting the `HF_TOKEN` environment variable to your API token."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5600a62ef8d646ce9f1548a0556a71c4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Uploading SAEs:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3dd87de2cc964219be85410687ef210a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "sae_weights.safetensors:   0%|          | 0.00/151M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bd5e625aaac44affa1bcb0b8ddf3359f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "sae_weights.safetensors:   0%|          | 0.00/151M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "README.md already exists in the repo, skipping upload\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sae_lens import upload_saes_to_huggingface\n",
+    "\n",
+    "layer_1_sae_path = \"layer_1_sae\"\n",
+    "layer_1_sae.save_model(layer_1_sae_path)\n",
+    "\n",
+    "saes_dict = {\n",
+    "    \"blocks.0.hook_resid_pre\": layer_0_sae, # values can be an SAE object\n",
+    "    \"blocks.1.hook_resid_pre\": layer_1_sae_path, # or a path to a saved SAE\n",
+    "}\n",
+    "\n",
+    "upload_saes_to_huggingface(\n",
+    "    saes_dict,\n",
+    "    # change this to your own huggingface username and repo\n",
+    "    hf_repo_id=\"chanind/sae-lens-upload-demo\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading our uploaded SAEs\n",
+    "\n",
+    "Now that the SAEs are uploaded, anyone can load them using `SAE.from_pretrained()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f7517877a23f4732ab6048aa059ad6e7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "blocks.0.hook_resid_pre/cfg.json:   0%|          | 0.00/520 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "857e5020f4a3440e870fcefa10836fa9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "sae_weights.safetensors:   0%|          | 0.00/151M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bcb51c20532941eeac0c3e0347514c82",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "blocks.1.hook_resid_pre/cfg.json:   0%|          | 0.00/520 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a14513e22283459f89006f2c0e206196",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "sae_weights.safetensors:   0%|          | 0.00/151M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from sae_lens import SAE\n",
+    "\n",
+    "uploaded_sae_layer_0 = SAE.from_pretrained(\n",
+    "    release=\"chanind/sae-lens-upload-demo\",\n",
+    "    sae_id=\"blocks.0.hook_resid_pre\",\n",
+    "    device=\"cpu\",\n",
+    ")[0]\n",
+    "uploaded_sae_layer_1 = SAE.from_pretrained(\n",
+    "    release=\"chanind/sae-lens-upload-demo\",\n",
+    "    sae_id=\"blocks.1.hook_resid_pre\",\n",
+    "    device=\"cpu\",\n",
+    ")[0]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "sae-lens-CSfAEFdT-py3.11",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
# Description

This PR adds a `upload_saes_to_huggingface()` function which uploads a dictionary of SAEs into a huggingface repo. This PR also adjusts the `SAE.from_pretrained()` function so that if the users passes a huggingface repository directly as the `release` param, the SAE can be directly loaded from huggingface even if it's not in the `pretrained_saes.yaml` file. 

An example repo generated from this function can be seen at https://huggingface.co/chanind/sae-lens-upload-demo. The README.md is also autogenerated as part of the upload.

This PR also adds a tutorial notebook, `uploading_saes_to_huggingface.ipynb` and adds a corresponding section to the training docs.  A screenshot from the new training docs is show below:

<img width="715" alt="Screenshot 2024-08-10 at 00 12 42" src="https://github.com/user-attachments/assets/0b206025-a7ba-48f7-87b9-9d6816d82a02">


Fixes #234

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
