### PR TITLE
chore: adding more metatadata to pyproject.toml for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,16 @@ authors = ["Joseph Bloom"]
 readme = "README.md"
 packages = [{include = "sae_lens"}]
 include = ["pretrained_saes.yaml"]
+repository = "https://github.com/jbloomAus/SAELens"
+homepage = "https://jbloomaus.github.io/SAELens"
+license = "MIT"
+keywords = [
+    "deep-learning",
+    "sparse-autoencoders",
+    "mechanistic-interpretability",
+    "PyTorch",
+]
+classifiers = ["Topic :: Scientific/Engineering :: Artificial Intelligence"]
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
# Description

This PR adds more metadata to pyproject.toml which PyPI will automatically parse and show on the [SAELens PyPI page](https://pypi.org/project/sae-lens/). This will add links to the git repo, homepage, keywords, topic, and license. This is minor, but doesn't hurt to add and makes the project look a bit more polished when people land on the PyPI.