### PR TITLE
fix: fix memory crash / perf improvement when batching huge samples

### DIFF
--- a/tests/unit/training/test_tokenization_and_batching.py
+++ b/tests/unit/training/test_tokenization_and_batching.py
@@ -1,3 +1,6 @@
+from itertools import islice
+
+import pytest
 import torch
 
 from sae_lens.tokenization_and_batching import (
@@ -8,62 +11,85 @@ from sae_lens.tokenization_and_batching import (
 
 def test_add_tokens_to_batch_can_start_a_new_batch():
     tokens = torch.arange(10)
-    new_batch, remaining_tokens = _add_tokens_to_batch(
-        batch=None, tokens=tokens, context_size=5, is_start_of_sequence=True
+    new_batch, new_offset = _add_tokens_to_batch(
+        batch=None, tokens=tokens, offset=1, context_size=5, is_start_of_sequence=True
     )
-    assert torch.all(new_batch == tokens[:5])
-    assert torch.all(remaining_tokens == tokens[5:])
+    assert torch.all(new_batch == tokens[1:6])
+    assert new_offset == 6
 
 
 def test_add_tokens_to_batch_adds_bos_if_new_batch():
     tokens = torch.arange(10)
-    new_batch, remaining_tokens = _add_tokens_to_batch(
+    new_batch, new_offset = _add_tokens_to_batch(
         batch=None,
         tokens=tokens,
+        offset=0,
         context_size=5,
         is_start_of_sequence=True,
         begin_batch_token_id=999,
         sequence_separator_token_id=998,
     )
+    remaining_tokens = tokens[new_offset:]
     assert new_batch.tolist() == [999] + tokens[:4].tolist()
     assert torch.all(remaining_tokens == tokens[4:])
 
 
-def test_add_tokens_to_batch_does_not_adds_bos_if_the_bos_is_already_there():
-    tokens = torch.tensor([999, 1, 2, 3])
-    new_batch, remaining_tokens = _add_tokens_to_batch(
+def test_add_tokens_respects_token_offset_when_adding_bos_if_new_batch():
+    tokens = torch.arange(10)
+    new_batch, new_offset = _add_tokens_to_batch(
         batch=None,
         tokens=tokens,
+        offset=2,
+        context_size=5,
+        is_start_of_sequence=True,
+        begin_batch_token_id=999,
+        sequence_separator_token_id=998,
+    )
+    assert new_batch.tolist() == [999] + tokens[2:6].tolist()
+    assert new_offset == 6
+
+
+def test_add_tokens_to_batch_does_not_adds_bos_if_the_bos_is_already_there():
+    tokens = torch.tensor([999, 1, 2, 3])
+    new_batch, new_offset = _add_tokens_to_batch(
+        batch=None,
+        tokens=tokens,
+        offset=0,
         context_size=5,
         is_start_of_sequence=True,
         begin_batch_token_id=999,
     )
+    remaining_tokens = tokens[new_offset:]
     assert new_batch.tolist() == tokens.tolist()
     assert len(remaining_tokens) == 0
 
 
 def test_add_tokens_to_batch_uses_all_tokens_if_less_than_context_size():
     tokens = torch.arange(3)
-    new_batch, remaining_tokens = _add_tokens_to_batch(
+    new_batch, new_offset = _add_tokens_to_batch(
         batch=None,
         tokens=tokens,
+        offset=0,
         context_size=5,
         is_start_of_sequence=False,
     )
+    remaining_tokens = tokens[new_offset:]
     assert torch.all(new_batch == tokens)
     assert remaining_tokens.shape == (0,)
 
 
 def test_add_tokens_to_batch_can_append_both_the_bos_and_start_of_sequence_token():
     tokens = torch.arange(10)
-    new_batch, remaining_tokens = _add_tokens_to_batch(
+    new_batch, new_offset = _add_tokens_to_batch(
         batch=None,
         tokens=tokens,
+        offset=0,
         context_size=5,
         is_start_of_sequence=True,
         begin_batch_token_id=999,
         begin_sequence_token_id=998,
     )
+    remaining_tokens = tokens[new_offset:]
     assert new_batch.tolist() == [999, 998] + tokens[:3].tolist()
     assert torch.all(remaining_tokens == tokens[3:])
 
@@ -71,12 +97,14 @@ def test_add_tokens_to_batch_can_append_both_the_bos_and_start_of_sequence_token
 def test_add_tokens_to_batch_appends_to_the_existing_batch():
     batch = torch.arange(4)
     tokens = torch.arange(10)
-    new_batch, remaining_tokens = _add_tokens_to_batch(
+    new_batch, new_offset = _add_tokens_to_batch(
         batch=batch,
         tokens=tokens,
+        offset=0,
         context_size=5,
         is_start_of_sequence=True,
     )
+    remaining_tokens = tokens[new_offset:]
     assert new_batch.tolist() == batch.tolist() + tokens[:1].tolist()
     assert torch.all(remaining_tokens == tokens[1:])
 
@@ -84,14 +112,16 @@ def test_add_tokens_to_batch_appends_to_the_existing_batch():
 def test_add_tokens_to_batch_can_separate_sequences():
     batch = torch.arange(3)
     tokens = torch.arange(10)
-    new_batch, remaining_tokens = _add_tokens_to_batch(
+    new_batch, new_offset = _add_tokens_to_batch(
         batch=batch,
         tokens=tokens,
+        offset=0,
         context_size=5,
         is_start_of_sequence=True,
         sequence_separator_token_id=997,
         begin_batch_token_id=999,
     )
+    remaining_tokens = tokens[new_offset:]
     assert new_batch.tolist() == batch.tolist() + [997] + tokens[:1].tolist()
     assert torch.all(remaining_tokens == tokens[1:])
 
@@ -99,25 +129,31 @@ def test_add_tokens_to_batch_can_separate_sequences():
 def test_add_tokens_to_batch_can_both_separate_sequences_and_add_seq_start_token():
     batch = torch.arange(2)
     tokens = torch.arange(10)
-    new_batch, remaining_tokens = _add_tokens_to_batch(
+    new_batch, new_offset = _add_tokens_to_batch(
         batch=batch,
         tokens=tokens,
+        offset=0,
         context_size=5,
         is_start_of_sequence=True,
         sequence_separator_token_id=997,
         begin_sequence_token_id=998,
         begin_batch_token_id=999,
     )
+    remaining_tokens = tokens[new_offset:]
     assert new_batch.tolist() == batch.tolist() + [997, 998] + tokens[:1].tolist()
     assert torch.all(remaining_tokens == tokens[1:])
 
 
-def test_add_tokens_to_batch_wont_return_more_remaining_tokens_than_the_original():
+@pytest.mark.parametrize("offset", [0, 1, 3])
+def test_add_tokens_to_batch_wont_return_more_remaining_tokens_than_the_original(
+    offset: int,
+):
     batch = torch.arange(4)
     tokens = torch.arange(10)
-    new_batch, remaining_tokens = _add_tokens_to_batch(
+    new_batch, new_offset = _add_tokens_to_batch(
         batch=batch,
         tokens=tokens,
+        offset=offset,
         context_size=5,
         is_start_of_sequence=True,
         sequence_separator_token_id=997,
@@ -125,21 +161,23 @@ def test_add_tokens_to_batch_wont_return_more_remaining_tokens_than_the_original
         begin_batch_token_id=999,
     )
     assert new_batch.tolist() == batch.tolist() + [997]
-    assert torch.all(remaining_tokens == tokens)
+    assert new_offset == offset
 
 
 def test_add_tokens_to_batch_collapses_separate_sequences_and_add_seq_start_token_if_identical():
     batch = torch.arange(2)
     tokens = torch.arange(10)
-    new_batch, remaining_tokens = _add_tokens_to_batch(
+    new_batch, new_offset = _add_tokens_to_batch(
         batch=batch,
         tokens=tokens,
+        offset=0,
         context_size=5,
         is_start_of_sequence=True,
         sequence_separator_token_id=998,
         begin_sequence_token_id=998,
         begin_batch_token_id=999,
     )
+    remaining_tokens = tokens[new_offset:]
     assert new_batch.tolist() == batch.tolist() + [998] + tokens[:2].tolist()
     assert torch.all(remaining_tokens == tokens[2:])
 
@@ -147,14 +185,16 @@ def test_add_tokens_to_batch_collapses_separate_sequences_and_add_seq_start_toke
 def test_add_tokens_to_batch_skips_add_seq_start_token_if_not_start_of_seq():
     batch = torch.arange(2)
     tokens = torch.arange(10)
-    new_batch, remaining_tokens = _add_tokens_to_batch(
+    new_batch, new_offset = _add_tokens_to_batch(
         batch=batch,
         tokens=tokens,
+        offset=0,
         context_size=5,
         is_start_of_sequence=False,
         sequence_separator_token_id=997,
         begin_sequence_token_id=998,
     )
+    remaining_tokens = tokens[new_offset:]
     assert new_batch.tolist() == batch.tolist() + [997] + tokens[:2].tolist()
     assert torch.all(remaining_tokens == tokens[2:])
 
@@ -292,3 +332,22 @@ def test_concat_and_batch_collapses_identical_special_tokens():
         [999, 13, 14, 15, 16],
     ]
     assert batches.tolist() == expected
+
+
+def test_concat_and_batch_sequences_works_with_extremely_long_samples():
+    seq = torch.arange(10_000_000)
+    batches_list = list(
+        islice(
+            concat_and_batch_sequences(
+                tokens_iterator=iter([seq]),
+                context_size=5,
+                begin_sequence_token_id=999,
+                begin_batch_token_id=999,
+            ),
+            50_000,  # cut off after 50k batchs so test still runs fast
+        )
+    )
+    assert len(batches_list) == 50_000
+    for batch in batches_list:
+        assert batch.shape == (5,)
+        assert batch[0] == 999


### PR DESCRIPTION
# Description

This PR fixes an issue where memory usage spikes and crashes the Python interpreter when batching extremely long samples. I found that I was unable to run pretokenization on the [monology/pile-uncopyrighted dataset](https://huggingface.co/datasets/monology/pile-uncopyrighted), and discovered that the reason is this dataset includes some extremely long text samples, upwards of 47 million characters in a single sample.

Our batching code previously would remove a single batch of tokens from the sample, and then return the batch and the remaining tokens. However, by returning the remaining tokens, this causes a lot of copies of this huge tensor, and seems to cause memory and performance issues.

To address this, this PR instead keeps track of an int offset within the sample and simply increments that offset as batches are formed, thus never directly modifying or copying the full sample. This means torch doesn't need to copy this potentially huge tensor over and over, saving memory and improving performance.

This also has the side-effect of speeding up batching and pretokenization since it avoids the unnecessary copying of the full sample tensor during batching.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)