### PR TITLE
feat: updated pretrained yml gemmascope and neuronpedia ids

### DIFF
--- a/docs/generate_sae_table.py
+++ b/docs/generate_sae_table.py
@@ -15,8 +15,9 @@ from sae_lens.toolkit.pretrained_sae_loaders import (
 )
 
 INCLUDED_CFG = [
-    # "id",
-    # "architecture",
+    "id",
+    "architecture",
+    "neuronpedia",
     # "model_name",
     "hook_name",
     "hook_layer",
@@ -45,7 +46,7 @@ def generate_sae_table():
     markdown_content += "*This file contains the contents of `sae_lens/pretrained_saes.yaml` in Markdown*\n\n"
 
     # Generate content for each model
-    for model_name, model_info in tqdm(data["SAE_LOOKUP"].items()):
+    for model_name, model_info in tqdm(data.items()):
         repo_link = f"https://huggingface.co/{model_info['repo_id']}"
         markdown_content += f"## [{model_name}]({repo_link})\n\n"
         markdown_content += f"- **Huggingface Repo**: {model_info['repo_id']}\n"
@@ -114,6 +115,10 @@ def generate_sae_table():
                 )
                 cfg = handle_config_defaulting(cfg)
                 cfg = SAEConfig.from_dict(cfg).to_dict()
+
+            if "neuronpedia" not in info.keys():
+                info["neuronpedia"] = None
+
             info.update(cfg)
 
         # cfg_to_in

--- a/docs/sae_table.md
+++ b/docs/sae_table.md
@@ -13,21 +13,21 @@ This is a list of SAEs importable from the SAELens package. Click on each link f
     - [Dashboards](https://www.neuronpedia.org/gpt2sm-res-jb)
     - [Publication](https://www.lesswrong.com/posts/f9EgfLSurAiqRJySD/open-source-sparse-autoencoders-for-all-residual-stream)
 
-| hook_name                 |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
-|:--------------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
-| blocks.0.hook_resid_pre   |            0 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.1.hook_resid_pre   |            1 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.2.hook_resid_pre   |            2 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.3.hook_resid_pre   |            3 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.4.hook_resid_pre   |            4 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.5.hook_resid_pre   |            5 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.6.hook_resid_pre   |            6 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.7.hook_resid_pre   |            7 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.8.hook_resid_pre   |            8 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.9.hook_resid_pre   |            9 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.10.hook_resid_pre  |           10 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.11.hook_resid_pre  |           11 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.11.hook_resid_post |           11 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| id                        | architecture   | neuronpedia          | hook_name                 |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
+|:--------------------------|:---------------|:---------------------|:--------------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
+| blocks.0.hook_resid_pre   | standard       | gpt2-small/0-res-jb  | blocks.0.hook_resid_pre   |            0 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.1.hook_resid_pre   | standard       | gpt2-small/1-res-jb  | blocks.1.hook_resid_pre   |            1 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.2.hook_resid_pre   | standard       | gpt2-small/2-res-jb  | blocks.2.hook_resid_pre   |            2 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.3.hook_resid_pre   | standard       | gpt2-small/3-res-jb  | blocks.3.hook_resid_pre   |            3 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.4.hook_resid_pre   | standard       | gpt2-small/4-res-jb  | blocks.4.hook_resid_pre   |            4 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.5.hook_resid_pre   | standard       | gpt2-small/0-res-jb  | blocks.5.hook_resid_pre   |            5 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.6.hook_resid_pre   | standard       | gpt2-small/6-res-jb  | blocks.6.hook_resid_pre   |            6 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.7.hook_resid_pre   | standard       | gpt2-small/7-res-jb  | blocks.7.hook_resid_pre   |            7 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.8.hook_resid_pre   | standard       | gpt2-small/8-res-jb  | blocks.8.hook_resid_pre   |            8 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.9.hook_resid_pre   | standard       | gpt2-small/9-res-jb  | blocks.9.hook_resid_pre   |            9 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.10.hook_resid_pre  | standard       | gpt2-small/10-res-jb | blocks.10.hook_resid_pre  |           10 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.11.hook_resid_pre  | standard       | gpt2-small/11-res-jb | blocks.11.hook_resid_pre  |           11 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.11.hook_resid_post | standard       | gpt2-small/11-res-jb | blocks.11.hook_resid_post |           11 |   24576 |            128 | Skylion007/openwebtext | none                    |
 
 ## [gpt2-small-hook-z-kk](https://huggingface.co/ckkissane/attn-saes-gpt2-small-all-layers)
 
@@ -38,20 +38,20 @@ This is a list of SAEs importable from the SAELens package. Click on each link f
     - [Dashboards](https://www.neuronpedia.org/gpt2sm-kk)
     - [Publication](https://www.lesswrong.com/posts/FSTRedtjuHa4Gfdbr/attention-saes-scale-to-gpt-2-small)
 
-| hook_name             |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
-|:----------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
-| blocks.0.attn.hook_z  |            0 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.1.attn.hook_z  |            1 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.2.attn.hook_z  |            2 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.3.attn.hook_z  |            3 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.4.attn.hook_z  |            4 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.5.attn.hook_z  |            5 |   49152 |            128 | Skylion007/openwebtext | none                    |
-| blocks.6.attn.hook_z  |            6 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.7.attn.hook_z  |            7 |   49152 |            128 | Skylion007/openwebtext | none                    |
-| blocks.8.attn.hook_z  |            8 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.9.attn.hook_z  |            9 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.10.attn.hook_z |           10 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.11.attn.hook_z |           11 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| id               | architecture   | neuronpedia          | hook_name             |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
+|:-----------------|:---------------|:---------------------|:----------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
+| blocks.0.hook_z  | standard       | gpt2-small/0-att-kk  | blocks.0.attn.hook_z  |            0 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.1.hook_z  | standard       | gpt2-small/1-att-kk  | blocks.1.attn.hook_z  |            1 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.2.hook_z  | standard       | gpt2-small/2-att-kk  | blocks.2.attn.hook_z  |            2 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.3.hook_z  | standard       | gpt2-small/3-att-kk  | blocks.3.attn.hook_z  |            3 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.4.hook_z  | standard       | gpt2-small/4-att-kk  | blocks.4.attn.hook_z  |            4 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.5.hook_z  | standard       | gpt2-small/5-att-kk  | blocks.5.attn.hook_z  |            5 |   49152 |            128 | Skylion007/openwebtext | none                    |
+| blocks.6.hook_z  | standard       | gpt2-small/6-att-kk  | blocks.6.attn.hook_z  |            6 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.7.hook_z  | standard       | gpt2-small/7-att-kk  | blocks.7.attn.hook_z  |            7 |   49152 |            128 | Skylion007/openwebtext | none                    |
+| blocks.8.hook_z  | standard       | gpt2-small/8-att-kk  | blocks.8.attn.hook_z  |            8 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.9.hook_z  | standard       | gpt2-small/9-att-kk  | blocks.9.attn.hook_z  |            9 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.10.hook_z | standard       | gpt2-small/10-att-kk | blocks.10.attn.hook_z |           10 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.11.hook_z | standard       | gpt2-small/11-att-kk | blocks.11.attn.hook_z |           11 |   24576 |            128 | Skylion007/openwebtext | none                    |
 
 ## [gpt2-small-mlp-tm](https://huggingface.co/tommmcgrath/gpt2-small-mlp-out-saes)
 
@@ -60,20 +60,20 @@ This is a list of SAEs importable from the SAELens package. Click on each link f
 - **Additional Links**:
     - [Model](https://huggingface.co/gpt2)
 
-| hook_name              |   hook_layer |   d_sae |   context_size | dataset_path                                          | normalize_activations    |
-|:-----------------------|-------------:|--------:|---------------:|:------------------------------------------------------|:-------------------------|
-| blocks.0.hook_mlp_out  |            0 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
-| blocks.1.hook_mlp_out  |            1 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
-| blocks.2.hook_mlp_out  |            2 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
-| blocks.3.hook_mlp_out  |            3 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
-| blocks.4.hook_mlp_out  |            4 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
-| blocks.5.hook_mlp_out  |            5 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
-| blocks.6.hook_mlp_out  |            6 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
-| blocks.7.hook_mlp_out  |            7 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
-| blocks.8.hook_mlp_out  |            8 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
-| blocks.9.hook_mlp_out  |            9 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
-| blocks.10.hook_mlp_out |           10 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
-| blocks.11.hook_mlp_out |           11 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
+| id                     | architecture   | neuronpedia   | hook_name              |   hook_layer |   d_sae |   context_size | dataset_path                                          | normalize_activations    |
+|:-----------------------|:---------------|:--------------|:-----------------------|-------------:|--------:|---------------:|:------------------------------------------------------|:-------------------------|
+| blocks.0.hook_mlp_out  | standard       |               | blocks.0.hook_mlp_out  |            0 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
+| blocks.1.hook_mlp_out  | standard       |               | blocks.1.hook_mlp_out  |            1 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
+| blocks.2.hook_mlp_out  | standard       |               | blocks.2.hook_mlp_out  |            2 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
+| blocks.3.hook_mlp_out  | standard       |               | blocks.3.hook_mlp_out  |            3 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
+| blocks.4.hook_mlp_out  | standard       |               | blocks.4.hook_mlp_out  |            4 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
+| blocks.5.hook_mlp_out  | standard       |               | blocks.5.hook_mlp_out  |            5 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
+| blocks.6.hook_mlp_out  | standard       |               | blocks.6.hook_mlp_out  |            6 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
+| blocks.7.hook_mlp_out  | standard       |               | blocks.7.hook_mlp_out  |            7 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
+| blocks.8.hook_mlp_out  | standard       |               | blocks.8.hook_mlp_out  |            8 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
+| blocks.9.hook_mlp_out  | standard       |               | blocks.9.hook_mlp_out  |            9 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
+| blocks.10.hook_mlp_out | standard       |               | blocks.10.hook_mlp_out |           10 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
+| blocks.11.hook_mlp_out | standard       |               | blocks.11.hook_mlp_out |           11 |   24576 |            512 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | expected_average_only_in |
 
 ## [gpt2-small-res-jb-feature-splitting](https://huggingface.co/jbloom/GPT2-Small-Feature-Splitting-Experiment-Layer-8)
 
@@ -83,56 +83,56 @@ This is a list of SAEs importable from the SAELens package. Click on each link f
     - [Model](https://huggingface.co/gpt2)
     - [Dashboards](https://www.neuronpedia.org/gpt2sm-rfs-jb)
 
-| hook_name               |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
-|:------------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
-| blocks.8.hook_resid_pre |            8 |     768 |            128 | Skylion007/openwebtext | none                    |
-| blocks.8.hook_resid_pre |            8 |    1536 |            128 | Skylion007/openwebtext | none                    |
-| blocks.8.hook_resid_pre |            8 |    3072 |            128 | Skylion007/openwebtext | none                    |
-| blocks.8.hook_resid_pre |            8 |    6144 |            128 | Skylion007/openwebtext | none                    |
-| blocks.8.hook_resid_pre |            8 |   12288 |            128 | Skylion007/openwebtext | none                    |
-| blocks.8.hook_resid_pre |            8 |   24576 |            128 | Skylion007/openwebtext | none                    |
-| blocks.8.hook_resid_pre |            8 |   49152 |            128 | Skylion007/openwebtext | none                    |
-| blocks.8.hook_resid_pre |            8 |   98304 |            128 | Skylion007/openwebtext | none                    |
+| id                            | architecture   | neuronpedia                 | hook_name               |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
+|:------------------------------|:---------------|:----------------------------|:------------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
+| blocks.8.hook_resid_pre_768   | standard       | gpt2-small/8-res_fs768-jb   | blocks.8.hook_resid_pre |            8 |     768 |            128 | Skylion007/openwebtext | none                    |
+| blocks.8.hook_resid_pre_1536  | standard       | gpt2-small/8-res_fs1536-jb  | blocks.8.hook_resid_pre |            8 |    1536 |            128 | Skylion007/openwebtext | none                    |
+| blocks.8.hook_resid_pre_3072  | standard       | gpt2-small/8-res_fs3072-jb  | blocks.8.hook_resid_pre |            8 |    3072 |            128 | Skylion007/openwebtext | none                    |
+| blocks.8.hook_resid_pre_6144  | standard       | gpt2-small/8-res_fs6144-jb  | blocks.8.hook_resid_pre |            8 |    6144 |            128 | Skylion007/openwebtext | none                    |
+| blocks.8.hook_resid_pre_12288 | standard       | gpt2-small/8-res_fs12288-jb | blocks.8.hook_resid_pre |            8 |   12288 |            128 | Skylion007/openwebtext | none                    |
+| blocks.8.hook_resid_pre_24576 | standard       | gpt2-small/8-res_fs24576-jb | blocks.8.hook_resid_pre |            8 |   24576 |            128 | Skylion007/openwebtext | none                    |
+| blocks.8.hook_resid_pre_49152 | standard       | gpt2-small/8-res_fs49152-jb | blocks.8.hook_resid_pre |            8 |   49152 |            128 | Skylion007/openwebtext | none                    |
+| blocks.8.hook_resid_pre_98304 | standard       | gpt2-small/8-res_fs98304-jb | blocks.8.hook_resid_pre |            8 |   98304 |            128 | Skylion007/openwebtext | none                    |
 
 ## [gpt2-small-resid-post-v5-32k](https://huggingface.co/jbloom/GPT2-Small-OAI-v5-32k-resid-post-SAEs)
 
 - **Huggingface Repo**: jbloom/GPT2-Small-OAI-v5-32k-resid-post-SAEs
 - **model**: gpt2-small
 
-| hook_name                 |   hook_layer |   d_sae |   context_size | dataset_path                                          | normalize_activations   |
-|:--------------------------|-------------:|--------:|---------------:|:------------------------------------------------------|:------------------------|
-| blocks.0.hook_resid_post  |            0 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.1.hook_resid_post  |            1 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.2.hook_resid_post  |            2 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.3.hook_resid_post  |            3 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.4.hook_resid_post  |            4 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.5.hook_resid_post  |            5 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.6.hook_resid_post  |            6 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.7.hook_resid_post  |            7 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.8.hook_resid_post  |            8 |   32768 |             64 | Skylion007/openwebtext                                | layer_norm              |
-| blocks.9.hook_resid_post  |            9 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.10.hook_resid_post |           10 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.11.hook_resid_post |           11 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| id                        | architecture   | neuronpedia                    | hook_name                 |   hook_layer |   d_sae |   context_size | dataset_path                                          | normalize_activations   |
+|:--------------------------|:---------------|:-------------------------------|:--------------------------|-------------:|--------:|---------------:|:------------------------------------------------------|:------------------------|
+| blocks.0.hook_resid_post  | standard       | gpt2-small/0-res_post_32k-oai  | blocks.0.hook_resid_post  |            0 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.1.hook_resid_post  | standard       | gpt2-small/1-res_post_32k-oai  | blocks.1.hook_resid_post  |            1 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.2.hook_resid_post  | standard       | gpt2-small/2-res_post_32k-oai  | blocks.2.hook_resid_post  |            2 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.3.hook_resid_post  | standard       | gpt2-small/3-res_post_32k-oai  | blocks.3.hook_resid_post  |            3 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.4.hook_resid_post  | standard       | gpt2-small/4-res_post_32k-oai  | blocks.4.hook_resid_post  |            4 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.5.hook_resid_post  | standard       | gpt2-small/5-res_post_32k-oai  | blocks.5.hook_resid_post  |            5 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.6.hook_resid_post  | standard       | gpt2-small/6-res_post_32k-oai  | blocks.6.hook_resid_post  |            6 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.7.hook_resid_post  | standard       | gpt2-small/7-res_post_32k-oai  | blocks.7.hook_resid_post  |            7 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.8.hook_resid_post  | standard       | gpt2-small/8-res_post_32k-oai  | blocks.8.hook_resid_post  |            8 |   32768 |             64 | Skylion007/openwebtext                                | layer_norm              |
+| blocks.9.hook_resid_post  | standard       | gpt2-small/9-res_post_32k-oai  | blocks.9.hook_resid_post  |            9 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.10.hook_resid_post | standard       | gpt2-small/10-res_post_32k-oai | blocks.10.hook_resid_post |           10 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.11.hook_resid_post | standard       | gpt2-small/11-res_post_32k-oai | blocks.11.hook_resid_post |           11 |   32768 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
 
 ## [gpt2-small-resid-post-v5-128k](https://huggingface.co/jbloom/GPT2-Small-OAI-v5-128k-resid-post-SAEs)
 
 - **Huggingface Repo**: jbloom/GPT2-Small-OAI-v5-128k-resid-post-SAEs
 - **model**: gpt2-small
 
-| hook_name                 |   hook_layer |   d_sae |   context_size | dataset_path                                          | normalize_activations   |
-|:--------------------------|-------------:|--------:|---------------:|:------------------------------------------------------|:------------------------|
-| blocks.0.hook_resid_post  |            0 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.1.hook_resid_post  |            1 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.2.hook_resid_post  |            2 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.3.hook_resid_post  |            3 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.4.hook_resid_post  |            4 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.5.hook_resid_post  |            5 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.6.hook_resid_post  |            6 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.7.hook_resid_post  |            7 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.8.hook_resid_post  |            8 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.9.hook_resid_post  |            9 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.10.hook_resid_post |           10 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
-| blocks.11.hook_resid_post |           11 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| id                        | architecture   | neuronpedia                     | hook_name                 |   hook_layer |   d_sae |   context_size | dataset_path                                          | normalize_activations   |
+|:--------------------------|:---------------|:--------------------------------|:--------------------------|-------------:|--------:|---------------:|:------------------------------------------------------|:------------------------|
+| blocks.0.hook_resid_post  | standard       | gpt2-small/0-res_post_128k-oai  | blocks.0.hook_resid_post  |            0 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.1.hook_resid_post  | standard       | gpt2-small/1-res_post_128k-oai  | blocks.1.hook_resid_post  |            1 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.2.hook_resid_post  | standard       | gpt2-small/2-res_post_128k-oai  | blocks.2.hook_resid_post  |            2 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.3.hook_resid_post  | standard       | gpt2-small/3-res_post_128k-oai  | blocks.3.hook_resid_post  |            3 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.4.hook_resid_post  | standard       | gpt2-small/4-res_post_128k-oai  | blocks.4.hook_resid_post  |            4 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.5.hook_resid_post  | standard       | gpt2-small/5-res_post_128k-oai  | blocks.5.hook_resid_post  |            5 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.6.hook_resid_post  | standard       | gpt2-small/6-res_post_128k-oai  | blocks.6.hook_resid_post  |            6 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.7.hook_resid_post  | standard       | gpt2-small/7-res_post_128k-oai  | blocks.7.hook_resid_post  |            7 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.8.hook_resid_post  | standard       | gpt2-small/8-res_post_128k-oai  | blocks.8.hook_resid_post  |            8 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.9.hook_resid_post  | standard       | gpt2-small/9-res_post_128k-oai  | blocks.9.hook_resid_post  |            9 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.10.hook_resid_post | standard       | gpt2-small/10-res_post_128k-oai | blocks.10.hook_resid_post |           10 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
+| blocks.11.hook_resid_post | standard       | gpt2-small/11-res_post_128k-oai | blocks.11.hook_resid_post |           11 |  131072 |             64 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | layer_norm              |
 
 ## [gemma-2b-res-jb](https://huggingface.co/jbloom/Gemma-2b-Residual-Stream-SAEs)
 
@@ -142,13 +142,13 @@ This is a list of SAEs importable from the SAELens package. Click on each link f
     - [Model](https://huggingface.co/google/gemma-2b)
     - [Dashboards](https://www.neuronpedia.org/gemma2b-res-jb)
 
-| hook_name                 |   hook_layer |   d_sae |   context_size | dataset_path                      | normalize_activations    |
-|:--------------------------|-------------:|--------:|---------------:|:----------------------------------|:-------------------------|
-| blocks.0.hook_resid_post  |            0 |   16384 |           1024 | HuggingFaceFW/fineweb             | none                     |
-| blocks.6.hook_resid_post  |            6 |   16384 |           1024 | HuggingFaceFW/fineweb             | none                     |
-| blocks.10.hook_resid_post |           10 |   16384 |           1024 | ctigges/openwebtext-gemma-1024-cl | none                     |
-| blocks.12.hook_resid_post |           12 |   16384 |           1024 | HuggingFaceFW/fineweb             | expected_average_only_in |
-| blocks.17.hook_resid_post |           17 |   16384 |           1024 | ctigges/openwebtext-gemma-1024-cl | none                     |
+| id                        | architecture   | neuronpedia        | hook_name                 |   hook_layer |   d_sae |   context_size | dataset_path                      | normalize_activations    |
+|:--------------------------|:---------------|:-------------------|:--------------------------|-------------:|--------:|---------------:|:----------------------------------|:-------------------------|
+| blocks.0.hook_resid_post  | standard       | gemma-2b/0-res-jb  | blocks.0.hook_resid_post  |            0 |   16384 |           1024 | HuggingFaceFW/fineweb             | none                     |
+| blocks.6.hook_resid_post  | standard       | gemma-2b/6-res-jb  | blocks.6.hook_resid_post  |            6 |   16384 |           1024 | HuggingFaceFW/fineweb             | none                     |
+| blocks.10.hook_resid_post | standard       | gemma-2b/10-res-jb | blocks.10.hook_resid_post |           10 |   16384 |           1024 | ctigges/openwebtext-gemma-1024-cl | none                     |
+| blocks.12.hook_resid_post | standard       | gemma-2b/12-res-jb | blocks.12.hook_resid_post |           12 |   16384 |           1024 | HuggingFaceFW/fineweb             | expected_average_only_in |
+| blocks.17.hook_resid_post | standard       |                    | blocks.17.hook_resid_post |           17 |   16384 |           1024 | ctigges/openwebtext-gemma-1024-cl | none                     |
 
 ## [gemma-2b-it-res-jb](https://huggingface.co/jbloom/Gemma-2b-IT-Residual-Stream-SAEs)
 
@@ -158,140 +158,140 @@ This is a list of SAEs importable from the SAELens package. Click on each link f
     - [Model](https://huggingface.co/google/gemma-2b-it)
     - [Dashboards](https://www.neuronpedia.org/gemma2bit-res-jb)
 
-| hook_name                 |   hook_layer |   d_sae |   context_size | dataset_path              | normalize_activations   |
-|:--------------------------|-------------:|--------:|---------------:|:--------------------------|:------------------------|
-| blocks.12.hook_resid_post |           12 |   16384 |           1024 | chanind/openwebtext-gemma | none                    |
+| id                        | architecture   | neuronpedia           | hook_name                 |   hook_layer |   d_sae |   context_size | dataset_path              | normalize_activations   |
+|:--------------------------|:---------------|:----------------------|:--------------------------|-------------:|--------:|---------------:|:--------------------------|:------------------------|
+| blocks.12.hook_resid_post | standard       | gemma-2b-it/12-res-jb | blocks.12.hook_resid_post |           12 |   16384 |           1024 | chanind/openwebtext-gemma | none                    |
 
 ## [mistral-7b-res-wg](https://huggingface.co/JoshEngels/Mistral-7B-Residual-Stream-SAEs)
 
 - **Huggingface Repo**: JoshEngels/Mistral-7B-Residual-Stream-SAEs
 - **model**: mistral-7b
 
-| hook_name                |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
-|:-------------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
-| blocks.8.hook_resid_pre  |            8 |   65536 |            256 | monology/pile-uncopyrighted | none                    |
-| blocks.16.hook_resid_pre |           16 |   65536 |            256 | monology/pile-uncopyrighted | none                    |
-| blocks.24.hook_resid_pre |           24 |   65536 |            256 | monology/pile-uncopyrighted | none                    |
+| id                       | architecture   | neuronpedia   | hook_name                |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
+|:-------------------------|:---------------|:--------------|:-------------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
+| blocks.8.hook_resid_pre  | standard       |               | blocks.8.hook_resid_pre  |            8 |   65536 |            256 | monology/pile-uncopyrighted | none                    |
+| blocks.16.hook_resid_pre | standard       |               | blocks.16.hook_resid_pre |           16 |   65536 |            256 | monology/pile-uncopyrighted | none                    |
+| blocks.24.hook_resid_pre | standard       |               | blocks.24.hook_resid_pre |           24 |   65536 |            256 | monology/pile-uncopyrighted | none                    |
 
 ## [gpt2-small-resid-mid-v5-32k](https://huggingface.co/jbloom/GPT2-Small-OAI-v5-32k-resid-mid-SAEs)
 
 - **Huggingface Repo**: jbloom/GPT2-Small-OAI-v5-32k-resid-mid-SAEs
 - **model**: gpt2-small
 
-| hook_name                |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
-|:-------------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
-| blocks.0.hook_resid_mid  |            0 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.1.hook_resid_mid  |            1 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.2.hook_resid_mid  |            2 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.3.hook_resid_mid  |            3 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.4.hook_resid_mid  |            4 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.5.hook_resid_mid  |            5 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.6.hook_resid_mid  |            6 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.7.hook_resid_mid  |            7 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.8.hook_resid_mid  |            8 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.9.hook_resid_mid  |            9 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.10.hook_resid_mid |           10 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.11.hook_resid_mid |           11 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| id                       | architecture   | neuronpedia   | hook_name                |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
+|:-------------------------|:---------------|:--------------|:-------------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
+| blocks.0.hook_resid_mid  | standard       |               | blocks.0.hook_resid_mid  |            0 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.1.hook_resid_mid  | standard       |               | blocks.1.hook_resid_mid  |            1 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.2.hook_resid_mid  | standard       |               | blocks.2.hook_resid_mid  |            2 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.3.hook_resid_mid  | standard       |               | blocks.3.hook_resid_mid  |            3 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.4.hook_resid_mid  | standard       |               | blocks.4.hook_resid_mid  |            4 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.5.hook_resid_mid  | standard       |               | blocks.5.hook_resid_mid  |            5 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.6.hook_resid_mid  | standard       |               | blocks.6.hook_resid_mid  |            6 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.7.hook_resid_mid  | standard       |               | blocks.7.hook_resid_mid  |            7 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.8.hook_resid_mid  | standard       |               | blocks.8.hook_resid_mid  |            8 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.9.hook_resid_mid  | standard       |               | blocks.9.hook_resid_mid  |            9 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.10.hook_resid_mid | standard       |               | blocks.10.hook_resid_mid |           10 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.11.hook_resid_mid | standard       |               | blocks.11.hook_resid_mid |           11 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
 
 ## [gpt2-small-resid-mid-v5-128k](https://huggingface.co/jbloom/GPT2-Small-OAI-v5-128k-resid-mid-SAEs)
 
 - **Huggingface Repo**: jbloom/GPT2-Small-OAI-v5-128k-resid-mid-SAEs
 - **model**: gpt2-small
 
-| hook_name                |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
-|:-------------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
-| blocks.0.hook_resid_mid  |            0 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.1.hook_resid_mid  |            1 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.2.hook_resid_mid  |            2 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.3.hook_resid_mid  |            3 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.4.hook_resid_mid  |            4 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.5.hook_resid_mid  |            5 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.6.hook_resid_mid  |            6 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.7.hook_resid_mid  |            7 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.8.hook_resid_mid  |            8 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.9.hook_resid_mid  |            9 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.10.hook_resid_mid |           10 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.11.hook_resid_mid |           11 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| id                       | architecture   | neuronpedia   | hook_name                |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
+|:-------------------------|:---------------|:--------------|:-------------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
+| blocks.0.hook_resid_mid  | standard       |               | blocks.0.hook_resid_mid  |            0 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.1.hook_resid_mid  | standard       |               | blocks.1.hook_resid_mid  |            1 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.2.hook_resid_mid  | standard       |               | blocks.2.hook_resid_mid  |            2 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.3.hook_resid_mid  | standard       |               | blocks.3.hook_resid_mid  |            3 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.4.hook_resid_mid  | standard       |               | blocks.4.hook_resid_mid  |            4 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.5.hook_resid_mid  | standard       |               | blocks.5.hook_resid_mid  |            5 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.6.hook_resid_mid  | standard       |               | blocks.6.hook_resid_mid  |            6 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.7.hook_resid_mid  | standard       |               | blocks.7.hook_resid_mid  |            7 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.8.hook_resid_mid  | standard       |               | blocks.8.hook_resid_mid  |            8 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.9.hook_resid_mid  | standard       |               | blocks.9.hook_resid_mid  |            9 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.10.hook_resid_mid | standard       |               | blocks.10.hook_resid_mid |           10 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.11.hook_resid_mid | standard       |               | blocks.11.hook_resid_mid |           11 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
 
 ## [gpt2-small-mlp-out-v5-32k](https://huggingface.co/jbloom/GPT2-Small-OAI-v5-32k-mlp-out-SAEs)
 
 - **Huggingface Repo**: jbloom/GPT2-Small-OAI-v5-32k-mlp-out-SAEs
 - **model**: gpt2-small
 
-| hook_name              |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
-|:-----------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
-| blocks.0.hook_mlp_out  |            0 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.1.hook_mlp_out  |            1 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.2.hook_mlp_out  |            2 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.3.hook_mlp_out  |            3 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.4.hook_mlp_out  |            4 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.5.hook_mlp_out  |            5 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.6.hook_mlp_out  |            6 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.7.hook_mlp_out  |            7 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.8.hook_mlp_out  |            8 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.9.hook_mlp_out  |            9 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.10.hook_mlp_out |           10 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.11.hook_mlp_out |           11 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| id                     | architecture   | neuronpedia                   | hook_name              |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
+|:-----------------------|:---------------|:------------------------------|:-----------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
+| blocks.0.hook_mlp_out  | standard       | gpt2-small/0-res_mlp_32k-oai  | blocks.0.hook_mlp_out  |            0 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.1.hook_mlp_out  | standard       | gpt2-small/1-res_mlp_32k-oai  | blocks.1.hook_mlp_out  |            1 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.2.hook_mlp_out  | standard       | gpt2-small/2-res_mlp_32k-oai  | blocks.2.hook_mlp_out  |            2 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.3.hook_mlp_out  | standard       | gpt2-small/3-res_mlp_32k-oai  | blocks.3.hook_mlp_out  |            3 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.4.hook_mlp_out  | standard       | gpt2-small/4-res_mlp_32k-oai  | blocks.4.hook_mlp_out  |            4 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.5.hook_mlp_out  | standard       | gpt2-small/5-res_mlp_32k-oai  | blocks.5.hook_mlp_out  |            5 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.6.hook_mlp_out  | standard       | gpt2-small/6-res_mlp_32k-oai  | blocks.6.hook_mlp_out  |            6 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.7.hook_mlp_out  | standard       | gpt2-small/7-res_mlp_32k-oai  | blocks.7.hook_mlp_out  |            7 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.8.hook_mlp_out  | standard       | gpt2-small/8-res_mlp_32k-oai  | blocks.8.hook_mlp_out  |            8 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.9.hook_mlp_out  | standard       | gpt2-small/9-res_mlp_32k-oai  | blocks.9.hook_mlp_out  |            9 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.10.hook_mlp_out | standard       | gpt2-small/10-res_mlp_32k-oai | blocks.10.hook_mlp_out |           10 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.11.hook_mlp_out | standard       | gpt2-small/11-res_mlp_32k-oai | blocks.11.hook_mlp_out |           11 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
 
 ## [gpt2-small-mlp-out-v5-128k](https://huggingface.co/jbloom/GPT2-Small-OAI-v5-128k-mlp-out-SAEs)
 
 - **Huggingface Repo**: jbloom/GPT2-Small-OAI-v5-128k-mlp-out-SAEs
 - **model**: gpt2-small
 
-| hook_name              |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
-|:-----------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
-| blocks.0.hook_mlp_out  |            0 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.1.hook_mlp_out  |            1 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.2.hook_mlp_out  |            2 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.3.hook_mlp_out  |            3 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.4.hook_mlp_out  |            4 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.5.hook_mlp_out  |            5 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.6.hook_mlp_out  |            6 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.7.hook_mlp_out  |            7 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.8.hook_mlp_out  |            8 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.9.hook_mlp_out  |            9 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.10.hook_mlp_out |           10 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.11.hook_mlp_out |           11 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| id                     | architecture   | neuronpedia                    | hook_name              |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
+|:-----------------------|:---------------|:-------------------------------|:-----------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
+| blocks.0.hook_mlp_out  | standard       | gpt2-small/0-res_mlp_128k-oai  | blocks.0.hook_mlp_out  |            0 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.1.hook_mlp_out  | standard       | gpt2-small/1-res_mlp_128k-oai  | blocks.1.hook_mlp_out  |            1 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.2.hook_mlp_out  | standard       | gpt2-small/2-res_mlp_128k-oai  | blocks.2.hook_mlp_out  |            2 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.3.hook_mlp_out  | standard       | gpt2-small/3-res_mlp_128k-oai  | blocks.3.hook_mlp_out  |            3 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.4.hook_mlp_out  | standard       | gpt2-small/4-res_mlp_128k-oai  | blocks.4.hook_mlp_out  |            4 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.5.hook_mlp_out  | standard       | gpt2-small/5-res_mlp_128k-oai  | blocks.5.hook_mlp_out  |            5 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.6.hook_mlp_out  | standard       | gpt2-small/6-res_mlp_128k-oai  | blocks.6.hook_mlp_out  |            6 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.7.hook_mlp_out  | standard       | gpt2-small/7-res_mlp_128k-oai  | blocks.7.hook_mlp_out  |            7 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.8.hook_mlp_out  | standard       | gpt2-small/8-res_mlp_128k-oai  | blocks.8.hook_mlp_out  |            8 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.9.hook_mlp_out  | standard       | gpt2-small/9-res_mlp_128k-oai  | blocks.9.hook_mlp_out  |            9 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.10.hook_mlp_out | standard       | gpt2-small/10-res_mlp_128k-oai | blocks.10.hook_mlp_out |           10 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.11.hook_mlp_out | standard       | gpt2-small/11-res_mlp_128k-oai | blocks.11.hook_mlp_out |           11 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
 
 ## [gpt2-small-attn-out-v5-32k](https://huggingface.co/jbloom/GPT2-Small-OAI-v5-32k-attn-out-SAEs)
 
 - **Huggingface Repo**: jbloom/GPT2-Small-OAI-v5-32k-attn-out-SAEs
 - **model**: gpt2-small
 
-| hook_name               |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
-|:------------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
-| blocks.0.hook_attn_out  |            0 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.1.hook_attn_out  |            1 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.2.hook_attn_out  |            2 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.3.hook_attn_out  |            3 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.4.hook_attn_out  |            4 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.5.hook_attn_out  |            5 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.6.hook_attn_out  |            6 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.7.hook_attn_out  |            7 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.8.hook_attn_out  |            8 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.9.hook_attn_out  |            9 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.10.hook_attn_out |           10 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.11.hook_attn_out |           11 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| id                      | architecture   | neuronpedia                   | hook_name               |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
+|:------------------------|:---------------|:------------------------------|:------------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
+| blocks.0.hook_attn_out  | standard       | gpt2-small/0-res_att_32k-oai  | blocks.0.hook_attn_out  |            0 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.1.hook_attn_out  | standard       | gpt2-small/1-res_att_32k-oai  | blocks.1.hook_attn_out  |            1 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.2.hook_attn_out  | standard       | gpt2-small/2-res_att_32k-oai  | blocks.2.hook_attn_out  |            2 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.3.hook_attn_out  | standard       | gpt2-small/3-res_att_32k-oai  | blocks.3.hook_attn_out  |            3 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.4.hook_attn_out  | standard       | gpt2-small/4-res_att_32k-oai  | blocks.4.hook_attn_out  |            4 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.5.hook_attn_out  | standard       | gpt2-small/5-res_att_32k-oai  | blocks.5.hook_attn_out  |            5 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.6.hook_attn_out  | standard       | gpt2-small/6-res_att_32k-oai  | blocks.6.hook_attn_out  |            6 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.7.hook_attn_out  | standard       | gpt2-small/7-res_att_32k-oai  | blocks.7.hook_attn_out  |            7 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.8.hook_attn_out  | standard       | gpt2-small/8-res_att_32k-oai  | blocks.8.hook_attn_out  |            8 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.9.hook_attn_out  | standard       | gpt2-small/9-res_att_32k-oai  | blocks.9.hook_attn_out  |            9 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.10.hook_attn_out | standard       | gpt2-small/10-res_att_32k-oai | blocks.10.hook_attn_out |           10 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.11.hook_attn_out | standard       | gpt2-small/11-res_att_32k-oai | blocks.11.hook_attn_out |           11 |   32768 |             64 | Skylion007/openwebtext | layer_norm              |
 
 ## [gpt2-small-attn-out-v5-128k](https://huggingface.co/jbloom/GPT2-Small-OAI-v5-128k-attn-out-SAEs)
 
 - **Huggingface Repo**: jbloom/GPT2-Small-OAI-v5-128k-attn-out-SAEs
 - **model**: gpt2-small
 
-| hook_name               |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
-|:------------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
-| blocks.0.hook_attn_out  |            0 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.1.hook_attn_out  |            1 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.2.hook_attn_out  |            2 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.3.hook_attn_out  |            3 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.4.hook_attn_out  |            4 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.5.hook_attn_out  |            5 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.6.hook_attn_out  |            6 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.7.hook_attn_out  |            7 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.8.hook_attn_out  |            8 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.9.hook_attn_out  |            9 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.10.hook_attn_out |           10 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
-| blocks.11.hook_attn_out |           11 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| id                      | architecture   | neuronpedia                    | hook_name               |   hook_layer |   d_sae |   context_size | dataset_path           | normalize_activations   |
+|:------------------------|:---------------|:-------------------------------|:------------------------|-------------:|--------:|---------------:|:-----------------------|:------------------------|
+| blocks.0.hook_attn_out  | standard       | gpt2-small/0-res_att_128k-oai  | blocks.0.hook_attn_out  |            0 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.1.hook_attn_out  | standard       | gpt2-small/1-res_att_128k-oai  | blocks.1.hook_attn_out  |            1 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.2.hook_attn_out  | standard       | gpt2-small/2-res_att_128k-oai  | blocks.2.hook_attn_out  |            2 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.3.hook_attn_out  | standard       | gpt2-small/3-res_att_128k-oai  | blocks.3.hook_attn_out  |            3 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.4.hook_attn_out  | standard       | gpt2-small/4-res_att_128k-oai  | blocks.4.hook_attn_out  |            4 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.5.hook_attn_out  | standard       | gpt2-small/5-res_att_128k-oai  | blocks.5.hook_attn_out  |            5 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.6.hook_attn_out  | standard       | gpt2-small/6-res_att_128k-oai  | blocks.6.hook_attn_out  |            6 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.7.hook_attn_out  | standard       | gpt2-small/7-res_att_128k-oai  | blocks.7.hook_attn_out  |            7 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.8.hook_attn_out  | standard       | gpt2-small/8-res_att_128k-oai  | blocks.8.hook_attn_out  |            8 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.9.hook_attn_out  | standard       | gpt2-small/9-res_att_128k-oai  | blocks.9.hook_attn_out  |            9 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.10.hook_attn_out | standard       | gpt2-small/10-res_att_128k-oai | blocks.10.hook_attn_out |           10 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
+| blocks.11.hook_attn_out | standard       | gpt2-small/11-res_att_128k-oai | blocks.11.hook_attn_out |           11 |  131072 |             64 | Skylion007/openwebtext | layer_norm              |
 
 ## [gemma-scope-2b-pt-res-canonical](https://huggingface.co/google/gemma-scope-2b-pt-res)
 
@@ -302,1161 +302,1357 @@ This is a list of SAEs importable from the SAELens package. Click on each link f
     - [Dashboards](https://www.neuronpedia.org/gemma-2-2b/gemmascope-res-16k)
     - [Publication](https://huggingface.co/google/gemma-scope)
 
-| hook_name                 |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
-|:--------------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
-| blocks.0.hook_resid_post  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_resid_post  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_resid_post  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_resid_post  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_resid_post  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_resid_post  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_resid_post  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_resid_post  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_resid_post  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_resid_post |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_resid_post |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_resid_post |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_resid_post |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_resid_post |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_resid_post |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_resid_post |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_resid_post |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_resid_post |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_resid_post |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_resid_post |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_resid_post |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_resid_post |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |  262144 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   32768 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |  524288 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_resid_post  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_resid_post  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_resid_post  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_resid_post  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_resid_post  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_resid_post  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_resid_post  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_resid_post  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_resid_post  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_resid_post |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_resid_post |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_resid_post |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_resid_post |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_resid_post |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_resid_post |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_resid_post |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_resid_post |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_resid_post |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_resid_post |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_resid_post |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_resid_post |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_resid_post |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| id                            | architecture   | neuronpedia   | hook_name                 |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
+|:------------------------------|:---------------|:--------------|:--------------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
+| layer_0/width_16k/canonical   | jumprelu       |               | blocks.0.hook_resid_post  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/canonical   | jumprelu       |               | blocks.1.hook_resid_post  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/canonical   | jumprelu       |               | blocks.2.hook_resid_post  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/canonical   | jumprelu       |               | blocks.3.hook_resid_post  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/canonical   | jumprelu       |               | blocks.4.hook_resid_post  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/canonical   | jumprelu       |               | blocks.5.hook_resid_post  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/canonical   | jumprelu       |               | blocks.6.hook_resid_post  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/canonical   | jumprelu       |               | blocks.7.hook_resid_post  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/canonical   | jumprelu       |               | blocks.8.hook_resid_post  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/canonical   | jumprelu       |               | blocks.9.hook_resid_post  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/canonical  | jumprelu       |               | blocks.10.hook_resid_post |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/canonical  | jumprelu       |               | blocks.11.hook_resid_post |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/canonical  | jumprelu       |               | blocks.12.hook_resid_post |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/canonical  | jumprelu       |               | blocks.13.hook_resid_post |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/canonical  | jumprelu       |               | blocks.14.hook_resid_post |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/canonical  | jumprelu       |               | blocks.15.hook_resid_post |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/canonical  | jumprelu       |               | blocks.16.hook_resid_post |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/canonical  | jumprelu       |               | blocks.17.hook_resid_post |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/canonical  | jumprelu       |               | blocks.18.hook_resid_post |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/canonical  | jumprelu       |               | blocks.19.hook_resid_post |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/canonical  | jumprelu       |               | blocks.20.hook_resid_post |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/canonical  | jumprelu       |               | blocks.21.hook_resid_post |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/canonical  | jumprelu       |               | blocks.22.hook_resid_post |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/canonical  | jumprelu       |               | blocks.23.hook_resid_post |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/canonical  | jumprelu       |               | blocks.24.hook_resid_post |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/canonical  | jumprelu       |               | blocks.25.hook_resid_post |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_1m/canonical    | jumprelu       |               | blocks.5.hook_resid_post  |            5 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_1m/canonical   | jumprelu       |               | blocks.12.hook_resid_post |           12 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_1m/canonical   | jumprelu       |               | blocks.19.hook_resid_post |           19 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_262k/canonical | jumprelu       |               | blocks.12.hook_resid_post |           12 |  262144 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_32k/canonical  | jumprelu       |               | blocks.12.hook_resid_post |           12 |   32768 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_524k/canonical | jumprelu       |               | blocks.12.hook_resid_post |           12 |  524288 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/canonical   | jumprelu       |               | blocks.0.hook_resid_post  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/canonical   | jumprelu       |               | blocks.1.hook_resid_post  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/canonical   | jumprelu       |               | blocks.2.hook_resid_post  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/canonical   | jumprelu       |               | blocks.3.hook_resid_post  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/canonical   | jumprelu       |               | blocks.4.hook_resid_post  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/canonical   | jumprelu       |               | blocks.5.hook_resid_post  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/canonical   | jumprelu       |               | blocks.6.hook_resid_post  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/canonical   | jumprelu       |               | blocks.7.hook_resid_post  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/canonical   | jumprelu       |               | blocks.8.hook_resid_post  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/canonical   | jumprelu       |               | blocks.9.hook_resid_post  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/canonical  | jumprelu       |               | blocks.10.hook_resid_post |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/canonical  | jumprelu       |               | blocks.11.hook_resid_post |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/canonical  | jumprelu       |               | blocks.12.hook_resid_post |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/canonical  | jumprelu       |               | blocks.13.hook_resid_post |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/canonical  | jumprelu       |               | blocks.14.hook_resid_post |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/canonical  | jumprelu       |               | blocks.15.hook_resid_post |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/canonical  | jumprelu       |               | blocks.16.hook_resid_post |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/canonical  | jumprelu       |               | blocks.17.hook_resid_post |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/canonical  | jumprelu       |               | blocks.18.hook_resid_post |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/canonical  | jumprelu       |               | blocks.19.hook_resid_post |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/canonical  | jumprelu       |               | blocks.20.hook_resid_post |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/canonical  | jumprelu       |               | blocks.21.hook_resid_post |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/canonical  | jumprelu       |               | blocks.22.hook_resid_post |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/canonical  | jumprelu       |               | blocks.23.hook_resid_post |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/canonical  | jumprelu       |               | blocks.24.hook_resid_post |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/canonical  | jumprelu       |               | blocks.25.hook_resid_post |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
 
 ## [gemma-scope-2b-pt-res](https://huggingface.co/google/gemma-scope-2b-pt-res)
 
 - **Huggingface Repo**: google/gemma-scope-2b-pt-res
 - **model**: gemma-2-2b
 
-| hook_name                 |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
-|:--------------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
-| blocks.0.hook_resid_post  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_resid_post  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_resid_post  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_resid_post  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_resid_post  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_resid_post  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_resid_post  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_resid_post  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_resid_post  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_resid_post  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_resid_post  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_resid_post  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_resid_post  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_resid_post  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_resid_post  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_resid_post  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_resid_post  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_resid_post  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_resid_post  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_resid_post  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_resid_post  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_resid_post  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_resid_post  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_resid_post  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_resid_post  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_resid_post  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_resid_post  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_resid_post  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_resid_post  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_resid_post  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_resid_post  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_resid_post  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_resid_post  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_resid_post  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_resid_post  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_resid_post  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_resid_post  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_resid_post  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_resid_post  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_resid_post  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_resid_post  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_resid_post  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_resid_post  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_resid_post  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_resid_post  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_resid_post  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_resid_post  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_resid_post |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_resid_post |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_resid_post |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_resid_post |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_resid_post |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_resid_post |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_resid_post |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_resid_post |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_resid_post |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_resid_post |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_resid_post |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_resid_post |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_resid_post |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_resid_post |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_resid_post |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_resid_post |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_resid_post |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_resid_post |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_resid_post |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_resid_post |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_resid_post |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_resid_post |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_resid_post |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_resid_post |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_resid_post |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_resid_post |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_resid_post |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_resid_post |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_resid_post |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_resid_post |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_resid_post |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_resid_post |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_resid_post |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_resid_post |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_resid_post |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_resid_post |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_resid_post |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_resid_post |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_resid_post |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_resid_post |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_resid_post |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_resid_post |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_resid_post |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_resid_post |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_resid_post |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_resid_post |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_resid_post |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_resid_post |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_resid_post |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_resid_post |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_resid_post |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_resid_post |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_resid_post |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_resid_post |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_resid_post |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_resid_post |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_resid_post |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_resid_post |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_resid_post |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_resid_post |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_resid_post |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_resid_post |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_resid_post |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_resid_post |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_resid_post |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_resid_post |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_resid_post |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_resid_post |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_resid_post |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |  262144 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |  262144 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |  262144 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |  262144 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |  262144 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |  262144 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   32768 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   32768 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   32768 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   32768 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   32768 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   32768 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |  524288 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |  524288 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |  524288 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |  524288 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |  524288 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |  524288 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_resid_post  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_resid_post  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_resid_post  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_resid_post  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_resid_post  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_resid_post  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_resid_post  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_resid_post  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_resid_post  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_resid_post  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_resid_post  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_resid_post  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_resid_post  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_resid_post  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_resid_post  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_resid_post  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_resid_post  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_resid_post  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_resid_post  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_resid_post  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_resid_post  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_resid_post  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_resid_post  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_resid_post  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_resid_post  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_resid_post  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_resid_post  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_resid_post  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_resid_post  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_resid_post  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_resid_post  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_resid_post  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_resid_post  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_resid_post  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_resid_post  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_resid_post  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_resid_post  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_resid_post  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_resid_post  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_resid_post  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_resid_post  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_resid_post  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_resid_post  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_resid_post  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_resid_post  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_resid_post  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_resid_post |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_resid_post |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_resid_post |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_resid_post |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_resid_post |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_resid_post |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_resid_post |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_resid_post |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_resid_post |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_resid_post |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_resid_post |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_resid_post |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_resid_post |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_resid_post |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_resid_post |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_resid_post |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_resid_post |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_resid_post |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_resid_post |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_resid_post |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_resid_post |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_resid_post |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_resid_post |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_resid_post |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_resid_post |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_resid_post |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_resid_post |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_resid_post |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_resid_post |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_resid_post |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_resid_post |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_resid_post |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_resid_post |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_resid_post |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_resid_post |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_resid_post |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_resid_post |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_resid_post |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_resid_post |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_resid_post |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_resid_post |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_resid_post |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_resid_post |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_resid_post |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_resid_post |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_resid_post |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_resid_post |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_resid_post |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_resid_post |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_resid_post |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_resid_post |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_resid_post |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_resid_post |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_resid_post |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_resid_post |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_resid_post |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_resid_post |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_resid_post |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_resid_post |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_resid_post |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_resid_post |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_resid_post |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_resid_post |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_resid_post |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_resid_post |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_resid_post |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_resid_post |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_resid_post |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_resid_post |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_resid_post |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_resid_post |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| id                                 | architecture   | neuronpedia   | hook_name                 |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
+|:-----------------------------------|:---------------|:--------------|:--------------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
+| layer_0/width_16k/average_l0_105   | jumprelu       |               | blocks.0.hook_resid_post  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_16k/average_l0_13    | jumprelu       |               | blocks.0.hook_resid_post  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_16k/average_l0_226   | jumprelu       |               | blocks.0.hook_resid_post  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_16k/average_l0_25    | jumprelu       |               | blocks.0.hook_resid_post  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_16k/average_l0_46    | jumprelu       |               | blocks.0.hook_resid_post  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/average_l0_10    | jumprelu       |               | blocks.1.hook_resid_post  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/average_l0_102   | jumprelu       |               | blocks.1.hook_resid_post  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/average_l0_20    | jumprelu       |               | blocks.1.hook_resid_post  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/average_l0_250   | jumprelu       |               | blocks.1.hook_resid_post  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/average_l0_40    | jumprelu       |               | blocks.1.hook_resid_post  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/average_l0_13    | jumprelu       |               | blocks.2.hook_resid_post  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/average_l0_141   | jumprelu       |               | blocks.2.hook_resid_post  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/average_l0_142   | jumprelu       |               | blocks.2.hook_resid_post  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/average_l0_24    | jumprelu       |               | blocks.2.hook_resid_post  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/average_l0_304   | jumprelu       |               | blocks.2.hook_resid_post  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/average_l0_53    | jumprelu       |               | blocks.2.hook_resid_post  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/average_l0_14    | jumprelu       |               | blocks.3.hook_resid_post  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/average_l0_142   | jumprelu       |               | blocks.3.hook_resid_post  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/average_l0_28    | jumprelu       |               | blocks.3.hook_resid_post  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/average_l0_315   | jumprelu       |               | blocks.3.hook_resid_post  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/average_l0_59    | jumprelu       |               | blocks.3.hook_resid_post  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/average_l0_124   | jumprelu       |               | blocks.4.hook_resid_post  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/average_l0_125   | jumprelu       |               | blocks.4.hook_resid_post  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/average_l0_17    | jumprelu       |               | blocks.4.hook_resid_post  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/average_l0_281   | jumprelu       |               | blocks.4.hook_resid_post  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/average_l0_31    | jumprelu       |               | blocks.4.hook_resid_post  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/average_l0_60    | jumprelu       |               | blocks.4.hook_resid_post  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/average_l0_143   | jumprelu       |               | blocks.5.hook_resid_post  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/average_l0_18    | jumprelu       |               | blocks.5.hook_resid_post  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/average_l0_309   | jumprelu       |               | blocks.5.hook_resid_post  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/average_l0_34    | jumprelu       |               | blocks.5.hook_resid_post  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/average_l0_68    | jumprelu       |               | blocks.5.hook_resid_post  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/average_l0_144   | jumprelu       |               | blocks.6.hook_resid_post  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/average_l0_19    | jumprelu       |               | blocks.6.hook_resid_post  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/average_l0_301   | jumprelu       |               | blocks.6.hook_resid_post  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/average_l0_36    | jumprelu       |               | blocks.6.hook_resid_post  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/average_l0_70    | jumprelu       |               | blocks.6.hook_resid_post  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/average_l0_137   | jumprelu       |               | blocks.7.hook_resid_post  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/average_l0_20    | jumprelu       |               | blocks.7.hook_resid_post  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/average_l0_285   | jumprelu       |               | blocks.7.hook_resid_post  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/average_l0_36    | jumprelu       |               | blocks.7.hook_resid_post  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/average_l0_69    | jumprelu       |               | blocks.7.hook_resid_post  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/average_l0_142   | jumprelu       |               | blocks.8.hook_resid_post  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/average_l0_20    | jumprelu       |               | blocks.8.hook_resid_post  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/average_l0_301   | jumprelu       |               | blocks.8.hook_resid_post  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/average_l0_37    | jumprelu       |               | blocks.8.hook_resid_post  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/average_l0_71    | jumprelu       |               | blocks.8.hook_resid_post  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/average_l0_151   | jumprelu       |               | blocks.9.hook_resid_post  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/average_l0_21    | jumprelu       |               | blocks.9.hook_resid_post  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/average_l0_340   | jumprelu       |               | blocks.9.hook_resid_post  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/average_l0_37    | jumprelu       |               | blocks.9.hook_resid_post  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/average_l0_73    | jumprelu       |               | blocks.9.hook_resid_post  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/average_l0_166  | jumprelu       |               | blocks.10.hook_resid_post |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/average_l0_21   | jumprelu       |               | blocks.10.hook_resid_post |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/average_l0_39   | jumprelu       |               | blocks.10.hook_resid_post |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/average_l0_395  | jumprelu       |               | blocks.10.hook_resid_post |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/average_l0_77   | jumprelu       |               | blocks.10.hook_resid_post |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/average_l0_168  | jumprelu       |               | blocks.11.hook_resid_post |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/average_l0_22   | jumprelu       |               | blocks.11.hook_resid_post |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/average_l0_393  | jumprelu       |               | blocks.11.hook_resid_post |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/average_l0_41   | jumprelu       |               | blocks.11.hook_resid_post |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/average_l0_79   | jumprelu       |               | blocks.11.hook_resid_post |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/average_l0_80   | jumprelu       |               | blocks.11.hook_resid_post |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/average_l0_176  | jumprelu       |               | blocks.12.hook_resid_post |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/average_l0_22   | jumprelu       |               | blocks.12.hook_resid_post |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/average_l0_41   | jumprelu       |               | blocks.12.hook_resid_post |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/average_l0_445  | jumprelu       |               | blocks.12.hook_resid_post |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/average_l0_82   | jumprelu       |               | blocks.12.hook_resid_post |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/average_l0_173  | jumprelu       |               | blocks.13.hook_resid_post |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/average_l0_23   | jumprelu       |               | blocks.13.hook_resid_post |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/average_l0_403  | jumprelu       |               | blocks.13.hook_resid_post |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/average_l0_43   | jumprelu       |               | blocks.13.hook_resid_post |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/average_l0_83   | jumprelu       |               | blocks.13.hook_resid_post |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/average_l0_84   | jumprelu       |               | blocks.13.hook_resid_post |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/average_l0_173  | jumprelu       |               | blocks.14.hook_resid_post |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/average_l0_23   | jumprelu       |               | blocks.14.hook_resid_post |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/average_l0_388  | jumprelu       |               | blocks.14.hook_resid_post |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/average_l0_43   | jumprelu       |               | blocks.14.hook_resid_post |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/average_l0_83   | jumprelu       |               | blocks.14.hook_resid_post |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/average_l0_84   | jumprelu       |               | blocks.14.hook_resid_post |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/average_l0_150  | jumprelu       |               | blocks.15.hook_resid_post |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/average_l0_23   | jumprelu       |               | blocks.15.hook_resid_post |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/average_l0_308  | jumprelu       |               | blocks.15.hook_resid_post |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/average_l0_41   | jumprelu       |               | blocks.15.hook_resid_post |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/average_l0_78   | jumprelu       |               | blocks.15.hook_resid_post |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/average_l0_154  | jumprelu       |               | blocks.16.hook_resid_post |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/average_l0_23   | jumprelu       |               | blocks.16.hook_resid_post |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/average_l0_335  | jumprelu       |               | blocks.16.hook_resid_post |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/average_l0_42   | jumprelu       |               | blocks.16.hook_resid_post |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/average_l0_78   | jumprelu       |               | blocks.16.hook_resid_post |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/average_l0_150  | jumprelu       |               | blocks.17.hook_resid_post |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/average_l0_23   | jumprelu       |               | blocks.17.hook_resid_post |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/average_l0_304  | jumprelu       |               | blocks.17.hook_resid_post |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/average_l0_42   | jumprelu       |               | blocks.17.hook_resid_post |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/average_l0_77   | jumprelu       |               | blocks.17.hook_resid_post |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/average_l0_138  | jumprelu       |               | blocks.18.hook_resid_post |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/average_l0_23   | jumprelu       |               | blocks.18.hook_resid_post |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/average_l0_280  | jumprelu       |               | blocks.18.hook_resid_post |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/average_l0_40   | jumprelu       |               | blocks.18.hook_resid_post |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/average_l0_74   | jumprelu       |               | blocks.18.hook_resid_post |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/average_l0_137  | jumprelu       |               | blocks.19.hook_resid_post |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/average_l0_23   | jumprelu       |               | blocks.19.hook_resid_post |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/average_l0_279  | jumprelu       |               | blocks.19.hook_resid_post |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/average_l0_40   | jumprelu       |               | blocks.19.hook_resid_post |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/average_l0_73   | jumprelu       |               | blocks.19.hook_resid_post |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_139  | jumprelu       |               | blocks.20.hook_resid_post |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_22   | jumprelu       |               | blocks.20.hook_resid_post |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_294  | jumprelu       |               | blocks.20.hook_resid_post |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_38   | jumprelu       |               | blocks.20.hook_resid_post |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_71   | jumprelu       |               | blocks.20.hook_resid_post |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/average_l0_139  | jumprelu       |               | blocks.21.hook_resid_post |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/average_l0_22   | jumprelu       |               | blocks.21.hook_resid_post |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/average_l0_301  | jumprelu       |               | blocks.21.hook_resid_post |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/average_l0_38   | jumprelu       |               | blocks.21.hook_resid_post |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/average_l0_70   | jumprelu       |               | blocks.21.hook_resid_post |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/average_l0_147  | jumprelu       |               | blocks.22.hook_resid_post |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/average_l0_21   | jumprelu       |               | blocks.22.hook_resid_post |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/average_l0_349  | jumprelu       |               | blocks.22.hook_resid_post |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/average_l0_38   | jumprelu       |               | blocks.22.hook_resid_post |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/average_l0_72   | jumprelu       |               | blocks.22.hook_resid_post |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/average_l0_157  | jumprelu       |               | blocks.23.hook_resid_post |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/average_l0_21   | jumprelu       |               | blocks.23.hook_resid_post |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/average_l0_38   | jumprelu       |               | blocks.23.hook_resid_post |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/average_l0_404  | jumprelu       |               | blocks.23.hook_resid_post |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/average_l0_74   | jumprelu       |               | blocks.23.hook_resid_post |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/average_l0_75   | jumprelu       |               | blocks.23.hook_resid_post |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/average_l0_158  | jumprelu       |               | blocks.24.hook_resid_post |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/average_l0_20   | jumprelu       |               | blocks.24.hook_resid_post |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/average_l0_38   | jumprelu       |               | blocks.24.hook_resid_post |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/average_l0_457  | jumprelu       |               | blocks.24.hook_resid_post |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/average_l0_73   | jumprelu       |               | blocks.24.hook_resid_post |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/average_l0_116  | jumprelu       |               | blocks.25.hook_resid_post |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/average_l0_16   | jumprelu       |               | blocks.25.hook_resid_post |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/average_l0_28   | jumprelu       |               | blocks.25.hook_resid_post |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/average_l0_285  | jumprelu       |               | blocks.25.hook_resid_post |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/average_l0_55   | jumprelu       |               | blocks.25.hook_resid_post |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_1m/average_l0_114    | jumprelu       |               | blocks.5.hook_resid_post  |            5 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_1m/average_l0_13     | jumprelu       |               | blocks.5.hook_resid_post  |            5 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_1m/average_l0_21     | jumprelu       |               | blocks.5.hook_resid_post  |            5 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_1m/average_l0_36     | jumprelu       |               | blocks.5.hook_resid_post  |            5 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_1m/average_l0_63     | jumprelu       |               | blocks.5.hook_resid_post  |            5 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_1m/average_l0_9      | jumprelu       |               | blocks.5.hook_resid_post  |            5 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_1m/average_l0_107   | jumprelu       |               | blocks.12.hook_resid_post |           12 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_1m/average_l0_19    | jumprelu       |               | blocks.12.hook_resid_post |           12 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_1m/average_l0_207   | jumprelu       |               | blocks.12.hook_resid_post |           12 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_1m/average_l0_26    | jumprelu       |               | blocks.12.hook_resid_post |           12 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_1m/average_l0_58    | jumprelu       |               | blocks.12.hook_resid_post |           12 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_1m/average_l0_73    | jumprelu       |               | blocks.12.hook_resid_post |           12 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_1m/average_l0_157   | jumprelu       |               | blocks.19.hook_resid_post |           19 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_1m/average_l0_16    | jumprelu       |               | blocks.19.hook_resid_post |           19 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_1m/average_l0_18    | jumprelu       |               | blocks.19.hook_resid_post |           19 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_1m/average_l0_29    | jumprelu       |               | blocks.19.hook_resid_post |           19 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_1m/average_l0_50    | jumprelu       |               | blocks.19.hook_resid_post |           19 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_1m/average_l0_88    | jumprelu       |               | blocks.19.hook_resid_post |           19 | 1048576 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_262k/average_l0_11  | jumprelu       |               | blocks.12.hook_resid_post |           12 |  262144 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_262k/average_l0_121 | jumprelu       |               | blocks.12.hook_resid_post |           12 |  262144 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_262k/average_l0_21  | jumprelu       |               | blocks.12.hook_resid_post |           12 |  262144 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_262k/average_l0_243 | jumprelu       |               | blocks.12.hook_resid_post |           12 |  262144 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_262k/average_l0_36  | jumprelu       |               | blocks.12.hook_resid_post |           12 |  262144 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_262k/average_l0_67  | jumprelu       |               | blocks.12.hook_resid_post |           12 |  262144 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_32k/average_l0_12   | jumprelu       |               | blocks.12.hook_resid_post |           12 |   32768 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_32k/average_l0_155  | jumprelu       |               | blocks.12.hook_resid_post |           12 |   32768 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_32k/average_l0_22   | jumprelu       |               | blocks.12.hook_resid_post |           12 |   32768 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_32k/average_l0_360  | jumprelu       |               | blocks.12.hook_resid_post |           12 |   32768 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_32k/average_l0_40   | jumprelu       |               | blocks.12.hook_resid_post |           12 |   32768 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_32k/average_l0_76   | jumprelu       |               | blocks.12.hook_resid_post |           12 |   32768 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_524k/average_l0_115 | jumprelu       |               | blocks.12.hook_resid_post |           12 |  524288 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_524k/average_l0_22  | jumprelu       |               | blocks.12.hook_resid_post |           12 |  524288 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_524k/average_l0_227 | jumprelu       |               | blocks.12.hook_resid_post |           12 |  524288 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_524k/average_l0_29  | jumprelu       |               | blocks.12.hook_resid_post |           12 |  524288 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_524k/average_l0_46  | jumprelu       |               | blocks.12.hook_resid_post |           12 |  524288 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_524k/average_l0_65  | jumprelu       |               | blocks.12.hook_resid_post |           12 |  524288 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/average_l0_11    | jumprelu       |               | blocks.0.hook_resid_post  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/average_l0_17    | jumprelu       |               | blocks.0.hook_resid_post  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/average_l0_27    | jumprelu       |               | blocks.0.hook_resid_post  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/average_l0_43    | jumprelu       |               | blocks.0.hook_resid_post  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/average_l0_73    | jumprelu       |               | blocks.0.hook_resid_post  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/average_l0_121   | jumprelu       |               | blocks.1.hook_resid_post  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/average_l0_16    | jumprelu       |               | blocks.1.hook_resid_post  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/average_l0_30    | jumprelu       |               | blocks.1.hook_resid_post  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/average_l0_54    | jumprelu       |               | blocks.1.hook_resid_post  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/average_l0_9     | jumprelu       |               | blocks.1.hook_resid_post  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/average_l0_11    | jumprelu       |               | blocks.2.hook_resid_post  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/average_l0_169   | jumprelu       |               | blocks.2.hook_resid_post  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/average_l0_20    | jumprelu       |               | blocks.2.hook_resid_post  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/average_l0_37    | jumprelu       |               | blocks.2.hook_resid_post  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/average_l0_77    | jumprelu       |               | blocks.2.hook_resid_post  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/average_l0_13    | jumprelu       |               | blocks.3.hook_resid_post  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/average_l0_193   | jumprelu       |               | blocks.3.hook_resid_post  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/average_l0_23    | jumprelu       |               | blocks.3.hook_resid_post  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/average_l0_42    | jumprelu       |               | blocks.3.hook_resid_post  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/average_l0_89    | jumprelu       |               | blocks.3.hook_resid_post  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/average_l0_14    | jumprelu       |               | blocks.4.hook_resid_post  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/average_l0_177   | jumprelu       |               | blocks.4.hook_resid_post  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/average_l0_25    | jumprelu       |               | blocks.4.hook_resid_post  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/average_l0_46    | jumprelu       |               | blocks.4.hook_resid_post  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/average_l0_89    | jumprelu       |               | blocks.4.hook_resid_post  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/average_l0_105   | jumprelu       |               | blocks.5.hook_resid_post  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/average_l0_17    | jumprelu       |               | blocks.5.hook_resid_post  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/average_l0_211   | jumprelu       |               | blocks.5.hook_resid_post  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/average_l0_29    | jumprelu       |               | blocks.5.hook_resid_post  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/average_l0_53    | jumprelu       |               | blocks.5.hook_resid_post  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/average_l0_107   | jumprelu       |               | blocks.6.hook_resid_post  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/average_l0_17    | jumprelu       |               | blocks.6.hook_resid_post  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/average_l0_208   | jumprelu       |               | blocks.6.hook_resid_post  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/average_l0_30    | jumprelu       |               | blocks.6.hook_resid_post  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/average_l0_56    | jumprelu       |               | blocks.6.hook_resid_post  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/average_l0_107   | jumprelu       |               | blocks.7.hook_resid_post  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/average_l0_18    | jumprelu       |               | blocks.7.hook_resid_post  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/average_l0_203   | jumprelu       |               | blocks.7.hook_resid_post  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/average_l0_31    | jumprelu       |               | blocks.7.hook_resid_post  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/average_l0_57    | jumprelu       |               | blocks.7.hook_resid_post  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/average_l0_111   | jumprelu       |               | blocks.8.hook_resid_post  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/average_l0_19    | jumprelu       |               | blocks.8.hook_resid_post  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/average_l0_213   | jumprelu       |               | blocks.8.hook_resid_post  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/average_l0_33    | jumprelu       |               | blocks.8.hook_resid_post  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/average_l0_59    | jumprelu       |               | blocks.8.hook_resid_post  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/average_l0_118   | jumprelu       |               | blocks.9.hook_resid_post  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/average_l0_19    | jumprelu       |               | blocks.9.hook_resid_post  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/average_l0_240   | jumprelu       |               | blocks.9.hook_resid_post  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/average_l0_34    | jumprelu       |               | blocks.9.hook_resid_post  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/average_l0_61    | jumprelu       |               | blocks.9.hook_resid_post  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/average_l0_128  | jumprelu       |               | blocks.10.hook_resid_post |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/average_l0_20   | jumprelu       |               | blocks.10.hook_resid_post |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/average_l0_265  | jumprelu       |               | blocks.10.hook_resid_post |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/average_l0_36   | jumprelu       |               | blocks.10.hook_resid_post |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/average_l0_66   | jumprelu       |               | blocks.10.hook_resid_post |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/average_l0_134  | jumprelu       |               | blocks.11.hook_resid_post |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/average_l0_21   | jumprelu       |               | blocks.11.hook_resid_post |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/average_l0_273  | jumprelu       |               | blocks.11.hook_resid_post |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/average_l0_37   | jumprelu       |               | blocks.11.hook_resid_post |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/average_l0_70   | jumprelu       |               | blocks.11.hook_resid_post |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/average_l0_141  | jumprelu       |               | blocks.12.hook_resid_post |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/average_l0_21   | jumprelu       |               | blocks.12.hook_resid_post |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/average_l0_297  | jumprelu       |               | blocks.12.hook_resid_post |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/average_l0_38   | jumprelu       |               | blocks.12.hook_resid_post |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/average_l0_72   | jumprelu       |               | blocks.12.hook_resid_post |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/average_l0_142  | jumprelu       |               | blocks.13.hook_resid_post |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/average_l0_22   | jumprelu       |               | blocks.13.hook_resid_post |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/average_l0_288  | jumprelu       |               | blocks.13.hook_resid_post |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/average_l0_40   | jumprelu       |               | blocks.13.hook_resid_post |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/average_l0_74   | jumprelu       |               | blocks.13.hook_resid_post |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/average_l0_75   | jumprelu       |               | blocks.13.hook_resid_post |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/average_l0_144  | jumprelu       |               | blocks.14.hook_resid_post |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/average_l0_21   | jumprelu       |               | blocks.14.hook_resid_post |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/average_l0_284  | jumprelu       |               | blocks.14.hook_resid_post |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/average_l0_40   | jumprelu       |               | blocks.14.hook_resid_post |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/average_l0_73   | jumprelu       |               | blocks.14.hook_resid_post |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/average_l0_127  | jumprelu       |               | blocks.15.hook_resid_post |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/average_l0_21   | jumprelu       |               | blocks.15.hook_resid_post |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/average_l0_240  | jumprelu       |               | blocks.15.hook_resid_post |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/average_l0_38   | jumprelu       |               | blocks.15.hook_resid_post |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/average_l0_68   | jumprelu       |               | blocks.15.hook_resid_post |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/average_l0_128  | jumprelu       |               | blocks.16.hook_resid_post |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/average_l0_21   | jumprelu       |               | blocks.16.hook_resid_post |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/average_l0_244  | jumprelu       |               | blocks.16.hook_resid_post |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/average_l0_38   | jumprelu       |               | blocks.16.hook_resid_post |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/average_l0_69   | jumprelu       |               | blocks.16.hook_resid_post |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/average_l0_125  | jumprelu       |               | blocks.17.hook_resid_post |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/average_l0_21   | jumprelu       |               | blocks.17.hook_resid_post |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/average_l0_233  | jumprelu       |               | blocks.17.hook_resid_post |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/average_l0_38   | jumprelu       |               | blocks.17.hook_resid_post |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/average_l0_68   | jumprelu       |               | blocks.17.hook_resid_post |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/average_l0_116  | jumprelu       |               | blocks.18.hook_resid_post |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/average_l0_117  | jumprelu       |               | blocks.18.hook_resid_post |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/average_l0_21   | jumprelu       |               | blocks.18.hook_resid_post |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/average_l0_216  | jumprelu       |               | blocks.18.hook_resid_post |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/average_l0_36   | jumprelu       |               | blocks.18.hook_resid_post |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/average_l0_64   | jumprelu       |               | blocks.18.hook_resid_post |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/average_l0_115  | jumprelu       |               | blocks.19.hook_resid_post |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/average_l0_21   | jumprelu       |               | blocks.19.hook_resid_post |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/average_l0_216  | jumprelu       |               | blocks.19.hook_resid_post |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/average_l0_35   | jumprelu       |               | blocks.19.hook_resid_post |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/average_l0_63   | jumprelu       |               | blocks.19.hook_resid_post |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/average_l0_114  | jumprelu       |               | blocks.20.hook_resid_post |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/average_l0_20   | jumprelu       |               | blocks.20.hook_resid_post |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/average_l0_221  | jumprelu       |               | blocks.20.hook_resid_post |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/average_l0_34   | jumprelu       |               | blocks.20.hook_resid_post |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/average_l0_61   | jumprelu       |               | blocks.20.hook_resid_post |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/average_l0_111  | jumprelu       |               | blocks.21.hook_resid_post |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/average_l0_112  | jumprelu       |               | blocks.21.hook_resid_post |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/average_l0_20   | jumprelu       |               | blocks.21.hook_resid_post |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/average_l0_225  | jumprelu       |               | blocks.21.hook_resid_post |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/average_l0_33   | jumprelu       |               | blocks.21.hook_resid_post |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/average_l0_61   | jumprelu       |               | blocks.21.hook_resid_post |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/average_l0_116  | jumprelu       |               | blocks.22.hook_resid_post |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/average_l0_117  | jumprelu       |               | blocks.22.hook_resid_post |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/average_l0_20   | jumprelu       |               | blocks.22.hook_resid_post |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/average_l0_248  | jumprelu       |               | blocks.22.hook_resid_post |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/average_l0_33   | jumprelu       |               | blocks.22.hook_resid_post |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/average_l0_62   | jumprelu       |               | blocks.22.hook_resid_post |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/average_l0_123  | jumprelu       |               | blocks.23.hook_resid_post |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/average_l0_124  | jumprelu       |               | blocks.23.hook_resid_post |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/average_l0_20   | jumprelu       |               | blocks.23.hook_resid_post |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/average_l0_272  | jumprelu       |               | blocks.23.hook_resid_post |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/average_l0_35   | jumprelu       |               | blocks.23.hook_resid_post |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/average_l0_64   | jumprelu       |               | blocks.23.hook_resid_post |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/average_l0_124  | jumprelu       |               | blocks.24.hook_resid_post |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/average_l0_19   | jumprelu       |               | blocks.24.hook_resid_post |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/average_l0_273  | jumprelu       |               | blocks.24.hook_resid_post |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/average_l0_34   | jumprelu       |               | blocks.24.hook_resid_post |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/average_l0_63   | jumprelu       |               | blocks.24.hook_resid_post |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/average_l0_15   | jumprelu       |               | blocks.25.hook_resid_post |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/average_l0_197  | jumprelu       |               | blocks.25.hook_resid_post |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/average_l0_26   | jumprelu       |               | blocks.25.hook_resid_post |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/average_l0_48   | jumprelu       |               | blocks.25.hook_resid_post |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/average_l0_93   | jumprelu       |               | blocks.25.hook_resid_post |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
 
 ## [gemma-scope-2b-pt-mlp-canonical](https://huggingface.co/google/gemma-scope-2b-pt-mlp)
 
 - **Huggingface Repo**: google/gemma-scope-2b-pt-mlp
 - **model**: gemma-2-2b
 
-| hook_name              |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
-|:-----------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
-| blocks.0.hook_mlp_out  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_mlp_out  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_mlp_out  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_mlp_out  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_mlp_out  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_mlp_out  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_mlp_out  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_mlp_out  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_mlp_out  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_mlp_out  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_mlp_out |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_mlp_out |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_mlp_out |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_mlp_out |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_mlp_out |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_mlp_out |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_mlp_out |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_mlp_out |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_mlp_out |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_mlp_out |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_mlp_out |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_mlp_out |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_mlp_out |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_mlp_out |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_mlp_out |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_mlp_out  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_mlp_out  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_mlp_out  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_mlp_out  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_mlp_out  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_mlp_out  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_mlp_out  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_mlp_out  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_mlp_out  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_mlp_out  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_mlp_out |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_mlp_out |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_mlp_out |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_mlp_out |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_mlp_out |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_mlp_out |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_mlp_out |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_mlp_out |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_mlp_out |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_mlp_out |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_mlp_out |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_mlp_out |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_mlp_out |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_mlp_out |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_mlp_out |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| id                           | architecture   | neuronpedia   | hook_name              |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
+|:-----------------------------|:---------------|:--------------|:-----------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
+| layer_0/width_16k/canonical  | jumprelu       |               | blocks.0.hook_mlp_out  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/canonical  | jumprelu       |               | blocks.1.hook_mlp_out  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/canonical  | jumprelu       |               | blocks.2.hook_mlp_out  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/canonical  | jumprelu       |               | blocks.3.hook_mlp_out  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/canonical  | jumprelu       |               | blocks.4.hook_mlp_out  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/canonical  | jumprelu       |               | blocks.5.hook_mlp_out  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/canonical  | jumprelu       |               | blocks.6.hook_mlp_out  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/canonical  | jumprelu       |               | blocks.7.hook_mlp_out  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/canonical  | jumprelu       |               | blocks.8.hook_mlp_out  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/canonical  | jumprelu       |               | blocks.9.hook_mlp_out  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/canonical | jumprelu       |               | blocks.10.hook_mlp_out |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/canonical | jumprelu       |               | blocks.11.hook_mlp_out |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/canonical | jumprelu       |               | blocks.12.hook_mlp_out |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/canonical | jumprelu       |               | blocks.13.hook_mlp_out |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/canonical | jumprelu       |               | blocks.14.hook_mlp_out |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/canonical | jumprelu       |               | blocks.15.hook_mlp_out |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/canonical | jumprelu       |               | blocks.16.hook_mlp_out |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/canonical | jumprelu       |               | blocks.17.hook_mlp_out |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/canonical | jumprelu       |               | blocks.18.hook_mlp_out |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/canonical | jumprelu       |               | blocks.19.hook_mlp_out |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/canonical | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/canonical | jumprelu       |               | blocks.21.hook_mlp_out |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/canonical | jumprelu       |               | blocks.22.hook_mlp_out |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/canonical | jumprelu       |               | blocks.23.hook_mlp_out |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/canonical | jumprelu       |               | blocks.24.hook_mlp_out |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/canonical | jumprelu       |               | blocks.25.hook_mlp_out |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/canonical  | jumprelu       |               | blocks.0.hook_mlp_out  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/canonical  | jumprelu       |               | blocks.1.hook_mlp_out  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/canonical  | jumprelu       |               | blocks.2.hook_mlp_out  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/canonical  | jumprelu       |               | blocks.3.hook_mlp_out  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/canonical  | jumprelu       |               | blocks.4.hook_mlp_out  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/canonical  | jumprelu       |               | blocks.5.hook_mlp_out  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/canonical  | jumprelu       |               | blocks.6.hook_mlp_out  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/canonical  | jumprelu       |               | blocks.7.hook_mlp_out  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/canonical  | jumprelu       |               | blocks.8.hook_mlp_out  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/canonical  | jumprelu       |               | blocks.9.hook_mlp_out  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/canonical | jumprelu       |               | blocks.10.hook_mlp_out |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/canonical | jumprelu       |               | blocks.11.hook_mlp_out |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/canonical | jumprelu       |               | blocks.12.hook_mlp_out |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/canonical | jumprelu       |               | blocks.13.hook_mlp_out |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/canonical | jumprelu       |               | blocks.14.hook_mlp_out |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/canonical | jumprelu       |               | blocks.15.hook_mlp_out |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/canonical | jumprelu       |               | blocks.16.hook_mlp_out |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/canonical | jumprelu       |               | blocks.17.hook_mlp_out |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/canonical | jumprelu       |               | blocks.18.hook_mlp_out |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/canonical | jumprelu       |               | blocks.19.hook_mlp_out |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/canonical | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/canonical | jumprelu       |               | blocks.21.hook_mlp_out |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/canonical | jumprelu       |               | blocks.22.hook_mlp_out |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/canonical | jumprelu       |               | blocks.23.hook_mlp_out |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/canonical | jumprelu       |               | blocks.24.hook_mlp_out |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/canonical | jumprelu       |               | blocks.25.hook_mlp_out |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
 
 ## [gemma-scope-2b-pt-mlp](https://huggingface.co/google/gemma-scope-2b-pt-mlp)
 
 - **Huggingface Repo**: google/gemma-scope-2b-pt-mlp
 - **model**: gemma-2-2b
 
-| hook_name              |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
-|:-----------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
-| blocks.0.hook_mlp_out  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_mlp_out  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_mlp_out  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_mlp_out  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_mlp_out  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_mlp_out  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_mlp_out  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_mlp_out  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_mlp_out  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_mlp_out  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_mlp_out  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_mlp_out  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_mlp_out  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_mlp_out  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_mlp_out  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_mlp_out  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_mlp_out  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_mlp_out  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_mlp_out  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_mlp_out  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_mlp_out  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_mlp_out  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_mlp_out  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_mlp_out  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_mlp_out  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_mlp_out  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_mlp_out  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_mlp_out  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_mlp_out  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_mlp_out  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_mlp_out  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_mlp_out  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_mlp_out  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_mlp_out  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_mlp_out  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_mlp_out  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_mlp_out  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_mlp_out  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_mlp_out  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_mlp_out  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_mlp_out  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_mlp_out  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_mlp_out  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_mlp_out  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_mlp_out  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_mlp_out  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_mlp_out  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_mlp_out  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_mlp_out  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_mlp_out  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_mlp_out |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_mlp_out |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_mlp_out |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_mlp_out |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_mlp_out |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_mlp_out |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_mlp_out |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_mlp_out |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_mlp_out |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_mlp_out |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_mlp_out |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_mlp_out |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_mlp_out |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_mlp_out |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_mlp_out |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_mlp_out |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_mlp_out |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_mlp_out |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_mlp_out |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_mlp_out |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_mlp_out |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_mlp_out |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_mlp_out |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_mlp_out |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_mlp_out |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_mlp_out |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_mlp_out |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_mlp_out |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_mlp_out |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_mlp_out |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_mlp_out |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_mlp_out |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_mlp_out |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_mlp_out |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_mlp_out |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_mlp_out |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_mlp_out |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_mlp_out |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_mlp_out |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_mlp_out |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_mlp_out |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_mlp_out |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_mlp_out |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_mlp_out |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_mlp_out |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_mlp_out |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_mlp_out |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_mlp_out |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_mlp_out |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_mlp_out |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_mlp_out |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_mlp_out |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_mlp_out |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_mlp_out |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_mlp_out |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_mlp_out |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_mlp_out |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_mlp_out |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_mlp_out |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_mlp_out |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_mlp_out |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_mlp_out |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_mlp_out |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_mlp_out |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_mlp_out |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_mlp_out |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_mlp_out |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_mlp_out |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_mlp_out |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_mlp_out |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_mlp_out |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_mlp_out |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_mlp_out |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_mlp_out |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_mlp_out |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_mlp_out  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_mlp_out  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_mlp_out  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_mlp_out  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.hook_mlp_out  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_mlp_out  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_mlp_out  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_mlp_out  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_mlp_out  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_mlp_out  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_mlp_out  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_mlp_out  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_mlp_out  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_mlp_out  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_mlp_out  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_mlp_out  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_mlp_out  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_mlp_out  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_mlp_out  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_mlp_out  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_mlp_out  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_mlp_out  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_mlp_out  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_mlp_out  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_mlp_out  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_mlp_out  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_mlp_out  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_mlp_out  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_mlp_out  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_mlp_out  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_mlp_out  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_mlp_out  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_mlp_out  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_mlp_out  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_mlp_out  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_mlp_out  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_mlp_out  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_mlp_out  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_mlp_out  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_mlp_out  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_mlp_out  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_mlp_out  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_mlp_out  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_mlp_out  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_mlp_out  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_mlp_out  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_mlp_out  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_mlp_out  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_mlp_out  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_mlp_out  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_mlp_out |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_mlp_out |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_mlp_out |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_mlp_out |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_mlp_out |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_mlp_out |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_mlp_out |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_mlp_out |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_mlp_out |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_mlp_out |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_mlp_out |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_mlp_out |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_mlp_out |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_mlp_out |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_mlp_out |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_mlp_out |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_mlp_out |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_mlp_out |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_mlp_out |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_mlp_out |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_mlp_out |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_mlp_out |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_mlp_out |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_mlp_out |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_mlp_out |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_mlp_out |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_mlp_out |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_mlp_out |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_mlp_out |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_mlp_out |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_mlp_out |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_mlp_out |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_mlp_out |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_mlp_out |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_mlp_out |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_mlp_out |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_mlp_out |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_mlp_out |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_mlp_out |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_mlp_out |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_mlp_out |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_mlp_out |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_mlp_out |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_mlp_out |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_mlp_out |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_mlp_out |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_mlp_out |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_mlp_out |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_mlp_out |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_mlp_out |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_mlp_out |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_mlp_out |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_mlp_out |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_mlp_out |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_mlp_out |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_mlp_out |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_mlp_out |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_mlp_out |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_mlp_out |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_mlp_out |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_mlp_out |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_mlp_out |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_mlp_out |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_mlp_out |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_mlp_out |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_mlp_out |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_mlp_out |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_mlp_out |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_mlp_out |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_mlp_out |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_mlp_out |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_mlp_out |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_mlp_out |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_mlp_out |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_mlp_out |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| id                                | architecture   | neuronpedia   | hook_name              |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
+|:----------------------------------|:---------------|:--------------|:-----------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
+| layer_0/width_16k/average_l0_119  | jumprelu       |               | blocks.0.hook_mlp_out  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_16k/average_l0_16   | jumprelu       |               | blocks.0.hook_mlp_out  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_16k/average_l0_30   | jumprelu       |               | blocks.0.hook_mlp_out  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_16k/average_l0_60   | jumprelu       |               | blocks.0.hook_mlp_out  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_16k/average_l0_9    | jumprelu       |               | blocks.0.hook_mlp_out  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/average_l0_105  | jumprelu       |               | blocks.1.hook_mlp_out  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/average_l0_12   | jumprelu       |               | blocks.1.hook_mlp_out  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/average_l0_239  | jumprelu       |               | blocks.1.hook_mlp_out  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/average_l0_24   | jumprelu       |               | blocks.1.hook_mlp_out  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/average_l0_50   | jumprelu       |               | blocks.1.hook_mlp_out  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/average_l0_19   | jumprelu       |               | blocks.2.hook_mlp_out  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/average_l0_213  | jumprelu       |               | blocks.2.hook_mlp_out  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/average_l0_41   | jumprelu       |               | blocks.2.hook_mlp_out  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/average_l0_434  | jumprelu       |               | blocks.2.hook_mlp_out  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/average_l0_95   | jumprelu       |               | blocks.2.hook_mlp_out  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/average_l0_195  | jumprelu       |               | blocks.3.hook_mlp_out  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/average_l0_21   | jumprelu       |               | blocks.3.hook_mlp_out  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/average_l0_377  | jumprelu       |               | blocks.3.hook_mlp_out  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/average_l0_44   | jumprelu       |               | blocks.3.hook_mlp_out  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/average_l0_95   | jumprelu       |               | blocks.3.hook_mlp_out  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/average_l0_18   | jumprelu       |               | blocks.4.hook_mlp_out  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/average_l0_198  | jumprelu       |               | blocks.4.hook_mlp_out  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/average_l0_38   | jumprelu       |               | blocks.4.hook_mlp_out  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/average_l0_433  | jumprelu       |               | blocks.4.hook_mlp_out  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/average_l0_85   | jumprelu       |               | blocks.4.hook_mlp_out  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/average_l0_114  | jumprelu       |               | blocks.5.hook_mlp_out  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/average_l0_23   | jumprelu       |               | blocks.5.hook_mlp_out  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/average_l0_269  | jumprelu       |               | blocks.5.hook_mlp_out  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/average_l0_48   | jumprelu       |               | blocks.5.hook_mlp_out  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/average_l0_575  | jumprelu       |               | blocks.5.hook_mlp_out  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/average_l0_133  | jumprelu       |               | blocks.6.hook_mlp_out  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/average_l0_25   | jumprelu       |               | blocks.6.hook_mlp_out  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/average_l0_328  | jumprelu       |               | blocks.6.hook_mlp_out  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/average_l0_55   | jumprelu       |               | blocks.6.hook_mlp_out  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/average_l0_699  | jumprelu       |               | blocks.6.hook_mlp_out  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/average_l0_146  | jumprelu       |               | blocks.7.hook_mlp_out  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/average_l0_28   | jumprelu       |               | blocks.7.hook_mlp_out  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/average_l0_355  | jumprelu       |               | blocks.7.hook_mlp_out  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/average_l0_60   | jumprelu       |               | blocks.7.hook_mlp_out  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/average_l0_731  | jumprelu       |               | blocks.7.hook_mlp_out  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/average_l0_136  | jumprelu       |               | blocks.8.hook_mlp_out  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/average_l0_27   | jumprelu       |               | blocks.8.hook_mlp_out  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/average_l0_351  | jumprelu       |               | blocks.8.hook_mlp_out  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/average_l0_56   | jumprelu       |               | blocks.8.hook_mlp_out  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/average_l0_739  | jumprelu       |               | blocks.8.hook_mlp_out  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/average_l0_216  | jumprelu       |               | blocks.9.hook_mlp_out  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/average_l0_38   | jumprelu       |               | blocks.9.hook_mlp_out  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/average_l0_482  | jumprelu       |               | blocks.9.hook_mlp_out  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/average_l0_861  | jumprelu       |               | blocks.9.hook_mlp_out  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/average_l0_88   | jumprelu       |               | blocks.9.hook_mlp_out  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/average_l0_110 | jumprelu       |               | blocks.10.hook_mlp_out |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/average_l0_266 | jumprelu       |               | blocks.10.hook_mlp_out |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/average_l0_45  | jumprelu       |               | blocks.10.hook_mlp_out |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/average_l0_568 | jumprelu       |               | blocks.10.hook_mlp_out |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/average_l0_908 | jumprelu       |               | blocks.10.hook_mlp_out |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/average_l0_234 | jumprelu       |               | blocks.11.hook_mlp_out |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/average_l0_42  | jumprelu       |               | blocks.11.hook_mlp_out |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/average_l0_499 | jumprelu       |               | blocks.11.hook_mlp_out |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/average_l0_847 | jumprelu       |               | blocks.11.hook_mlp_out |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/average_l0_98  | jumprelu       |               | blocks.11.hook_mlp_out |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/average_l0_108 | jumprelu       |               | blocks.12.hook_mlp_out |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/average_l0_262 | jumprelu       |               | blocks.12.hook_mlp_out |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/average_l0_44  | jumprelu       |               | blocks.12.hook_mlp_out |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/average_l0_548 | jumprelu       |               | blocks.12.hook_mlp_out |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/average_l0_879 | jumprelu       |               | blocks.12.hook_mlp_out |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/average_l0_112 | jumprelu       |               | blocks.13.hook_mlp_out |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/average_l0_267 | jumprelu       |               | blocks.13.hook_mlp_out |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/average_l0_47  | jumprelu       |               | blocks.13.hook_mlp_out |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/average_l0_553 | jumprelu       |               | blocks.13.hook_mlp_out |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/average_l0_892 | jumprelu       |               | blocks.13.hook_mlp_out |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/average_l0_246 | jumprelu       |               | blocks.14.hook_mlp_out |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/average_l0_41  | jumprelu       |               | blocks.14.hook_mlp_out |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/average_l0_536 | jumprelu       |               | blocks.14.hook_mlp_out |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/average_l0_894 | jumprelu       |               | blocks.14.hook_mlp_out |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/average_l0_97  | jumprelu       |               | blocks.14.hook_mlp_out |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/average_l0_207 | jumprelu       |               | blocks.15.hook_mlp_out |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/average_l0_35  | jumprelu       |               | blocks.15.hook_mlp_out |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/average_l0_492 | jumprelu       |               | blocks.15.hook_mlp_out |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/average_l0_80  | jumprelu       |               | blocks.15.hook_mlp_out |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/average_l0_879 | jumprelu       |               | blocks.15.hook_mlp_out |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/average_l0_185 | jumprelu       |               | blocks.16.hook_mlp_out |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/average_l0_33  | jumprelu       |               | blocks.16.hook_mlp_out |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/average_l0_452 | jumprelu       |               | blocks.16.hook_mlp_out |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/average_l0_72  | jumprelu       |               | blocks.16.hook_mlp_out |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/average_l0_847 | jumprelu       |               | blocks.16.hook_mlp_out |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/average_l0_179 | jumprelu       |               | blocks.17.hook_mlp_out |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/average_l0_31  | jumprelu       |               | blocks.17.hook_mlp_out |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/average_l0_453 | jumprelu       |               | blocks.17.hook_mlp_out |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/average_l0_68  | jumprelu       |               | blocks.17.hook_mlp_out |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/average_l0_853 | jumprelu       |               | blocks.17.hook_mlp_out |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/average_l0_106 | jumprelu       |               | blocks.18.hook_mlp_out |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/average_l0_24  | jumprelu       |               | blocks.18.hook_mlp_out |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/average_l0_292 | jumprelu       |               | blocks.18.hook_mlp_out |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/average_l0_47  | jumprelu       |               | blocks.18.hook_mlp_out |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/average_l0_672 | jumprelu       |               | blocks.18.hook_mlp_out |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/average_l0_109 | jumprelu       |               | blocks.19.hook_mlp_out |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/average_l0_25  | jumprelu       |               | blocks.19.hook_mlp_out |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/average_l0_295 | jumprelu       |               | blocks.19.hook_mlp_out |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/average_l0_50  | jumprelu       |               | blocks.19.hook_mlp_out |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/average_l0_673 | jumprelu       |               | blocks.19.hook_mlp_out |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_109 | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_24  | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_289 | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_49  | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_658 | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/average_l0_113 | jumprelu       |               | blocks.21.hook_mlp_out |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/average_l0_23  | jumprelu       |               | blocks.21.hook_mlp_out |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/average_l0_279 | jumprelu       |               | blocks.21.hook_mlp_out |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/average_l0_48  | jumprelu       |               | blocks.21.hook_mlp_out |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/average_l0_633 | jumprelu       |               | blocks.21.hook_mlp_out |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/average_l0_121 | jumprelu       |               | blocks.22.hook_mlp_out |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/average_l0_24  | jumprelu       |               | blocks.22.hook_mlp_out |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/average_l0_290 | jumprelu       |               | blocks.22.hook_mlp_out |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/average_l0_51  | jumprelu       |               | blocks.22.hook_mlp_out |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/average_l0_624 | jumprelu       |               | blocks.22.hook_mlp_out |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/average_l0_128 | jumprelu       |               | blocks.23.hook_mlp_out |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/average_l0_27  | jumprelu       |               | blocks.23.hook_mlp_out |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/average_l0_287 | jumprelu       |               | blocks.23.hook_mlp_out |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/average_l0_57  | jumprelu       |               | blocks.23.hook_mlp_out |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/average_l0_627 | jumprelu       |               | blocks.23.hook_mlp_out |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/average_l0_158 | jumprelu       |               | blocks.24.hook_mlp_out |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/average_l0_19  | jumprelu       |               | blocks.24.hook_mlp_out |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/average_l0_35  | jumprelu       |               | blocks.24.hook_mlp_out |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/average_l0_357 | jumprelu       |               | blocks.24.hook_mlp_out |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/average_l0_73  | jumprelu       |               | blocks.24.hook_mlp_out |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/average_l0_126 | jumprelu       |               | blocks.25.hook_mlp_out |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/average_l0_15  | jumprelu       |               | blocks.25.hook_mlp_out |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/average_l0_277 | jumprelu       |               | blocks.25.hook_mlp_out |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/average_l0_29  | jumprelu       |               | blocks.25.hook_mlp_out |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/average_l0_59  | jumprelu       |               | blocks.25.hook_mlp_out |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/average_l0_12   | jumprelu       |               | blocks.0.hook_mlp_out  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/average_l0_21   | jumprelu       |               | blocks.0.hook_mlp_out  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/average_l0_39   | jumprelu       |               | blocks.0.hook_mlp_out  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/average_l0_7    | jumprelu       |               | blocks.0.hook_mlp_out  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/average_l0_72   | jumprelu       |               | blocks.0.hook_mlp_out  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/average_l0_11   | jumprelu       |               | blocks.1.hook_mlp_out  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/average_l0_127  | jumprelu       |               | blocks.1.hook_mlp_out  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/average_l0_20   | jumprelu       |               | blocks.1.hook_mlp_out  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/average_l0_37   | jumprelu       |               | blocks.1.hook_mlp_out  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/average_l0_67   | jumprelu       |               | blocks.1.hook_mlp_out  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/average_l0_134  | jumprelu       |               | blocks.2.hook_mlp_out  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/average_l0_16   | jumprelu       |               | blocks.2.hook_mlp_out  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/average_l0_265  | jumprelu       |               | blocks.2.hook_mlp_out  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/average_l0_31   | jumprelu       |               | blocks.2.hook_mlp_out  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/average_l0_60   | jumprelu       |               | blocks.2.hook_mlp_out  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/average_l0_144  | jumprelu       |               | blocks.3.hook_mlp_out  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/average_l0_18   | jumprelu       |               | blocks.3.hook_mlp_out  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/average_l0_279  | jumprelu       |               | blocks.3.hook_mlp_out  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/average_l0_33   | jumprelu       |               | blocks.3.hook_mlp_out  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/average_l0_68   | jumprelu       |               | blocks.3.hook_mlp_out  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/average_l0_138  | jumprelu       |               | blocks.4.hook_mlp_out  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/average_l0_17   | jumprelu       |               | blocks.4.hook_mlp_out  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/average_l0_299  | jumprelu       |               | blocks.4.hook_mlp_out  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/average_l0_32   | jumprelu       |               | blocks.4.hook_mlp_out  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/average_l0_66   | jumprelu       |               | blocks.4.hook_mlp_out  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/average_l0_186  | jumprelu       |               | blocks.5.hook_mlp_out  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/average_l0_22   | jumprelu       |               | blocks.5.hook_mlp_out  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/average_l0_407  | jumprelu       |               | blocks.5.hook_mlp_out  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/average_l0_43   | jumprelu       |               | blocks.5.hook_mlp_out  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/average_l0_86   | jumprelu       |               | blocks.5.hook_mlp_out  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/average_l0_101  | jumprelu       |               | blocks.6.hook_mlp_out  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/average_l0_224  | jumprelu       |               | blocks.6.hook_mlp_out  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/average_l0_24   | jumprelu       |               | blocks.6.hook_mlp_out  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/average_l0_47   | jumprelu       |               | blocks.6.hook_mlp_out  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/average_l0_515  | jumprelu       |               | blocks.6.hook_mlp_out  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/average_l0_115  | jumprelu       |               | blocks.7.hook_mlp_out  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/average_l0_266  | jumprelu       |               | blocks.7.hook_mlp_out  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/average_l0_28   | jumprelu       |               | blocks.7.hook_mlp_out  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/average_l0_56   | jumprelu       |               | blocks.7.hook_mlp_out  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/average_l0_571  | jumprelu       |               | blocks.7.hook_mlp_out  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/average_l0_110  | jumprelu       |               | blocks.8.hook_mlp_out  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/average_l0_256  | jumprelu       |               | blocks.8.hook_mlp_out  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/average_l0_31   | jumprelu       |               | blocks.8.hook_mlp_out  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/average_l0_547  | jumprelu       |               | blocks.8.hook_mlp_out  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/average_l0_55   | jumprelu       |               | blocks.8.hook_mlp_out  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/average_l0_168  | jumprelu       |               | blocks.9.hook_mlp_out  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/average_l0_38   | jumprelu       |               | blocks.9.hook_mlp_out  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/average_l0_387  | jumprelu       |               | blocks.9.hook_mlp_out  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/average_l0_745  | jumprelu       |               | blocks.9.hook_mlp_out  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/average_l0_77   | jumprelu       |               | blocks.9.hook_mlp_out  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/average_l0_218 | jumprelu       |               | blocks.10.hook_mlp_out |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/average_l0_43  | jumprelu       |               | blocks.10.hook_mlp_out |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/average_l0_474 | jumprelu       |               | blocks.10.hook_mlp_out |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/average_l0_851 | jumprelu       |               | blocks.10.hook_mlp_out |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/average_l0_95  | jumprelu       |               | blocks.10.hook_mlp_out |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/average_l0_200 | jumprelu       |               | blocks.11.hook_mlp_out |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/average_l0_41  | jumprelu       |               | blocks.11.hook_mlp_out |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/average_l0_436 | jumprelu       |               | blocks.11.hook_mlp_out |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/average_l0_771 | jumprelu       |               | blocks.11.hook_mlp_out |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/average_l0_88  | jumprelu       |               | blocks.11.hook_mlp_out |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/average_l0_222 | jumprelu       |               | blocks.12.hook_mlp_out |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/average_l0_44  | jumprelu       |               | blocks.12.hook_mlp_out |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/average_l0_482 | jumprelu       |               | blocks.12.hook_mlp_out |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/average_l0_848 | jumprelu       |               | blocks.12.hook_mlp_out |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/average_l0_96  | jumprelu       |               | blocks.12.hook_mlp_out |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/average_l0_228 | jumprelu       |               | blocks.13.hook_mlp_out |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/average_l0_44  | jumprelu       |               | blocks.13.hook_mlp_out |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/average_l0_480 | jumprelu       |               | blocks.13.hook_mlp_out |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/average_l0_841 | jumprelu       |               | blocks.13.hook_mlp_out |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/average_l0_98  | jumprelu       |               | blocks.13.hook_mlp_out |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/average_l0_204 | jumprelu       |               | blocks.14.hook_mlp_out |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/average_l0_39  | jumprelu       |               | blocks.14.hook_mlp_out |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/average_l0_463 | jumprelu       |               | blocks.14.hook_mlp_out |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/average_l0_816 | jumprelu       |               | blocks.14.hook_mlp_out |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/average_l0_89  | jumprelu       |               | blocks.14.hook_mlp_out |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/average_l0_164 | jumprelu       |               | blocks.15.hook_mlp_out |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/average_l0_35  | jumprelu       |               | blocks.15.hook_mlp_out |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/average_l0_405 | jumprelu       |               | blocks.15.hook_mlp_out |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/average_l0_72  | jumprelu       |               | blocks.15.hook_mlp_out |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/average_l0_754 | jumprelu       |               | blocks.15.hook_mlp_out |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/average_l0_142 | jumprelu       |               | blocks.16.hook_mlp_out |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/average_l0_32  | jumprelu       |               | blocks.16.hook_mlp_out |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/average_l0_348 | jumprelu       |               | blocks.16.hook_mlp_out |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/average_l0_66  | jumprelu       |               | blocks.16.hook_mlp_out |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/average_l0_695 | jumprelu       |               | blocks.16.hook_mlp_out |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/average_l0_136 | jumprelu       |               | blocks.17.hook_mlp_out |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/average_l0_30  | jumprelu       |               | blocks.17.hook_mlp_out |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/average_l0_342 | jumprelu       |               | blocks.17.hook_mlp_out |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/average_l0_61  | jumprelu       |               | blocks.17.hook_mlp_out |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/average_l0_666 | jumprelu       |               | blocks.17.hook_mlp_out |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/average_l0_191 | jumprelu       |               | blocks.18.hook_mlp_out |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/average_l0_24  | jumprelu       |               | blocks.18.hook_mlp_out |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/average_l0_44  | jumprelu       |               | blocks.18.hook_mlp_out |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/average_l0_491 | jumprelu       |               | blocks.18.hook_mlp_out |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/average_l0_88  | jumprelu       |               | blocks.18.hook_mlp_out |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/average_l0_192 | jumprelu       |               | blocks.19.hook_mlp_out |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/average_l0_25  | jumprelu       |               | blocks.19.hook_mlp_out |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/average_l0_45  | jumprelu       |               | blocks.19.hook_mlp_out |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/average_l0_470 | jumprelu       |               | blocks.19.hook_mlp_out |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/average_l0_88  | jumprelu       |               | blocks.19.hook_mlp_out |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/average_l0_189 | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/average_l0_23  | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/average_l0_44  | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/average_l0_446 | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/average_l0_88  | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/average_l0_192 | jumprelu       |               | blocks.21.hook_mlp_out |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/average_l0_23  | jumprelu       |               | blocks.21.hook_mlp_out |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/average_l0_42  | jumprelu       |               | blocks.21.hook_mlp_out |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/average_l0_472 | jumprelu       |               | blocks.21.hook_mlp_out |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/average_l0_86  | jumprelu       |               | blocks.21.hook_mlp_out |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/average_l0_203 | jumprelu       |               | blocks.22.hook_mlp_out |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/average_l0_23  | jumprelu       |               | blocks.22.hook_mlp_out |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/average_l0_46  | jumprelu       |               | blocks.22.hook_mlp_out |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/average_l0_487 | jumprelu       |               | blocks.22.hook_mlp_out |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/average_l0_92  | jumprelu       |               | blocks.22.hook_mlp_out |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/average_l0_102 | jumprelu       |               | blocks.23.hook_mlp_out |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/average_l0_218 | jumprelu       |               | blocks.23.hook_mlp_out |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/average_l0_25  | jumprelu       |               | blocks.23.hook_mlp_out |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/average_l0_49  | jumprelu       |               | blocks.23.hook_mlp_out |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/average_l0_497 | jumprelu       |               | blocks.23.hook_mlp_out |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/average_l0_128 | jumprelu       |               | blocks.24.hook_mlp_out |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/average_l0_18  | jumprelu       |               | blocks.24.hook_mlp_out |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/average_l0_268 | jumprelu       |               | blocks.24.hook_mlp_out |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/average_l0_32  | jumprelu       |               | blocks.24.hook_mlp_out |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/average_l0_62  | jumprelu       |               | blocks.24.hook_mlp_out |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/average_l0_107 | jumprelu       |               | blocks.25.hook_mlp_out |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/average_l0_14  | jumprelu       |               | blocks.25.hook_mlp_out |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/average_l0_215 | jumprelu       |               | blocks.25.hook_mlp_out |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/average_l0_26  | jumprelu       |               | blocks.25.hook_mlp_out |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/average_l0_52  | jumprelu       |               | blocks.25.hook_mlp_out |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
 
 ## [gemma-scope-2b-pt-att](https://huggingface.co/google/gemma-scope-2b-pt-att)
 
 - **Huggingface Repo**: google/gemma-scope-2b-pt-att
 - **model**: gemma-2-2b
 
-| hook_name             |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
-|:----------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
-| blocks.0.attn.hook_z  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.attn.hook_z  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.attn.hook_z  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.attn.hook_z  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.attn.hook_z  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.attn.hook_z  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.attn.hook_z  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.attn.hook_z  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.attn.hook_z  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.attn.hook_z  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.attn.hook_z  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.attn.hook_z  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.attn.hook_z  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.attn.hook_z  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.attn.hook_z  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.attn.hook_z  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.attn.hook_z  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.attn.hook_z  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.attn.hook_z  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.attn.hook_z  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.attn.hook_z  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.attn.hook_z  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.attn.hook_z  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.attn.hook_z  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.attn.hook_z  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.attn.hook_z  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.attn.hook_z  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.attn.hook_z  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.attn.hook_z  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.attn.hook_z  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.attn.hook_z  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.attn.hook_z  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.attn.hook_z  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.attn.hook_z  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.attn.hook_z  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.attn.hook_z  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.attn.hook_z  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.attn.hook_z  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.attn.hook_z  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.attn.hook_z  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.attn.hook_z  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.attn.hook_z  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.attn.hook_z  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.attn.hook_z  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.attn.hook_z  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.attn.hook_z  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.attn.hook_z  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.attn.hook_z  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.attn.hook_z  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.attn.hook_z  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.attn.hook_z |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.attn.hook_z |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.attn.hook_z |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.attn.hook_z |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.attn.hook_z |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.attn.hook_z |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.attn.hook_z |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.attn.hook_z |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.attn.hook_z |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.attn.hook_z |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.attn.hook_z |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.attn.hook_z |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.attn.hook_z |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.attn.hook_z |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.attn.hook_z |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.attn.hook_z |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.attn.hook_z |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.attn.hook_z |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.attn.hook_z |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.attn.hook_z |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.attn.hook_z |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.attn.hook_z |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.attn.hook_z |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.attn.hook_z |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.attn.hook_z |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.attn.hook_z |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.attn.hook_z |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.attn.hook_z |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.attn.hook_z |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.attn.hook_z |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.attn.hook_z |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.attn.hook_z |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.attn.hook_z |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.attn.hook_z |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.attn.hook_z |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.attn.hook_z |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.attn.hook_z |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.attn.hook_z |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.attn.hook_z |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.attn.hook_z |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.attn.hook_z |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.attn.hook_z |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.attn.hook_z |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.attn.hook_z |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.attn.hook_z |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.attn.hook_z |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.attn.hook_z |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.attn.hook_z |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.attn.hook_z |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.attn.hook_z |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.attn.hook_z |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.attn.hook_z |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.attn.hook_z |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.attn.hook_z |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.attn.hook_z |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.attn.hook_z |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.attn.hook_z |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.attn.hook_z |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.attn.hook_z |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.attn.hook_z |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.attn.hook_z |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.attn.hook_z |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.attn.hook_z |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.attn.hook_z |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.attn.hook_z |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.attn.hook_z |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.attn.hook_z |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.attn.hook_z |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.attn.hook_z |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.attn.hook_z |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.attn.hook_z |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.attn.hook_z |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.attn.hook_z |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.attn.hook_z |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.attn.hook_z |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.attn.hook_z |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.attn.hook_z |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.attn.hook_z |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.attn.hook_z |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.attn.hook_z |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.attn.hook_z  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.attn.hook_z  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.attn.hook_z  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.attn.hook_z  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.attn.hook_z  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.attn.hook_z  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.attn.hook_z  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.attn.hook_z  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.attn.hook_z  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.attn.hook_z  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.attn.hook_z  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.attn.hook_z  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.attn.hook_z  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.attn.hook_z  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.attn.hook_z  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.attn.hook_z  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.attn.hook_z  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.attn.hook_z  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.attn.hook_z  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.attn.hook_z  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.attn.hook_z  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.attn.hook_z  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.attn.hook_z  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.attn.hook_z  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.attn.hook_z  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.attn.hook_z  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.attn.hook_z  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.attn.hook_z  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.attn.hook_z  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.attn.hook_z  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.attn.hook_z  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.attn.hook_z  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.attn.hook_z  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.attn.hook_z  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.attn.hook_z  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.attn.hook_z  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.attn.hook_z  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.attn.hook_z  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.attn.hook_z  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.attn.hook_z  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.attn.hook_z  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.attn.hook_z  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.attn.hook_z  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.attn.hook_z  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.attn.hook_z  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.attn.hook_z  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.attn.hook_z  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.attn.hook_z  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.attn.hook_z  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.attn.hook_z  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.attn.hook_z |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.attn.hook_z |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.attn.hook_z |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.attn.hook_z |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.attn.hook_z |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.attn.hook_z |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.attn.hook_z |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.attn.hook_z |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.attn.hook_z |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.attn.hook_z |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.attn.hook_z |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.attn.hook_z |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.attn.hook_z |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.attn.hook_z |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.attn.hook_z |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.attn.hook_z |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.attn.hook_z |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.attn.hook_z |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.attn.hook_z |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.attn.hook_z |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.attn.hook_z |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.attn.hook_z |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.attn.hook_z |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.attn.hook_z |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.attn.hook_z |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.attn.hook_z |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.attn.hook_z |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.attn.hook_z |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.attn.hook_z |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.attn.hook_z |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.attn.hook_z |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.attn.hook_z |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.attn.hook_z |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.attn.hook_z |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.attn.hook_z |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.attn.hook_z |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.attn.hook_z |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.attn.hook_z |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.attn.hook_z |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.attn.hook_z |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.attn.hook_z |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.attn.hook_z |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.attn.hook_z |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.attn.hook_z |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.attn.hook_z |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.attn.hook_z |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.attn.hook_z |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.attn.hook_z |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.attn.hook_z |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.attn.hook_z |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.attn.hook_z |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.attn.hook_z |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.attn.hook_z |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.attn.hook_z |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.attn.hook_z |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.attn.hook_z |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.attn.hook_z |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.attn.hook_z |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.attn.hook_z |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.attn.hook_z |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.attn.hook_z |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.attn.hook_z |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.attn.hook_z |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.attn.hook_z |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.attn.hook_z |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.attn.hook_z |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.attn.hook_z |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.attn.hook_z |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.attn.hook_z |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.attn.hook_z |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.attn.hook_z |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.attn.hook_z |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.attn.hook_z |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.attn.hook_z |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.attn.hook_z |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.attn.hook_z |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.attn.hook_z |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.attn.hook_z |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.attn.hook_z |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.attn.hook_z |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| id                                | architecture   | neuronpedia   | hook_name             |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
+|:----------------------------------|:---------------|:--------------|:----------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
+| layer_0/width_16k/average_l0_104  | jumprelu       |               | blocks.0.attn.hook_z  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_16k/average_l0_12   | jumprelu       |               | blocks.0.attn.hook_z  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_16k/average_l0_18   | jumprelu       |               | blocks.0.attn.hook_z  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_16k/average_l0_30   | jumprelu       |               | blocks.0.attn.hook_z  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_16k/average_l0_57   | jumprelu       |               | blocks.0.attn.hook_z  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/average_l0_146  | jumprelu       |               | blocks.1.attn.hook_z  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/average_l0_20   | jumprelu       |               | blocks.1.attn.hook_z  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/average_l0_251  | jumprelu       |               | blocks.1.attn.hook_z  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/average_l0_40   | jumprelu       |               | blocks.1.attn.hook_z  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/average_l0_79   | jumprelu       |               | blocks.1.attn.hook_z  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/average_l0_174  | jumprelu       |               | blocks.2.attn.hook_z  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/average_l0_19   | jumprelu       |               | blocks.2.attn.hook_z  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/average_l0_297  | jumprelu       |               | blocks.2.attn.hook_z  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/average_l0_43   | jumprelu       |               | blocks.2.attn.hook_z  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/average_l0_93   | jumprelu       |               | blocks.2.attn.hook_z  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/average_l0_117  | jumprelu       |               | blocks.3.attn.hook_z  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/average_l0_219  | jumprelu       |               | blocks.3.attn.hook_z  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/average_l0_24   | jumprelu       |               | blocks.3.attn.hook_z  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/average_l0_386  | jumprelu       |               | blocks.3.attn.hook_z  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/average_l0_55   | jumprelu       |               | blocks.3.attn.hook_z  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/average_l0_116  | jumprelu       |               | blocks.4.attn.hook_z  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/average_l0_249  | jumprelu       |               | blocks.4.attn.hook_z  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/average_l0_26   | jumprelu       |               | blocks.4.attn.hook_z  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/average_l0_454  | jumprelu       |               | blocks.4.attn.hook_z  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/average_l0_53   | jumprelu       |               | blocks.4.attn.hook_z  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/average_l0_135  | jumprelu       |               | blocks.5.attn.hook_z  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/average_l0_268  | jumprelu       |               | blocks.5.attn.hook_z  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/average_l0_30   | jumprelu       |               | blocks.5.attn.hook_z  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/average_l0_449  | jumprelu       |               | blocks.5.attn.hook_z  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/average_l0_59   | jumprelu       |               | blocks.5.attn.hook_z  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/average_l0_143  | jumprelu       |               | blocks.6.attn.hook_z  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/average_l0_292  | jumprelu       |               | blocks.6.attn.hook_z  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/average_l0_30   | jumprelu       |               | blocks.6.attn.hook_z  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/average_l0_479  | jumprelu       |               | blocks.6.attn.hook_z  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/average_l0_61   | jumprelu       |               | blocks.6.attn.hook_z  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/average_l0_184  | jumprelu       |               | blocks.7.attn.hook_z  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/average_l0_331  | jumprelu       |               | blocks.7.attn.hook_z  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/average_l0_46   | jumprelu       |               | blocks.7.attn.hook_z  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/average_l0_537  | jumprelu       |               | blocks.7.attn.hook_z  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/average_l0_99   | jumprelu       |               | blocks.7.attn.hook_z  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/average_l0_129  | jumprelu       |               | blocks.8.attn.hook_z  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/average_l0_282  | jumprelu       |               | blocks.8.attn.hook_z  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/average_l0_32   | jumprelu       |               | blocks.8.attn.hook_z  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/average_l0_482  | jumprelu       |               | blocks.8.attn.hook_z  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/average_l0_64   | jumprelu       |               | blocks.8.attn.hook_z  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/average_l0_127  | jumprelu       |               | blocks.9.attn.hook_z  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/average_l0_270  | jumprelu       |               | blocks.9.attn.hook_z  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/average_l0_34   | jumprelu       |               | blocks.9.attn.hook_z  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/average_l0_499  | jumprelu       |               | blocks.9.attn.hook_z  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/average_l0_64   | jumprelu       |               | blocks.9.attn.hook_z  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/average_l0_148 | jumprelu       |               | blocks.10.attn.hook_z |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/average_l0_307 | jumprelu       |               | blocks.10.attn.hook_z |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/average_l0_36  | jumprelu       |               | blocks.10.attn.hook_z |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/average_l0_541 | jumprelu       |               | blocks.10.attn.hook_z |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/average_l0_70  | jumprelu       |               | blocks.10.attn.hook_z |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/average_l0_170 | jumprelu       |               | blocks.11.attn.hook_z |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/average_l0_350 | jumprelu       |               | blocks.11.attn.hook_z |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/average_l0_41  | jumprelu       |               | blocks.11.attn.hook_z |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/average_l0_593 | jumprelu       |               | blocks.11.attn.hook_z |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/average_l0_80  | jumprelu       |               | blocks.11.attn.hook_z |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/average_l0_184 | jumprelu       |               | blocks.12.attn.hook_z |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/average_l0_328 | jumprelu       |               | blocks.12.attn.hook_z |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/average_l0_41  | jumprelu       |               | blocks.12.attn.hook_z |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/average_l0_514 | jumprelu       |               | blocks.12.attn.hook_z |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/average_l0_85  | jumprelu       |               | blocks.12.attn.hook_z |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/average_l0_203 | jumprelu       |               | blocks.13.attn.hook_z |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/average_l0_372 | jumprelu       |               | blocks.13.attn.hook_z |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/average_l0_43  | jumprelu       |               | blocks.13.attn.hook_z |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/average_l0_570 | jumprelu       |               | blocks.13.attn.hook_z |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/average_l0_92  | jumprelu       |               | blocks.13.attn.hook_z |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/average_l0_161 | jumprelu       |               | blocks.14.attn.hook_z |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/average_l0_298 | jumprelu       |               | blocks.14.attn.hook_z |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/average_l0_37  | jumprelu       |               | blocks.14.attn.hook_z |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/average_l0_468 | jumprelu       |               | blocks.14.attn.hook_z |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/average_l0_71  | jumprelu       |               | blocks.14.attn.hook_z |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/average_l0_195 | jumprelu       |               | blocks.15.attn.hook_z |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/average_l0_342 | jumprelu       |               | blocks.15.attn.hook_z |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/average_l0_44  | jumprelu       |               | blocks.15.attn.hook_z |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/average_l0_535 | jumprelu       |               | blocks.15.attn.hook_z |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/average_l0_98  | jumprelu       |               | blocks.15.attn.hook_z |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/average_l0_144 | jumprelu       |               | blocks.16.attn.hook_z |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/average_l0_293 | jumprelu       |               | blocks.16.attn.hook_z |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/average_l0_37  | jumprelu       |               | blocks.16.attn.hook_z |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/average_l0_527 | jumprelu       |               | blocks.16.attn.hook_z |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/average_l0_71  | jumprelu       |               | blocks.16.attn.hook_z |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/average_l0_176 | jumprelu       |               | blocks.17.attn.hook_z |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/average_l0_316 | jumprelu       |               | blocks.17.attn.hook_z |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/average_l0_38  | jumprelu       |               | blocks.17.attn.hook_z |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/average_l0_509 | jumprelu       |               | blocks.17.attn.hook_z |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/average_l0_79  | jumprelu       |               | blocks.17.attn.hook_z |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/average_l0_144 | jumprelu       |               | blocks.18.attn.hook_z |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/average_l0_292 | jumprelu       |               | blocks.18.attn.hook_z |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/average_l0_34  | jumprelu       |               | blocks.18.attn.hook_z |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/average_l0_491 | jumprelu       |               | blocks.18.attn.hook_z |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/average_l0_72  | jumprelu       |               | blocks.18.attn.hook_z |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/average_l0_122 | jumprelu       |               | blocks.19.attn.hook_z |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/average_l0_249 | jumprelu       |               | blocks.19.attn.hook_z |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/average_l0_28  | jumprelu       |               | blocks.19.attn.hook_z |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/average_l0_423 | jumprelu       |               | blocks.19.attn.hook_z |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/average_l0_56  | jumprelu       |               | blocks.19.attn.hook_z |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_141 | jumprelu       |               | blocks.20.attn.hook_z |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_274 | jumprelu       |               | blocks.20.attn.hook_z |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_31  | jumprelu       |               | blocks.20.attn.hook_z |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_446 | jumprelu       |               | blocks.20.attn.hook_z |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_62  | jumprelu       |               | blocks.20.attn.hook_z |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/average_l0_142 | jumprelu       |               | blocks.21.attn.hook_z |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/average_l0_301 | jumprelu       |               | blocks.21.attn.hook_z |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/average_l0_32  | jumprelu       |               | blocks.21.attn.hook_z |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/average_l0_505 | jumprelu       |               | blocks.21.attn.hook_z |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/average_l0_65  | jumprelu       |               | blocks.21.attn.hook_z |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/average_l0_106 | jumprelu       |               | blocks.22.attn.hook_z |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/average_l0_215 | jumprelu       |               | blocks.22.attn.hook_z |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/average_l0_22  | jumprelu       |               | blocks.22.attn.hook_z |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/average_l0_373 | jumprelu       |               | blocks.22.attn.hook_z |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/average_l0_47  | jumprelu       |               | blocks.22.attn.hook_z |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/average_l0_161 | jumprelu       |               | blocks.23.attn.hook_z |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/average_l0_30  | jumprelu       |               | blocks.23.attn.hook_z |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/average_l0_300 | jumprelu       |               | blocks.23.attn.hook_z |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/average_l0_474 | jumprelu       |               | blocks.23.attn.hook_z |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/average_l0_73  | jumprelu       |               | blocks.23.attn.hook_z |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/average_l0_212 | jumprelu       |               | blocks.24.attn.hook_z |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/average_l0_372 | jumprelu       |               | blocks.24.attn.hook_z |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/average_l0_39  | jumprelu       |               | blocks.24.attn.hook_z |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/average_l0_558 | jumprelu       |               | blocks.24.attn.hook_z |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/average_l0_96  | jumprelu       |               | blocks.24.attn.hook_z |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/average_l0_177 | jumprelu       |               | blocks.25.attn.hook_z |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/average_l0_313 | jumprelu       |               | blocks.25.attn.hook_z |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/average_l0_35  | jumprelu       |               | blocks.25.attn.hook_z |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/average_l0_492 | jumprelu       |               | blocks.25.attn.hook_z |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/average_l0_77  | jumprelu       |               | blocks.25.attn.hook_z |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/average_l0_10   | jumprelu       |               | blocks.0.attn.hook_z  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/average_l0_16   | jumprelu       |               | blocks.0.attn.hook_z  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/average_l0_24   | jumprelu       |               | blocks.0.attn.hook_z  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/average_l0_43   | jumprelu       |               | blocks.0.attn.hook_z  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/average_l0_75   | jumprelu       |               | blocks.0.attn.hook_z  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/average_l0_15   | jumprelu       |               | blocks.1.attn.hook_z  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/average_l0_181  | jumprelu       |               | blocks.1.attn.hook_z  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/average_l0_28   | jumprelu       |               | blocks.1.attn.hook_z  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/average_l0_55   | jumprelu       |               | blocks.1.attn.hook_z  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/average_l0_98   | jumprelu       |               | blocks.1.attn.hook_z  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/average_l0_125  | jumprelu       |               | blocks.2.attn.hook_z  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/average_l0_14   | jumprelu       |               | blocks.2.attn.hook_z  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/average_l0_228  | jumprelu       |               | blocks.2.attn.hook_z  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/average_l0_28   | jumprelu       |               | blocks.2.attn.hook_z  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/average_l0_59   | jumprelu       |               | blocks.2.attn.hook_z  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/average_l0_174  | jumprelu       |               | blocks.3.attn.hook_z  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/average_l0_19   | jumprelu       |               | blocks.3.attn.hook_z  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/average_l0_320  | jumprelu       |               | blocks.3.attn.hook_z  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/average_l0_39   | jumprelu       |               | blocks.3.attn.hook_z  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/average_l0_83   | jumprelu       |               | blocks.3.attn.hook_z  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/average_l0_188  | jumprelu       |               | blocks.4.attn.hook_z  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/average_l0_22   | jumprelu       |               | blocks.4.attn.hook_z  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/average_l0_382  | jumprelu       |               | blocks.4.attn.hook_z  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/average_l0_43   | jumprelu       |               | blocks.4.attn.hook_z  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/average_l0_87   | jumprelu       |               | blocks.4.attn.hook_z  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/average_l0_227  | jumprelu       |               | blocks.5.attn.hook_z  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/average_l0_28   | jumprelu       |               | blocks.5.attn.hook_z  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/average_l0_400  | jumprelu       |               | blocks.5.attn.hook_z  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/average_l0_51   | jumprelu       |               | blocks.5.attn.hook_z  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/average_l0_99   | jumprelu       |               | blocks.5.attn.hook_z  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/average_l0_112  | jumprelu       |               | blocks.6.attn.hook_z  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/average_l0_261  | jumprelu       |               | blocks.6.attn.hook_z  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/average_l0_30   | jumprelu       |               | blocks.6.attn.hook_z  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/average_l0_449  | jumprelu       |               | blocks.6.attn.hook_z  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/average_l0_55   | jumprelu       |               | blocks.6.attn.hook_z  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/average_l0_176  | jumprelu       |               | blocks.7.attn.hook_z  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/average_l0_311  | jumprelu       |               | blocks.7.attn.hook_z  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/average_l0_519  | jumprelu       |               | blocks.7.attn.hook_z  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/average_l0_52   | jumprelu       |               | blocks.7.attn.hook_z  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/average_l0_96   | jumprelu       |               | blocks.7.attn.hook_z  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/average_l0_112  | jumprelu       |               | blocks.8.attn.hook_z  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/average_l0_246  | jumprelu       |               | blocks.8.attn.hook_z  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/average_l0_35   | jumprelu       |               | blocks.8.attn.hook_z  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/average_l0_454  | jumprelu       |               | blocks.8.attn.hook_z  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/average_l0_56   | jumprelu       |               | blocks.8.attn.hook_z  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/average_l0_107  | jumprelu       |               | blocks.9.attn.hook_z  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/average_l0_231  | jumprelu       |               | blocks.9.attn.hook_z  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/average_l0_31   | jumprelu       |               | blocks.9.attn.hook_z  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/average_l0_454  | jumprelu       |               | blocks.9.attn.hook_z  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/average_l0_57   | jumprelu       |               | blocks.9.attn.hook_z  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/average_l0_134 | jumprelu       |               | blocks.10.attn.hook_z |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/average_l0_292 | jumprelu       |               | blocks.10.attn.hook_z |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/average_l0_35  | jumprelu       |               | blocks.10.attn.hook_z |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/average_l0_521 | jumprelu       |               | blocks.10.attn.hook_z |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/average_l0_67  | jumprelu       |               | blocks.10.attn.hook_z |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/average_l0_154 | jumprelu       |               | blocks.11.attn.hook_z |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/average_l0_330 | jumprelu       |               | blocks.11.attn.hook_z |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/average_l0_41  | jumprelu       |               | blocks.11.attn.hook_z |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/average_l0_576 | jumprelu       |               | blocks.11.attn.hook_z |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/average_l0_75  | jumprelu       |               | blocks.11.attn.hook_z |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/average_l0_172 | jumprelu       |               | blocks.12.attn.hook_z |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/average_l0_320 | jumprelu       |               | blocks.12.attn.hook_z |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/average_l0_39  | jumprelu       |               | blocks.12.attn.hook_z |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/average_l0_503 | jumprelu       |               | blocks.12.attn.hook_z |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/average_l0_79  | jumprelu       |               | blocks.12.attn.hook_z |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/average_l0_191 | jumprelu       |               | blocks.13.attn.hook_z |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/average_l0_363 | jumprelu       |               | blocks.13.attn.hook_z |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/average_l0_41  | jumprelu       |               | blocks.13.attn.hook_z |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/average_l0_556 | jumprelu       |               | blocks.13.attn.hook_z |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/average_l0_87  | jumprelu       |               | blocks.13.attn.hook_z |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/average_l0_138 | jumprelu       |               | blocks.14.attn.hook_z |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/average_l0_283 | jumprelu       |               | blocks.14.attn.hook_z |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/average_l0_37  | jumprelu       |               | blocks.14.attn.hook_z |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/average_l0_453 | jumprelu       |               | blocks.14.attn.hook_z |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/average_l0_66  | jumprelu       |               | blocks.14.attn.hook_z |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/average_l0_182 | jumprelu       |               | blocks.15.attn.hook_z |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/average_l0_327 | jumprelu       |               | blocks.15.attn.hook_z |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/average_l0_42  | jumprelu       |               | blocks.15.attn.hook_z |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/average_l0_517 | jumprelu       |               | blocks.15.attn.hook_z |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/average_l0_90  | jumprelu       |               | blocks.15.attn.hook_z |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/average_l0_129 | jumprelu       |               | blocks.16.attn.hook_z |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/average_l0_260 | jumprelu       |               | blocks.16.attn.hook_z |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/average_l0_35  | jumprelu       |               | blocks.16.attn.hook_z |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/average_l0_502 | jumprelu       |               | blocks.16.attn.hook_z |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/average_l0_64  | jumprelu       |               | blocks.16.attn.hook_z |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/average_l0_157 | jumprelu       |               | blocks.17.attn.hook_z |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/average_l0_293 | jumprelu       |               | blocks.17.attn.hook_z |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/average_l0_35  | jumprelu       |               | blocks.17.attn.hook_z |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/average_l0_489 | jumprelu       |               | blocks.17.attn.hook_z |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/average_l0_70  | jumprelu       |               | blocks.17.attn.hook_z |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/average_l0_123 | jumprelu       |               | blocks.18.attn.hook_z |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/average_l0_255 | jumprelu       |               | blocks.18.attn.hook_z |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/average_l0_29  | jumprelu       |               | blocks.18.attn.hook_z |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/average_l0_466 | jumprelu       |               | blocks.18.attn.hook_z |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/average_l0_58  | jumprelu       |               | blocks.18.attn.hook_z |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/average_l0_106 | jumprelu       |               | blocks.19.attn.hook_z |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/average_l0_220 | jumprelu       |               | blocks.19.attn.hook_z |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/average_l0_26  | jumprelu       |               | blocks.19.attn.hook_z |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/average_l0_411 | jumprelu       |               | blocks.19.attn.hook_z |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/average_l0_49  | jumprelu       |               | blocks.19.attn.hook_z |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/average_l0_102 | jumprelu       |               | blocks.20.attn.hook_z |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/average_l0_242 | jumprelu       |               | blocks.20.attn.hook_z |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/average_l0_26  | jumprelu       |               | blocks.20.attn.hook_z |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/average_l0_419 | jumprelu       |               | blocks.20.attn.hook_z |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/average_l0_49  | jumprelu       |               | blocks.20.attn.hook_z |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/average_l0_118 | jumprelu       |               | blocks.21.attn.hook_z |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/average_l0_266 | jumprelu       |               | blocks.21.attn.hook_z |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/average_l0_29  | jumprelu       |               | blocks.21.attn.hook_z |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/average_l0_474 | jumprelu       |               | blocks.21.attn.hook_z |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/average_l0_56  | jumprelu       |               | blocks.21.attn.hook_z |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/average_l0_112 | jumprelu       |               | blocks.22.attn.hook_z |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/average_l0_196 | jumprelu       |               | blocks.22.attn.hook_z |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/average_l0_20  | jumprelu       |               | blocks.22.attn.hook_z |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/average_l0_361 | jumprelu       |               | blocks.22.attn.hook_z |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/average_l0_37  | jumprelu       |               | blocks.22.attn.hook_z |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/average_l0_140 | jumprelu       |               | blocks.23.attn.hook_z |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/average_l0_27  | jumprelu       |               | blocks.23.attn.hook_z |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/average_l0_276 | jumprelu       |               | blocks.23.attn.hook_z |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/average_l0_457 | jumprelu       |               | blocks.23.attn.hook_z |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/average_l0_56  | jumprelu       |               | blocks.23.attn.hook_z |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/average_l0_186 | jumprelu       |               | blocks.24.attn.hook_z |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/average_l0_32  | jumprelu       |               | blocks.24.attn.hook_z |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/average_l0_347 | jumprelu       |               | blocks.24.attn.hook_z |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/average_l0_537 | jumprelu       |               | blocks.24.attn.hook_z |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/average_l0_77  | jumprelu       |               | blocks.24.attn.hook_z |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/average_l0_153 | jumprelu       |               | blocks.25.attn.hook_z |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/average_l0_290 | jumprelu       |               | blocks.25.attn.hook_z |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/average_l0_30  | jumprelu       |               | blocks.25.attn.hook_z |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/average_l0_465 | jumprelu       |               | blocks.25.attn.hook_z |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/average_l0_63  | jumprelu       |               | blocks.25.attn.hook_z |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+
+## [gemma-scope-2b-pt-att-canonical](https://huggingface.co/google/gemma-scope-2b-pt-att)
+
+- **Huggingface Repo**: google/gemma-scope-2b-pt-att
+- **model**: gemma-2-2b
+
+| id                           | architecture   | neuronpedia   | hook_name             |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
+|:-----------------------------|:---------------|:--------------|:----------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
+| layer_0/width_16k/canonical  | jumprelu       |               | blocks.0.attn.hook_z  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/canonical  | jumprelu       |               | blocks.1.attn.hook_z  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/canonical  | jumprelu       |               | blocks.2.attn.hook_z  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/canonical  | jumprelu       |               | blocks.3.attn.hook_z  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/canonical  | jumprelu       |               | blocks.4.attn.hook_z  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/canonical  | jumprelu       |               | blocks.5.attn.hook_z  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/canonical  | jumprelu       |               | blocks.6.attn.hook_z  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/canonical  | jumprelu       |               | blocks.7.attn.hook_z  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/canonical  | jumprelu       |               | blocks.8.attn.hook_z  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/canonical  | jumprelu       |               | blocks.9.attn.hook_z  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/canonical | jumprelu       |               | blocks.10.attn.hook_z |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/canonical | jumprelu       |               | blocks.11.attn.hook_z |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/canonical | jumprelu       |               | blocks.12.attn.hook_z |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/canonical | jumprelu       |               | blocks.13.attn.hook_z |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/canonical | jumprelu       |               | blocks.14.attn.hook_z |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/canonical | jumprelu       |               | blocks.15.attn.hook_z |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/canonical | jumprelu       |               | blocks.16.attn.hook_z |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/canonical | jumprelu       |               | blocks.17.attn.hook_z |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/canonical | jumprelu       |               | blocks.18.attn.hook_z |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/canonical | jumprelu       |               | blocks.19.attn.hook_z |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/canonical | jumprelu       |               | blocks.20.attn.hook_z |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/canonical | jumprelu       |               | blocks.21.attn.hook_z |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/canonical | jumprelu       |               | blocks.22.attn.hook_z |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/canonical | jumprelu       |               | blocks.23.attn.hook_z |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/canonical | jumprelu       |               | blocks.24.attn.hook_z |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/canonical | jumprelu       |               | blocks.25.attn.hook_z |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_65k/canonical  | jumprelu       |               | blocks.0.attn.hook_z  |            0 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_65k/canonical  | jumprelu       |               | blocks.1.attn.hook_z  |            1 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_65k/canonical  | jumprelu       |               | blocks.2.attn.hook_z  |            2 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_65k/canonical  | jumprelu       |               | blocks.3.attn.hook_z  |            3 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_65k/canonical  | jumprelu       |               | blocks.4.attn.hook_z  |            4 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_65k/canonical  | jumprelu       |               | blocks.5.attn.hook_z  |            5 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_65k/canonical  | jumprelu       |               | blocks.6.attn.hook_z  |            6 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_65k/canonical  | jumprelu       |               | blocks.7.attn.hook_z  |            7 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_65k/canonical  | jumprelu       |               | blocks.8.attn.hook_z  |            8 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_65k/canonical  | jumprelu       |               | blocks.9.attn.hook_z  |            9 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_65k/canonical | jumprelu       |               | blocks.10.attn.hook_z |           10 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_65k/canonical | jumprelu       |               | blocks.11.attn.hook_z |           11 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_65k/canonical | jumprelu       |               | blocks.12.attn.hook_z |           12 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_65k/canonical | jumprelu       |               | blocks.13.attn.hook_z |           13 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_65k/canonical | jumprelu       |               | blocks.14.attn.hook_z |           14 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_65k/canonical | jumprelu       |               | blocks.15.attn.hook_z |           15 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_65k/canonical | jumprelu       |               | blocks.16.attn.hook_z |           16 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_65k/canonical | jumprelu       |               | blocks.17.attn.hook_z |           17 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_65k/canonical | jumprelu       |               | blocks.18.attn.hook_z |           18 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_65k/canonical | jumprelu       |               | blocks.19.attn.hook_z |           19 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_65k/canonical | jumprelu       |               | blocks.20.attn.hook_z |           20 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_65k/canonical | jumprelu       |               | blocks.21.attn.hook_z |           21 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_65k/canonical | jumprelu       |               | blocks.22.attn.hook_z |           22 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_65k/canonical | jumprelu       |               | blocks.23.attn.hook_z |           23 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_65k/canonical | jumprelu       |               | blocks.24.attn.hook_z |           24 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_65k/canonical | jumprelu       |               | blocks.25.attn.hook_z |           25 |   65536 |           1024 | monology/pile-uncopyrighted |                         |
 
 ## [gemma-scope-9b-pt-att](https://huggingface.co/google/gemma-scope-9b-pt-att)
 
 - **Huggingface Repo**: google/gemma-scope-9b-pt-att
 - **model**: gemma-2-2b
 
-| hook_name             |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
-|:----------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
-| blocks.0.attn.hook_z  |            0 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.attn.hook_z  |            1 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.attn.hook_z  |            2 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.attn.hook_z  |            3 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.attn.hook_z  |            4 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.attn.hook_z  |            5 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.attn.hook_z  |            6 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.attn.hook_z  |            6 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.attn.hook_z  |            7 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.attn.hook_z  |            8 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.attn.hook_z  |            9 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.attn.hook_z |           10 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.attn.hook_z |           11 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.attn.hook_z |           12 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.attn.hook_z |           13 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.attn.hook_z |           14 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.attn.hook_z |           15 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.attn.hook_z |           16 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.attn.hook_z |           17 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.attn.hook_z |           18 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.attn.hook_z |           19 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.attn.hook_z |           20 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.attn.hook_z |           21 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.attn.hook_z |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.attn.hook_z |           23 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.attn.hook_z |           24 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.attn.hook_z |           25 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.26.attn.hook_z |           26 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.27.attn.hook_z |           27 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.28.attn.hook_z |           28 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.29.attn.hook_z |           29 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.30.attn.hook_z |           30 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.31.attn.hook_z |           31 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.32.attn.hook_z |           32 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.33.attn.hook_z |           33 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.34.attn.hook_z |           34 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.35.attn.hook_z |           35 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.36.attn.hook_z |           36 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.37.attn.hook_z |           37 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.38.attn.hook_z |           38 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.39.attn.hook_z |           39 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.40.attn.hook_z |           40 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.41.attn.hook_z |           41 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.0.attn.hook_z  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.attn.hook_z  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.attn.hook_z  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.attn.hook_z  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.attn.hook_z  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.attn.hook_z  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.attn.hook_z  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.attn.hook_z  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.attn.hook_z  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.attn.hook_z  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.attn.hook_z |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.attn.hook_z |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.attn.hook_z |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.attn.hook_z |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.attn.hook_z |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.attn.hook_z |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.attn.hook_z |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.attn.hook_z |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.attn.hook_z |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.attn.hook_z |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.attn.hook_z |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.attn.hook_z |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.attn.hook_z |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.attn.hook_z |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.attn.hook_z |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.attn.hook_z |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.26.attn.hook_z |           26 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.27.attn.hook_z |           27 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.28.attn.hook_z |           28 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.29.attn.hook_z |           29 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.30.attn.hook_z |           30 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.31.attn.hook_z |           31 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.32.attn.hook_z |           32 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.33.attn.hook_z |           33 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.34.attn.hook_z |           34 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.35.attn.hook_z |           35 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.36.attn.hook_z |           36 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.37.attn.hook_z |           37 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.37.attn.hook_z |           37 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.38.attn.hook_z |           38 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.39.attn.hook_z |           39 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.40.attn.hook_z |           40 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.40.attn.hook_z |           40 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.41.attn.hook_z |           41 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| id                                 | architecture   | neuronpedia   | hook_name             |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
+|:-----------------------------------|:---------------|:--------------|:----------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
+| layer_0/width_131k/average_l0_55   | jumprelu       |               | blocks.0.attn.hook_z  |            0 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_131k/average_l0_116  | jumprelu       |               | blocks.1.attn.hook_z  |            1 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_131k/average_l0_11   | jumprelu       |               | blocks.2.attn.hook_z  |            2 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_131k/average_l0_10   | jumprelu       |               | blocks.3.attn.hook_z  |            3 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_131k/average_l0_12   | jumprelu       |               | blocks.4.attn.hook_z  |            4 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_131k/average_l0_12   | jumprelu       |               | blocks.5.attn.hook_z  |            5 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_131k/average_l0_14   | jumprelu       |               | blocks.6.attn.hook_z  |            6 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_131k/average_l0_148  | jumprelu       |               | blocks.6.attn.hook_z  |            6 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_131k/average_l0_106  | jumprelu       |               | blocks.7.attn.hook_z  |            7 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_131k/average_l0_16   | jumprelu       |               | blocks.8.attn.hook_z  |            8 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_131k/average_l0_111  | jumprelu       |               | blocks.9.attn.hook_z  |            9 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_131k/average_l0_16  | jumprelu       |               | blocks.10.attn.hook_z |           10 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_131k/average_l0_104 | jumprelu       |               | blocks.11.attn.hook_z |           11 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_131k/average_l0_110 | jumprelu       |               | blocks.12.attn.hook_z |           12 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_131k/average_l0_126 | jumprelu       |               | blocks.13.attn.hook_z |           13 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_131k/average_l0_131 | jumprelu       |               | blocks.14.attn.hook_z |           14 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_131k/average_l0_130 | jumprelu       |               | blocks.15.attn.hook_z |           15 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_131k/average_l0_140 | jumprelu       |               | blocks.16.attn.hook_z |           16 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_131k/average_l0_191 | jumprelu       |               | blocks.17.attn.hook_z |           17 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_131k/average_l0_133 | jumprelu       |               | blocks.18.attn.hook_z |           18 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_131k/average_l0_152 | jumprelu       |               | blocks.19.attn.hook_z |           19 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_131k/average_l0_125 | jumprelu       |               | blocks.20.attn.hook_z |           20 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_131k/average_l0_150 | jumprelu       |               | blocks.21.attn.hook_z |           21 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_131k/average_l0_115 | jumprelu       |               | blocks.22.attn.hook_z |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_131k/average_l0_134 | jumprelu       |               | blocks.23.attn.hook_z |           23 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_131k/average_l0_130 | jumprelu       |               | blocks.24.attn.hook_z |           24 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_131k/average_l0_115 | jumprelu       |               | blocks.25.attn.hook_z |           25 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_26/width_131k/average_l0_120 | jumprelu       |               | blocks.26.attn.hook_z |           26 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_27/width_131k/average_l0_102 | jumprelu       |               | blocks.27.attn.hook_z |           27 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_28/width_131k/average_l0_115 | jumprelu       |               | blocks.28.attn.hook_z |           28 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_29/width_131k/average_l0_128 | jumprelu       |               | blocks.29.attn.hook_z |           29 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_30/width_131k/average_l0_109 | jumprelu       |               | blocks.30.attn.hook_z |           30 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_31/width_131k/average_l0_117 | jumprelu       |               | blocks.31.attn.hook_z |           31 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_32/width_131k/average_l0_117 | jumprelu       |               | blocks.32.attn.hook_z |           32 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_33/width_131k/average_l0_128 | jumprelu       |               | blocks.33.attn.hook_z |           33 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_34/width_131k/average_l0_15  | jumprelu       |               | blocks.34.attn.hook_z |           34 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_35/width_131k/average_l0_124 | jumprelu       |               | blocks.35.attn.hook_z |           35 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_36/width_131k/average_l0_105 | jumprelu       |               | blocks.36.attn.hook_z |           36 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_37/width_131k/average_l0_124 | jumprelu       |               | blocks.37.attn.hook_z |           37 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_38/width_131k/average_l0_135 | jumprelu       |               | blocks.38.attn.hook_z |           38 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_39/width_131k/average_l0_120 | jumprelu       |               | blocks.39.attn.hook_z |           39 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_40/width_131k/average_l0_144 | jumprelu       |               | blocks.40.attn.hook_z |           40 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_41/width_131k/average_l0_13  | jumprelu       |               | blocks.41.attn.hook_z |           41 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_0/width_16k/average_l0_12    | jumprelu       |               | blocks.0.attn.hook_z  |            0 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_16k/average_l0_147   | jumprelu       |               | blocks.1.attn.hook_z  |            1 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_16k/average_l0_15    | jumprelu       |               | blocks.2.attn.hook_z  |            2 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/average_l0_102   | jumprelu       |               | blocks.3.attn.hook_z  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_16k/average_l0_126   | jumprelu       |               | blocks.4.attn.hook_z  |            4 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_16k/average_l0_125   | jumprelu       |               | blocks.5.attn.hook_z  |            5 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_16k/average_l0_108   | jumprelu       |               | blocks.6.attn.hook_z  |            6 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_16k/average_l0_70    | jumprelu       |               | blocks.7.attn.hook_z  |            7 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_16k/average_l0_150   | jumprelu       |               | blocks.8.attn.hook_z  |            8 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_16k/average_l0_172   | jumprelu       |               | blocks.9.attn.hook_z  |            9 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/average_l0_132  | jumprelu       |               | blocks.10.attn.hook_z |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_16k/average_l0_153  | jumprelu       |               | blocks.11.attn.hook_z |           11 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_16k/average_l0_149  | jumprelu       |               | blocks.12.attn.hook_z |           12 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_16k/average_l0_170  | jumprelu       |               | blocks.13.attn.hook_z |           13 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_16k/average_l0_179  | jumprelu       |               | blocks.14.attn.hook_z |           14 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_16k/average_l0_168  | jumprelu       |               | blocks.15.attn.hook_z |           15 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_16k/average_l0_172  | jumprelu       |               | blocks.16.attn.hook_z |           16 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_16k/average_l0_110  | jumprelu       |               | blocks.17.attn.hook_z |           17 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_16k/average_l0_171  | jumprelu       |               | blocks.18.attn.hook_z |           18 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_16k/average_l0_186  | jumprelu       |               | blocks.19.attn.hook_z |           19 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_158  | jumprelu       |               | blocks.20.attn.hook_z |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_16k/average_l0_195  | jumprelu       |               | blocks.21.attn.hook_z |           21 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_16k/average_l0_141  | jumprelu       |               | blocks.22.attn.hook_z |           22 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_16k/average_l0_173  | jumprelu       |               | blocks.23.attn.hook_z |           23 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_16k/average_l0_167  | jumprelu       |               | blocks.24.attn.hook_z |           24 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_16k/average_l0_156  | jumprelu       |               | blocks.25.attn.hook_z |           25 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_26/width_16k/average_l0_159  | jumprelu       |               | blocks.26.attn.hook_z |           26 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_27/width_16k/average_l0_136  | jumprelu       |               | blocks.27.attn.hook_z |           27 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_28/width_16k/average_l0_143  | jumprelu       |               | blocks.28.attn.hook_z |           28 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_29/width_16k/average_l0_171  | jumprelu       |               | blocks.29.attn.hook_z |           29 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_30/width_16k/average_l0_157  | jumprelu       |               | blocks.30.attn.hook_z |           30 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_31/width_16k/average_l0_168  | jumprelu       |               | blocks.31.attn.hook_z |           31 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_32/width_16k/average_l0_158  | jumprelu       |               | blocks.32.attn.hook_z |           32 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_33/width_16k/average_l0_158  | jumprelu       |               | blocks.33.attn.hook_z |           33 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_34/width_16k/average_l0_17   | jumprelu       |               | blocks.34.attn.hook_z |           34 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_35/width_16k/average_l0_14   | jumprelu       |               | blocks.35.attn.hook_z |           35 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_36/width_16k/average_l0_144  | jumprelu       |               | blocks.36.attn.hook_z |           36 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_37/width_16k/average_l0_17   | jumprelu       |               | blocks.37.attn.hook_z |           37 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_37/width_16k/average_l0_172  | jumprelu       |               | blocks.37.attn.hook_z |           37 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_38/width_16k/average_l0_175  | jumprelu       |               | blocks.38.attn.hook_z |           38 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_39/width_16k/average_l0_15   | jumprelu       |               | blocks.39.attn.hook_z |           39 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_40/width_16k/average_l0_18   | jumprelu       |               | blocks.40.attn.hook_z |           40 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_40/width_16k/average_l0_189  | jumprelu       |               | blocks.40.attn.hook_z |           40 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_41/width_16k/average_l0_129  | jumprelu       |               | blocks.41.attn.hook_z |           41 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
 
 ## [gemma-scope-9b-pt-mlp](https://huggingface.co/google/gemma-scope-9b-pt-mlp)
 
 - **Huggingface Repo**: google/gemma-scope-9b-pt-mlp
 - **model**: gemma-2-2b
 
-| hook_name              |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
-|:-----------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
-| blocks.0.hook_mlp_out  |            0 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_mlp_out  |            1 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.1.hook_mlp_out  |            1 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.2.hook_mlp_out  |            2 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_mlp_out  |            3 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.4.hook_mlp_out  |            4 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.5.hook_mlp_out  |            5 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.6.hook_mlp_out  |            6 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.7.hook_mlp_out  |            7 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.8.hook_mlp_out  |            8 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_mlp_out  |            9 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.9.hook_mlp_out  |            9 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_mlp_out |           10 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.11.hook_mlp_out |           11 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.12.hook_mlp_out |           12 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.13.hook_mlp_out |           13 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.14.hook_mlp_out |           14 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.15.hook_mlp_out |           15 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_mlp_out |           16 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.16.hook_mlp_out |           16 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.17.hook_mlp_out |           17 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.18.hook_mlp_out |           18 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.19.hook_mlp_out |           19 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.21.hook_mlp_out |           21 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_mlp_out |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_mlp_out |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.23.hook_mlp_out |           23 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.24.hook_mlp_out |           24 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.25.hook_mlp_out |           25 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.26.hook_mlp_out |           26 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.27.hook_mlp_out |           27 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.28.hook_mlp_out |           28 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.29.hook_mlp_out |           29 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.30.hook_mlp_out |           30 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.31.hook_mlp_out |           31 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.32.hook_mlp_out |           32 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.33.hook_mlp_out |           33 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.34.hook_mlp_out |           34 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.35.hook_mlp_out |           35 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.36.hook_mlp_out |           36 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.37.hook_mlp_out |           37 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.38.hook_mlp_out |           38 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.39.hook_mlp_out |           39 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.40.hook_mlp_out |           40 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.41.hook_mlp_out |           41 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.3.hook_mlp_out  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_mlp_out |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.26.hook_mlp_out |           26 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.26.hook_mlp_out |           26 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.31.hook_mlp_out |           31 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| id                                 | architecture   | neuronpedia   | hook_name              |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
+|:-----------------------------------|:---------------|:--------------|:-----------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
+| layer_0/width_131k/average_l0_11   | jumprelu       |               | blocks.0.hook_mlp_out  |            0 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_131k/average_l0_10   | jumprelu       |               | blocks.1.hook_mlp_out  |            1 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_1/width_131k/average_l0_106  | jumprelu       |               | blocks.1.hook_mlp_out  |            1 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_2/width_131k/average_l0_12   | jumprelu       |               | blocks.2.hook_mlp_out  |            2 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_131k/average_l0_109  | jumprelu       |               | blocks.3.hook_mlp_out  |            3 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_4/width_131k/average_l0_14   | jumprelu       |               | blocks.4.hook_mlp_out  |            4 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_5/width_131k/average_l0_12   | jumprelu       |               | blocks.5.hook_mlp_out  |            5 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_6/width_131k/average_l0_12   | jumprelu       |               | blocks.6.hook_mlp_out  |            6 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_7/width_131k/average_l0_13   | jumprelu       |               | blocks.7.hook_mlp_out  |            7 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_8/width_131k/average_l0_15   | jumprelu       |               | blocks.8.hook_mlp_out  |            8 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_131k/average_l0_12   | jumprelu       |               | blocks.9.hook_mlp_out  |            9 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_9/width_131k/average_l0_129  | jumprelu       |               | blocks.9.hook_mlp_out  |            9 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_131k/average_l0_12  | jumprelu       |               | blocks.10.hook_mlp_out |           10 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_11/width_131k/average_l0_120 | jumprelu       |               | blocks.11.hook_mlp_out |           11 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_12/width_131k/average_l0_159 | jumprelu       |               | blocks.12.hook_mlp_out |           12 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_13/width_131k/average_l0_160 | jumprelu       |               | blocks.13.hook_mlp_out |           13 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_14/width_131k/average_l0_174 | jumprelu       |               | blocks.14.hook_mlp_out |           14 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_15/width_131k/average_l0_194 | jumprelu       |               | blocks.15.hook_mlp_out |           15 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_131k/average_l0_17  | jumprelu       |               | blocks.16.hook_mlp_out |           16 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_16/width_131k/average_l0_175 | jumprelu       |               | blocks.16.hook_mlp_out |           16 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_17/width_131k/average_l0_207 | jumprelu       |               | blocks.17.hook_mlp_out |           17 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_18/width_131k/average_l0_174 | jumprelu       |               | blocks.18.hook_mlp_out |           18 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_19/width_131k/average_l0_189 | jumprelu       |               | blocks.19.hook_mlp_out |           19 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_131k/average_l0_20  | jumprelu       |               | blocks.20.hook_mlp_out |           20 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_21/width_131k/average_l0_16  | jumprelu       |               | blocks.21.hook_mlp_out |           21 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_131k/average_l0_17  | jumprelu       |               | blocks.22.hook_mlp_out |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_131k/average_l0_172 | jumprelu       |               | blocks.22.hook_mlp_out |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_23/width_131k/average_l0_146 | jumprelu       |               | blocks.23.hook_mlp_out |           23 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_24/width_131k/average_l0_147 | jumprelu       |               | blocks.24.hook_mlp_out |           24 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_25/width_131k/average_l0_139 | jumprelu       |               | blocks.25.hook_mlp_out |           25 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_26/width_131k/average_l0_110 | jumprelu       |               | blocks.26.hook_mlp_out |           26 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_27/width_131k/average_l0_14  | jumprelu       |               | blocks.27.hook_mlp_out |           27 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_28/width_131k/average_l0_15  | jumprelu       |               | blocks.28.hook_mlp_out |           28 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_29/width_131k/average_l0_15  | jumprelu       |               | blocks.29.hook_mlp_out |           29 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_30/width_131k/average_l0_14  | jumprelu       |               | blocks.30.hook_mlp_out |           30 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_31/width_131k/average_l0_12  | jumprelu       |               | blocks.31.hook_mlp_out |           31 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_32/width_131k/average_l0_12  | jumprelu       |               | blocks.32.hook_mlp_out |           32 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_33/width_131k/average_l0_12  | jumprelu       |               | blocks.33.hook_mlp_out |           33 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_34/width_131k/average_l0_10  | jumprelu       |               | blocks.34.hook_mlp_out |           34 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_35/width_131k/average_l0_10  | jumprelu       |               | blocks.35.hook_mlp_out |           35 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_36/width_131k/average_l0_11  | jumprelu       |               | blocks.36.hook_mlp_out |           36 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_37/width_131k/average_l0_12  | jumprelu       |               | blocks.37.hook_mlp_out |           37 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_38/width_131k/average_l0_11  | jumprelu       |               | blocks.38.hook_mlp_out |           38 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_39/width_131k/average_l0_11  | jumprelu       |               | blocks.39.hook_mlp_out |           39 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_40/width_131k/average_l0_11  | jumprelu       |               | blocks.40.hook_mlp_out |           40 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_41/width_131k/average_l0_14  | jumprelu       |               | blocks.41.hook_mlp_out |           41 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_3/width_16k/average_l0_126   | jumprelu       |               | blocks.3.hook_mlp_out  |            3 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_16k/average_l0_114  | jumprelu       |               | blocks.10.hook_mlp_out |           10 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_146  | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_1522 | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_23   | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_384  | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_56   | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_20/width_16k/average_l0_868  | jumprelu       |               | blocks.20.hook_mlp_out |           20 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_26/width_16k/average_l0_14   | jumprelu       |               | blocks.26.hook_mlp_out |           26 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_26/width_16k/average_l0_142  | jumprelu       |               | blocks.26.hook_mlp_out |           26 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_31/width_16k/average_l0_12   | jumprelu       |               | blocks.31.hook_mlp_out |           31 |   16384 |           1024 | monology/pile-uncopyrighted |                         |
 
 ## [gemma-scope-27b-pt-res](https://huggingface.co/google/gemma-scope-27b-pt-res)
 
 - **Huggingface Repo**: google/gemma-scope-27b-pt-res
 - **model**: gemma-2-2b
 
-| hook_name                 |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
-|:--------------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
-| blocks.10.hook_resid_post |           10 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_resid_post |           10 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_resid_post |           10 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_resid_post |           10 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_resid_post |           10 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.10.hook_resid_post |           10 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.22.hook_resid_post |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.34.hook_resid_post |           34 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.34.hook_resid_post |           34 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.34.hook_resid_post |           34 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.34.hook_resid_post |           34 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.34.hook_resid_post |           34 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
-| blocks.34.hook_resid_post |           34 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| id                                 | architecture   | neuronpedia   | hook_name                 |   hook_layer |   d_sae |   context_size | dataset_path                | normalize_activations   |
+|:-----------------------------------|:---------------|:--------------|:--------------------------|-------------:|--------:|---------------:|:----------------------------|:------------------------|
+| layer_10/width_131k/average_l0_106 | jumprelu       |               | blocks.10.hook_resid_post |           10 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_131k/average_l0_15  | jumprelu       |               | blocks.10.hook_resid_post |           10 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_131k/average_l0_200 | jumprelu       |               | blocks.10.hook_resid_post |           10 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_131k/average_l0_24  | jumprelu       |               | blocks.10.hook_resid_post |           10 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_131k/average_l0_37  | jumprelu       |               | blocks.10.hook_resid_post |           10 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_10/width_131k/average_l0_64  | jumprelu       |               | blocks.10.hook_resid_post |           10 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_131k/average_l0_150 | jumprelu       |               | blocks.22.hook_resid_post |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_131k/average_l0_20  | jumprelu       |               | blocks.22.hook_resid_post |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_131k/average_l0_290 | jumprelu       |               | blocks.22.hook_resid_post |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_131k/average_l0_31  | jumprelu       |               | blocks.22.hook_resid_post |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_131k/average_l0_48  | jumprelu       |               | blocks.22.hook_resid_post |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_22/width_131k/average_l0_82  | jumprelu       |               | blocks.22.hook_resid_post |           22 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_34/width_131k/average_l0_155 | jumprelu       |               | blocks.34.hook_resid_post |           34 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_34/width_131k/average_l0_21  | jumprelu       |               | blocks.34.hook_resid_post |           34 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_34/width_131k/average_l0_333 | jumprelu       |               | blocks.34.hook_resid_post |           34 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_34/width_131k/average_l0_38  | jumprelu       |               | blocks.34.hook_resid_post |           34 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_34/width_131k/average_l0_72  | jumprelu       |               | blocks.34.hook_resid_post |           34 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+| layer_34/width_131k/average_l0_785 | jumprelu       |               | blocks.34.hook_resid_post |           34 |  131072 |           1024 | monology/pile-uncopyrighted |                         |
+
+## [pythia-70m-deduped-res-sm](https://huggingface.co/ctigges/pythia-70m-deduped__res-sm_processed)
+
+- **Huggingface Repo**: ctigges/pythia-70m-deduped__res-sm_processed
+- **model**: pythia-70m-deduped
+- **Additional Links**:
+    - [Model](https://huggingface.co/EleutherAI/pythia-70m-deduped)
+    - [Dashboards](https://www.neuronpedia.org/pythia-70m-deduped)
+
+| id                       | architecture   | neuronpedia                 | hook_name                |   hook_layer |   d_sae |   context_size | dataset_path                     | normalize_activations   |
+|:-------------------------|:---------------|:----------------------------|:-------------------------|-------------:|--------:|---------------:|:---------------------------------|:------------------------|
+| blocks.0.hook_resid_pre  | standard       | pythia-70m-deduped/e-att-sm | blocks.0.hook_resid_pre  |            0 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+| blocks.0.hook_resid_post | standard       | pythia-70m-deduped/0-res-sm | blocks.0.hook_resid_post |            0 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+| blocks.1.hook_resid_post | standard       | pythia-70m-deduped/1-res-sm | blocks.1.hook_resid_post |            1 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+| blocks.2.hook_resid_post | standard       | pythia-70m-deduped/2-res-sm | blocks.2.hook_resid_post |            2 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+| blocks.3.hook_resid_post | standard       | pythia-70m-deduped/3-res-sm | blocks.3.hook_resid_post |            3 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+| blocks.4.hook_resid_post | standard       | pythia-70m-deduped/4-res-sm | blocks.4.hook_resid_post |            4 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+| blocks.5.hook_resid_post | standard       | pythia-70m-deduped/5-res-sm | blocks.5.hook_resid_post |            5 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+
+## [pythia-70m-deduped-mlp-sm](https://huggingface.co/ctigges/pythia-70m-deduped__mlp-sm_processed)
+
+- **Huggingface Repo**: ctigges/pythia-70m-deduped__mlp-sm_processed
+- **model**: pythia-70m-deduped
+- **Additional Links**:
+    - [Model](https://huggingface.co/EleutherAI/pythia-70m-deduped)
+    - [Dashboards](https://www.neuronpedia.org/pythia-70m-deduped)
+
+| id                    | architecture   | neuronpedia                 | hook_name             |   hook_layer |   d_sae |   context_size | dataset_path                     | normalize_activations   |
+|:----------------------|:---------------|:----------------------------|:----------------------|-------------:|--------:|---------------:|:---------------------------------|:------------------------|
+| blocks.0.hook_mlp_out | standard       | pythia-70m-deduped/0-mlp-sm | blocks.0.hook_mlp_out |            0 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+| blocks.1.hook_mlp_out | standard       | pythia-70m-deduped/1-mlp-sm | blocks.1.hook_mlp_out |            1 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+| blocks.2.hook_mlp_out | standard       | pythia-70m-deduped/2-mlp-sm | blocks.2.hook_mlp_out |            2 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+| blocks.3.hook_mlp_out | standard       | pythia-70m-deduped/3-mlp-sm | blocks.3.hook_mlp_out |            3 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+| blocks.4.hook_mlp_out | standard       | pythia-70m-deduped/4-mlp-sm | blocks.4.hook_mlp_out |            4 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+| blocks.5.hook_mlp_out | standard       | pythia-70m-deduped/5-mlp-sm | blocks.5.hook_mlp_out |            5 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+
+## [pythia-70m-deduped-att-sm](https://huggingface.co/ctigges/pythia-70m-deduped__att-sm_processed)
+
+- **Huggingface Repo**: ctigges/pythia-70m-deduped__att-sm_processed
+- **model**: pythia-70m-deduped
+- **Additional Links**:
+    - [Model](https://huggingface.co/EleutherAI/pythia-70m-deduped)
+    - [Dashboards](https://www.neuronpedia.org/pythia-70m-deduped)
+
+| id                     | architecture   | neuronpedia                 | hook_name              |   hook_layer |   d_sae |   context_size | dataset_path                     | normalize_activations   |
+|:-----------------------|:---------------|:----------------------------|:-----------------------|-------------:|--------:|---------------:|:---------------------------------|:------------------------|
+| blocks.0.hook_attn_out | standard       | pythia-70m-deduped/0-att-sm | blocks.0.hook_attn_out |            0 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+| blocks.1.hook_attn_out | standard       | pythia-70m-deduped/1-att-sm | blocks.1.hook_attn_out |            1 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+| blocks.2.hook_attn_out | standard       | pythia-70m-deduped/2-att-sm | blocks.2.hook_attn_out |            2 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+| blocks.3.hook_attn_out | standard       | pythia-70m-deduped/3-att-sm | blocks.3.hook_attn_out |            3 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+| blocks.4.hook_attn_out | standard       | pythia-70m-deduped/4-att-sm | blocks.4.hook_attn_out |            4 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+| blocks.5.hook_attn_out | standard       | pythia-70m-deduped/5-att-sm | blocks.5.hook_attn_out |            5 |   32768 |            128 | EleutherAI/the_pile_deduplicated | none                    |
+
+## [gpt2-small-res_sll-ajt](https://huggingface.co/neuronpedia/gpt2-small__res_sll-ajt)
+
+- **Huggingface Repo**: neuronpedia/gpt2-small__res_sll-ajt
+- **model**: gpt2-small
+- **Additional Links**:
+    - [Model](https://huggingface.co/gpt2)
+    - [Dashboards](https://www.neuronpedia.org/gpt2-small/res_sll-ajt)
+
+| id                       | architecture   | neuronpedia               | hook_name                |   hook_layer |   d_sae |   context_size | dataset_path                                          | normalize_activations   |
+|:-------------------------|:---------------|:--------------------------|:-------------------------|-------------:|--------:|---------------:|:------------------------------------------------------|:------------------------|
+| blocks.2.hook_resid_pre  | standard       | gpt2-small/2-res_sll-ajt  | blocks.2.hook_resid_pre  |            2 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
+| blocks.6.hook_resid_pre  | standard       | gpt2-small/6-res_sll-ajt  | blocks.6.hook_resid_pre  |            6 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
+| blocks.10.hook_resid_pre | standard       | gpt2-small/10-res_sll-ajt | blocks.10.hook_resid_pre |           10 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
+
+## [gpt2-small-res_slefr-ajt](https://huggingface.co/neuronpedia/gpt2-small__res_slefr-ajt)
+
+- **Huggingface Repo**: neuronpedia/gpt2-small__res_slefr-ajt
+- **model**: gpt2-small
+- **Additional Links**:
+    - [Model](https://huggingface.co/gpt2)
+    - [Dashboards](https://www.neuronpedia.org/gpt2-small/res_slefr-ajt)
+
+| id                       | architecture   | neuronpedia                 | hook_name                |   hook_layer |   d_sae |   context_size | dataset_path                                          | normalize_activations   |
+|:-------------------------|:---------------|:----------------------------|:-------------------------|-------------:|--------:|---------------:|:------------------------------------------------------|:------------------------|
+| blocks.2.hook_resid_pre  | standard       | gpt2-small/2-res_slefr-ajt  | blocks.2.hook_resid_pre  |            2 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
+| blocks.6.hook_resid_pre  | standard       | gpt2-small/6-res_slefr-ajt  | blocks.6.hook_resid_pre  |            6 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
+| blocks.10.hook_resid_pre | standard       | gpt2-small/10-res_slefr-ajt | blocks.10.hook_resid_pre |           10 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
+
+## [gpt2-small-res_scl-ajt](https://huggingface.co/neuronpedia/gpt2-small__res_scl-ajt)
+
+- **Huggingface Repo**: neuronpedia/gpt2-small__res_scl-ajt
+- **model**: gpt2-small
+- **Additional Links**:
+    - [Model](https://huggingface.co/gpt2)
+    - [Dashboards](https://www.neuronpedia.org/gpt2-small/res_scl-ajt)
+
+| id                       | architecture   | neuronpedia               | hook_name                |   hook_layer |   d_sae |   context_size | dataset_path                                          | normalize_activations   |
+|:-------------------------|:---------------|:--------------------------|:-------------------------|-------------:|--------:|---------------:|:------------------------------------------------------|:------------------------|
+| blocks.2.hook_resid_pre  | standard       | gpt2-small/2-res_scl-ajt  | blocks.2.hook_resid_pre  |            2 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
+| blocks.6.hook_resid_pre  | standard       | gpt2-small/6-res_scl-ajt  | blocks.6.hook_resid_pre  |            6 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
+| blocks.10.hook_resid_pre | standard       | gpt2-small/10-res_scl-ajt | blocks.10.hook_resid_pre |           10 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
+
+## [gpt2-small-res_sle-ajt](https://huggingface.co/neuronpedia/gpt2-small__res_sle-ajt)
+
+- **Huggingface Repo**: neuronpedia/gpt2-small__res_sle-ajt
+- **model**: gpt2-small
+- **Additional Links**:
+    - [Model](https://huggingface.co/gpt2)
+    - [Dashboards](https://www.neuronpedia.org/gpt2-small/res_sle-ajt)
+
+| id                       | architecture   | neuronpedia               | hook_name                |   hook_layer |   d_sae |   context_size | dataset_path                                          | normalize_activations   |
+|:-------------------------|:---------------|:--------------------------|:-------------------------|-------------:|--------:|---------------:|:------------------------------------------------------|:------------------------|
+| blocks.2.hook_resid_pre  | standard       | gpt2-small/2-res_sle-ajt  | blocks.2.hook_resid_pre  |            2 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
+| blocks.6.hook_resid_pre  | standard       | gpt2-small/6-res_sle-ajt  | blocks.6.hook_resid_pre  |            6 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
+| blocks.10.hook_resid_pre | standard       | gpt2-small/10-res_sle-ajt | blocks.10.hook_resid_pre |           10 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
+
+## [gpt2-small-res_sce-ajt](https://huggingface.co/neuronpedia/gpt2-small__res_sce-ajt)
+
+- **Huggingface Repo**: neuronpedia/gpt2-small__res_sce-ajt
+- **model**: gpt2-small
+- **Additional Links**:
+    - [Model](https://huggingface.co/gpt2)
+    - [Dashboards](https://www.neuronpedia.org/gpt2-small/res_sce-ajt)
+
+| id                       | architecture   | neuronpedia               | hook_name                |   hook_layer |   d_sae |   context_size | dataset_path                                          | normalize_activations   |
+|:-------------------------|:---------------|:--------------------------|:-------------------------|-------------:|--------:|---------------:|:------------------------------------------------------|:------------------------|
+| blocks.2.hook_resid_pre  | standard       | gpt2-small/2-res_sce-ajt  | blocks.2.hook_resid_pre  |            2 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
+| blocks.6.hook_resid_pre  | standard       | gpt2-small/6-res_sce-ajt  | blocks.6.hook_resid_pre  |            6 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
+| blocks.10.hook_resid_pre | standard       | gpt2-small/10-res_sce-ajt | blocks.10.hook_resid_pre |           10 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
+
+## [gpt2-small-res_scefr-ajt](https://huggingface.co/neuronpedia/gpt2-small__res_scefr-ajt)
+
+- **Huggingface Repo**: neuronpedia/gpt2-small__res_scefr-ajt
+- **model**: gpt2-small
+- **Additional Links**:
+    - [Model](https://huggingface.co/gpt2)
+    - [Dashboards](https://www.neuronpedia.org/gpt2-small/res_scefr-ajt)
+
+| id                       | architecture   | neuronpedia                 | hook_name                |   hook_layer |   d_sae |   context_size | dataset_path                                          | normalize_activations   |
+|:-------------------------|:---------------|:----------------------------|:-------------------------|-------------:|--------:|---------------:|:------------------------------------------------------|:------------------------|
+| blocks.2.hook_resid_pre  | standard       | gpt2-small/2-res_scefr-ajt  | blocks.2.hook_resid_pre  |            2 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
+| blocks.6.hook_resid_pre  | standard       | gpt2-small/6-res_scefr-ajt  | blocks.6.hook_resid_pre  |            6 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
+| blocks.10.hook_resid_pre | standard       | gpt2-small/10-res_scefr-ajt | blocks.10.hook_resid_pre |           10 |   46080 |            128 | apollo-research/Skylion007-openwebtext-tokenizer-gpt2 | none                    |
 

--- a/sae_lens/analysis/neuronpedia_integration.py
+++ b/sae_lens/analysis/neuronpedia_integration.py
@@ -31,6 +31,8 @@ from neuron_explainer.explanations.simulator import (
 )
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 
+from sae_lens import SAE
+
 NEURONPEDIA_DOMAIN = "https://neuronpedia.org"
 
 # Constants for replacing NaNs and Infs in outputs
@@ -57,30 +59,37 @@ def NanAndInfReplacer(value: str):
         return NAN_REPLACEMENT
 
 
-def get_neuronpedia_feature(
-    feature: int, layer: int, model: str = "gpt2-small", dataset: str = "res-jb"
-) -> dict[str, Any]:
-    """Fetch a feature from Neuronpedia API."""
-    url = f"{NEURONPEDIA_DOMAIN}/api/feature/{model}/{layer}-{dataset}/{feature}"
-    result = requests.get(url).json()
-    result["index"] = int(result["index"])
-    return result
+def open_neuronpedia_feature_dashboard(sae: SAE, index: int):
+    sae_id = sae.cfg.neuronpedia_id
+    if sae_id is None:
+        print(
+            "SAE does not have a Neuronpedia ID. Either dashboards for this SAE do not exist (yet) on Neuronpedia, or the SAE was not loaded via the from_pretrained method"
+        )
+    else:
+        url = f"{NEURONPEDIA_DOMAIN}/{sae_id}/{index}"
+        webbrowser.open(url)
 
 
 def get_neuronpedia_quick_list(
+    sae: SAE,
     features: list[int],
-    layer: int,
-    model: str = "gpt2-small",
-    dataset: str = "res-jb",
     name: str = "temporary_list",
 ):
+
+    sae_id = sae.cfg.neuronpedia_id
+    if sae_id is None:
+        print(
+            "SAE does not have a Neuronpedia ID. Either dashboards for this SAE do not exist (yet) on Neuronpedia, or the SAE was not loaded via the from_pretrained method"
+        )
+    assert sae_id is not None
+
     url = NEURONPEDIA_DOMAIN + "/quick-list/"
     name = urllib.parse.quote(name)
     url = url + "?name=" + name
     list_feature = [
         {
-            "modelId": model,
-            "layer": f"{layer}-{dataset}",
+            "modelId": sae.cfg.model_name,
+            "layer": sae_id.split("/")[1],
             "index": str(feature),
         }
         for feature in features
@@ -89,6 +98,16 @@ def get_neuronpedia_quick_list(
     webbrowser.open(url)
 
     return url
+
+
+def get_neuronpedia_feature(
+    feature: int, layer: int, model: str = "gpt2-small", dataset: str = "res-jb"
+) -> dict[str, Any]:
+    """Fetch a feature from Neuronpedia API."""
+    url = f"{NEURONPEDIA_DOMAIN}/api/feature/{model}/{layer}-{dataset}/{feature}"
+    result = requests.get(url).json()
+    result["index"] = int(result["index"])
+    return result
 
 
 class NeuronpediaActivation:

--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -1,5160 +1,6579 @@
-SAE_LOOKUP:
-  gpt2-small-res-jb:
-    repo_id: jbloom/GPT2-Small-SAEs-Reformatted
-    model: gpt2-small
-    conversion_func:
-    links:
-      model: https://huggingface.co/gpt2
-      dashboards: https://www.neuronpedia.org/gpt2sm-res-jb
-      publication: https://www.lesswrong.com/posts/f9EgfLSurAiqRJySD/open-source-sparse-autoencoders-for-all-residual-stream
-    saes:
-      - id: blocks.0.hook_resid_pre
-        path: blocks.0.hook_resid_pre
-        variance_explained: 0.999
-        l0: 10.0
-      - id: blocks.1.hook_resid_pre
-        path: blocks.1.hook_resid_pre
-        variance_explained: 0.999
-        l0: 10.0
-      - id: blocks.2.hook_resid_pre
-        path: blocks.2.hook_resid_pre
-        variance_explained: 0.999
-        l0: 18.0
-      - id: blocks.3.hook_resid_pre
-        path: blocks.3.hook_resid_pre
-        variance_explained: 0.999
-        l0: 23.0
-      - id: blocks.4.hook_resid_pre
-        path: blocks.4.hook_resid_pre
-        variance_explained: 0.9
-        l0: 31.0
-      - id: blocks.5.hook_resid_pre
-        path: blocks.5.hook_resid_pre
-        variance_explained: 0.9
-        l0: 41.0
-      - id: blocks.6.hook_resid_pre
-        path: blocks.6.hook_resid_pre
-        variance_explained: 0.9
-        l0: 51.0
-      - id: blocks.7.hook_resid_pre
-        path: blocks.7.hook_resid_pre
-        variance_explained: 0.9
-        l0: 54.0
-      - id: blocks.8.hook_resid_pre
-        path: blocks.8.hook_resid_pre
-        variance_explained: 0.9
-        l0: 60.0
-      - id: blocks.9.hook_resid_pre
-        path: blocks.9.hook_resid_pre
-        variance_explained: 0.77
-        l0: 70.0
-      - id: blocks.10.hook_resid_pre
-        path: blocks.10.hook_resid_pre
-        variance_explained: 0.77
-        l0: 52.0
-      - id: blocks.11.hook_resid_pre
-        path: blocks.11.hook_resid_pre
-        variance_explained: 0.77
-        l0: 56.0
-      - id: blocks.11.hook_resid_post
-        path: blocks.11.hook_resid_post
-        variance_explained: 0.77
-        l0: 70.0
-  gpt2-small-hook-z-kk:
-    repo_id: ckkissane/attn-saes-gpt2-small-all-layers
-    model: gpt2-small
-    conversion_func: connor_rob_hook_z
-    links:
-      model: https://huggingface.co/gpt2
-      dashboards: https://www.neuronpedia.org/gpt2sm-kk
-      publication: https://www.lesswrong.com/posts/FSTRedtjuHa4Gfdbr/attention-saes-scale-to-gpt-2-small
-    saes:
-      - id: blocks.0.hook_z
-        path: gpt2-small_L0_Hcat_z_lr1.20e-03_l11.80e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
-        variance_explained: 0.13
-        l0: 3.0
-      - id: blocks.1.hook_z
-        path: gpt2-small_L1_Hcat_z_lr1.20e-03_l18.00e-01_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v5.pt
-        variance_explained: 0.42
-        l0: 23.0
-      - id: blocks.2.hook_z
-        path: gpt2-small_L2_Hcat_z_lr1.20e-03_l11.00e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v4.pt
-        variance_explained: 0.4
-        l0: 16.0
-      - id: blocks.3.hook_z
-        path: gpt2-small_L3_Hcat_z_lr1.20e-03_l19.00e-01_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
-        variance_explained: 0.43
-        l0: 15.0
-      - id: blocks.4.hook_z
-        path: gpt2-small_L4_Hcat_z_lr1.20e-03_l11.10e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v7.pt
-        variance_explained: 0.27
-        l0: 14.0
-      - id: blocks.5.hook_z
-        path: gpt2-small_L5_Hcat_z_lr1.20e-03_l11.00e+00_ds49152_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
-        variance_explained: 0.13
-        l0: 17.0
-      - id: blocks.6.hook_z
-        path: gpt2-small_L6_Hcat_z_lr1.20e-03_l11.10e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
-        variance_explained: 0.0
-        l0: 17.0
-      - id: blocks.7.hook_z
-        path: gpt2-small_L7_Hcat_z_lr1.20e-03_l11.10e+00_ds49152_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
-        variance_explained: -7.55
-        l0: 19.0
-      - id: blocks.8.hook_z
-        path: gpt2-small_L8_Hcat_z_lr1.20e-03_l11.30e+00_ds24576_bs4096_dc1.00e-05_rsanthropic_rie25000_nr4_v6.pt
-        variance_explained: -0.22
-        l0: 23.0
-      - id: blocks.9.hook_z
-        path: gpt2-small_L9_Hcat_z_lr1.20e-03_l11.20e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
-        variance_explained: -0.54
-        l0: 23.0
-      - id: blocks.10.hook_z
-        path: gpt2-small_L10_Hcat_z_lr1.20e-03_l11.30e+00_ds24576_bs4096_dc1.00e-05_rsanthropic_rie25000_nr4_v9.pt
-        variance_explained: -0.27
-        l0: 14.0
-      - id: blocks.11.hook_z
-        path: gpt2-small_L11_Hcat_z_lr1.20e-03_l13.00e+00_ds24576_bs4096_dc3.16e-06_rsanthropic_rie25000_nr4_v9.pt
-        variance_explained: -0.7
-        l0: 9.4
-  gpt2-small-mlp-tm:
-    repo_id: tommmcgrath/gpt2-small-mlp-out-saes
-    model: gpt2-small
-    links:
-      model: https://huggingface.co/gpt2
-    conversion_func:
-    config_overrides:
-      dataset_path: Skylion007/openwebtext
-    saes:
-      - id: blocks.0.hook_mlp_out
-        path: sae_group_gpt2_blocks.0.hook_mlp_out_24576:v1
-        variance_explained: 0.999
-        l0: 15.0
-        norm_scaling_factor: 1.049317316132615
-      - id: blocks.1.hook_mlp_out
-        path: sae_group_gpt2_blocks.1.hook_mlp_out_24576:v0
-        variance_explained: 0.57
-        l0: 21.0
-        norm_scaling_factor: 2.3693984005104283
-      - id: blocks.2.hook_mlp_out
-        path: sae_group_gpt2_blocks.2.hook_mlp_out_24576:v0
-        variance_explained: 0.55
-        l0: 137.0
-        norm_scaling_factor: 1.6411934982190302
-      - id: blocks.3.hook_mlp_out
-        path: sae_group_gpt2_blocks.3.hook_mlp_out_24576:v0
-        variance_explained: 0.57
-        l0: 54.0
-        norm_scaling_factor: 1.8958522157897557
-      - id: blocks.4.hook_mlp_out
-        path: sae_group_gpt2_blocks.4.hook_mlp_out_24576:v0
-        variance_explained: 0.44
-        l0: 74.0
-        norm_scaling_factor: 1.81673478700627
-      - id: blocks.5.hook_mlp_out
-        path: sae_group_gpt2_blocks.5.hook_mlp_out_24576:v0
-        variance_explained: 0.52
-        l0: 76.0
-        norm_scaling_factor: 1.550234472245924
-      - id: blocks.6.hook_mlp_out
-        path: sae_group_gpt2_blocks.6.hook_mlp_out_24576:v0
-        variance_explained: 0.508
-        l0: 40.0
-        norm_scaling_factor: 1.3237742807210804
-      - id: blocks.7.hook_mlp_out
-        path: sae_group_gpt2_blocks.7.hook_mlp_out_24576:v0
-        variance_explained: 0.53
-        l0: 52.0
-        norm_scaling_factor: 1.1042905114723296
-      - id: blocks.8.hook_mlp_out
-        path: sae_group_gpt2_blocks.8.hook_mlp_out_24576:v1
-        variance_explained: 0.46
-        l0: 36.0
-        norm_scaling_factor: 0.9123762783479742
-      - id: blocks.9.hook_mlp_out
-        path: sae_group_gpt2_blocks.9.hook_mlp_out_24576:v0
-        variance_explained: 0.49
-        l0: 49.0
-        norm_scaling_factor: 0.6955335635232373
-      - id: blocks.10.hook_mlp_out
-        path: sae_group_gpt2_blocks.10.hook_mlp_out_24576:v0
-        variance_explained: 0.22
-        l0: 167.0
-        norm_scaling_factor: 0.3619728926727644
-      - id: blocks.11.hook_mlp_out
-        path: sae_group_gpt2_blocks.11.hook_mlp_out_24576:v2
-        variance_explained: 0.59
-        l0: 170.0
-        norm_scaling_factor: 0.2851548652550073
-  gpt2-small-res-jb-feature-splitting:
-    repo_id: jbloom/GPT2-Small-Feature-Splitting-Experiment-Layer-8
-    model: gpt2-small
-    links:
-      model: https://huggingface.co/gpt2
-      dashboards: https://www.neuronpedia.org/gpt2sm-rfs-jb
-    conversion_func:
-    saes:
-      - id: blocks.8.hook_resid_pre_768
-        path: blocks.8.hook_resid_pre_768
-        variance_explained: 0.61
-        l0: 36.0
-      - id: blocks.8.hook_resid_pre_1536
-        path: blocks.8.hook_resid_pre_1536
-        variance_explained: 0.67
-        l0: 39.0
-      - id: blocks.8.hook_resid_pre_3072
-        path: blocks.8.hook_resid_pre_3072
-        variance_explained: 0.72
-        l0: 41.0
-      - id: blocks.8.hook_resid_pre_6144
-        path: blocks.8.hook_resid_pre_6144
-        variance_explained: 0.76
-        l0: 43.0
-      - id: blocks.8.hook_resid_pre_12288
-        path: blocks.8.hook_resid_pre_12288
-        variance_explained: 0.77
-        l0: 43.0
-      - id: blocks.8.hook_resid_pre_24576
-        path: blocks.8.hook_resid_pre_24576
-        variance_explained: 0.79
-        l0: 40.0
-      - id: blocks.8.hook_resid_pre_49152
-        path: blocks.8.hook_resid_pre_49152
-        variance_explained: 0.81
-        l0: 40.0
-      - id: blocks.8.hook_resid_pre_98304
-        path: blocks.8.hook_resid_pre_98304
-        variance_explained: 0.82
-        l0: 43.0
-  gpt2-small-resid-post-v5-32k:
-    repo_id: jbloom/GPT2-Small-OAI-v5-32k-resid-post-SAEs
-    model: gpt2-small
-    conversion_func:
-    config_overrides:
-      dataset_path: Skylion007/openwebtext
-    saes:
-      - id: blocks.0.hook_resid_post
-        path: v5_32k_layer_0.pt
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.1.hook_resid_post
-        path: v5_32k_layer_1.pt
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.2.hook_resid_post
-        path: v5_32k_layer_2.pt
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.3.hook_resid_post
-        path: v5_32k_layer_3.pt
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.4.hook_resid_post
-        path: v5_32k_layer_4.pt
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.5.hook_resid_post
-        path: v5_32k_layer_5.pt
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.6.hook_resid_post
-        path: v5_32k_layer_6.pt
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.7.hook_resid_post
-        path: v5_32k_layer_7.pt
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.8.hook_resid_post
-        path: v5_32k_layer_8.pt
-        variance_explained: 0.74
-        l0: 32.0
-      - id: blocks.9.hook_resid_post
-        path: v5_32k_layer_9.pt
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.10.hook_resid_post
-        path: v5_32k_layer_10.pt
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.11.hook_resid_post
-        path: v5_32k_layer_11.pt
-        variance_explained: 0.9
-        l0: 32.0
-  gpt2-small-resid-post-v5-128k:
-    repo_id: jbloom/GPT2-Small-OAI-v5-128k-resid-post-SAEs
-    model: gpt2-small
-    conversion_func:
-    config_overrides:
-      dataset_path: Skylion007/openwebtext
-    saes:
-      - id: blocks.0.hook_resid_post
-        path: v5_128k_layer_0
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.1.hook_resid_post
-        path: v5_128k_layer_1
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.2.hook_resid_post
-        path: v5_128k_layer_2
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.3.hook_resid_post
-        path: v5_128k_layer_3
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.4.hook_resid_post
-        path: v5_128k_layer_4
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.5.hook_resid_post
-        path: v5_128k_layer_5
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.6.hook_resid_post
-        path: v5_128k_layer_6
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.7.hook_resid_post
-        path: v5_128k_layer_7
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.8.hook_resid_post
-        path: v5_128k_layer_8
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.9.hook_resid_post
-        path: v5_128k_layer_9
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.10.hook_resid_post
-        path: v5_128k_layer_10
-        variance_explained: 0.9
-        l0: 32.0
-      - id: blocks.11.hook_resid_post
-        path: v5_128k_layer_11
-        variance_explained: 0.9
-        l0: 32.0
-  gemma-2b-res-jb:
-    repo_id: jbloom/Gemma-2b-Residual-Stream-SAEs
-    model: gemma-2b
-    conversion_func:
-    links:
-      model: https://huggingface.co/google/gemma-2b
-      dashboards: https://www.neuronpedia.org/gemma2b-res-jb
-    saes:
-      - id: blocks.0.hook_resid_post
-        path: gemma_2b_blocks.0.hook_resid_post_16384_anthropic
-        variance_explained: 0.999
-        l0: 47.0
-      - id: blocks.6.hook_resid_post
-        path: gemma_2b_blocks.6.hook_resid_post_16384_anthropic_fast_lr
-        variance_explained: 0.71
-        l0: 56.0
-      - id: blocks.10.hook_resid_post
-        path: gemma_2b_blocks.10.hook_resid_post_16384
-        variance_explained: -0.20
-        l0: 62.0
-      - id: blocks.12.hook_resid_post
-        path: gemma_2b_blocks.12.hook_resid_post_16384
-        variance_explained: -0.65
-        l0: 62.0
-        norm_scaling_factor: 0.21381938399317255
-      - id: blocks.17.hook_resid_post
-        path: gemma_2b_blocks.17.hook_resid_post_16384
-        variance_explained: -0.85
-        l0: 54.0
-  gemma-2b-it-res-jb:
-    repo_id: jbloom/Gemma-2b-IT-Residual-Stream-SAEs
-    model: gemma-2b-it
-    conversion_func:
-    config_overrides:
-      dataset_path: Skylion007/openwebtext
-    links:
-      model: https://huggingface.co/google/gemma-2b-it
-      dashboards: https://www.neuronpedia.org/gemma2bit-res-jb
-    saes:
-      - id: blocks.12.hook_resid_post
-        path: gemma_2b_it_blocks.12.hook_resid_post_16384
-        variance_explained: 0.57
-        l0: 61.0
-  mistral-7b-res-wg:
-    repo_id: JoshEngels/Mistral-7B-Residual-Stream-SAEs
-    model: mistral-7b
-    conversion_func:
-    config_overrides:
-      normalize_activations: constant_norm_rescale
-    saes:
-      - id: blocks.8.hook_resid_pre
-        path: mistral_7b_layer_8
-        variance_explained: 0.94
-        l0: 92
-      - id: blocks.16.hook_resid_pre
-        path: mistral_7b_layer_16
-        variance_explained: 0.85
-        l0: 74
-      - id: blocks.24.hook_resid_pre
-        path: mistral_7b_layer_24
-        variance_explained: 0.72
-        l0: 75
-  gpt2-small-resid-mid-v5-32k:
-    repo_id: jbloom/GPT2-Small-OAI-v5-32k-resid-mid-SAEs
-    model: gpt2-small
-    conversion_func:
-    config_overrides:
-      dataset_path: Skylion007/openwebtext
-    saes:
-      - id: blocks.0.hook_resid_mid
-        path: v5_32k_layer_0
-      - id: blocks.1.hook_resid_mid
-        path: v5_32k_layer_1
-      - id: blocks.2.hook_resid_mid
-        path: v5_32k_layer_2
-      - id: blocks.3.hook_resid_mid
-        path: v5_32k_layer_3
-      - id: blocks.4.hook_resid_mid
-        path: v5_32k_layer_4
-      - id: blocks.5.hook_resid_mid
-        path: v5_32k_layer_5
-      - id: blocks.6.hook_resid_mid
-        path: v5_32k_layer_6
-      - id: blocks.7.hook_resid_mid
-        path: v5_32k_layer_7
-      - id: blocks.8.hook_resid_mid
-        path: v5_32k_layer_8
-      - id: blocks.9.hook_resid_mid
-        path: v5_32k_layer_9
-      - id: blocks.10.hook_resid_mid
-        path: v5_32k_layer_10
-      - id: blocks.11.hook_resid_mid
-        path: v5_32k_layer_11
-  gpt2-small-resid-mid-v5-128k:
-    repo_id: jbloom/GPT2-Small-OAI-v5-128k-resid-mid-SAEs
-    model: gpt2-small
-    conversion_func:
-    config_overrides:
-      dataset_path: Skylion007/openwebtext
-    saes:
-      - id: blocks.0.hook_resid_mid
-        path: v5_128k_layer_0
-      - id: blocks.1.hook_resid_mid
-        path: v5_128k_layer_1
-      - id: blocks.2.hook_resid_mid
-        path: v5_128k_layer_2
-      - id: blocks.3.hook_resid_mid
-        path: v5_128k_layer_3
-      - id: blocks.4.hook_resid_mid
-        path: v5_128k_layer_4
-      - id: blocks.5.hook_resid_mid
-        path: v5_128k_layer_5
-      - id: blocks.6.hook_resid_mid
-        path: v5_128k_layer_6
-      - id: blocks.7.hook_resid_mid
-        path: v5_128k_layer_7
-      - id: blocks.8.hook_resid_mid
-        path: v5_128k_layer_8
-      - id: blocks.9.hook_resid_mid
-        path: v5_128k_layer_9
-      - id: blocks.10.hook_resid_mid
-        path: v5_128k_layer_10
-      - id: blocks.11.hook_resid_mid
-        path: v5_128k_layer_11
-  gpt2-small-mlp-out-v5-32k:
-    repo_id: jbloom/GPT2-Small-OAI-v5-32k-mlp-out-SAEs
-    model: gpt2-small
-    conversion_func:
-    config_overrides:
-      dataset_path: Skylion007/openwebtext
-    saes:
-      - id: blocks.0.hook_mlp_out
-        path: v5_32k_layer_0
-      - id: blocks.1.hook_mlp_out
-        path: v5_32k_layer_1
-      - id: blocks.2.hook_mlp_out
-        path: v5_32k_layer_2
-      - id: blocks.3.hook_mlp_out
-        path: v5_32k_layer_3
-      - id: blocks.4.hook_mlp_out
-        path: v5_32k_layer_4
-      - id: blocks.5.hook_mlp_out
-        path: v5_32k_layer_5
-      - id: blocks.6.hook_mlp_out
-        path: v5_32k_layer_6
-      - id: blocks.7.hook_mlp_out
-        path: v5_32k_layer_7
-      - id: blocks.8.hook_mlp_out
-        path: v5_32k_layer_8
-      - id: blocks.9.hook_mlp_out
-        path: v5_32k_layer_9
-      - id: blocks.10.hook_mlp_out
-        path: v5_32k_layer_10
-      - id: blocks.11.hook_mlp_out
-        path: v5_32k_layer_11
-  gpt2-small-mlp-out-v5-128k:
-    repo_id: jbloom/GPT2-Small-OAI-v5-128k-mlp-out-SAEs
-    model: gpt2-small
-    conversion_func:
-    config_overrides:
-      dataset_path: Skylion007/openwebtext
-    saes:
-      - id: blocks.0.hook_mlp_out
-        path: v5_128k_layer_0
-      - id: blocks.1.hook_mlp_out
-        path: v5_128k_layer_1
-      - id: blocks.2.hook_mlp_out
-        path: v5_128k_layer_2
-      - id: blocks.3.hook_mlp_out
-        path: v5_128k_layer_3
-      - id: blocks.4.hook_mlp_out
-        path: v5_128k_layer_4
-      - id: blocks.5.hook_mlp_out
-        path: v5_128k_layer_5
-      - id: blocks.6.hook_mlp_out
-        path: v5_128k_layer_6
-      - id: blocks.7.hook_mlp_out
-        path: v5_128k_layer_7
-      - id: blocks.8.hook_mlp_out
-        path: v5_128k_layer_8
-      - id: blocks.9.hook_mlp_out
-        path: v5_128k_layer_9
-      - id: blocks.10.hook_mlp_out
-        path: v5_128k_layer_10
-      - id: blocks.11.hook_mlp_out
-        path: v5_128k_layer_11
-  gpt2-small-attn-out-v5-32k:
-    repo_id: jbloom/GPT2-Small-OAI-v5-32k-attn-out-SAEs
-    model: gpt2-small
-    conversion_func:
-    config_overrides:
-      dataset_path: Skylion007/openwebtext
-    saes:
-      - id: blocks.0.hook_attn_out
-        path: v5_32k_layer_0
-      - id: blocks.1.hook_attn_out
-        path: v5_32k_layer_1
-      - id: blocks.2.hook_attn_out
-        path: v5_32k_layer_2
-      - id: blocks.3.hook_attn_out
-        path: v5_32k_layer_3
-      - id: blocks.4.hook_attn_out
-        path: v5_32k_layer_4
-      - id: blocks.5.hook_attn_out
-        path: v5_32k_layer_5
-      - id: blocks.6.hook_attn_out
-        path: v5_32k_layer_6
-      - id: blocks.7.hook_attn_out
-        path: v5_32k_layer_7
-      - id: blocks.8.hook_attn_out
-        path: v5_32k_layer_8
-      - id: blocks.9.hook_attn_out
-        path: v5_32k_layer_9
-      - id: blocks.10.hook_attn_out
-        path: v5_32k_layer_10
-      - id: blocks.11.hook_attn_out
-        path: v5_32k_layer_11
-  gpt2-small-attn-out-v5-128k:
-    repo_id: jbloom/GPT2-Small-OAI-v5-128k-attn-out-SAEs
-    model: gpt2-small
-    conversion_func:
-    config_overrides:
-      dataset_path: Skylion007/openwebtext
-    saes:
-      - id: blocks.0.hook_attn_out
-        path: v5_128k_layer_0
-      - id: blocks.1.hook_attn_out
-        path: v5_128k_layer_1
-      - id: blocks.2.hook_attn_out
-        path: v5_128k_layer_2
-      - id: blocks.3.hook_attn_out
-        path: v5_128k_layer_3
-      - id: blocks.4.hook_attn_out
-        path: v5_128k_layer_4
-      - id: blocks.5.hook_attn_out
-        path: v5_128k_layer_5
-      - id: blocks.6.hook_attn_out
-        path: v5_128k_layer_6
-      - id: blocks.7.hook_attn_out
-        path: v5_128k_layer_7
-      - id: blocks.8.hook_attn_out
-        path: v5_128k_layer_8
-      - id: blocks.9.hook_attn_out
-        path: v5_128k_layer_9
-      - id: blocks.10.hook_attn_out
-        path: v5_128k_layer_10
-      - id: blocks.11.hook_attn_out
-        path: v5_128k_layer_11
-  gemma-scope-2b-pt-res-canonical:
-    repo_id: google/gemma-scope-2b-pt-res
-    model: gemma-2-2b
-    conversion_func: gemma_2
-    links:
-      model: https://huggingface.co/google/gemma-2-2b
-      dashboards: https://www.neuronpedia.org/gemma-2-2b/gemmascope-res-16k
-      publication: https://huggingface.co/google/gemma-scope
-    saes:
-      - id: layer_0/width_16k/canonical
-        path: layer_0/width_16k/canonical
+gpt2-small-res-jb:
+  repo_id: jbloom/GPT2-Small-SAEs-Reformatted
+  model: gpt2-small
+  conversion_func: null
+  links:
+    model: https://huggingface.co/gpt2
+    dashboards: https://www.neuronpedia.org/gpt2sm-res-jb
+    publication: https://www.lesswrong.com/posts/f9EgfLSurAiqRJySD/open-source-sparse-autoencoders-for-all-residual-stream
+  saes:
+  - id: blocks.0.hook_resid_pre
+    path: blocks.0.hook_resid_pre
+    neuronpedia: gpt2-small/0-res-jb
+    variance_explained: 0.999
+    l0: 10.0
+  - id: blocks.1.hook_resid_pre
+    path: blocks.1.hook_resid_pre
+    neuronpedia: gpt2-small/1-res-jb
+    variance_explained: 0.999
+    l0: 10.0
+  - id: blocks.2.hook_resid_pre
+    path: blocks.2.hook_resid_pre
+    neuronpedia: gpt2-small/2-res-jb
+    variance_explained: 0.999
+    l0: 18.0
+  - id: blocks.3.hook_resid_pre
+    path: blocks.3.hook_resid_pre
+    neuronpedia: gpt2-small/3-res-jb
+    variance_explained: 0.999
+    l0: 23.0
+  - id: blocks.4.hook_resid_pre
+    path: blocks.4.hook_resid_pre
+    neuronpedia: gpt2-small/4-res-jb
+    variance_explained: 0.9
+    l0: 31.0
+  - id: blocks.5.hook_resid_pre
+    path: blocks.5.hook_resid_pre
+    neuronpedia: gpt2-small/0-res-jb
+    variance_explained: 0.9
+    l0: 41.0
+  - id: blocks.6.hook_resid_pre
+    path: blocks.6.hook_resid_pre
+    neuronpedia: gpt2-small/6-res-jb
+    variance_explained: 0.9
+    l0: 51.0
+  - id: blocks.7.hook_resid_pre
+    path: blocks.7.hook_resid_pre
+    neuronpedia: gpt2-small/7-res-jb
+    variance_explained: 0.9
+    l0: 54.0
+  - id: blocks.8.hook_resid_pre
+    path: blocks.8.hook_resid_pre
+    neuronpedia: gpt2-small/8-res-jb
+    variance_explained: 0.9
+    l0: 60.0
+  - id: blocks.9.hook_resid_pre
+    path: blocks.9.hook_resid_pre
+    neuronpedia: gpt2-small/9-res-jb
+    variance_explained: 0.77
+    l0: 70.0
+  - id: blocks.10.hook_resid_pre
+    path: blocks.10.hook_resid_pre
+    neuronpedia: gpt2-small/10-res-jb
+    variance_explained: 0.77
+    l0: 52.0
+  - id: blocks.11.hook_resid_pre
+    path: blocks.11.hook_resid_pre
+    neuronpedia: gpt2-small/11-res-jb
+    variance_explained: 0.77
+    l0: 56.0
+  - id: blocks.11.hook_resid_post
+    path: blocks.11.hook_resid_post
+    neuronpedia: gpt2-small/12-res-jb
+    variance_explained: 0.77
+    l0: 70.0
+gpt2-small-hook-z-kk:
+  repo_id: ckkissane/attn-saes-gpt2-small-all-layers
+  model: gpt2-small
+  conversion_func: connor_rob_hook_z
+  links:
+    model: https://huggingface.co/gpt2
+    dashboards: https://www.neuronpedia.org/gpt2sm-kk
+    publication: https://www.lesswrong.com/posts/FSTRedtjuHa4Gfdbr/attention-saes-scale-to-gpt-2-small
+  saes:
+  - id: blocks.0.hook_z
+    path: gpt2-small_L0_Hcat_z_lr1.20e-03_l11.80e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
+    neuronpedia: gpt2-small/0-att-kk
+    variance_explained: 0.13
+    l0: 3.0
+  - id: blocks.1.hook_z
+    path: gpt2-small_L1_Hcat_z_lr1.20e-03_l18.00e-01_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v5.pt
+    neuronpedia: gpt2-small/1-att-kk
+    variance_explained: 0.42
+    l0: 23.0
+  - id: blocks.2.hook_z
+    path: gpt2-small_L2_Hcat_z_lr1.20e-03_l11.00e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v4.pt
+    neuronpedia: gpt2-small/2-att-kk
+    variance_explained: 0.4
+    l0: 16.0
+  - id: blocks.3.hook_z
+    path: gpt2-small_L3_Hcat_z_lr1.20e-03_l19.00e-01_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
+    neuronpedia: gpt2-small/3-att-kk
+    variance_explained: 0.43
+    l0: 15.0
+  - id: blocks.4.hook_z
+    path: gpt2-small_L4_Hcat_z_lr1.20e-03_l11.10e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v7.pt
+    neuronpedia: gpt2-small/4-att-kk
+    variance_explained: 0.27
+    l0: 14.0
+  - id: blocks.5.hook_z
+    path: gpt2-small_L5_Hcat_z_lr1.20e-03_l11.00e+00_ds49152_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
+    neuronpedia: gpt2-small/5-att-kk
+    variance_explained: 0.13
+    l0: 17.0
+  - id: blocks.6.hook_z
+    path: gpt2-small_L6_Hcat_z_lr1.20e-03_l11.10e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
+    neuronpedia: gpt2-small/6-att-kk
+    variance_explained: 0.0
+    l0: 17.0
+  - id: blocks.7.hook_z
+    path: gpt2-small_L7_Hcat_z_lr1.20e-03_l11.10e+00_ds49152_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
+    neuronpedia: gpt2-small/7-att-kk
+    variance_explained: -7.55
+    l0: 19.0
+  - id: blocks.8.hook_z
+    path: gpt2-small_L8_Hcat_z_lr1.20e-03_l11.30e+00_ds24576_bs4096_dc1.00e-05_rsanthropic_rie25000_nr4_v6.pt
+    neuronpedia: gpt2-small/8-att-kk
+    variance_explained: -0.22
+    l0: 23.0
+  - id: blocks.9.hook_z
+    path: gpt2-small_L9_Hcat_z_lr1.20e-03_l11.20e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
+    neuronpedia: gpt2-small/9-att-kk
+    variance_explained: -0.54
+    l0: 23.0
+  - id: blocks.10.hook_z
+    path: gpt2-small_L10_Hcat_z_lr1.20e-03_l11.30e+00_ds24576_bs4096_dc1.00e-05_rsanthropic_rie25000_nr4_v9.pt
+    neuronpedia: gpt2-small/10-att-kk
+    variance_explained: -0.27
+    l0: 14.0
+  - id: blocks.11.hook_z
+    path: gpt2-small_L11_Hcat_z_lr1.20e-03_l13.00e+00_ds24576_bs4096_dc3.16e-06_rsanthropic_rie25000_nr4_v9.pt
+    neuronpedia: gpt2-small/11-att-kk
+    variance_explained: -0.7
+    l0: 9.4
+gpt2-small-mlp-tm:
+  repo_id: tommmcgrath/gpt2-small-mlp-out-saes
+  model: gpt2-small
+  links:
+    model: https://huggingface.co/gpt2
+  conversion_func: null
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+  saes:
+  - id: blocks.0.hook_mlp_out
+    path: sae_group_gpt2_blocks.0.hook_mlp_out_24576:v1
+    variance_explained: 0.999
+    l0: 15.0
+    norm_scaling_factor: 1.049317316132615
+  - id: blocks.1.hook_mlp_out
+    path: sae_group_gpt2_blocks.1.hook_mlp_out_24576:v0
+    variance_explained: 0.57
+    l0: 21.0
+    norm_scaling_factor: 2.3693984005104283
+  - id: blocks.2.hook_mlp_out
+    path: sae_group_gpt2_blocks.2.hook_mlp_out_24576:v0
+    variance_explained: 0.55
+    l0: 137.0
+    norm_scaling_factor: 1.6411934982190302
+  - id: blocks.3.hook_mlp_out
+    path: sae_group_gpt2_blocks.3.hook_mlp_out_24576:v0
+    variance_explained: 0.57
+    l0: 54.0
+    norm_scaling_factor: 1.8958522157897557
+  - id: blocks.4.hook_mlp_out
+    path: sae_group_gpt2_blocks.4.hook_mlp_out_24576:v0
+    variance_explained: 0.44
+    l0: 74.0
+    norm_scaling_factor: 1.81673478700627
+  - id: blocks.5.hook_mlp_out
+    path: sae_group_gpt2_blocks.5.hook_mlp_out_24576:v0
+    variance_explained: 0.52
+    l0: 76.0
+    norm_scaling_factor: 1.550234472245924
+  - id: blocks.6.hook_mlp_out
+    path: sae_group_gpt2_blocks.6.hook_mlp_out_24576:v0
+    variance_explained: 0.508
+    l0: 40.0
+    norm_scaling_factor: 1.3237742807210804
+  - id: blocks.7.hook_mlp_out
+    path: sae_group_gpt2_blocks.7.hook_mlp_out_24576:v0
+    variance_explained: 0.53
+    l0: 52.0
+    norm_scaling_factor: 1.1042905114723296
+  - id: blocks.8.hook_mlp_out
+    path: sae_group_gpt2_blocks.8.hook_mlp_out_24576:v1
+    variance_explained: 0.46
+    l0: 36.0
+    norm_scaling_factor: 0.9123762783479742
+  - id: blocks.9.hook_mlp_out
+    path: sae_group_gpt2_blocks.9.hook_mlp_out_24576:v0
+    variance_explained: 0.49
+    l0: 49.0
+    norm_scaling_factor: 0.6955335635232373
+  - id: blocks.10.hook_mlp_out
+    path: sae_group_gpt2_blocks.10.hook_mlp_out_24576:v0
+    variance_explained: 0.22
+    l0: 167.0
+    norm_scaling_factor: 0.3619728926727644
+  - id: blocks.11.hook_mlp_out
+    path: sae_group_gpt2_blocks.11.hook_mlp_out_24576:v2
+    variance_explained: 0.59
+    l0: 170.0
+    norm_scaling_factor: 0.2851548652550073
+gpt2-small-res-jb-feature-splitting:
+  repo_id: jbloom/GPT2-Small-Feature-Splitting-Experiment-Layer-8
+  model: gpt2-small
+  links:
+    model: https://huggingface.co/gpt2
+    dashboards: https://www.neuronpedia.org/gpt2sm-rfs-jb
+  conversion_func: null
+  saes:
+  - id: blocks.8.hook_resid_pre_768
+    path: blocks.8.hook_resid_pre_768
+    neuronpedia: gpt2-small/8-res_fs768-jb
+    variance_explained: 0.61
+    l0: 36.0
+  - id: blocks.8.hook_resid_pre_1536
+    path: blocks.8.hook_resid_pre_1536
+    neuronpedia: gpt2-small/8-res_fs1536-jb
+    variance_explained: 0.67
+    l0: 39.0
+  - id: blocks.8.hook_resid_pre_3072
+    path: blocks.8.hook_resid_pre_3072
+    neuronpedia: gpt2-small/8-res_fs3072-jb
+    variance_explained: 0.72
+    l0: 41.0
+  - id: blocks.8.hook_resid_pre_6144
+    path: blocks.8.hook_resid_pre_6144
+    neuronpedia: gpt2-small/8-res_fs6144-jb
+    variance_explained: 0.76
+    l0: 43.0
+  - id: blocks.8.hook_resid_pre_12288
+    path: blocks.8.hook_resid_pre_12288
+    neuronpedia: gpt2-small/8-res_fs12288-jb
+    variance_explained: 0.77
+    l0: 43.0
+  - id: blocks.8.hook_resid_pre_24576
+    path: blocks.8.hook_resid_pre_24576
+    neuronpedia: gpt2-small/8-res_fs24576-jb
+    variance_explained: 0.79
+    l0: 40.0
+  - id: blocks.8.hook_resid_pre_49152
+    path: blocks.8.hook_resid_pre_49152
+    neuronpedia: gpt2-small/8-res_fs49152-jb
+    variance_explained: 0.81
+    l0: 40.0
+  - id: blocks.8.hook_resid_pre_98304
+    path: blocks.8.hook_resid_pre_98304
+    neuronpedia: gpt2-small/8-res_fs98304-jb
+    variance_explained: 0.82
+    l0: 43.0
+gpt2-small-resid-post-v5-32k:
+  repo_id: jbloom/GPT2-Small-OAI-v5-32k-resid-post-SAEs
+  model: gpt2-small
+  conversion_func: null
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+  saes:
+  - id: blocks.0.hook_resid_post
+    path: v5_32k_layer_0.pt
+    neuronpedia: gpt2-small/0-res_post_32k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.1.hook_resid_post
+    path: v5_32k_layer_1.pt
+    neuronpedia: gpt2-small/1-res_post_32k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.2.hook_resid_post
+    path: v5_32k_layer_2.pt
+    neuronpedia: gpt2-small/2-res_post_32k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.3.hook_resid_post
+    path: v5_32k_layer_3.pt
+    neuronpedia: gpt2-small/3-res_post_32k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.4.hook_resid_post
+    path: v5_32k_layer_4.pt
+    neuronpedia: gpt2-small/4-res_post_32k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.5.hook_resid_post
+    path: v5_32k_layer_5.pt
+    neuronpedia: gpt2-small/5-res_post_32k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.6.hook_resid_post
+    path: v5_32k_layer_6.pt
+    neuronpedia: gpt2-small/6-res_post_32k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.7.hook_resid_post
+    path: v5_32k_layer_7.pt
+    neuronpedia: gpt2-small/7-res_post_32k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.8.hook_resid_post
+    path: v5_32k_layer_8.pt
+    neuronpedia: gpt2-small/8-res_post_32k-oai
+    variance_explained: 0.74
+    l0: 32.0
+  - id: blocks.9.hook_resid_post
+    path: v5_32k_layer_9.pt
+    neuronpedia: gpt2-small/9-res_post_32k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.10.hook_resid_post
+    path: v5_32k_layer_10.pt
+    neuronpedia: gpt2-small/10-res_post_32k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.11.hook_resid_post
+    path: v5_32k_layer_11.pt
+    neuronpedia: gpt2-small/11-res_post_32k-oai
+    variance_explained: 0.9
+    l0: 32.0
+gpt2-small-resid-post-v5-128k:
+  repo_id: jbloom/GPT2-Small-OAI-v5-128k-resid-post-SAEs
+  model: gpt2-small
+  conversion_func: null
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+  saes:
+  - id: blocks.0.hook_resid_post
+    path: v5_128k_layer_0
+    neuronpedia: gpt2-small/0-res_post_128k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.1.hook_resid_post
+    path: v5_128k_layer_1
+    neuronpedia: gpt2-small/1-res_post_128k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.2.hook_resid_post
+    path: v5_128k_layer_2
+    neuronpedia: gpt2-small/2-res_post_128k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.3.hook_resid_post
+    path: v5_128k_layer_3
+    neuronpedia: gpt2-small/3-res_post_128k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.4.hook_resid_post
+    path: v5_128k_layer_4
+    neuronpedia: gpt2-small/4-res_post_128k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.5.hook_resid_post
+    path: v5_128k_layer_5
+    neuronpedia: gpt2-small/5-res_post_128k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.6.hook_resid_post
+    path: v5_128k_layer_6
+    neuronpedia: gpt2-small/6-res_post_128k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.7.hook_resid_post
+    path: v5_128k_layer_7
+    neuronpedia: gpt2-small/7-res_post_128k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.8.hook_resid_post
+    path: v5_128k_layer_8
+    neuronpedia: gpt2-small/8-res_post_128k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.9.hook_resid_post
+    path: v5_128k_layer_9
+    neuronpedia: gpt2-small/9-res_post_128k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.10.hook_resid_post
+    path: v5_128k_layer_10
+    neuronpedia: gpt2-small/10-res_post_128k-oai
+    variance_explained: 0.9
+    l0: 32.0
+  - id: blocks.11.hook_resid_post
+    path: v5_128k_layer_11
+    neuronpedia: gpt2-small/11-res_post_128k-oai
+    variance_explained: 0.9
+    l0: 32.0
+gemma-2b-res-jb:
+  repo_id: jbloom/Gemma-2b-Residual-Stream-SAEs
+  model: gemma-2b
+  conversion_func: null
+  links:
+    model: https://huggingface.co/google/gemma-2b
+    dashboards: https://www.neuronpedia.org/gemma2b-res-jb
+  saes:
+  - id: blocks.0.hook_resid_post
+    path: gemma_2b_blocks.0.hook_resid_post_16384_anthropic
+    neuronpedia: gemma-2b/0-res-jb
+    variance_explained: 0.999
+    l0: 47.0
+  - id: blocks.6.hook_resid_post
+    path: gemma_2b_blocks.6.hook_resid_post_16384_anthropic_fast_lr
+    neuronpedia: gemma-2b/6-res-jb
+    variance_explained: 0.71
+    l0: 56.0
+  - id: blocks.10.hook_resid_post
+    path: gemma_2b_blocks.10.hook_resid_post_16384
+    neuronpedia: gemma-2b/10-res-jb
+    variance_explained: -0.2
+    l0: 62.0
+  - id: blocks.12.hook_resid_post
+    path: gemma_2b_blocks.12.hook_resid_post_16384
+    neuronpedia: gemma-2b/12-res-jb
+    variance_explained: -0.65
+    l0: 62.0
+    norm_scaling_factor: 0.21381938399317255
+  - id: blocks.17.hook_resid_post
+    path: gemma_2b_blocks.17.hook_resid_post_16384
+    variance_explained: -0.85
+    l0: 54.0
+gemma-2b-it-res-jb:
+  repo_id: jbloom/Gemma-2b-IT-Residual-Stream-SAEs
+  model: gemma-2b-it
+  conversion_func: null
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+  links:
+    model: https://huggingface.co/google/gemma-2b-it
+    dashboards: https://www.neuronpedia.org/gemma2bit-res-jb
+  saes:
+  - id: blocks.12.hook_resid_post
+    path: gemma_2b_it_blocks.12.hook_resid_post_16384
+    neuronpedia: gemma-2b-it/12-res-jb
+    variance_explained: 0.57
+    l0: 61.0
+mistral-7b-res-wg:
+  repo_id: JoshEngels/Mistral-7B-Residual-Stream-SAEs
+  model: mistral-7b
+  conversion_func: null
+  config_overrides:
+    normalize_activations: constant_norm_rescale
+  saes:
+  - id: blocks.8.hook_resid_pre
+    path: mistral_7b_layer_8
+    variance_explained: 0.94
+    l0: 92
+  - id: blocks.16.hook_resid_pre
+    path: mistral_7b_layer_16
+    variance_explained: 0.85
+    l0: 74
+  - id: blocks.24.hook_resid_pre
+    path: mistral_7b_layer_24
+    variance_explained: 0.72
+    l0: 75
+gpt2-small-resid-mid-v5-32k:
+  repo_id: jbloom/GPT2-Small-OAI-v5-32k-resid-mid-SAEs
+  model: gpt2-small
+  conversion_func: null
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+  saes:
+  - id: blocks.0.hook_resid_mid
+    path: v5_32k_layer_0
+  - id: blocks.1.hook_resid_mid
+    path: v5_32k_layer_1
+  - id: blocks.2.hook_resid_mid
+    path: v5_32k_layer_2
+  - id: blocks.3.hook_resid_mid
+    path: v5_32k_layer_3
+  - id: blocks.4.hook_resid_mid
+    path: v5_32k_layer_4
+  - id: blocks.5.hook_resid_mid
+    path: v5_32k_layer_5
+  - id: blocks.6.hook_resid_mid
+    path: v5_32k_layer_6
+  - id: blocks.7.hook_resid_mid
+    path: v5_32k_layer_7
+  - id: blocks.8.hook_resid_mid
+    path: v5_32k_layer_8
+  - id: blocks.9.hook_resid_mid
+    path: v5_32k_layer_9
+  - id: blocks.10.hook_resid_mid
+    path: v5_32k_layer_10
+  - id: blocks.11.hook_resid_mid
+    path: v5_32k_layer_11
+gpt2-small-resid-mid-v5-128k:
+  repo_id: jbloom/GPT2-Small-OAI-v5-128k-resid-mid-SAEs
+  model: gpt2-small
+  conversion_func: null
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+  saes:
+  - id: blocks.0.hook_resid_mid
+    path: v5_128k_layer_0
+  - id: blocks.1.hook_resid_mid
+    path: v5_128k_layer_1
+  - id: blocks.2.hook_resid_mid
+    path: v5_128k_layer_2
+  - id: blocks.3.hook_resid_mid
+    path: v5_128k_layer_3
+  - id: blocks.4.hook_resid_mid
+    path: v5_128k_layer_4
+  - id: blocks.5.hook_resid_mid
+    path: v5_128k_layer_5
+  - id: blocks.6.hook_resid_mid
+    path: v5_128k_layer_6
+  - id: blocks.7.hook_resid_mid
+    path: v5_128k_layer_7
+  - id: blocks.8.hook_resid_mid
+    path: v5_128k_layer_8
+  - id: blocks.9.hook_resid_mid
+    path: v5_128k_layer_9
+  - id: blocks.10.hook_resid_mid
+    path: v5_128k_layer_10
+  - id: blocks.11.hook_resid_mid
+    path: v5_128k_layer_11
+gpt2-small-mlp-out-v5-32k:
+  repo_id: jbloom/GPT2-Small-OAI-v5-32k-mlp-out-SAEs
+  model: gpt2-small
+  conversion_func: null
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+  saes:
+  - id: blocks.0.hook_mlp_out
+    path: v5_32k_layer_0
+    neuronpedia: gpt2-small/0-res_mlp_32k-oai
+  - id: blocks.1.hook_mlp_out
+    path: v5_32k_layer_1
+    neuronpedia: gpt2-small/1-res_mlp_32k-oai
+  - id: blocks.2.hook_mlp_out
+    path: v5_32k_layer_2
+    neuronpedia: gpt2-small/2-res_mlp_32k-oai
+  - id: blocks.3.hook_mlp_out
+    path: v5_32k_layer_3
+    neuronpedia: gpt2-small/3-res_mlp_32k-oai
+  - id: blocks.4.hook_mlp_out
+    path: v5_32k_layer_4
+    neuronpedia: gpt2-small/4-res_mlp_32k-oai
+  - id: blocks.5.hook_mlp_out
+    path: v5_32k_layer_5
+    neuronpedia: gpt2-small/5-res_mlp_32k-oai
+  - id: blocks.6.hook_mlp_out
+    path: v5_32k_layer_6
+    neuronpedia: gpt2-small/6-res_mlp_32k-oai
+  - id: blocks.7.hook_mlp_out
+    path: v5_32k_layer_7
+    neuronpedia: gpt2-small/7-res_mlp_32k-oai
+  - id: blocks.8.hook_mlp_out
+    path: v5_32k_layer_8
+    neuronpedia: gpt2-small/8-res_mlp_32k-oai
+  - id: blocks.9.hook_mlp_out
+    path: v5_32k_layer_9
+    neuronpedia: gpt2-small/9-res_mlp_32k-oai
+  - id: blocks.10.hook_mlp_out
+    path: v5_32k_layer_10
+    neuronpedia: gpt2-small/10-res_mlp_32k-oai
+  - id: blocks.11.hook_mlp_out
+    path: v5_32k_layer_11
+    neuronpedia: gpt2-small/11-res_mlp_32k-oai
+gpt2-small-mlp-out-v5-128k:
+  repo_id: jbloom/GPT2-Small-OAI-v5-128k-mlp-out-SAEs
+  model: gpt2-small
+  conversion_func: null
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+  saes:
+  - id: blocks.0.hook_mlp_out
+    path: v5_128k_layer_0
+    neuronpedia: gpt2-small/0-res_mlp_128k-oai
+  - id: blocks.1.hook_mlp_out
+    path: v5_128k_layer_1
+    neuronpedia: gpt2-small/1-res_mlp_128k-oai
+  - id: blocks.2.hook_mlp_out
+    path: v5_128k_layer_2
+    neuronpedia: gpt2-small/2-res_mlp_128k-oai
+  - id: blocks.3.hook_mlp_out
+    path: v5_128k_layer_3
+    neuronpedia: gpt2-small/3-res_mlp_128k-oai
+  - id: blocks.4.hook_mlp_out
+    path: v5_128k_layer_4
+    neuronpedia: gpt2-small/4-res_mlp_128k-oai
+  - id: blocks.5.hook_mlp_out
+    path: v5_128k_layer_5
+    neuronpedia: gpt2-small/5-res_mlp_128k-oai
+  - id: blocks.6.hook_mlp_out
+    path: v5_128k_layer_6
+    neuronpedia: gpt2-small/6-res_mlp_128k-oai
+  - id: blocks.7.hook_mlp_out
+    path: v5_128k_layer_7
+    neuronpedia: gpt2-small/7-res_mlp_128k-oai
+  - id: blocks.8.hook_mlp_out
+    path: v5_128k_layer_8
+    neuronpedia: gpt2-small/8-res_mlp_128k-oai
+  - id: blocks.9.hook_mlp_out
+    path: v5_128k_layer_9
+    neuronpedia: gpt2-small/9-res_mlp_128k-oai
+  - id: blocks.10.hook_mlp_out
+    path: v5_128k_layer_10
+    neuronpedia: gpt2-small/10-res_mlp_128k-oai
+  - id: blocks.11.hook_mlp_out
+    path: v5_128k_layer_11
+    neuronpedia: gpt2-small/11-res_mlp_128k-oai
+gpt2-small-attn-out-v5-32k:
+  repo_id: jbloom/GPT2-Small-OAI-v5-32k-attn-out-SAEs
+  model: gpt2-small
+  conversion_func: null
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+  saes:
+  - id: blocks.0.hook_attn_out
+    path: v5_32k_layer_0
+    neuronpedia: gpt2-small/0-res_att_32k-oai
+  - id: blocks.1.hook_attn_out
+    path: v5_32k_layer_1
+    neuronpedia: gpt2-small/1-res_att_32k-oai
+  - id: blocks.2.hook_attn_out
+    path: v5_32k_layer_2
+    neuronpedia: gpt2-small/2-res_att_32k-oai
+  - id: blocks.3.hook_attn_out
+    path: v5_32k_layer_3
+    neuronpedia: gpt2-small/3-res_att_32k-oai
+  - id: blocks.4.hook_attn_out
+    path: v5_32k_layer_4
+    neuronpedia: gpt2-small/4-res_att_32k-oai
+  - id: blocks.5.hook_attn_out
+    path: v5_32k_layer_5
+    neuronpedia: gpt2-small/5-res_att_32k-oai
+  - id: blocks.6.hook_attn_out
+    path: v5_32k_layer_6
+    neuronpedia: gpt2-small/6-res_att_32k-oai
+  - id: blocks.7.hook_attn_out
+    path: v5_32k_layer_7
+    neuronpedia: gpt2-small/7-res_att_32k-oai
+  - id: blocks.8.hook_attn_out
+    path: v5_32k_layer_8
+    neuronpedia: gpt2-small/8-res_att_32k-oai
+  - id: blocks.9.hook_attn_out
+    path: v5_32k_layer_9
+    neuronpedia: gpt2-small/9-res_att_32k-oai
+  - id: blocks.10.hook_attn_out
+    path: v5_32k_layer_10
+    neuronpedia: gpt2-small/10-res_att_32k-oai
+  - id: blocks.11.hook_attn_out
+    path: v5_32k_layer_11
+    neuronpedia: gpt2-small/11-res_att_32k-oai
+gpt2-small-attn-out-v5-128k:
+  repo_id: jbloom/GPT2-Small-OAI-v5-128k-attn-out-SAEs
+  model: gpt2-small
+  conversion_func: null
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+  saes:
+  - id: blocks.0.hook_attn_out
+    path: v5_128k_layer_0
+    neuronpedia: gpt2-small/0-res_att_128k-oai
+  - id: blocks.1.hook_attn_out
+    path: v5_128k_layer_1
+    neuronpedia: gpt2-small/1-res_att_128k-oai
+  - id: blocks.2.hook_attn_out
+    path: v5_128k_layer_2
+    neuronpedia: gpt2-small/2-res_att_128k-oai
+  - id: blocks.3.hook_attn_out
+    path: v5_128k_layer_3
+    neuronpedia: gpt2-small/3-res_att_128k-oai
+  - id: blocks.4.hook_attn_out
+    path: v5_128k_layer_4
+    neuronpedia: gpt2-small/4-res_att_128k-oai
+  - id: blocks.5.hook_attn_out
+    path: v5_128k_layer_5
+    neuronpedia: gpt2-small/5-res_att_128k-oai
+  - id: blocks.6.hook_attn_out
+    path: v5_128k_layer_6
+    neuronpedia: gpt2-small/6-res_att_128k-oai
+  - id: blocks.7.hook_attn_out
+    path: v5_128k_layer_7
+    neuronpedia: gpt2-small/7-res_att_128k-oai
+  - id: blocks.8.hook_attn_out
+    path: v5_128k_layer_8
+    neuronpedia: gpt2-small/8-res_att_128k-oai
+  - id: blocks.9.hook_attn_out
+    path: v5_128k_layer_9
+    neuronpedia: gpt2-small/9-res_att_128k-oai
+  - id: blocks.10.hook_attn_out
+    path: v5_128k_layer_10
+    neuronpedia: gpt2-small/10-res_att_128k-oai
+  - id: blocks.11.hook_attn_out
+    path: v5_128k_layer_11
+    neuronpedia: gpt2-small/11-res_att_128k-oai
+gemma-scope-2b-pt-res:
+  repo_id: google/gemma-scope-2b-pt-res
+  model: gemma-2-2b
+  conversion_func: gemma_2
+  saes:
+  - id: layer_0/width_16k/average_l0_105
+    path: layer_0/width_16k/average_l0_105
+    l0: 105
+  - id: layer_0/width_16k/average_l0_13
+    path: layer_0/width_16k/average_l0_13
+    l0: 13
+  - id: layer_0/width_16k/average_l0_226
+    path: layer_0/width_16k/average_l0_226
+    l0: 226
+  - id: layer_0/width_16k/average_l0_25
+    path: layer_0/width_16k/average_l0_25
+    l0: 25
+  - id: layer_0/width_16k/average_l0_46
+    path: layer_0/width_16k/average_l0_46
+    l0: 46
+  - id: layer_1/width_16k/average_l0_10
+    path: layer_1/width_16k/average_l0_10
+    l0: 10
+  - id: layer_1/width_16k/average_l0_102
+    path: layer_1/width_16k/average_l0_102
+    l0: 102
+  - id: layer_1/width_16k/average_l0_20
+    path: layer_1/width_16k/average_l0_20
+    l0: 20
+  - id: layer_1/width_16k/average_l0_250
+    path: layer_1/width_16k/average_l0_250
+    l0: 250
+  - id: layer_1/width_16k/average_l0_40
+    path: layer_1/width_16k/average_l0_40
+    l0: 40
+  - id: layer_2/width_16k/average_l0_13
+    path: layer_2/width_16k/average_l0_13
+    l0: 13
+  - id: layer_2/width_16k/average_l0_141
+    path: layer_2/width_16k/average_l0_141
+    l0: 141
+  - id: layer_2/width_16k/average_l0_142
+    path: layer_2/width_16k/average_l0_142
+    l0: 142
+  - id: layer_2/width_16k/average_l0_24
+    path: layer_2/width_16k/average_l0_24
+    l0: 24
+  - id: layer_2/width_16k/average_l0_304
+    path: layer_2/width_16k/average_l0_304
+    l0: 304
+  - id: layer_2/width_16k/average_l0_53
+    path: layer_2/width_16k/average_l0_53
+    l0: 53
+  - id: layer_3/width_16k/average_l0_14
+    path: layer_3/width_16k/average_l0_14
+    l0: 14
+  - id: layer_3/width_16k/average_l0_142
+    path: layer_3/width_16k/average_l0_142
+    l0: 142
+  - id: layer_3/width_16k/average_l0_28
+    path: layer_3/width_16k/average_l0_28
+    l0: 28
+  - id: layer_3/width_16k/average_l0_315
+    path: layer_3/width_16k/average_l0_315
+    l0: 315
+  - id: layer_3/width_16k/average_l0_59
+    path: layer_3/width_16k/average_l0_59
+    l0: 59
+  - id: layer_4/width_16k/average_l0_124
+    path: layer_4/width_16k/average_l0_124
+    l0: 124
+  - id: layer_4/width_16k/average_l0_125
+    path: layer_4/width_16k/average_l0_125
+    l0: 125
+  - id: layer_4/width_16k/average_l0_17
+    path: layer_4/width_16k/average_l0_17
+    l0: 17
+  - id: layer_4/width_16k/average_l0_281
+    path: layer_4/width_16k/average_l0_281
+    l0: 281
+  - id: layer_4/width_16k/average_l0_31
+    path: layer_4/width_16k/average_l0_31
+    l0: 31
+  - id: layer_4/width_16k/average_l0_60
+    path: layer_4/width_16k/average_l0_60
+    l0: 60
+  - id: layer_5/width_16k/average_l0_143
+    path: layer_5/width_16k/average_l0_143
+    l0: 143
+  - id: layer_5/width_16k/average_l0_18
+    path: layer_5/width_16k/average_l0_18
+    l0: 18
+  - id: layer_5/width_16k/average_l0_309
+    path: layer_5/width_16k/average_l0_309
+    l0: 309
+  - id: layer_5/width_16k/average_l0_34
+    path: layer_5/width_16k/average_l0_34
+    l0: 34
+  - id: layer_5/width_16k/average_l0_68
+    path: layer_5/width_16k/average_l0_68
+    l0: 68
+  - id: layer_6/width_16k/average_l0_144
+    path: layer_6/width_16k/average_l0_144
+    l0: 144
+  - id: layer_6/width_16k/average_l0_19
+    path: layer_6/width_16k/average_l0_19
+    l0: 19
+  - id: layer_6/width_16k/average_l0_301
+    path: layer_6/width_16k/average_l0_301
+    l0: 301
+  - id: layer_6/width_16k/average_l0_36
+    path: layer_6/width_16k/average_l0_36
+    l0: 36
+  - id: layer_6/width_16k/average_l0_70
+    path: layer_6/width_16k/average_l0_70
+    l0: 70
+  - id: layer_7/width_16k/average_l0_137
+    path: layer_7/width_16k/average_l0_137
+    l0: 137
+  - id: layer_7/width_16k/average_l0_20
+    path: layer_7/width_16k/average_l0_20
+    l0: 20
+  - id: layer_7/width_16k/average_l0_285
+    path: layer_7/width_16k/average_l0_285
+    l0: 285
+  - id: layer_7/width_16k/average_l0_36
+    path: layer_7/width_16k/average_l0_36
+    l0: 36
+  - id: layer_7/width_16k/average_l0_69
+    path: layer_7/width_16k/average_l0_69
+    l0: 69
+  - id: layer_8/width_16k/average_l0_142
+    path: layer_8/width_16k/average_l0_142
+    l0: 142
+  - id: layer_8/width_16k/average_l0_20
+    path: layer_8/width_16k/average_l0_20
+    l0: 20
+  - id: layer_8/width_16k/average_l0_301
+    path: layer_8/width_16k/average_l0_301
+    l0: 301
+  - id: layer_8/width_16k/average_l0_37
+    path: layer_8/width_16k/average_l0_37
+    l0: 37
+  - id: layer_8/width_16k/average_l0_71
+    path: layer_8/width_16k/average_l0_71
+    l0: 71
+  - id: layer_9/width_16k/average_l0_151
+    path: layer_9/width_16k/average_l0_151
+    l0: 151
+  - id: layer_9/width_16k/average_l0_21
+    path: layer_9/width_16k/average_l0_21
+    l0: 21
+  - id: layer_9/width_16k/average_l0_340
+    path: layer_9/width_16k/average_l0_340
+    l0: 340
+  - id: layer_9/width_16k/average_l0_37
+    path: layer_9/width_16k/average_l0_37
+    l0: 37
+  - id: layer_9/width_16k/average_l0_73
+    path: layer_9/width_16k/average_l0_73
+    l0: 73
+  - id: layer_10/width_16k/average_l0_166
+    path: layer_10/width_16k/average_l0_166
+    l0: 166
+  - id: layer_10/width_16k/average_l0_21
+    path: layer_10/width_16k/average_l0_21
+    l0: 21
+  - id: layer_10/width_16k/average_l0_39
+    path: layer_10/width_16k/average_l0_39
+    l0: 39
+  - id: layer_10/width_16k/average_l0_395
+    path: layer_10/width_16k/average_l0_395
+    l0: 395
+  - id: layer_10/width_16k/average_l0_77
+    path: layer_10/width_16k/average_l0_77
+    l0: 77
+  - id: layer_11/width_16k/average_l0_168
+    path: layer_11/width_16k/average_l0_168
+    l0: 168
+  - id: layer_11/width_16k/average_l0_22
+    path: layer_11/width_16k/average_l0_22
+    l0: 22
+  - id: layer_11/width_16k/average_l0_393
+    path: layer_11/width_16k/average_l0_393
+    l0: 393
+  - id: layer_11/width_16k/average_l0_41
+    path: layer_11/width_16k/average_l0_41
+    l0: 41
+  - id: layer_11/width_16k/average_l0_79
+    path: layer_11/width_16k/average_l0_79
+    l0: 79
+  - id: layer_11/width_16k/average_l0_80
+    path: layer_11/width_16k/average_l0_80
+    l0: 80
+  - id: layer_12/width_16k/average_l0_176
+    path: layer_12/width_16k/average_l0_176
+    l0: 176
+  - id: layer_12/width_16k/average_l0_22
+    path: layer_12/width_16k/average_l0_22
+    l0: 22
+  - id: layer_12/width_16k/average_l0_41
+    path: layer_12/width_16k/average_l0_41
+    l0: 41
+  - id: layer_12/width_16k/average_l0_445
+    path: layer_12/width_16k/average_l0_445
+    l0: 445
+  - id: layer_12/width_16k/average_l0_82
+    path: layer_12/width_16k/average_l0_82
+    l0: 82
+  - id: layer_13/width_16k/average_l0_173
+    path: layer_13/width_16k/average_l0_173
+    l0: 173
+  - id: layer_13/width_16k/average_l0_23
+    path: layer_13/width_16k/average_l0_23
+    l0: 23
+  - id: layer_13/width_16k/average_l0_403
+    path: layer_13/width_16k/average_l0_403
+    l0: 403
+  - id: layer_13/width_16k/average_l0_43
+    path: layer_13/width_16k/average_l0_43
+    l0: 43
+  - id: layer_13/width_16k/average_l0_83
+    path: layer_13/width_16k/average_l0_83
+    l0: 83
+  - id: layer_13/width_16k/average_l0_84
+    path: layer_13/width_16k/average_l0_84
+    l0: 84
+  - id: layer_14/width_16k/average_l0_173
+    path: layer_14/width_16k/average_l0_173
+    l0: 173
+  - id: layer_14/width_16k/average_l0_23
+    path: layer_14/width_16k/average_l0_23
+    l0: 23
+  - id: layer_14/width_16k/average_l0_388
+    path: layer_14/width_16k/average_l0_388
+    l0: 388
+  - id: layer_14/width_16k/average_l0_43
+    path: layer_14/width_16k/average_l0_43
+    l0: 43
+  - id: layer_14/width_16k/average_l0_83
+    path: layer_14/width_16k/average_l0_83
+    l0: 83
+  - id: layer_14/width_16k/average_l0_84
+    path: layer_14/width_16k/average_l0_84
+    l0: 84
+  - id: layer_15/width_16k/average_l0_150
+    path: layer_15/width_16k/average_l0_150
+    l0: 150
+  - id: layer_15/width_16k/average_l0_23
+    path: layer_15/width_16k/average_l0_23
+    l0: 23
+  - id: layer_15/width_16k/average_l0_308
+    path: layer_15/width_16k/average_l0_308
+    l0: 308
+  - id: layer_15/width_16k/average_l0_41
+    path: layer_15/width_16k/average_l0_41
+    l0: 41
+  - id: layer_15/width_16k/average_l0_78
+    path: layer_15/width_16k/average_l0_78
+    l0: 78
+  - id: layer_16/width_16k/average_l0_154
+    path: layer_16/width_16k/average_l0_154
+    l0: 154
+  - id: layer_16/width_16k/average_l0_23
+    path: layer_16/width_16k/average_l0_23
+    l0: 23
+  - id: layer_16/width_16k/average_l0_335
+    path: layer_16/width_16k/average_l0_335
+    l0: 335
+  - id: layer_16/width_16k/average_l0_42
+    path: layer_16/width_16k/average_l0_42
+    l0: 42
+  - id: layer_16/width_16k/average_l0_78
+    path: layer_16/width_16k/average_l0_78
+    l0: 78
+  - id: layer_17/width_16k/average_l0_150
+    path: layer_17/width_16k/average_l0_150
+    l0: 150
+  - id: layer_17/width_16k/average_l0_23
+    path: layer_17/width_16k/average_l0_23
+    l0: 23
+  - id: layer_17/width_16k/average_l0_304
+    path: layer_17/width_16k/average_l0_304
+    l0: 304
+  - id: layer_17/width_16k/average_l0_42
+    path: layer_17/width_16k/average_l0_42
+    l0: 42
+  - id: layer_17/width_16k/average_l0_77
+    path: layer_17/width_16k/average_l0_77
+    l0: 77
+  - id: layer_18/width_16k/average_l0_138
+    path: layer_18/width_16k/average_l0_138
+    l0: 138
+  - id: layer_18/width_16k/average_l0_23
+    path: layer_18/width_16k/average_l0_23
+    l0: 23
+  - id: layer_18/width_16k/average_l0_280
+    path: layer_18/width_16k/average_l0_280
+    l0: 280
+  - id: layer_18/width_16k/average_l0_40
+    path: layer_18/width_16k/average_l0_40
+    l0: 40
+  - id: layer_18/width_16k/average_l0_74
+    path: layer_18/width_16k/average_l0_74
+    l0: 74
+  - id: layer_19/width_16k/average_l0_137
+    path: layer_19/width_16k/average_l0_137
+    l0: 137
+  - id: layer_19/width_16k/average_l0_23
+    path: layer_19/width_16k/average_l0_23
+    l0: 23
+  - id: layer_19/width_16k/average_l0_279
+    path: layer_19/width_16k/average_l0_279
+    l0: 279
+  - id: layer_19/width_16k/average_l0_40
+    path: layer_19/width_16k/average_l0_40
+    l0: 40
+  - id: layer_19/width_16k/average_l0_73
+    path: layer_19/width_16k/average_l0_73
+    l0: 73
+  - id: layer_20/width_16k/average_l0_139
+    path: layer_20/width_16k/average_l0_139
+    l0: 139
+  - id: layer_20/width_16k/average_l0_22
+    path: layer_20/width_16k/average_l0_22
+    l0: 22
+  - id: layer_20/width_16k/average_l0_294
+    path: layer_20/width_16k/average_l0_294
+    l0: 294
+  - id: layer_20/width_16k/average_l0_38
+    path: layer_20/width_16k/average_l0_38
+    l0: 38
+  - id: layer_20/width_16k/average_l0_71
+    path: layer_20/width_16k/average_l0_71
+    l0: 71
+  - id: layer_21/width_16k/average_l0_139
+    path: layer_21/width_16k/average_l0_139
+    l0: 139
+  - id: layer_21/width_16k/average_l0_22
+    path: layer_21/width_16k/average_l0_22
+    l0: 22
+  - id: layer_21/width_16k/average_l0_301
+    path: layer_21/width_16k/average_l0_301
+    l0: 301
+  - id: layer_21/width_16k/average_l0_38
+    path: layer_21/width_16k/average_l0_38
+    l0: 38
+  - id: layer_21/width_16k/average_l0_70
+    path: layer_21/width_16k/average_l0_70
+    l0: 70
+  - id: layer_22/width_16k/average_l0_147
+    path: layer_22/width_16k/average_l0_147
+    l0: 147
+  - id: layer_22/width_16k/average_l0_21
+    path: layer_22/width_16k/average_l0_21
+    l0: 21
+  - id: layer_22/width_16k/average_l0_349
+    path: layer_22/width_16k/average_l0_349
+    l0: 349
+  - id: layer_22/width_16k/average_l0_38
+    path: layer_22/width_16k/average_l0_38
+    l0: 38
+  - id: layer_22/width_16k/average_l0_72
+    path: layer_22/width_16k/average_l0_72
+    l0: 72
+  - id: layer_23/width_16k/average_l0_157
+    path: layer_23/width_16k/average_l0_157
+    l0: 157
+  - id: layer_23/width_16k/average_l0_21
+    path: layer_23/width_16k/average_l0_21
+    l0: 21
+  - id: layer_23/width_16k/average_l0_38
+    path: layer_23/width_16k/average_l0_38
+    l0: 38
+  - id: layer_23/width_16k/average_l0_404
+    path: layer_23/width_16k/average_l0_404
+    l0: 404
+  - id: layer_23/width_16k/average_l0_74
+    path: layer_23/width_16k/average_l0_74
+    l0: 74
+  - id: layer_23/width_16k/average_l0_75
+    path: layer_23/width_16k/average_l0_75
+    l0: 75
+  - id: layer_24/width_16k/average_l0_158
+    path: layer_24/width_16k/average_l0_158
+    l0: 158
+  - id: layer_24/width_16k/average_l0_20
+    path: layer_24/width_16k/average_l0_20
+    l0: 20
+  - id: layer_24/width_16k/average_l0_38
+    path: layer_24/width_16k/average_l0_38
+    l0: 38
+  - id: layer_24/width_16k/average_l0_457
+    path: layer_24/width_16k/average_l0_457
+    l0: 457
+  - id: layer_24/width_16k/average_l0_73
+    path: layer_24/width_16k/average_l0_73
+    l0: 73
+  - id: layer_25/width_16k/average_l0_116
+    path: layer_25/width_16k/average_l0_116
+    l0: 116
+  - id: layer_25/width_16k/average_l0_16
+    path: layer_25/width_16k/average_l0_16
+    l0: 16
+  - id: layer_25/width_16k/average_l0_28
+    path: layer_25/width_16k/average_l0_28
+    l0: 28
+  - id: layer_25/width_16k/average_l0_285
+    path: layer_25/width_16k/average_l0_285
+    l0: 285
+  - id: layer_25/width_16k/average_l0_55
+    path: layer_25/width_16k/average_l0_55
+    l0: 55
+  - id: layer_5/width_1m/average_l0_114
+    path: layer_5/width_1m/average_l0_114
+    l0: 114
+  - id: layer_5/width_1m/average_l0_13
+    path: layer_5/width_1m/average_l0_13
+    l0: 13
+  - id: layer_5/width_1m/average_l0_21
+    path: layer_5/width_1m/average_l0_21
+    l0: 21
+  - id: layer_5/width_1m/average_l0_36
+    path: layer_5/width_1m/average_l0_36
+    l0: 36
+  - id: layer_5/width_1m/average_l0_63
+    path: layer_5/width_1m/average_l0_63
+    l0: 63
+  - id: layer_5/width_1m/average_l0_9
+    path: layer_5/width_1m/average_l0_9
+    l0: 9
+  - id: layer_12/width_1m/average_l0_107
+    path: layer_12/width_1m/average_l0_107
+    l0: 107
+  - id: layer_12/width_1m/average_l0_19
+    path: layer_12/width_1m/average_l0_19
+    l0: 19
+  - id: layer_12/width_1m/average_l0_207
+    path: layer_12/width_1m/average_l0_207
+    l0: 207
+  - id: layer_12/width_1m/average_l0_26
+    path: layer_12/width_1m/average_l0_26
+    l0: 26
+  - id: layer_12/width_1m/average_l0_58
+    path: layer_12/width_1m/average_l0_58
+    l0: 58
+  - id: layer_12/width_1m/average_l0_73
+    path: layer_12/width_1m/average_l0_73
+    l0: 73
+  - id: layer_19/width_1m/average_l0_157
+    path: layer_19/width_1m/average_l0_157
+    l0: 157
+  - id: layer_19/width_1m/average_l0_16
+    path: layer_19/width_1m/average_l0_16
+    l0: 16
+  - id: layer_19/width_1m/average_l0_18
+    path: layer_19/width_1m/average_l0_18
+    l0: 18
+  - id: layer_19/width_1m/average_l0_29
+    path: layer_19/width_1m/average_l0_29
+    l0: 29
+  - id: layer_19/width_1m/average_l0_50
+    path: layer_19/width_1m/average_l0_50
+    l0: 50
+  - id: layer_19/width_1m/average_l0_88
+    path: layer_19/width_1m/average_l0_88
+    l0: 88
+  - id: layer_12/width_262k/average_l0_11
+    path: layer_12/width_262k/average_l0_11
+    l0: 11
+  - id: layer_12/width_262k/average_l0_121
+    path: layer_12/width_262k/average_l0_121
+    l0: 121
+  - id: layer_12/width_262k/average_l0_21
+    path: layer_12/width_262k/average_l0_21
+    l0: 21
+  - id: layer_12/width_262k/average_l0_243
+    path: layer_12/width_262k/average_l0_243
+    l0: 243
+  - id: layer_12/width_262k/average_l0_36
+    path: layer_12/width_262k/average_l0_36
+    l0: 36
+  - id: layer_12/width_262k/average_l0_67
+    path: layer_12/width_262k/average_l0_67
+    l0: 67
+  - id: layer_12/width_32k/average_l0_12
+    path: layer_12/width_32k/average_l0_12
+    l0: 12
+  - id: layer_12/width_32k/average_l0_155
+    path: layer_12/width_32k/average_l0_155
+    l0: 155
+  - id: layer_12/width_32k/average_l0_22
+    path: layer_12/width_32k/average_l0_22
+    l0: 22
+  - id: layer_12/width_32k/average_l0_360
+    path: layer_12/width_32k/average_l0_360
+    l0: 360
+  - id: layer_12/width_32k/average_l0_40
+    path: layer_12/width_32k/average_l0_40
+    l0: 40
+  - id: layer_12/width_32k/average_l0_76
+    path: layer_12/width_32k/average_l0_76
+    l0: 76
+  - id: layer_12/width_524k/average_l0_115
+    path: layer_12/width_524k/average_l0_115
+    l0: 115
+  - id: layer_12/width_524k/average_l0_22
+    path: layer_12/width_524k/average_l0_22
+    l0: 22
+  - id: layer_12/width_524k/average_l0_227
+    path: layer_12/width_524k/average_l0_227
+    l0: 227
+  - id: layer_12/width_524k/average_l0_29
+    path: layer_12/width_524k/average_l0_29
+    l0: 29
+  - id: layer_12/width_524k/average_l0_46
+    path: layer_12/width_524k/average_l0_46
+    l0: 46
+  - id: layer_12/width_524k/average_l0_65
+    path: layer_12/width_524k/average_l0_65
+    l0: 65
+  - id: layer_0/width_65k/average_l0_11
+    path: layer_0/width_65k/average_l0_11
+    l0: 11
+  - id: layer_0/width_65k/average_l0_17
+    path: layer_0/width_65k/average_l0_17
+    l0: 17
+  - id: layer_0/width_65k/average_l0_27
+    path: layer_0/width_65k/average_l0_27
+    l0: 27
+  - id: layer_0/width_65k/average_l0_43
+    path: layer_0/width_65k/average_l0_43
+    l0: 43
+  - id: layer_0/width_65k/average_l0_73
+    path: layer_0/width_65k/average_l0_73
+    l0: 73
+  - id: layer_1/width_65k/average_l0_121
+    path: layer_1/width_65k/average_l0_121
+    l0: 121
+  - id: layer_1/width_65k/average_l0_16
+    path: layer_1/width_65k/average_l0_16
+    l0: 16
+  - id: layer_1/width_65k/average_l0_30
+    path: layer_1/width_65k/average_l0_30
+    l0: 30
+  - id: layer_1/width_65k/average_l0_54
+    path: layer_1/width_65k/average_l0_54
+    l0: 54
+  - id: layer_1/width_65k/average_l0_9
+    path: layer_1/width_65k/average_l0_9
+    l0: 9
+  - id: layer_2/width_65k/average_l0_11
+    path: layer_2/width_65k/average_l0_11
+    l0: 11
+  - id: layer_2/width_65k/average_l0_169
+    path: layer_2/width_65k/average_l0_169
+    l0: 169
+  - id: layer_2/width_65k/average_l0_20
+    path: layer_2/width_65k/average_l0_20
+    l0: 20
+  - id: layer_2/width_65k/average_l0_37
+    path: layer_2/width_65k/average_l0_37
+    l0: 37
+  - id: layer_2/width_65k/average_l0_77
+    path: layer_2/width_65k/average_l0_77
+    l0: 77
+  - id: layer_3/width_65k/average_l0_13
+    path: layer_3/width_65k/average_l0_13
+    l0: 13
+  - id: layer_3/width_65k/average_l0_193
+    path: layer_3/width_65k/average_l0_193
+    l0: 193
+  - id: layer_3/width_65k/average_l0_23
+    path: layer_3/width_65k/average_l0_23
+    l0: 23
+  - id: layer_3/width_65k/average_l0_42
+    path: layer_3/width_65k/average_l0_42
+    l0: 42
+  - id: layer_3/width_65k/average_l0_89
+    path: layer_3/width_65k/average_l0_89
+    l0: 89
+  - id: layer_4/width_65k/average_l0_14
+    path: layer_4/width_65k/average_l0_14
+    l0: 14
+  - id: layer_4/width_65k/average_l0_177
+    path: layer_4/width_65k/average_l0_177
+    l0: 177
+  - id: layer_4/width_65k/average_l0_25
+    path: layer_4/width_65k/average_l0_25
+    l0: 25
+  - id: layer_4/width_65k/average_l0_46
+    path: layer_4/width_65k/average_l0_46
+    l0: 46
+  - id: layer_4/width_65k/average_l0_89
+    path: layer_4/width_65k/average_l0_89
+    l0: 89
+  - id: layer_5/width_65k/average_l0_105
+    path: layer_5/width_65k/average_l0_105
+    l0: 105
+  - id: layer_5/width_65k/average_l0_17
+    path: layer_5/width_65k/average_l0_17
+    l0: 17
+  - id: layer_5/width_65k/average_l0_211
+    path: layer_5/width_65k/average_l0_211
+    l0: 211
+  - id: layer_5/width_65k/average_l0_29
+    path: layer_5/width_65k/average_l0_29
+    l0: 29
+  - id: layer_5/width_65k/average_l0_53
+    path: layer_5/width_65k/average_l0_53
+    l0: 53
+  - id: layer_6/width_65k/average_l0_107
+    path: layer_6/width_65k/average_l0_107
+    l0: 107
+  - id: layer_6/width_65k/average_l0_17
+    path: layer_6/width_65k/average_l0_17
+    l0: 17
+  - id: layer_6/width_65k/average_l0_208
+    path: layer_6/width_65k/average_l0_208
+    l0: 208
+  - id: layer_6/width_65k/average_l0_30
+    path: layer_6/width_65k/average_l0_30
+    l0: 30
+  - id: layer_6/width_65k/average_l0_56
+    path: layer_6/width_65k/average_l0_56
+    l0: 56
+  - id: layer_7/width_65k/average_l0_107
+    path: layer_7/width_65k/average_l0_107
+    l0: 107
+  - id: layer_7/width_65k/average_l0_18
+    path: layer_7/width_65k/average_l0_18
+    l0: 18
+  - id: layer_7/width_65k/average_l0_203
+    path: layer_7/width_65k/average_l0_203
+    l0: 203
+  - id: layer_7/width_65k/average_l0_31
+    path: layer_7/width_65k/average_l0_31
+    l0: 31
+  - id: layer_7/width_65k/average_l0_57
+    path: layer_7/width_65k/average_l0_57
+    l0: 57
+  - id: layer_8/width_65k/average_l0_111
+    path: layer_8/width_65k/average_l0_111
+    l0: 111
+  - id: layer_8/width_65k/average_l0_19
+    path: layer_8/width_65k/average_l0_19
+    l0: 19
+  - id: layer_8/width_65k/average_l0_213
+    path: layer_8/width_65k/average_l0_213
+    l0: 213
+  - id: layer_8/width_65k/average_l0_33
+    path: layer_8/width_65k/average_l0_33
+    l0: 33
+  - id: layer_8/width_65k/average_l0_59
+    path: layer_8/width_65k/average_l0_59
+    l0: 59
+  - id: layer_9/width_65k/average_l0_118
+    path: layer_9/width_65k/average_l0_118
+    l0: 118
+  - id: layer_9/width_65k/average_l0_19
+    path: layer_9/width_65k/average_l0_19
+    l0: 19
+  - id: layer_9/width_65k/average_l0_240
+    path: layer_9/width_65k/average_l0_240
+    l0: 240
+  - id: layer_9/width_65k/average_l0_34
+    path: layer_9/width_65k/average_l0_34
+    l0: 34
+  - id: layer_9/width_65k/average_l0_61
+    path: layer_9/width_65k/average_l0_61
+    l0: 61
+  - id: layer_10/width_65k/average_l0_128
+    path: layer_10/width_65k/average_l0_128
+    l0: 128
+  - id: layer_10/width_65k/average_l0_20
+    path: layer_10/width_65k/average_l0_20
+    l0: 20
+  - id: layer_10/width_65k/average_l0_265
+    path: layer_10/width_65k/average_l0_265
+    l0: 265
+  - id: layer_10/width_65k/average_l0_36
+    path: layer_10/width_65k/average_l0_36
+    l0: 36
+  - id: layer_10/width_65k/average_l0_66
+    path: layer_10/width_65k/average_l0_66
+    l0: 66
+  - id: layer_11/width_65k/average_l0_134
+    path: layer_11/width_65k/average_l0_134
+    l0: 134
+  - id: layer_11/width_65k/average_l0_21
+    path: layer_11/width_65k/average_l0_21
+    l0: 21
+  - id: layer_11/width_65k/average_l0_273
+    path: layer_11/width_65k/average_l0_273
+    l0: 273
+  - id: layer_11/width_65k/average_l0_37
+    path: layer_11/width_65k/average_l0_37
+    l0: 37
+  - id: layer_11/width_65k/average_l0_70
+    path: layer_11/width_65k/average_l0_70
+    l0: 70
+  - id: layer_12/width_65k/average_l0_141
+    path: layer_12/width_65k/average_l0_141
+    l0: 141
+  - id: layer_12/width_65k/average_l0_21
+    path: layer_12/width_65k/average_l0_21
+    l0: 21
+  - id: layer_12/width_65k/average_l0_297
+    path: layer_12/width_65k/average_l0_297
+    l0: 297
+  - id: layer_12/width_65k/average_l0_38
+    path: layer_12/width_65k/average_l0_38
+    l0: 38
+  - id: layer_12/width_65k/average_l0_72
+    path: layer_12/width_65k/average_l0_72
+    l0: 72
+  - id: layer_13/width_65k/average_l0_142
+    path: layer_13/width_65k/average_l0_142
+    l0: 142
+  - id: layer_13/width_65k/average_l0_22
+    path: layer_13/width_65k/average_l0_22
+    l0: 22
+  - id: layer_13/width_65k/average_l0_288
+    path: layer_13/width_65k/average_l0_288
+    l0: 288
+  - id: layer_13/width_65k/average_l0_40
+    path: layer_13/width_65k/average_l0_40
+    l0: 40
+  - id: layer_13/width_65k/average_l0_74
+    path: layer_13/width_65k/average_l0_74
+    l0: 74
+  - id: layer_13/width_65k/average_l0_75
+    path: layer_13/width_65k/average_l0_75
+    l0: 75
+  - id: layer_14/width_65k/average_l0_144
+    path: layer_14/width_65k/average_l0_144
+    l0: 144
+  - id: layer_14/width_65k/average_l0_21
+    path: layer_14/width_65k/average_l0_21
+    l0: 21
+  - id: layer_14/width_65k/average_l0_284
+    path: layer_14/width_65k/average_l0_284
+    l0: 284
+  - id: layer_14/width_65k/average_l0_40
+    path: layer_14/width_65k/average_l0_40
+    l0: 40
+  - id: layer_14/width_65k/average_l0_73
+    path: layer_14/width_65k/average_l0_73
+    l0: 73
+  - id: layer_15/width_65k/average_l0_127
+    path: layer_15/width_65k/average_l0_127
+    l0: 127
+  - id: layer_15/width_65k/average_l0_21
+    path: layer_15/width_65k/average_l0_21
+    l0: 21
+  - id: layer_15/width_65k/average_l0_240
+    path: layer_15/width_65k/average_l0_240
+    l0: 240
+  - id: layer_15/width_65k/average_l0_38
+    path: layer_15/width_65k/average_l0_38
+    l0: 38
+  - id: layer_15/width_65k/average_l0_68
+    path: layer_15/width_65k/average_l0_68
+    l0: 68
+  - id: layer_16/width_65k/average_l0_128
+    path: layer_16/width_65k/average_l0_128
+    l0: 128
+  - id: layer_16/width_65k/average_l0_21
+    path: layer_16/width_65k/average_l0_21
+    l0: 21
+  - id: layer_16/width_65k/average_l0_244
+    path: layer_16/width_65k/average_l0_244
+    l0: 244
+  - id: layer_16/width_65k/average_l0_38
+    path: layer_16/width_65k/average_l0_38
+    l0: 38
+  - id: layer_16/width_65k/average_l0_69
+    path: layer_16/width_65k/average_l0_69
+    l0: 69
+  - id: layer_17/width_65k/average_l0_125
+    path: layer_17/width_65k/average_l0_125
+    l0: 125
+  - id: layer_17/width_65k/average_l0_21
+    path: layer_17/width_65k/average_l0_21
+    l0: 21
+  - id: layer_17/width_65k/average_l0_233
+    path: layer_17/width_65k/average_l0_233
+    l0: 233
+  - id: layer_17/width_65k/average_l0_38
+    path: layer_17/width_65k/average_l0_38
+    l0: 38
+  - id: layer_17/width_65k/average_l0_68
+    path: layer_17/width_65k/average_l0_68
+    l0: 68
+  - id: layer_18/width_65k/average_l0_116
+    path: layer_18/width_65k/average_l0_116
+    l0: 116
+  - id: layer_18/width_65k/average_l0_117
+    path: layer_18/width_65k/average_l0_117
+    l0: 117
+  - id: layer_18/width_65k/average_l0_21
+    path: layer_18/width_65k/average_l0_21
+    l0: 21
+  - id: layer_18/width_65k/average_l0_216
+    path: layer_18/width_65k/average_l0_216
+    l0: 216
+  - id: layer_18/width_65k/average_l0_36
+    path: layer_18/width_65k/average_l0_36
+    l0: 36
+  - id: layer_18/width_65k/average_l0_64
+    path: layer_18/width_65k/average_l0_64
+    l0: 64
+  - id: layer_19/width_65k/average_l0_115
+    path: layer_19/width_65k/average_l0_115
+    l0: 115
+  - id: layer_19/width_65k/average_l0_21
+    path: layer_19/width_65k/average_l0_21
+    l0: 21
+  - id: layer_19/width_65k/average_l0_216
+    path: layer_19/width_65k/average_l0_216
+    l0: 216
+  - id: layer_19/width_65k/average_l0_35
+    path: layer_19/width_65k/average_l0_35
+    l0: 35
+  - id: layer_19/width_65k/average_l0_63
+    path: layer_19/width_65k/average_l0_63
+    l0: 63
+  - id: layer_20/width_65k/average_l0_114
+    path: layer_20/width_65k/average_l0_114
+    l0: 114
+  - id: layer_20/width_65k/average_l0_20
+    path: layer_20/width_65k/average_l0_20
+    l0: 20
+  - id: layer_20/width_65k/average_l0_221
+    path: layer_20/width_65k/average_l0_221
+    l0: 221
+  - id: layer_20/width_65k/average_l0_34
+    path: layer_20/width_65k/average_l0_34
+    l0: 34
+  - id: layer_20/width_65k/average_l0_61
+    path: layer_20/width_65k/average_l0_61
+    l0: 61
+  - id: layer_21/width_65k/average_l0_111
+    path: layer_21/width_65k/average_l0_111
+    l0: 111
+  - id: layer_21/width_65k/average_l0_112
+    path: layer_21/width_65k/average_l0_112
+    l0: 112
+  - id: layer_21/width_65k/average_l0_20
+    path: layer_21/width_65k/average_l0_20
+    l0: 20
+  - id: layer_21/width_65k/average_l0_225
+    path: layer_21/width_65k/average_l0_225
+    l0: 225
+  - id: layer_21/width_65k/average_l0_33
+    path: layer_21/width_65k/average_l0_33
+    l0: 33
+  - id: layer_21/width_65k/average_l0_61
+    path: layer_21/width_65k/average_l0_61
+    l0: 61
+  - id: layer_22/width_65k/average_l0_116
+    path: layer_22/width_65k/average_l0_116
+    l0: 116
+  - id: layer_22/width_65k/average_l0_117
+    path: layer_22/width_65k/average_l0_117
+    l0: 117
+  - id: layer_22/width_65k/average_l0_20
+    path: layer_22/width_65k/average_l0_20
+    l0: 20
+  - id: layer_22/width_65k/average_l0_248
+    path: layer_22/width_65k/average_l0_248
+    l0: 248
+  - id: layer_22/width_65k/average_l0_33
+    path: layer_22/width_65k/average_l0_33
+    l0: 33
+  - id: layer_22/width_65k/average_l0_62
+    path: layer_22/width_65k/average_l0_62
+    l0: 62
+  - id: layer_23/width_65k/average_l0_123
+    path: layer_23/width_65k/average_l0_123
+    l0: 123
+  - id: layer_23/width_65k/average_l0_124
+    path: layer_23/width_65k/average_l0_124
+    l0: 124
+  - id: layer_23/width_65k/average_l0_20
+    path: layer_23/width_65k/average_l0_20
+    l0: 20
+  - id: layer_23/width_65k/average_l0_272
+    path: layer_23/width_65k/average_l0_272
+    l0: 272
+  - id: layer_23/width_65k/average_l0_35
+    path: layer_23/width_65k/average_l0_35
+    l0: 35
+  - id: layer_23/width_65k/average_l0_64
+    path: layer_23/width_65k/average_l0_64
+    l0: 64
+  - id: layer_24/width_65k/average_l0_124
+    path: layer_24/width_65k/average_l0_124
+    l0: 124
+  - id: layer_24/width_65k/average_l0_19
+    path: layer_24/width_65k/average_l0_19
+    l0: 19
+  - id: layer_24/width_65k/average_l0_273
+    path: layer_24/width_65k/average_l0_273
+    l0: 273
+  - id: layer_24/width_65k/average_l0_34
+    path: layer_24/width_65k/average_l0_34
+    l0: 34
+  - id: layer_24/width_65k/average_l0_63
+    path: layer_24/width_65k/average_l0_63
+    l0: 63
+  - id: layer_25/width_65k/average_l0_15
+    path: layer_25/width_65k/average_l0_15
+    l0: 15
+  - id: layer_25/width_65k/average_l0_197
+    path: layer_25/width_65k/average_l0_197
+    l0: 197
+  - id: layer_25/width_65k/average_l0_26
+    path: layer_25/width_65k/average_l0_26
+    l0: 26
+  - id: layer_25/width_65k/average_l0_48
+    path: layer_25/width_65k/average_l0_48
+    l0: 48
+  - id: layer_25/width_65k/average_l0_93
+    path: layer_25/width_65k/average_l0_93
+    l0: 93
+gemma-scope-2b-pt-res-canonical:
+  repo_id: google/gemma-scope-2b-pt-res
+  model: gemma-2-2b
+  conversion_func: gemma_2
+  links:
+    model: https://huggingface.co/google/gemma-2-2b
+    dashboards: https://www.neuronpedia.org/gemma-2-2b/gemmascope-res-16k
+    publication: https://huggingface.co/google/gemma-scope
+  saes:
+  - id: layer_0/width_16k/canonical
+    path: layer_0/width_16k/average_l0_105
+    neuronpedia: gemma-2-2b/0-gemmascope-res-16k
+  - id: layer_1/width_16k/canonical
+    path: layer_1/width_16k/average_l0_102
+    neuronpedia: gemma-2-2b/1-gemmascope-res-16k
+  - id: layer_2/width_16k/canonical
+    path: layer_2/width_16k/average_l0_141
+    neuronpedia: gemma-2-2b/2-gemmascope-res-16k
+  - id: layer_3/width_16k/canonical
+    path: layer_3/width_16k/average_l0_59
+    neuronpedia: gemma-2-2b/3-gemmascope-res-16k
+  - id: layer_4/width_16k/canonical
+    path: layer_4/width_16k/average_l0_124
+    neuronpedia: gemma-2-2b/4-gemmascope-res-16k
+  - id: layer_5/width_16k/canonical
+    path: layer_5/width_16k/average_l0_68
+    neuronpedia: gemma-2-2b/5-gemmascope-res-16k
+  - id: layer_6/width_16k/canonical
+    path: layer_6/width_16k/average_l0_70
+    neuronpedia: gemma-2-2b/6-gemmascope-res-16k
+  - id: layer_7/width_16k/canonical
+    path: layer_7/width_16k/average_l0_69
+    neuronpedia: gemma-2-2b/7-gemmascope-res-16k
+  - id: layer_8/width_16k/canonical
+    path: layer_8/width_16k/average_l0_71
+    neuronpedia: gemma-2-2b/8-gemmascope-res-16k
+  - id: layer_9/width_16k/canonical
+    path: layer_9/width_16k/average_l0_73
+    neuronpedia: gemma-2-2b/9-gemmascope-res-16k
+  - id: layer_10/width_16k/canonical
+    path: layer_10/width_16k/average_l0_77
+    neuronpedia: gemma-2-2b/10-gemmascope-res-16k
+  - id: layer_11/width_16k/canonical
+    path: layer_11/width_16k/average_l0_80
+    neuronpedia: gemma-2-2b/11-gemmascope-res-16k
+  - id: layer_12/width_16k/canonical
+    path: layer_12/width_16k/average_l0_82
+    neuronpedia: gemma-2-2b/12-gemmascope-res-16k
+  - id: layer_13/width_16k/canonical
+    path: layer_13/width_16k/average_l0_84
+    neuronpedia: gemma-2-2b/13-gemmascope-res-16k
+  - id: layer_14/width_16k/canonical
+    path: layer_14/width_16k/average_l0_84
+    neuronpedia: gemma-2-2b/14-gemmascope-res-16k
+  - id: layer_15/width_16k/canonical
+    path: layer_15/width_16k/average_l0_78
+    neuronpedia: gemma-2-2b/15-gemmascope-res-16k
+  - id: layer_16/width_16k/canonical
+    path: layer_16/width_16k/average_l0_78
+    neuronpedia: gemma-2-2b/16-gemmascope-res-16k
+  - id: layer_17/width_16k/canonical
+    path: layer_17/width_16k/average_l0_77
+    neuronpedia: gemma-2-2b/17-gemmascope-res-16k
+  - id: layer_18/width_16k/canonical
+    path: layer_18/width_16k/average_l0_74
+    neuronpedia: gemma-2-2b/18-gemmascope-res-16k
+  - id: layer_19/width_16k/canonical
+    path: layer_19/width_16k/average_l0_73
+    neuronpedia: gemma-2-2b/19-gemmascope-res-16k
+  - id: layer_20/width_16k/canonical
+    path: layer_20/width_16k/average_l0_71
+    neuronpedia: gemma-2-2b/20-gemmascope-res-16k
+  - id: layer_21/width_16k/canonical
+    path: layer_21/width_16k/average_l0_70
+    neuronpedia: gemma-2-2b/21-gemmascope-res-16k
+  - id: layer_22/width_16k/canonical
+    path: layer_22/width_16k/average_l0_72
+    neuronpedia: gemma-2-2b/22-gemmascope-res-16k
+  - id: layer_23/width_16k/canonical
+    path: layer_23/width_16k/average_l0_75
+    neuronpedia: gemma-2-2b/23-gemmascope-res-16k
+  - id: layer_24/width_16k/canonical
+    path: layer_24/width_16k/average_l0_73
+    neuronpedia: gemma-2-2b/24-gemmascope-res-16k
+  - id: layer_25/width_16k/canonical
+    path: layer_25/width_16k/average_l0_116
+    neuronpedia: gemma-2-2b/25-gemmascope-res-16k
+  - id: layer_5/width_1m/canonical
+    path: layer_5/width_1m/average_l0_114
+    neuronpedia: gemma-2-2b/5-gemmascope-res-1m
+  - id: layer_12/width_1m/canonical
+    path: layer_12/width_1m/average_l0_107
+    neuronpedia: gemma-2-2b/12-gemmascope-res-1m
+  - id: layer_19/width_1m/canonical
+    path: layer_19/width_1m/average_l0_88
+    neuronpedia: gemma-2-2b/19-gemmascope-res-1m
+  - id: layer_12/width_262k/canonical
+    path: layer_12/width_262k/average_l0_121
+    neuronpedia: gemma-2-2b/12-gemmascope-res-262k
+  - id: layer_12/width_32k/canonical
+    path: layer_12/width_32k/average_l0_76
+    neuronpedia: gemma-2-2b/12-gemmascope-res-32k
+  - id: layer_12/width_524k/canonical
+    path: layer_12/width_524k/average_l0_115
+    neuronpedia: gemma-2-2b/12-gemmascope-res-524k
+  - id: layer_0/width_65k/canonical
+    path: layer_0/width_65k/average_l0_73
+    neuronpedia: gemma-2-2b/0-gemmascope-res-65k
+  - id: layer_1/width_65k/canonical
+    path: layer_1/width_65k/average_l0_121
+    neuronpedia: gemma-2-2b/1-gemmascope-res-65k
+  - id: layer_2/width_65k/canonical
+    path: layer_2/width_65k/average_l0_77
+    neuronpedia: gemma-2-2b/2-gemmascope-res-65k
+  - id: layer_3/width_65k/canonical
+    path: layer_3/width_65k/average_l0_89
+    neuronpedia: gemma-2-2b/3-gemmascope-res-65k
+  - id: layer_4/width_65k/canonical
+    path: layer_4/width_65k/average_l0_89
+    neuronpedia: gemma-2-2b/4-gemmascope-res-65k
+  - id: layer_5/width_65k/canonical
+    path: layer_5/width_65k/average_l0_105
+    neuronpedia: gemma-2-2b/5-gemmascope-res-65k
+  - id: layer_6/width_65k/canonical
+    path: layer_6/width_65k/average_l0_107
+    neuronpedia: gemma-2-2b/6-gemmascope-res-65k
+  - id: layer_7/width_65k/canonical
+    path: layer_7/width_65k/average_l0_107
+    neuronpedia: gemma-2-2b/7-gemmascope-res-65k
+  - id: layer_8/width_65k/canonical
+    path: layer_8/width_65k/average_l0_111
+    neuronpedia: gemma-2-2b/8-gemmascope-res-65k
+  - id: layer_9/width_65k/canonical
+    path: layer_9/width_65k/average_l0_118
+    neuronpedia: gemma-2-2b/9-gemmascope-res-65k
+  - id: layer_10/width_65k/canonical
+    path: layer_10/width_65k/average_l0_128
+    neuronpedia: gemma-2-2b/10-gemmascope-res-65k
+  - id: layer_11/width_65k/canonical
+    path: layer_11/width_65k/average_l0_70
+    neuronpedia: gemma-2-2b/11-gemmascope-res-65k
+  - id: layer_12/width_65k/canonical
+    path: layer_12/width_65k/average_l0_72
+    neuronpedia: gemma-2-2b/12-gemmascope-res-65k
+  - id: layer_13/width_65k/canonical
+    path: layer_13/width_65k/average_l0_75
+    neuronpedia: gemma-2-2b/13-gemmascope-res-65k
+  - id: layer_14/width_65k/canonical
+    path: layer_14/width_65k/average_l0_73
+    neuronpedia: gemma-2-2b/14-gemmascope-res-65k
+  - id: layer_15/width_65k/canonical
+    path: layer_15/width_65k/average_l0_127
+    neuronpedia: gemma-2-2b/15-gemmascope-res-65k
+  - id: layer_16/width_65k/canonical
+    path: layer_16/width_65k/average_l0_128
+    neuronpedia: gemma-2-2b/16-gemmascope-res-65k
+  - id: layer_17/width_65k/canonical
+    path: layer_17/width_65k/average_l0_125
+    neuronpedia: gemma-2-2b/17-gemmascope-res-65k
+  - id: layer_18/width_65k/canonical
+    path: layer_18/width_65k/average_l0_116
+    neuronpedia: gemma-2-2b/18-gemmascope-res-65k
+  - id: layer_19/width_65k/canonical
+    path: layer_19/width_65k/average_l0_115
+    neuronpedia: gemma-2-2b/19-gemmascope-res-65k
+  - id: layer_20/width_65k/canonical
+    path: layer_20/width_65k/average_l0_114
+    neuronpedia: gemma-2-2b/20-gemmascope-res-65k
+  - id: layer_21/width_65k/canonical
+    path: layer_21/width_65k/average_l0_111
+    neuronpedia: gemma-2-2b/21-gemmascope-res-65k
+  - id: layer_22/width_65k/canonical
+    path: layer_22/width_65k/average_l0_116
+    neuronpedia: gemma-2-2b/22-gemmascope-res-65k
+  - id: layer_23/width_65k/canonical
+    path: layer_23/width_65k/average_l0_123
+    neuronpedia: gemma-2-2b/23-gemmascope-res-65k
+  - id: layer_24/width_65k/canonical
+    path: layer_24/width_65k/average_l0_124
+    neuronpedia: gemma-2-2b/24-gemmascope-res-65k
+  - id: layer_25/width_65k/canonical
+    path: layer_25/width_65k/average_l0_93
+    neuronpedia: gemma-2-2b/25-gemmascope-res-65k
+gemma-scope-2b-pt-mlp:
+  repo_id: google/gemma-scope-2b-pt-mlp
+  model: gemma-2-2b
+  conversion_func: gemma_2
+  saes:
+  - id: layer_0/width_16k/average_l0_119
+    path: layer_0/width_16k/average_l0_119
+    l0: 119
+  - id: layer_0/width_16k/average_l0_16
+    path: layer_0/width_16k/average_l0_16
+    l0: 16
+  - id: layer_0/width_16k/average_l0_30
+    path: layer_0/width_16k/average_l0_30
+    l0: 30
+  - id: layer_0/width_16k/average_l0_60
+    path: layer_0/width_16k/average_l0_60
+    l0: 60
+  - id: layer_0/width_16k/average_l0_9
+    path: layer_0/width_16k/average_l0_9
+    l0: 9
+  - id: layer_1/width_16k/average_l0_105
+    path: layer_1/width_16k/average_l0_105
+    l0: 105
+  - id: layer_1/width_16k/average_l0_12
+    path: layer_1/width_16k/average_l0_12
+    l0: 12
+  - id: layer_1/width_16k/average_l0_239
+    path: layer_1/width_16k/average_l0_239
+    l0: 239
+  - id: layer_1/width_16k/average_l0_24
+    path: layer_1/width_16k/average_l0_24
+    l0: 24
+  - id: layer_1/width_16k/average_l0_50
+    path: layer_1/width_16k/average_l0_50
+    l0: 50
+  - id: layer_2/width_16k/average_l0_19
+    path: layer_2/width_16k/average_l0_19
+    l0: 19
+  - id: layer_2/width_16k/average_l0_213
+    path: layer_2/width_16k/average_l0_213
+    l0: 213
+  - id: layer_2/width_16k/average_l0_41
+    path: layer_2/width_16k/average_l0_41
+    l0: 41
+  - id: layer_2/width_16k/average_l0_434
+    path: layer_2/width_16k/average_l0_434
+    l0: 434
+  - id: layer_2/width_16k/average_l0_95
+    path: layer_2/width_16k/average_l0_95
+    l0: 95
+  - id: layer_3/width_16k/average_l0_195
+    path: layer_3/width_16k/average_l0_195
+    l0: 195
+  - id: layer_3/width_16k/average_l0_21
+    path: layer_3/width_16k/average_l0_21
+    l0: 21
+  - id: layer_3/width_16k/average_l0_377
+    path: layer_3/width_16k/average_l0_377
+    l0: 377
+  - id: layer_3/width_16k/average_l0_44
+    path: layer_3/width_16k/average_l0_44
+    l0: 44
+  - id: layer_3/width_16k/average_l0_95
+    path: layer_3/width_16k/average_l0_95
+    l0: 95
+  - id: layer_4/width_16k/average_l0_18
+    path: layer_4/width_16k/average_l0_18
+    l0: 18
+  - id: layer_4/width_16k/average_l0_198
+    path: layer_4/width_16k/average_l0_198
+    l0: 198
+  - id: layer_4/width_16k/average_l0_38
+    path: layer_4/width_16k/average_l0_38
+    l0: 38
+  - id: layer_4/width_16k/average_l0_433
+    path: layer_4/width_16k/average_l0_433
+    l0: 433
+  - id: layer_4/width_16k/average_l0_85
+    path: layer_4/width_16k/average_l0_85
+    l0: 85
+  - id: layer_5/width_16k/average_l0_114
+    path: layer_5/width_16k/average_l0_114
+    l0: 114
+  - id: layer_5/width_16k/average_l0_23
+    path: layer_5/width_16k/average_l0_23
+    l0: 23
+  - id: layer_5/width_16k/average_l0_269
+    path: layer_5/width_16k/average_l0_269
+    l0: 269
+  - id: layer_5/width_16k/average_l0_48
+    path: layer_5/width_16k/average_l0_48
+    l0: 48
+  - id: layer_5/width_16k/average_l0_575
+    path: layer_5/width_16k/average_l0_575
+    l0: 575
+  - id: layer_6/width_16k/average_l0_133
+    path: layer_6/width_16k/average_l0_133
+    l0: 133
+  - id: layer_6/width_16k/average_l0_25
+    path: layer_6/width_16k/average_l0_25
+    l0: 25
+  - id: layer_6/width_16k/average_l0_328
+    path: layer_6/width_16k/average_l0_328
+    l0: 328
+  - id: layer_6/width_16k/average_l0_55
+    path: layer_6/width_16k/average_l0_55
+    l0: 55
+  - id: layer_6/width_16k/average_l0_699
+    path: layer_6/width_16k/average_l0_699
+    l0: 699
+  - id: layer_7/width_16k/average_l0_146
+    path: layer_7/width_16k/average_l0_146
+    l0: 146
+  - id: layer_7/width_16k/average_l0_28
+    path: layer_7/width_16k/average_l0_28
+    l0: 28
+  - id: layer_7/width_16k/average_l0_355
+    path: layer_7/width_16k/average_l0_355
+    l0: 355
+  - id: layer_7/width_16k/average_l0_60
+    path: layer_7/width_16k/average_l0_60
+    l0: 60
+  - id: layer_7/width_16k/average_l0_731
+    path: layer_7/width_16k/average_l0_731
+    l0: 731
+  - id: layer_8/width_16k/average_l0_136
+    path: layer_8/width_16k/average_l0_136
+    l0: 136
+  - id: layer_8/width_16k/average_l0_27
+    path: layer_8/width_16k/average_l0_27
+    l0: 27
+  - id: layer_8/width_16k/average_l0_351
+    path: layer_8/width_16k/average_l0_351
+    l0: 351
+  - id: layer_8/width_16k/average_l0_56
+    path: layer_8/width_16k/average_l0_56
+    l0: 56
+  - id: layer_8/width_16k/average_l0_739
+    path: layer_8/width_16k/average_l0_739
+    l0: 739
+  - id: layer_9/width_16k/average_l0_216
+    path: layer_9/width_16k/average_l0_216
+    l0: 216
+  - id: layer_9/width_16k/average_l0_38
+    path: layer_9/width_16k/average_l0_38
+    l0: 38
+  - id: layer_9/width_16k/average_l0_482
+    path: layer_9/width_16k/average_l0_482
+    l0: 482
+  - id: layer_9/width_16k/average_l0_861
+    path: layer_9/width_16k/average_l0_861
+    l0: 861
+  - id: layer_9/width_16k/average_l0_88
+    path: layer_9/width_16k/average_l0_88
+    l0: 88
+  - id: layer_10/width_16k/average_l0_110
+    path: layer_10/width_16k/average_l0_110
+    l0: 110
+  - id: layer_10/width_16k/average_l0_266
+    path: layer_10/width_16k/average_l0_266
+    l0: 266
+  - id: layer_10/width_16k/average_l0_45
+    path: layer_10/width_16k/average_l0_45
+    l0: 45
+  - id: layer_10/width_16k/average_l0_568
+    path: layer_10/width_16k/average_l0_568
+    l0: 568
+  - id: layer_10/width_16k/average_l0_908
+    path: layer_10/width_16k/average_l0_908
+    l0: 908
+  - id: layer_11/width_16k/average_l0_234
+    path: layer_11/width_16k/average_l0_234
+    l0: 234
+  - id: layer_11/width_16k/average_l0_42
+    path: layer_11/width_16k/average_l0_42
+    l0: 42
+  - id: layer_11/width_16k/average_l0_499
+    path: layer_11/width_16k/average_l0_499
+    l0: 499
+  - id: layer_11/width_16k/average_l0_847
+    path: layer_11/width_16k/average_l0_847
+    l0: 847
+  - id: layer_11/width_16k/average_l0_98
+    path: layer_11/width_16k/average_l0_98
+    l0: 98
+  - id: layer_12/width_16k/average_l0_108
+    path: layer_12/width_16k/average_l0_108
+    l0: 108
+  - id: layer_12/width_16k/average_l0_262
+    path: layer_12/width_16k/average_l0_262
+    l0: 262
+  - id: layer_12/width_16k/average_l0_44
+    path: layer_12/width_16k/average_l0_44
+    l0: 44
+  - id: layer_12/width_16k/average_l0_548
+    path: layer_12/width_16k/average_l0_548
+    l0: 548
+  - id: layer_12/width_16k/average_l0_879
+    path: layer_12/width_16k/average_l0_879
+    l0: 879
+  - id: layer_13/width_16k/average_l0_112
+    path: layer_13/width_16k/average_l0_112
+    l0: 112
+  - id: layer_13/width_16k/average_l0_267
+    path: layer_13/width_16k/average_l0_267
+    l0: 267
+  - id: layer_13/width_16k/average_l0_47
+    path: layer_13/width_16k/average_l0_47
+    l0: 47
+  - id: layer_13/width_16k/average_l0_553
+    path: layer_13/width_16k/average_l0_553
+    l0: 553
+  - id: layer_13/width_16k/average_l0_892
+    path: layer_13/width_16k/average_l0_892
+    l0: 892
+  - id: layer_14/width_16k/average_l0_246
+    path: layer_14/width_16k/average_l0_246
+    l0: 246
+  - id: layer_14/width_16k/average_l0_41
+    path: layer_14/width_16k/average_l0_41
+    l0: 41
+  - id: layer_14/width_16k/average_l0_536
+    path: layer_14/width_16k/average_l0_536
+    l0: 536
+  - id: layer_14/width_16k/average_l0_894
+    path: layer_14/width_16k/average_l0_894
+    l0: 894
+  - id: layer_14/width_16k/average_l0_97
+    path: layer_14/width_16k/average_l0_97
+    l0: 97
+  - id: layer_15/width_16k/average_l0_207
+    path: layer_15/width_16k/average_l0_207
+    l0: 207
+  - id: layer_15/width_16k/average_l0_35
+    path: layer_15/width_16k/average_l0_35
+    l0: 35
+  - id: layer_15/width_16k/average_l0_492
+    path: layer_15/width_16k/average_l0_492
+    l0: 492
+  - id: layer_15/width_16k/average_l0_80
+    path: layer_15/width_16k/average_l0_80
+    l0: 80
+  - id: layer_15/width_16k/average_l0_879
+    path: layer_15/width_16k/average_l0_879
+    l0: 879
+  - id: layer_16/width_16k/average_l0_185
+    path: layer_16/width_16k/average_l0_185
+    l0: 185
+  - id: layer_16/width_16k/average_l0_33
+    path: layer_16/width_16k/average_l0_33
+    l0: 33
+  - id: layer_16/width_16k/average_l0_452
+    path: layer_16/width_16k/average_l0_452
+    l0: 452
+  - id: layer_16/width_16k/average_l0_72
+    path: layer_16/width_16k/average_l0_72
+    l0: 72
+  - id: layer_16/width_16k/average_l0_847
+    path: layer_16/width_16k/average_l0_847
+    l0: 847
+  - id: layer_17/width_16k/average_l0_179
+    path: layer_17/width_16k/average_l0_179
+    l0: 179
+  - id: layer_17/width_16k/average_l0_31
+    path: layer_17/width_16k/average_l0_31
+    l0: 31
+  - id: layer_17/width_16k/average_l0_453
+    path: layer_17/width_16k/average_l0_453
+    l0: 453
+  - id: layer_17/width_16k/average_l0_68
+    path: layer_17/width_16k/average_l0_68
+    l0: 68
+  - id: layer_17/width_16k/average_l0_853
+    path: layer_17/width_16k/average_l0_853
+    l0: 853
+  - id: layer_18/width_16k/average_l0_106
+    path: layer_18/width_16k/average_l0_106
+    l0: 106
+  - id: layer_18/width_16k/average_l0_24
+    path: layer_18/width_16k/average_l0_24
+    l0: 24
+  - id: layer_18/width_16k/average_l0_292
+    path: layer_18/width_16k/average_l0_292
+    l0: 292
+  - id: layer_18/width_16k/average_l0_47
+    path: layer_18/width_16k/average_l0_47
+    l0: 47
+  - id: layer_18/width_16k/average_l0_672
+    path: layer_18/width_16k/average_l0_672
+    l0: 672
+  - id: layer_19/width_16k/average_l0_109
+    path: layer_19/width_16k/average_l0_109
+    l0: 109
+  - id: layer_19/width_16k/average_l0_25
+    path: layer_19/width_16k/average_l0_25
+    l0: 25
+  - id: layer_19/width_16k/average_l0_295
+    path: layer_19/width_16k/average_l0_295
+    l0: 295
+  - id: layer_19/width_16k/average_l0_50
+    path: layer_19/width_16k/average_l0_50
+    l0: 50
+  - id: layer_19/width_16k/average_l0_673
+    path: layer_19/width_16k/average_l0_673
+    l0: 673
+  - id: layer_20/width_16k/average_l0_109
+    path: layer_20/width_16k/average_l0_109
+    l0: 109
+  - id: layer_20/width_16k/average_l0_24
+    path: layer_20/width_16k/average_l0_24
+    l0: 24
+  - id: layer_20/width_16k/average_l0_289
+    path: layer_20/width_16k/average_l0_289
+    l0: 289
+  - id: layer_20/width_16k/average_l0_49
+    path: layer_20/width_16k/average_l0_49
+    l0: 49
+  - id: layer_20/width_16k/average_l0_658
+    path: layer_20/width_16k/average_l0_658
+    l0: 658
+  - id: layer_21/width_16k/average_l0_113
+    path: layer_21/width_16k/average_l0_113
+    l0: 113
+  - id: layer_21/width_16k/average_l0_23
+    path: layer_21/width_16k/average_l0_23
+    l0: 23
+  - id: layer_21/width_16k/average_l0_279
+    path: layer_21/width_16k/average_l0_279
+    l0: 279
+  - id: layer_21/width_16k/average_l0_48
+    path: layer_21/width_16k/average_l0_48
+    l0: 48
+  - id: layer_21/width_16k/average_l0_633
+    path: layer_21/width_16k/average_l0_633
+    l0: 633
+  - id: layer_22/width_16k/average_l0_121
+    path: layer_22/width_16k/average_l0_121
+    l0: 121
+  - id: layer_22/width_16k/average_l0_24
+    path: layer_22/width_16k/average_l0_24
+    l0: 24
+  - id: layer_22/width_16k/average_l0_290
+    path: layer_22/width_16k/average_l0_290
+    l0: 290
+  - id: layer_22/width_16k/average_l0_51
+    path: layer_22/width_16k/average_l0_51
+    l0: 51
+  - id: layer_22/width_16k/average_l0_624
+    path: layer_22/width_16k/average_l0_624
+    l0: 624
+  - id: layer_23/width_16k/average_l0_128
+    path: layer_23/width_16k/average_l0_128
+    l0: 128
+  - id: layer_23/width_16k/average_l0_27
+    path: layer_23/width_16k/average_l0_27
+    l0: 27
+  - id: layer_23/width_16k/average_l0_287
+    path: layer_23/width_16k/average_l0_287
+    l0: 287
+  - id: layer_23/width_16k/average_l0_57
+    path: layer_23/width_16k/average_l0_57
+    l0: 57
+  - id: layer_23/width_16k/average_l0_627
+    path: layer_23/width_16k/average_l0_627
+    l0: 627
+  - id: layer_24/width_16k/average_l0_158
+    path: layer_24/width_16k/average_l0_158
+    l0: 158
+  - id: layer_24/width_16k/average_l0_19
+    path: layer_24/width_16k/average_l0_19
+    l0: 19
+  - id: layer_24/width_16k/average_l0_35
+    path: layer_24/width_16k/average_l0_35
+    l0: 35
+  - id: layer_24/width_16k/average_l0_357
+    path: layer_24/width_16k/average_l0_357
+    l0: 357
+  - id: layer_24/width_16k/average_l0_73
+    path: layer_24/width_16k/average_l0_73
+    l0: 73
+  - id: layer_25/width_16k/average_l0_126
+    path: layer_25/width_16k/average_l0_126
+    l0: 126
+  - id: layer_25/width_16k/average_l0_15
+    path: layer_25/width_16k/average_l0_15
+    l0: 15
+  - id: layer_25/width_16k/average_l0_277
+    path: layer_25/width_16k/average_l0_277
+    l0: 277
+  - id: layer_25/width_16k/average_l0_29
+    path: layer_25/width_16k/average_l0_29
+    l0: 29
+  - id: layer_25/width_16k/average_l0_59
+    path: layer_25/width_16k/average_l0_59
+    l0: 59
+  - id: layer_0/width_65k/average_l0_12
+    path: layer_0/width_65k/average_l0_12
+    l0: 12
+  - id: layer_0/width_65k/average_l0_21
+    path: layer_0/width_65k/average_l0_21
+    l0: 21
+  - id: layer_0/width_65k/average_l0_39
+    path: layer_0/width_65k/average_l0_39
+    l0: 39
+  - id: layer_0/width_65k/average_l0_7
+    path: layer_0/width_65k/average_l0_7
+    l0: 7
+  - id: layer_0/width_65k/average_l0_72
+    path: layer_0/width_65k/average_l0_72
+    l0: 72
+  - id: layer_1/width_65k/average_l0_11
+    path: layer_1/width_65k/average_l0_11
+    l0: 11
+  - id: layer_1/width_65k/average_l0_127
+    path: layer_1/width_65k/average_l0_127
+    l0: 127
+  - id: layer_1/width_65k/average_l0_20
+    path: layer_1/width_65k/average_l0_20
+    l0: 20
+  - id: layer_1/width_65k/average_l0_37
+    path: layer_1/width_65k/average_l0_37
+    l0: 37
+  - id: layer_1/width_65k/average_l0_67
+    path: layer_1/width_65k/average_l0_67
+    l0: 67
+  - id: layer_2/width_65k/average_l0_134
+    path: layer_2/width_65k/average_l0_134
+    l0: 134
+  - id: layer_2/width_65k/average_l0_16
+    path: layer_2/width_65k/average_l0_16
+    l0: 16
+  - id: layer_2/width_65k/average_l0_265
+    path: layer_2/width_65k/average_l0_265
+    l0: 265
+  - id: layer_2/width_65k/average_l0_31
+    path: layer_2/width_65k/average_l0_31
+    l0: 31
+  - id: layer_2/width_65k/average_l0_60
+    path: layer_2/width_65k/average_l0_60
+    l0: 60
+  - id: layer_3/width_65k/average_l0_144
+    path: layer_3/width_65k/average_l0_144
+    l0: 144
+  - id: layer_3/width_65k/average_l0_18
+    path: layer_3/width_65k/average_l0_18
+    l0: 18
+  - id: layer_3/width_65k/average_l0_279
+    path: layer_3/width_65k/average_l0_279
+    l0: 279
+  - id: layer_3/width_65k/average_l0_33
+    path: layer_3/width_65k/average_l0_33
+    l0: 33
+  - id: layer_3/width_65k/average_l0_68
+    path: layer_3/width_65k/average_l0_68
+    l0: 68
+  - id: layer_4/width_65k/average_l0_138
+    path: layer_4/width_65k/average_l0_138
+    l0: 138
+  - id: layer_4/width_65k/average_l0_17
+    path: layer_4/width_65k/average_l0_17
+    l0: 17
+  - id: layer_4/width_65k/average_l0_299
+    path: layer_4/width_65k/average_l0_299
+    l0: 299
+  - id: layer_4/width_65k/average_l0_32
+    path: layer_4/width_65k/average_l0_32
+    l0: 32
+  - id: layer_4/width_65k/average_l0_66
+    path: layer_4/width_65k/average_l0_66
+    l0: 66
+  - id: layer_5/width_65k/average_l0_186
+    path: layer_5/width_65k/average_l0_186
+    l0: 186
+  - id: layer_5/width_65k/average_l0_22
+    path: layer_5/width_65k/average_l0_22
+    l0: 22
+  - id: layer_5/width_65k/average_l0_407
+    path: layer_5/width_65k/average_l0_407
+    l0: 407
+  - id: layer_5/width_65k/average_l0_43
+    path: layer_5/width_65k/average_l0_43
+    l0: 43
+  - id: layer_5/width_65k/average_l0_86
+    path: layer_5/width_65k/average_l0_86
+    l0: 86
+  - id: layer_6/width_65k/average_l0_101
+    path: layer_6/width_65k/average_l0_101
+    l0: 101
+  - id: layer_6/width_65k/average_l0_224
+    path: layer_6/width_65k/average_l0_224
+    l0: 224
+  - id: layer_6/width_65k/average_l0_24
+    path: layer_6/width_65k/average_l0_24
+    l0: 24
+  - id: layer_6/width_65k/average_l0_47
+    path: layer_6/width_65k/average_l0_47
+    l0: 47
+  - id: layer_6/width_65k/average_l0_515
+    path: layer_6/width_65k/average_l0_515
+    l0: 515
+  - id: layer_7/width_65k/average_l0_115
+    path: layer_7/width_65k/average_l0_115
+    l0: 115
+  - id: layer_7/width_65k/average_l0_266
+    path: layer_7/width_65k/average_l0_266
+    l0: 266
+  - id: layer_7/width_65k/average_l0_28
+    path: layer_7/width_65k/average_l0_28
+    l0: 28
+  - id: layer_7/width_65k/average_l0_56
+    path: layer_7/width_65k/average_l0_56
+    l0: 56
+  - id: layer_7/width_65k/average_l0_571
+    path: layer_7/width_65k/average_l0_571
+    l0: 571
+  - id: layer_8/width_65k/average_l0_110
+    path: layer_8/width_65k/average_l0_110
+    l0: 110
+  - id: layer_8/width_65k/average_l0_256
+    path: layer_8/width_65k/average_l0_256
+    l0: 256
+  - id: layer_8/width_65k/average_l0_31
+    path: layer_8/width_65k/average_l0_31
+    l0: 31
+  - id: layer_8/width_65k/average_l0_547
+    path: layer_8/width_65k/average_l0_547
+    l0: 547
+  - id: layer_8/width_65k/average_l0_55
+    path: layer_8/width_65k/average_l0_55
+    l0: 55
+  - id: layer_9/width_65k/average_l0_168
+    path: layer_9/width_65k/average_l0_168
+    l0: 168
+  - id: layer_9/width_65k/average_l0_38
+    path: layer_9/width_65k/average_l0_38
+    l0: 38
+  - id: layer_9/width_65k/average_l0_387
+    path: layer_9/width_65k/average_l0_387
+    l0: 387
+  - id: layer_9/width_65k/average_l0_745
+    path: layer_9/width_65k/average_l0_745
+    l0: 745
+  - id: layer_9/width_65k/average_l0_77
+    path: layer_9/width_65k/average_l0_77
+    l0: 77
+  - id: layer_10/width_65k/average_l0_218
+    path: layer_10/width_65k/average_l0_218
+    l0: 218
+  - id: layer_10/width_65k/average_l0_43
+    path: layer_10/width_65k/average_l0_43
+    l0: 43
+  - id: layer_10/width_65k/average_l0_474
+    path: layer_10/width_65k/average_l0_474
+    l0: 474
+  - id: layer_10/width_65k/average_l0_851
+    path: layer_10/width_65k/average_l0_851
+    l0: 851
+  - id: layer_10/width_65k/average_l0_95
+    path: layer_10/width_65k/average_l0_95
+    l0: 95
+  - id: layer_11/width_65k/average_l0_200
+    path: layer_11/width_65k/average_l0_200
+    l0: 200
+  - id: layer_11/width_65k/average_l0_41
+    path: layer_11/width_65k/average_l0_41
+    l0: 41
+  - id: layer_11/width_65k/average_l0_436
+    path: layer_11/width_65k/average_l0_436
+    l0: 436
+  - id: layer_11/width_65k/average_l0_771
+    path: layer_11/width_65k/average_l0_771
+    l0: 771
+  - id: layer_11/width_65k/average_l0_88
+    path: layer_11/width_65k/average_l0_88
+    l0: 88
+  - id: layer_12/width_65k/average_l0_222
+    path: layer_12/width_65k/average_l0_222
+    l0: 222
+  - id: layer_12/width_65k/average_l0_44
+    path: layer_12/width_65k/average_l0_44
+    l0: 44
+  - id: layer_12/width_65k/average_l0_482
+    path: layer_12/width_65k/average_l0_482
+    l0: 482
+  - id: layer_12/width_65k/average_l0_848
+    path: layer_12/width_65k/average_l0_848
+    l0: 848
+  - id: layer_12/width_65k/average_l0_96
+    path: layer_12/width_65k/average_l0_96
+    l0: 96
+  - id: layer_13/width_65k/average_l0_228
+    path: layer_13/width_65k/average_l0_228
+    l0: 228
+  - id: layer_13/width_65k/average_l0_44
+    path: layer_13/width_65k/average_l0_44
+    l0: 44
+  - id: layer_13/width_65k/average_l0_480
+    path: layer_13/width_65k/average_l0_480
+    l0: 480
+  - id: layer_13/width_65k/average_l0_841
+    path: layer_13/width_65k/average_l0_841
+    l0: 841
+  - id: layer_13/width_65k/average_l0_98
+    path: layer_13/width_65k/average_l0_98
+    l0: 98
+  - id: layer_14/width_65k/average_l0_204
+    path: layer_14/width_65k/average_l0_204
+    l0: 204
+  - id: layer_14/width_65k/average_l0_39
+    path: layer_14/width_65k/average_l0_39
+    l0: 39
+  - id: layer_14/width_65k/average_l0_463
+    path: layer_14/width_65k/average_l0_463
+    l0: 463
+  - id: layer_14/width_65k/average_l0_816
+    path: layer_14/width_65k/average_l0_816
+    l0: 816
+  - id: layer_14/width_65k/average_l0_89
+    path: layer_14/width_65k/average_l0_89
+    l0: 89
+  - id: layer_15/width_65k/average_l0_164
+    path: layer_15/width_65k/average_l0_164
+    l0: 164
+  - id: layer_15/width_65k/average_l0_35
+    path: layer_15/width_65k/average_l0_35
+    l0: 35
+  - id: layer_15/width_65k/average_l0_405
+    path: layer_15/width_65k/average_l0_405
+    l0: 405
+  - id: layer_15/width_65k/average_l0_72
+    path: layer_15/width_65k/average_l0_72
+    l0: 72
+  - id: layer_15/width_65k/average_l0_754
+    path: layer_15/width_65k/average_l0_754
+    l0: 754
+  - id: layer_16/width_65k/average_l0_142
+    path: layer_16/width_65k/average_l0_142
+    l0: 142
+  - id: layer_16/width_65k/average_l0_32
+    path: layer_16/width_65k/average_l0_32
+    l0: 32
+  - id: layer_16/width_65k/average_l0_348
+    path: layer_16/width_65k/average_l0_348
+    l0: 348
+  - id: layer_16/width_65k/average_l0_66
+    path: layer_16/width_65k/average_l0_66
+    l0: 66
+  - id: layer_16/width_65k/average_l0_695
+    path: layer_16/width_65k/average_l0_695
+    l0: 695
+  - id: layer_17/width_65k/average_l0_136
+    path: layer_17/width_65k/average_l0_136
+    l0: 136
+  - id: layer_17/width_65k/average_l0_30
+    path: layer_17/width_65k/average_l0_30
+    l0: 30
+  - id: layer_17/width_65k/average_l0_342
+    path: layer_17/width_65k/average_l0_342
+    l0: 342
+  - id: layer_17/width_65k/average_l0_61
+    path: layer_17/width_65k/average_l0_61
+    l0: 61
+  - id: layer_17/width_65k/average_l0_666
+    path: layer_17/width_65k/average_l0_666
+    l0: 666
+  - id: layer_18/width_65k/average_l0_191
+    path: layer_18/width_65k/average_l0_191
+    l0: 191
+  - id: layer_18/width_65k/average_l0_24
+    path: layer_18/width_65k/average_l0_24
+    l0: 24
+  - id: layer_18/width_65k/average_l0_44
+    path: layer_18/width_65k/average_l0_44
+    l0: 44
+  - id: layer_18/width_65k/average_l0_491
+    path: layer_18/width_65k/average_l0_491
+    l0: 491
+  - id: layer_18/width_65k/average_l0_88
+    path: layer_18/width_65k/average_l0_88
+    l0: 88
+  - id: layer_19/width_65k/average_l0_192
+    path: layer_19/width_65k/average_l0_192
+    l0: 192
+  - id: layer_19/width_65k/average_l0_25
+    path: layer_19/width_65k/average_l0_25
+    l0: 25
+  - id: layer_19/width_65k/average_l0_45
+    path: layer_19/width_65k/average_l0_45
+    l0: 45
+  - id: layer_19/width_65k/average_l0_470
+    path: layer_19/width_65k/average_l0_470
+    l0: 470
+  - id: layer_19/width_65k/average_l0_88
+    path: layer_19/width_65k/average_l0_88
+    l0: 88
+  - id: layer_20/width_65k/average_l0_189
+    path: layer_20/width_65k/average_l0_189
+    l0: 189
+  - id: layer_20/width_65k/average_l0_23
+    path: layer_20/width_65k/average_l0_23
+    l0: 23
+  - id: layer_20/width_65k/average_l0_44
+    path: layer_20/width_65k/average_l0_44
+    l0: 44
+  - id: layer_20/width_65k/average_l0_446
+    path: layer_20/width_65k/average_l0_446
+    l0: 446
+  - id: layer_20/width_65k/average_l0_88
+    path: layer_20/width_65k/average_l0_88
+    l0: 88
+  - id: layer_21/width_65k/average_l0_192
+    path: layer_21/width_65k/average_l0_192
+    l0: 192
+  - id: layer_21/width_65k/average_l0_23
+    path: layer_21/width_65k/average_l0_23
+    l0: 23
+  - id: layer_21/width_65k/average_l0_42
+    path: layer_21/width_65k/average_l0_42
+    l0: 42
+  - id: layer_21/width_65k/average_l0_472
+    path: layer_21/width_65k/average_l0_472
+    l0: 472
+  - id: layer_21/width_65k/average_l0_86
+    path: layer_21/width_65k/average_l0_86
+    l0: 86
+  - id: layer_22/width_65k/average_l0_203
+    path: layer_22/width_65k/average_l0_203
+    l0: 203
+  - id: layer_22/width_65k/average_l0_23
+    path: layer_22/width_65k/average_l0_23
+    l0: 23
+  - id: layer_22/width_65k/average_l0_46
+    path: layer_22/width_65k/average_l0_46
+    l0: 46
+  - id: layer_22/width_65k/average_l0_487
+    path: layer_22/width_65k/average_l0_487
+    l0: 487
+  - id: layer_22/width_65k/average_l0_92
+    path: layer_22/width_65k/average_l0_92
+    l0: 92
+  - id: layer_23/width_65k/average_l0_102
+    path: layer_23/width_65k/average_l0_102
+    l0: 102
+  - id: layer_23/width_65k/average_l0_218
+    path: layer_23/width_65k/average_l0_218
+    l0: 218
+  - id: layer_23/width_65k/average_l0_25
+    path: layer_23/width_65k/average_l0_25
+    l0: 25
+  - id: layer_23/width_65k/average_l0_49
+    path: layer_23/width_65k/average_l0_49
+    l0: 49
+  - id: layer_23/width_65k/average_l0_497
+    path: layer_23/width_65k/average_l0_497
+    l0: 497
+  - id: layer_24/width_65k/average_l0_128
+    path: layer_24/width_65k/average_l0_128
+    l0: 128
+  - id: layer_24/width_65k/average_l0_18
+    path: layer_24/width_65k/average_l0_18
+    l0: 18
+  - id: layer_24/width_65k/average_l0_268
+    path: layer_24/width_65k/average_l0_268
+    l0: 268
+  - id: layer_24/width_65k/average_l0_32
+    path: layer_24/width_65k/average_l0_32
+    l0: 32
+  - id: layer_24/width_65k/average_l0_62
+    path: layer_24/width_65k/average_l0_62
+    l0: 62
+  - id: layer_25/width_65k/average_l0_107
+    path: layer_25/width_65k/average_l0_107
+    l0: 107
+  - id: layer_25/width_65k/average_l0_14
+    path: layer_25/width_65k/average_l0_14
+    l0: 14
+  - id: layer_25/width_65k/average_l0_215
+    path: layer_25/width_65k/average_l0_215
+    l0: 215
+  - id: layer_25/width_65k/average_l0_26
+    path: layer_25/width_65k/average_l0_26
+    l0: 26
+  - id: layer_25/width_65k/average_l0_52
+    path: layer_25/width_65k/average_l0_52
+    l0: 52
+gemma-scope-2b-pt-mlp-canonical:
+  repo_id: google/gemma-scope-2b-pt-mlp
+  model: gemma-2-2b
+  conversion_func: gemma_2
+  saes:
+  - id: layer_0/width_16k/canonical
+    path: layer_0/width_16k/average_l0_119
+    neuronpedia: gemma-2-2b/0-gemmascope-mlp-16k
+  - id: layer_1/width_16k/canonical
+    path: layer_1/width_16k/average_l0_105
+    neuronpedia: gemma-2-2b/1-gemmascope-mlp-16k
+  - id: layer_2/width_16k/canonical
+    path: layer_2/width_16k/average_l0_95
+    neuronpedia: gemma-2-2b/2-gemmascope-mlp-16k
+  - id: layer_3/width_16k/canonical
+    path: layer_3/width_16k/average_l0_95
+    neuronpedia: gemma-2-2b/3-gemmascope-mlp-16k
+  - id: layer_4/width_16k/canonical
+    path: layer_4/width_16k/average_l0_85
+    neuronpedia: gemma-2-2b/4-gemmascope-mlp-16k
+  - id: layer_5/width_16k/canonical
+    path: layer_5/width_16k/average_l0_114
+    neuronpedia: gemma-2-2b/5-gemmascope-mlp-16k
+  - id: layer_6/width_16k/canonical
+    path: layer_6/width_16k/average_l0_133
+    neuronpedia: gemma-2-2b/6-gemmascope-mlp-16k
+  - id: layer_7/width_16k/canonical
+    path: layer_7/width_16k/average_l0_60
+    neuronpedia: gemma-2-2b/7-gemmascope-mlp-16k
+  - id: layer_8/width_16k/canonical
+    path: layer_8/width_16k/average_l0_136
+    neuronpedia: gemma-2-2b/8-gemmascope-mlp-16k
+  - id: layer_9/width_16k/canonical
+    path: layer_9/width_16k/average_l0_88
+    neuronpedia: gemma-2-2b/9-gemmascope-mlp-16k
+  - id: layer_10/width_16k/canonical
+    path: layer_10/width_16k/average_l0_110
+    neuronpedia: gemma-2-2b/10-gemmascope-mlp-16k
+  - id: layer_11/width_16k/canonical
+    path: layer_11/width_16k/average_l0_98
+    neuronpedia: gemma-2-2b/11-gemmascope-mlp-16k
+  - id: layer_12/width_16k/canonical
+    path: layer_12/width_16k/average_l0_108
+    neuronpedia: gemma-2-2b/12-gemmascope-mlp-16k
+  - id: layer_13/width_16k/canonical
+    path: layer_13/width_16k/average_l0_112
+    neuronpedia: gemma-2-2b/13-gemmascope-mlp-16k
+  - id: layer_14/width_16k/canonical
+    path: layer_14/width_16k/average_l0_97
+    neuronpedia: gemma-2-2b/14-gemmascope-mlp-16k
+  - id: layer_15/width_16k/canonical
+    path: layer_15/width_16k/average_l0_80
+    neuronpedia: gemma-2-2b/15-gemmascope-mlp-16k
+  - id: layer_16/width_16k/canonical
+    path: layer_16/width_16k/average_l0_72
+    neuronpedia: gemma-2-2b/16-gemmascope-mlp-16k
+  - id: layer_17/width_16k/canonical
+    path: layer_17/width_16k/average_l0_68
+    neuronpedia: gemma-2-2b/17-gemmascope-mlp-16k
+  - id: layer_18/width_16k/canonical
+    path: layer_18/width_16k/average_l0_106
+    neuronpedia: gemma-2-2b/18-gemmascope-mlp-16k
+  - id: layer_19/width_16k/canonical
+    path: layer_19/width_16k/average_l0_109
+    neuronpedia: gemma-2-2b/19-gemmascope-mlp-16k
+  - id: layer_20/width_16k/canonical
+    path: layer_20/width_16k/average_l0_109
+    neuronpedia: gemma-2-2b/20-gemmascope-mlp-16k
+  - id: layer_21/width_16k/canonical
+    path: layer_21/width_16k/average_l0_113
+    neuronpedia: gemma-2-2b/21-gemmascope-mlp-16k
+  - id: layer_22/width_16k/canonical
+    path: layer_22/width_16k/average_l0_121
+    neuronpedia: gemma-2-2b/22-gemmascope-mlp-16k
+  - id: layer_23/width_16k/canonical
+    path: layer_23/width_16k/average_l0_128
+    neuronpedia: gemma-2-2b/23-gemmascope-mlp-16k
+  - id: layer_24/width_16k/canonical
+    path: layer_24/width_16k/average_l0_73
+    neuronpedia: gemma-2-2b/24-gemmascope-mlp-16k
+  - id: layer_25/width_16k/canonical
+    path: layer_25/width_16k/average_l0_126
+    neuronpedia: gemma-2-2b/25-gemmascope-mlp-16k
+  - id: layer_0/width_65k/canonical
+    path: layer_0/width_65k/average_l0_72
+    neuronpedia: gemma-2-2b/0-gemmascope-mlp-65k
+  - id: layer_1/width_65k/canonical
+    path: layer_1/width_65k/average_l0_127
+    neuronpedia: gemma-2-2b/1-gemmascope-mlp-65k
+  - id: layer_2/width_65k/canonical
+    path: layer_2/width_65k/average_l0_134
+    neuronpedia: gemma-2-2b/2-gemmascope-mlp-65k
+  - id: layer_3/width_65k/canonical
+    path: layer_3/width_65k/average_l0_68
+    neuronpedia: gemma-2-2b/3-gemmascope-mlp-65k
+  - id: layer_4/width_65k/canonical
+    path: layer_4/width_65k/average_l0_66
+    neuronpedia: gemma-2-2b/4-gemmascope-mlp-65k
+  - id: layer_5/width_65k/canonical
+    path: layer_5/width_65k/average_l0_86
+    neuronpedia: gemma-2-2b/5-gemmascope-mlp-65k
+  - id: layer_6/width_65k/canonical
+    path: layer_6/width_65k/average_l0_101
+    neuronpedia: gemma-2-2b/6-gemmascope-mlp-65k
+  - id: layer_7/width_65k/canonical
+    path: layer_7/width_65k/average_l0_115
+    neuronpedia: gemma-2-2b/7-gemmascope-mlp-65k
+  - id: layer_8/width_65k/canonical
+    path: layer_8/width_65k/average_l0_110
+    neuronpedia: gemma-2-2b/8-gemmascope-mlp-65k
+  - id: layer_9/width_65k/canonical
+    path: layer_9/width_65k/average_l0_77
+    neuronpedia: gemma-2-2b/9-gemmascope-mlp-65k
+  - id: layer_10/width_65k/canonical
+    path: layer_10/width_65k/average_l0_95
+    neuronpedia: gemma-2-2b/10-gemmascope-mlp-65k
+  - id: layer_11/width_65k/canonical
+    path: layer_11/width_65k/average_l0_88
+    neuronpedia: gemma-2-2b/11-gemmascope-mlp-65k
+  - id: layer_12/width_65k/canonical
+    path: layer_12/width_65k/average_l0_96
+    neuronpedia: gemma-2-2b/12-gemmascope-mlp-65k
+  - id: layer_13/width_65k/canonical
+    path: layer_13/width_65k/average_l0_98
+    neuronpedia: gemma-2-2b/13-gemmascope-mlp-65k
+  - id: layer_14/width_65k/canonical
+    path: layer_14/width_65k/average_l0_89
+    neuronpedia: gemma-2-2b/14-gemmascope-mlp-65k
+  - id: layer_15/width_65k/canonical
+    path: layer_15/width_65k/average_l0_72
+    neuronpedia: gemma-2-2b/15-gemmascope-mlp-65k
+  - id: layer_16/width_65k/canonical
+    path: layer_16/width_65k/average_l0_66
+    neuronpedia: gemma-2-2b/16-gemmascope-mlp-65k
+  - id: layer_17/width_65k/canonical
+    path: layer_17/width_65k/average_l0_136
+    neuronpedia: gemma-2-2b/17-gemmascope-mlp-65k
+  - id: layer_18/width_65k/canonical
+    path: layer_18/width_65k/average_l0_88
+    neuronpedia: gemma-2-2b/18-gemmascope-mlp-65k
+  - id: layer_19/width_65k/canonical
+    path: layer_19/width_65k/average_l0_88
+    neuronpedia: gemma-2-2b/19-gemmascope-mlp-65k
+  - id: layer_20/width_65k/canonical
+    path: layer_20/width_65k/average_l0_88
+    neuronpedia: gemma-2-2b/20-gemmascope-mlp-65k
+  - id: layer_21/width_65k/canonical
+    path: layer_21/width_65k/average_l0_86
+    neuronpedia: gemma-2-2b/21-gemmascope-mlp-65k
+  - id: layer_22/width_65k/canonical
+    path: layer_22/width_65k/average_l0_92
+    neuronpedia: gemma-2-2b/22-gemmascope-mlp-65k
+  - id: layer_23/width_65k/canonical
+    path: layer_23/width_65k/average_l0_102
+    neuronpedia: gemma-2-2b/23-gemmascope-mlp-65k
+  - id: layer_24/width_65k/canonical
+    path: layer_24/width_65k/average_l0_128
+    neuronpedia: gemma-2-2b/24-gemmascope-mlp-65k
+  - id: layer_25/width_65k/canonical
+    path: layer_25/width_65k/average_l0_107
+    neuronpedia: gemma-2-2b/25-gemmascope-mlp-65k
+gemma-scope-2b-pt-att:
+  repo_id: google/gemma-scope-2b-pt-att
+  model: gemma-2-2b
+  conversion_func: gemma_2
+  saes:
+  - id: layer_0/width_16k/average_l0_104
+    path: layer_0/width_16k/average_l0_104
+    l0: 104
+  - id: layer_0/width_16k/average_l0_12
+    path: layer_0/width_16k/average_l0_12
+    l0: 12
+  - id: layer_0/width_16k/average_l0_18
+    path: layer_0/width_16k/average_l0_18
+    l0: 18
+  - id: layer_0/width_16k/average_l0_30
+    path: layer_0/width_16k/average_l0_30
+    l0: 30
+  - id: layer_0/width_16k/average_l0_57
+    path: layer_0/width_16k/average_l0_57
+    l0: 57
+  - id: layer_1/width_16k/average_l0_146
+    path: layer_1/width_16k/average_l0_146
+    l0: 146
+  - id: layer_1/width_16k/average_l0_20
+    path: layer_1/width_16k/average_l0_20
+    l0: 20
+  - id: layer_1/width_16k/average_l0_251
+    path: layer_1/width_16k/average_l0_251
+    l0: 251
+  - id: layer_1/width_16k/average_l0_40
+    path: layer_1/width_16k/average_l0_40
+    l0: 40
+  - id: layer_1/width_16k/average_l0_79
+    path: layer_1/width_16k/average_l0_79
+    l0: 79
+  - id: layer_2/width_16k/average_l0_174
+    path: layer_2/width_16k/average_l0_174
+    l0: 174
+  - id: layer_2/width_16k/average_l0_19
+    path: layer_2/width_16k/average_l0_19
+    l0: 19
+  - id: layer_2/width_16k/average_l0_297
+    path: layer_2/width_16k/average_l0_297
+    l0: 297
+  - id: layer_2/width_16k/average_l0_43
+    path: layer_2/width_16k/average_l0_43
+    l0: 43
+  - id: layer_2/width_16k/average_l0_93
+    path: layer_2/width_16k/average_l0_93
+    l0: 93
+  - id: layer_3/width_16k/average_l0_117
+    path: layer_3/width_16k/average_l0_117
+    l0: 117
+  - id: layer_3/width_16k/average_l0_219
+    path: layer_3/width_16k/average_l0_219
+    l0: 219
+  - id: layer_3/width_16k/average_l0_24
+    path: layer_3/width_16k/average_l0_24
+    l0: 24
+  - id: layer_3/width_16k/average_l0_386
+    path: layer_3/width_16k/average_l0_386
+    l0: 386
+  - id: layer_3/width_16k/average_l0_55
+    path: layer_3/width_16k/average_l0_55
+    l0: 55
+  - id: layer_4/width_16k/average_l0_116
+    path: layer_4/width_16k/average_l0_116
+    l0: 116
+  - id: layer_4/width_16k/average_l0_249
+    path: layer_4/width_16k/average_l0_249
+    l0: 249
+  - id: layer_4/width_16k/average_l0_26
+    path: layer_4/width_16k/average_l0_26
+    l0: 26
+  - id: layer_4/width_16k/average_l0_454
+    path: layer_4/width_16k/average_l0_454
+    l0: 454
+  - id: layer_4/width_16k/average_l0_53
+    path: layer_4/width_16k/average_l0_53
+    l0: 53
+  - id: layer_5/width_16k/average_l0_135
+    path: layer_5/width_16k/average_l0_135
+    l0: 135
+  - id: layer_5/width_16k/average_l0_268
+    path: layer_5/width_16k/average_l0_268
+    l0: 268
+  - id: layer_5/width_16k/average_l0_30
+    path: layer_5/width_16k/average_l0_30
+    l0: 30
+  - id: layer_5/width_16k/average_l0_449
+    path: layer_5/width_16k/average_l0_449
+    l0: 449
+  - id: layer_5/width_16k/average_l0_59
+    path: layer_5/width_16k/average_l0_59
+    l0: 59
+  - id: layer_6/width_16k/average_l0_143
+    path: layer_6/width_16k/average_l0_143
+    l0: 143
+  - id: layer_6/width_16k/average_l0_292
+    path: layer_6/width_16k/average_l0_292
+    l0: 292
+  - id: layer_6/width_16k/average_l0_30
+    path: layer_6/width_16k/average_l0_30
+    l0: 30
+  - id: layer_6/width_16k/average_l0_479
+    path: layer_6/width_16k/average_l0_479
+    l0: 479
+  - id: layer_6/width_16k/average_l0_61
+    path: layer_6/width_16k/average_l0_61
+    l0: 61
+  - id: layer_7/width_16k/average_l0_184
+    path: layer_7/width_16k/average_l0_184
+    l0: 184
+  - id: layer_7/width_16k/average_l0_331
+    path: layer_7/width_16k/average_l0_331
+    l0: 331
+  - id: layer_7/width_16k/average_l0_46
+    path: layer_7/width_16k/average_l0_46
+    l0: 46
+  - id: layer_7/width_16k/average_l0_537
+    path: layer_7/width_16k/average_l0_537
+    l0: 537
+  - id: layer_7/width_16k/average_l0_99
+    path: layer_7/width_16k/average_l0_99
+    l0: 99
+  - id: layer_8/width_16k/average_l0_129
+    path: layer_8/width_16k/average_l0_129
+    l0: 129
+  - id: layer_8/width_16k/average_l0_282
+    path: layer_8/width_16k/average_l0_282
+    l0: 282
+  - id: layer_8/width_16k/average_l0_32
+    path: layer_8/width_16k/average_l0_32
+    l0: 32
+  - id: layer_8/width_16k/average_l0_482
+    path: layer_8/width_16k/average_l0_482
+    l0: 482
+  - id: layer_8/width_16k/average_l0_64
+    path: layer_8/width_16k/average_l0_64
+    l0: 64
+  - id: layer_9/width_16k/average_l0_127
+    path: layer_9/width_16k/average_l0_127
+    l0: 127
+  - id: layer_9/width_16k/average_l0_270
+    path: layer_9/width_16k/average_l0_270
+    l0: 270
+  - id: layer_9/width_16k/average_l0_34
+    path: layer_9/width_16k/average_l0_34
+    l0: 34
+  - id: layer_9/width_16k/average_l0_499
+    path: layer_9/width_16k/average_l0_499
+    l0: 499
+  - id: layer_9/width_16k/average_l0_64
+    path: layer_9/width_16k/average_l0_64
+    l0: 64
+  - id: layer_10/width_16k/average_l0_148
+    path: layer_10/width_16k/average_l0_148
+    l0: 148
+  - id: layer_10/width_16k/average_l0_307
+    path: layer_10/width_16k/average_l0_307
+    l0: 307
+  - id: layer_10/width_16k/average_l0_36
+    path: layer_10/width_16k/average_l0_36
+    l0: 36
+  - id: layer_10/width_16k/average_l0_541
+    path: layer_10/width_16k/average_l0_541
+    l0: 541
+  - id: layer_10/width_16k/average_l0_70
+    path: layer_10/width_16k/average_l0_70
+    l0: 70
+  - id: layer_11/width_16k/average_l0_170
+    path: layer_11/width_16k/average_l0_170
+    l0: 170
+  - id: layer_11/width_16k/average_l0_350
+    path: layer_11/width_16k/average_l0_350
+    l0: 350
+  - id: layer_11/width_16k/average_l0_41
+    path: layer_11/width_16k/average_l0_41
+    l0: 41
+  - id: layer_11/width_16k/average_l0_593
+    path: layer_11/width_16k/average_l0_593
+    l0: 593
+  - id: layer_11/width_16k/average_l0_80
+    path: layer_11/width_16k/average_l0_80
+    l0: 80
+  - id: layer_12/width_16k/average_l0_184
+    path: layer_12/width_16k/average_l0_184
+    l0: 184
+  - id: layer_12/width_16k/average_l0_328
+    path: layer_12/width_16k/average_l0_328
+    l0: 328
+  - id: layer_12/width_16k/average_l0_41
+    path: layer_12/width_16k/average_l0_41
+    l0: 41
+  - id: layer_12/width_16k/average_l0_514
+    path: layer_12/width_16k/average_l0_514
+    l0: 514
+  - id: layer_12/width_16k/average_l0_85
+    path: layer_12/width_16k/average_l0_85
+    l0: 85
+  - id: layer_13/width_16k/average_l0_203
+    path: layer_13/width_16k/average_l0_203
+    l0: 203
+  - id: layer_13/width_16k/average_l0_372
+    path: layer_13/width_16k/average_l0_372
+    l0: 372
+  - id: layer_13/width_16k/average_l0_43
+    path: layer_13/width_16k/average_l0_43
+    l0: 43
+  - id: layer_13/width_16k/average_l0_570
+    path: layer_13/width_16k/average_l0_570
+    l0: 570
+  - id: layer_13/width_16k/average_l0_92
+    path: layer_13/width_16k/average_l0_92
+    l0: 92
+  - id: layer_14/width_16k/average_l0_161
+    path: layer_14/width_16k/average_l0_161
+    l0: 161
+  - id: layer_14/width_16k/average_l0_298
+    path: layer_14/width_16k/average_l0_298
+    l0: 298
+  - id: layer_14/width_16k/average_l0_37
+    path: layer_14/width_16k/average_l0_37
+    l0: 37
+  - id: layer_14/width_16k/average_l0_468
+    path: layer_14/width_16k/average_l0_468
+    l0: 468
+  - id: layer_14/width_16k/average_l0_71
+    path: layer_14/width_16k/average_l0_71
+    l0: 71
+  - id: layer_15/width_16k/average_l0_195
+    path: layer_15/width_16k/average_l0_195
+    l0: 195
+  - id: layer_15/width_16k/average_l0_342
+    path: layer_15/width_16k/average_l0_342
+    l0: 342
+  - id: layer_15/width_16k/average_l0_44
+    path: layer_15/width_16k/average_l0_44
+    l0: 44
+  - id: layer_15/width_16k/average_l0_535
+    path: layer_15/width_16k/average_l0_535
+    l0: 535
+  - id: layer_15/width_16k/average_l0_98
+    path: layer_15/width_16k/average_l0_98
+    l0: 98
+  - id: layer_16/width_16k/average_l0_144
+    path: layer_16/width_16k/average_l0_144
+    l0: 144
+  - id: layer_16/width_16k/average_l0_293
+    path: layer_16/width_16k/average_l0_293
+    l0: 293
+  - id: layer_16/width_16k/average_l0_37
+    path: layer_16/width_16k/average_l0_37
+    l0: 37
+  - id: layer_16/width_16k/average_l0_527
+    path: layer_16/width_16k/average_l0_527
+    l0: 527
+  - id: layer_16/width_16k/average_l0_71
+    path: layer_16/width_16k/average_l0_71
+    l0: 71
+  - id: layer_17/width_16k/average_l0_176
+    path: layer_17/width_16k/average_l0_176
+    l0: 176
+  - id: layer_17/width_16k/average_l0_316
+    path: layer_17/width_16k/average_l0_316
+    l0: 316
+  - id: layer_17/width_16k/average_l0_38
+    path: layer_17/width_16k/average_l0_38
+    l0: 38
+  - id: layer_17/width_16k/average_l0_509
+    path: layer_17/width_16k/average_l0_509
+    l0: 509
+  - id: layer_17/width_16k/average_l0_79
+    path: layer_17/width_16k/average_l0_79
+    l0: 79
+  - id: layer_18/width_16k/average_l0_144
+    path: layer_18/width_16k/average_l0_144
+    l0: 144
+  - id: layer_18/width_16k/average_l0_292
+    path: layer_18/width_16k/average_l0_292
+    l0: 292
+  - id: layer_18/width_16k/average_l0_34
+    path: layer_18/width_16k/average_l0_34
+    l0: 34
+  - id: layer_18/width_16k/average_l0_491
+    path: layer_18/width_16k/average_l0_491
+    l0: 491
+  - id: layer_18/width_16k/average_l0_72
+    path: layer_18/width_16k/average_l0_72
+    l0: 72
+  - id: layer_19/width_16k/average_l0_122
+    path: layer_19/width_16k/average_l0_122
+    l0: 122
+  - id: layer_19/width_16k/average_l0_249
+    path: layer_19/width_16k/average_l0_249
+    l0: 249
+  - id: layer_19/width_16k/average_l0_28
+    path: layer_19/width_16k/average_l0_28
+    l0: 28
+  - id: layer_19/width_16k/average_l0_423
+    path: layer_19/width_16k/average_l0_423
+    l0: 423
+  - id: layer_19/width_16k/average_l0_56
+    path: layer_19/width_16k/average_l0_56
+    l0: 56
+  - id: layer_20/width_16k/average_l0_141
+    path: layer_20/width_16k/average_l0_141
+    l0: 141
+  - id: layer_20/width_16k/average_l0_274
+    path: layer_20/width_16k/average_l0_274
+    l0: 274
+  - id: layer_20/width_16k/average_l0_31
+    path: layer_20/width_16k/average_l0_31
+    l0: 31
+  - id: layer_20/width_16k/average_l0_446
+    path: layer_20/width_16k/average_l0_446
+    l0: 446
+  - id: layer_20/width_16k/average_l0_62
+    path: layer_20/width_16k/average_l0_62
+    l0: 62
+  - id: layer_21/width_16k/average_l0_142
+    path: layer_21/width_16k/average_l0_142
+    l0: 142
+  - id: layer_21/width_16k/average_l0_301
+    path: layer_21/width_16k/average_l0_301
+    l0: 301
+  - id: layer_21/width_16k/average_l0_32
+    path: layer_21/width_16k/average_l0_32
+    l0: 32
+  - id: layer_21/width_16k/average_l0_505
+    path: layer_21/width_16k/average_l0_505
+    l0: 505
+  - id: layer_21/width_16k/average_l0_65
+    path: layer_21/width_16k/average_l0_65
+    l0: 65
+  - id: layer_22/width_16k/average_l0_106
+    path: layer_22/width_16k/average_l0_106
+    l0: 106
+  - id: layer_22/width_16k/average_l0_215
+    path: layer_22/width_16k/average_l0_215
+    l0: 215
+  - id: layer_22/width_16k/average_l0_22
+    path: layer_22/width_16k/average_l0_22
+    l0: 22
+  - id: layer_22/width_16k/average_l0_373
+    path: layer_22/width_16k/average_l0_373
+    l0: 373
+  - id: layer_22/width_16k/average_l0_47
+    path: layer_22/width_16k/average_l0_47
+    l0: 47
+  - id: layer_23/width_16k/average_l0_161
+    path: layer_23/width_16k/average_l0_161
+    l0: 161
+  - id: layer_23/width_16k/average_l0_30
+    path: layer_23/width_16k/average_l0_30
+    l0: 30
+  - id: layer_23/width_16k/average_l0_300
+    path: layer_23/width_16k/average_l0_300
+    l0: 300
+  - id: layer_23/width_16k/average_l0_474
+    path: layer_23/width_16k/average_l0_474
+    l0: 474
+  - id: layer_23/width_16k/average_l0_73
+    path: layer_23/width_16k/average_l0_73
+    l0: 73
+  - id: layer_24/width_16k/average_l0_212
+    path: layer_24/width_16k/average_l0_212
+    l0: 212
+  - id: layer_24/width_16k/average_l0_372
+    path: layer_24/width_16k/average_l0_372
+    l0: 372
+  - id: layer_24/width_16k/average_l0_39
+    path: layer_24/width_16k/average_l0_39
+    l0: 39
+  - id: layer_24/width_16k/average_l0_558
+    path: layer_24/width_16k/average_l0_558
+    l0: 558
+  - id: layer_24/width_16k/average_l0_96
+    path: layer_24/width_16k/average_l0_96
+    l0: 96
+  - id: layer_25/width_16k/average_l0_177
+    path: layer_25/width_16k/average_l0_177
+    l0: 177
+  - id: layer_25/width_16k/average_l0_313
+    path: layer_25/width_16k/average_l0_313
+    l0: 313
+  - id: layer_25/width_16k/average_l0_35
+    path: layer_25/width_16k/average_l0_35
+    l0: 35
+  - id: layer_25/width_16k/average_l0_492
+    path: layer_25/width_16k/average_l0_492
+    l0: 492
+  - id: layer_25/width_16k/average_l0_77
+    path: layer_25/width_16k/average_l0_77
+    l0: 77
+  - id: layer_0/width_65k/average_l0_10
+    path: layer_0/width_65k/average_l0_10
+    l0: 10
+  - id: layer_0/width_65k/average_l0_16
+    path: layer_0/width_65k/average_l0_16
+    l0: 16
+  - id: layer_0/width_65k/average_l0_24
+    path: layer_0/width_65k/average_l0_24
+    l0: 24
+  - id: layer_0/width_65k/average_l0_43
+    path: layer_0/width_65k/average_l0_43
+    l0: 43
+  - id: layer_0/width_65k/average_l0_75
+    path: layer_0/width_65k/average_l0_75
+    l0: 75
+  - id: layer_1/width_65k/average_l0_15
+    path: layer_1/width_65k/average_l0_15
+    l0: 15
+  - id: layer_1/width_65k/average_l0_181
+    path: layer_1/width_65k/average_l0_181
+    l0: 181
+  - id: layer_1/width_65k/average_l0_28
+    path: layer_1/width_65k/average_l0_28
+    l0: 28
+  - id: layer_1/width_65k/average_l0_55
+    path: layer_1/width_65k/average_l0_55
+    l0: 55
+  - id: layer_1/width_65k/average_l0_98
+    path: layer_1/width_65k/average_l0_98
+    l0: 98
+  - id: layer_2/width_65k/average_l0_125
+    path: layer_2/width_65k/average_l0_125
+    l0: 125
+  - id: layer_2/width_65k/average_l0_14
+    path: layer_2/width_65k/average_l0_14
+    l0: 14
+  - id: layer_2/width_65k/average_l0_228
+    path: layer_2/width_65k/average_l0_228
+    l0: 228
+  - id: layer_2/width_65k/average_l0_28
+    path: layer_2/width_65k/average_l0_28
+    l0: 28
+  - id: layer_2/width_65k/average_l0_59
+    path: layer_2/width_65k/average_l0_59
+    l0: 59
+  - id: layer_3/width_65k/average_l0_174
+    path: layer_3/width_65k/average_l0_174
+    l0: 174
+  - id: layer_3/width_65k/average_l0_19
+    path: layer_3/width_65k/average_l0_19
+    l0: 19
+  - id: layer_3/width_65k/average_l0_320
+    path: layer_3/width_65k/average_l0_320
+    l0: 320
+  - id: layer_3/width_65k/average_l0_39
+    path: layer_3/width_65k/average_l0_39
+    l0: 39
+  - id: layer_3/width_65k/average_l0_83
+    path: layer_3/width_65k/average_l0_83
+    l0: 83
+  - id: layer_4/width_65k/average_l0_188
+    path: layer_4/width_65k/average_l0_188
+    l0: 188
+  - id: layer_4/width_65k/average_l0_22
+    path: layer_4/width_65k/average_l0_22
+    l0: 22
+  - id: layer_4/width_65k/average_l0_382
+    path: layer_4/width_65k/average_l0_382
+    l0: 382
+  - id: layer_4/width_65k/average_l0_43
+    path: layer_4/width_65k/average_l0_43
+    l0: 43
+  - id: layer_4/width_65k/average_l0_87
+    path: layer_4/width_65k/average_l0_87
+    l0: 87
+  - id: layer_5/width_65k/average_l0_227
+    path: layer_5/width_65k/average_l0_227
+    l0: 227
+  - id: layer_5/width_65k/average_l0_28
+    path: layer_5/width_65k/average_l0_28
+    l0: 28
+  - id: layer_5/width_65k/average_l0_400
+    path: layer_5/width_65k/average_l0_400
+    l0: 400
+  - id: layer_5/width_65k/average_l0_51
+    path: layer_5/width_65k/average_l0_51
+    l0: 51
+  - id: layer_5/width_65k/average_l0_99
+    path: layer_5/width_65k/average_l0_99
+    l0: 99
+  - id: layer_6/width_65k/average_l0_112
+    path: layer_6/width_65k/average_l0_112
+    l0: 112
+  - id: layer_6/width_65k/average_l0_261
+    path: layer_6/width_65k/average_l0_261
+    l0: 261
+  - id: layer_6/width_65k/average_l0_30
+    path: layer_6/width_65k/average_l0_30
+    l0: 30
+  - id: layer_6/width_65k/average_l0_449
+    path: layer_6/width_65k/average_l0_449
+    l0: 449
+  - id: layer_6/width_65k/average_l0_55
+    path: layer_6/width_65k/average_l0_55
+    l0: 55
+  - id: layer_7/width_65k/average_l0_176
+    path: layer_7/width_65k/average_l0_176
+    l0: 176
+  - id: layer_7/width_65k/average_l0_311
+    path: layer_7/width_65k/average_l0_311
+    l0: 311
+  - id: layer_7/width_65k/average_l0_519
+    path: layer_7/width_65k/average_l0_519
+    l0: 519
+  - id: layer_7/width_65k/average_l0_52
+    path: layer_7/width_65k/average_l0_52
+    l0: 52
+  - id: layer_7/width_65k/average_l0_96
+    path: layer_7/width_65k/average_l0_96
+    l0: 96
+  - id: layer_8/width_65k/average_l0_112
+    path: layer_8/width_65k/average_l0_112
+    l0: 112
+  - id: layer_8/width_65k/average_l0_246
+    path: layer_8/width_65k/average_l0_246
+    l0: 246
+  - id: layer_8/width_65k/average_l0_35
+    path: layer_8/width_65k/average_l0_35
+    l0: 35
+  - id: layer_8/width_65k/average_l0_454
+    path: layer_8/width_65k/average_l0_454
+    l0: 454
+  - id: layer_8/width_65k/average_l0_56
+    path: layer_8/width_65k/average_l0_56
+    l0: 56
+  - id: layer_9/width_65k/average_l0_107
+    path: layer_9/width_65k/average_l0_107
+    l0: 107
+  - id: layer_9/width_65k/average_l0_231
+    path: layer_9/width_65k/average_l0_231
+    l0: 231
+  - id: layer_9/width_65k/average_l0_31
+    path: layer_9/width_65k/average_l0_31
+    l0: 31
+  - id: layer_9/width_65k/average_l0_454
+    path: layer_9/width_65k/average_l0_454
+    l0: 454
+  - id: layer_9/width_65k/average_l0_57
+    path: layer_9/width_65k/average_l0_57
+    l0: 57
+  - id: layer_10/width_65k/average_l0_134
+    path: layer_10/width_65k/average_l0_134
+    l0: 134
+  - id: layer_10/width_65k/average_l0_292
+    path: layer_10/width_65k/average_l0_292
+    l0: 292
+  - id: layer_10/width_65k/average_l0_35
+    path: layer_10/width_65k/average_l0_35
+    l0: 35
+  - id: layer_10/width_65k/average_l0_521
+    path: layer_10/width_65k/average_l0_521
+    l0: 521
+  - id: layer_10/width_65k/average_l0_67
+    path: layer_10/width_65k/average_l0_67
+    l0: 67
+  - id: layer_11/width_65k/average_l0_154
+    path: layer_11/width_65k/average_l0_154
+    l0: 154
+  - id: layer_11/width_65k/average_l0_330
+    path: layer_11/width_65k/average_l0_330
+    l0: 330
+  - id: layer_11/width_65k/average_l0_41
+    path: layer_11/width_65k/average_l0_41
+    l0: 41
+  - id: layer_11/width_65k/average_l0_576
+    path: layer_11/width_65k/average_l0_576
+    l0: 576
+  - id: layer_11/width_65k/average_l0_75
+    path: layer_11/width_65k/average_l0_75
+    l0: 75
+  - id: layer_12/width_65k/average_l0_172
+    path: layer_12/width_65k/average_l0_172
+    l0: 172
+  - id: layer_12/width_65k/average_l0_320
+    path: layer_12/width_65k/average_l0_320
+    l0: 320
+  - id: layer_12/width_65k/average_l0_39
+    path: layer_12/width_65k/average_l0_39
+    l0: 39
+  - id: layer_12/width_65k/average_l0_503
+    path: layer_12/width_65k/average_l0_503
+    l0: 503
+  - id: layer_12/width_65k/average_l0_79
+    path: layer_12/width_65k/average_l0_79
+    l0: 79
+  - id: layer_13/width_65k/average_l0_191
+    path: layer_13/width_65k/average_l0_191
+    l0: 191
+  - id: layer_13/width_65k/average_l0_363
+    path: layer_13/width_65k/average_l0_363
+    l0: 363
+  - id: layer_13/width_65k/average_l0_41
+    path: layer_13/width_65k/average_l0_41
+    l0: 41
+  - id: layer_13/width_65k/average_l0_556
+    path: layer_13/width_65k/average_l0_556
+    l0: 556
+  - id: layer_13/width_65k/average_l0_87
+    path: layer_13/width_65k/average_l0_87
+    l0: 87
+  - id: layer_14/width_65k/average_l0_138
+    path: layer_14/width_65k/average_l0_138
+    l0: 138
+  - id: layer_14/width_65k/average_l0_283
+    path: layer_14/width_65k/average_l0_283
+    l0: 283
+  - id: layer_14/width_65k/average_l0_37
+    path: layer_14/width_65k/average_l0_37
+    l0: 37
+  - id: layer_14/width_65k/average_l0_453
+    path: layer_14/width_65k/average_l0_453
+    l0: 453
+  - id: layer_14/width_65k/average_l0_66
+    path: layer_14/width_65k/average_l0_66
+    l0: 66
+  - id: layer_15/width_65k/average_l0_182
+    path: layer_15/width_65k/average_l0_182
+    l0: 182
+  - id: layer_15/width_65k/average_l0_327
+    path: layer_15/width_65k/average_l0_327
+    l0: 327
+  - id: layer_15/width_65k/average_l0_42
+    path: layer_15/width_65k/average_l0_42
+    l0: 42
+  - id: layer_15/width_65k/average_l0_517
+    path: layer_15/width_65k/average_l0_517
+    l0: 517
+  - id: layer_15/width_65k/average_l0_90
+    path: layer_15/width_65k/average_l0_90
+    l0: 90
+  - id: layer_16/width_65k/average_l0_129
+    path: layer_16/width_65k/average_l0_129
+    l0: 129
+  - id: layer_16/width_65k/average_l0_260
+    path: layer_16/width_65k/average_l0_260
+    l0: 260
+  - id: layer_16/width_65k/average_l0_35
+    path: layer_16/width_65k/average_l0_35
+    l0: 35
+  - id: layer_16/width_65k/average_l0_502
+    path: layer_16/width_65k/average_l0_502
+    l0: 502
+  - id: layer_16/width_65k/average_l0_64
+    path: layer_16/width_65k/average_l0_64
+    l0: 64
+  - id: layer_17/width_65k/average_l0_157
+    path: layer_17/width_65k/average_l0_157
+    l0: 157
+  - id: layer_17/width_65k/average_l0_293
+    path: layer_17/width_65k/average_l0_293
+    l0: 293
+  - id: layer_17/width_65k/average_l0_35
+    path: layer_17/width_65k/average_l0_35
+    l0: 35
+  - id: layer_17/width_65k/average_l0_489
+    path: layer_17/width_65k/average_l0_489
+    l0: 489
+  - id: layer_17/width_65k/average_l0_70
+    path: layer_17/width_65k/average_l0_70
+    l0: 70
+  - id: layer_18/width_65k/average_l0_123
+    path: layer_18/width_65k/average_l0_123
+    l0: 123
+  - id: layer_18/width_65k/average_l0_255
+    path: layer_18/width_65k/average_l0_255
+    l0: 255
+  - id: layer_18/width_65k/average_l0_29
+    path: layer_18/width_65k/average_l0_29
+    l0: 29
+  - id: layer_18/width_65k/average_l0_466
+    path: layer_18/width_65k/average_l0_466
+    l0: 466
+  - id: layer_18/width_65k/average_l0_58
+    path: layer_18/width_65k/average_l0_58
+    l0: 58
+  - id: layer_19/width_65k/average_l0_106
+    path: layer_19/width_65k/average_l0_106
+    l0: 106
+  - id: layer_19/width_65k/average_l0_220
+    path: layer_19/width_65k/average_l0_220
+    l0: 220
+  - id: layer_19/width_65k/average_l0_26
+    path: layer_19/width_65k/average_l0_26
+    l0: 26
+  - id: layer_19/width_65k/average_l0_411
+    path: layer_19/width_65k/average_l0_411
+    l0: 411
+  - id: layer_19/width_65k/average_l0_49
+    path: layer_19/width_65k/average_l0_49
+    l0: 49
+  - id: layer_20/width_65k/average_l0_102
+    path: layer_20/width_65k/average_l0_102
+    l0: 102
+  - id: layer_20/width_65k/average_l0_242
+    path: layer_20/width_65k/average_l0_242
+    l0: 242
+  - id: layer_20/width_65k/average_l0_26
+    path: layer_20/width_65k/average_l0_26
+    l0: 26
+  - id: layer_20/width_65k/average_l0_419
+    path: layer_20/width_65k/average_l0_419
+    l0: 419
+  - id: layer_20/width_65k/average_l0_49
+    path: layer_20/width_65k/average_l0_49
+    l0: 49
+  - id: layer_21/width_65k/average_l0_118
+    path: layer_21/width_65k/average_l0_118
+    l0: 118
+  - id: layer_21/width_65k/average_l0_266
+    path: layer_21/width_65k/average_l0_266
+    l0: 266
+  - id: layer_21/width_65k/average_l0_29
+    path: layer_21/width_65k/average_l0_29
+    l0: 29
+  - id: layer_21/width_65k/average_l0_474
+    path: layer_21/width_65k/average_l0_474
+    l0: 474
+  - id: layer_21/width_65k/average_l0_56
+    path: layer_21/width_65k/average_l0_56
+    l0: 56
+  - id: layer_22/width_65k/average_l0_112
+    path: layer_22/width_65k/average_l0_112
+    l0: 112
+  - id: layer_22/width_65k/average_l0_196
+    path: layer_22/width_65k/average_l0_196
+    l0: 196
+  - id: layer_22/width_65k/average_l0_20
+    path: layer_22/width_65k/average_l0_20
+    l0: 20
+  - id: layer_22/width_65k/average_l0_361
+    path: layer_22/width_65k/average_l0_361
+    l0: 361
+  - id: layer_22/width_65k/average_l0_37
+    path: layer_22/width_65k/average_l0_37
+    l0: 37
+  - id: layer_23/width_65k/average_l0_140
+    path: layer_23/width_65k/average_l0_140
+    l0: 140
+  - id: layer_23/width_65k/average_l0_27
+    path: layer_23/width_65k/average_l0_27
+    l0: 27
+  - id: layer_23/width_65k/average_l0_276
+    path: layer_23/width_65k/average_l0_276
+    l0: 276
+  - id: layer_23/width_65k/average_l0_457
+    path: layer_23/width_65k/average_l0_457
+    l0: 457
+  - id: layer_23/width_65k/average_l0_56
+    path: layer_23/width_65k/average_l0_56
+    l0: 56
+  - id: layer_24/width_65k/average_l0_186
+    path: layer_24/width_65k/average_l0_186
+    l0: 186
+  - id: layer_24/width_65k/average_l0_32
+    path: layer_24/width_65k/average_l0_32
+    l0: 32
+  - id: layer_24/width_65k/average_l0_347
+    path: layer_24/width_65k/average_l0_347
+    l0: 347
+  - id: layer_24/width_65k/average_l0_537
+    path: layer_24/width_65k/average_l0_537
+    l0: 537
+  - id: layer_24/width_65k/average_l0_77
+    path: layer_24/width_65k/average_l0_77
+    l0: 77
+  - id: layer_25/width_65k/average_l0_153
+    path: layer_25/width_65k/average_l0_153
+    l0: 153
+  - id: layer_25/width_65k/average_l0_290
+    path: layer_25/width_65k/average_l0_290
+    l0: 290
+  - id: layer_25/width_65k/average_l0_30
+    path: layer_25/width_65k/average_l0_30
+    l0: 30
+  - id: layer_25/width_65k/average_l0_465
+    path: layer_25/width_65k/average_l0_465
+    l0: 465
+  - id: layer_25/width_65k/average_l0_63
+    path: layer_25/width_65k/average_l0_63
+    l0: 63
+gemma-scope-2b-pt-att-canonical:
+  repo_id: google/gemma-scope-2b-pt-att
+  model: gemma-2-2b
+  conversion_func: gemma_2
+  saes:
+  - id: layer_0/width_16k/canonical
+    path: layer_0/width_16k/average_l0_104
+    neuronpedia: gemma-2-2b/0-gemmascope-att-16k
+  - id: layer_1/width_16k/canonical
+    path: layer_1/width_16k/average_l0_79
+    neuronpedia: gemma-2-2b/1-gemmascope-att-16k
+  - id: layer_2/width_16k/canonical
+    path: layer_2/width_16k/average_l0_93
+    neuronpedia: gemma-2-2b/2-gemmascope-att-16k
+  - id: layer_3/width_16k/canonical
+    path: layer_3/width_16k/average_l0_117
+    neuronpedia: gemma-2-2b/3-gemmascope-att-16k
+  - id: layer_4/width_16k/canonical
+    path: layer_4/width_16k/average_l0_116
+    neuronpedia: gemma-2-2b/4-gemmascope-att-16k
+  - id: layer_5/width_16k/canonical
+    path: layer_5/width_16k/average_l0_135
+    neuronpedia: gemma-2-2b/5-gemmascope-att-16k
+  - id: layer_6/width_16k/canonical
+    path: layer_6/width_16k/average_l0_61
+    neuronpedia: gemma-2-2b/6-gemmascope-att-16k
+  - id: layer_7/width_16k/canonical
+    path: layer_7/width_16k/average_l0_99
+    neuronpedia: gemma-2-2b/7-gemmascope-att-16k
+  - id: layer_8/width_16k/canonical
+    path: layer_8/width_16k/average_l0_129
+    neuronpedia: gemma-2-2b/8-gemmascope-att-16k
+  - id: layer_9/width_16k/canonical
+    path: layer_9/width_16k/average_l0_127
+    neuronpedia: gemma-2-2b/9-gemmascope-att-16k
+  - id: layer_10/width_16k/canonical
+    path: layer_10/width_16k/average_l0_70
+    neuronpedia: gemma-2-2b/10-gemmascope-att-16k
+  - id: layer_11/width_16k/canonical
+    path: layer_11/width_16k/average_l0_80
+    neuronpedia: gemma-2-2b/11-gemmascope-att-16k
+  - id: layer_12/width_16k/canonical
+    path: layer_12/width_16k/average_l0_85
+    neuronpedia: gemma-2-2b/12-gemmascope-att-16k
+  - id: layer_13/width_16k/canonical
+    path: layer_13/width_16k/average_l0_92
+    neuronpedia: gemma-2-2b/13-gemmascope-att-16k
+  - id: layer_14/width_16k/canonical
+    path: layer_14/width_16k/average_l0_71
+    neuronpedia: gemma-2-2b/14-gemmascope-att-16k
+  - id: layer_15/width_16k/canonical
+    path: layer_15/width_16k/average_l0_98
+    neuronpedia: gemma-2-2b/15-gemmascope-att-16k
+  - id: layer_16/width_16k/canonical
+    path: layer_16/width_16k/average_l0_71
+    neuronpedia: gemma-2-2b/16-gemmascope-att-16k
+  - id: layer_17/width_16k/canonical
+    path: layer_17/width_16k/average_l0_79
+    neuronpedia: gemma-2-2b/17-gemmascope-att-16k
+  - id: layer_18/width_16k/canonical
+    path: layer_18/width_16k/average_l0_72
+    neuronpedia: gemma-2-2b/18-gemmascope-att-16k
+  - id: layer_19/width_16k/canonical
+    path: layer_19/width_16k/average_l0_122
+    neuronpedia: gemma-2-2b/19-gemmascope-att-16k
+  - id: layer_20/width_16k/canonical
+    path: layer_20/width_16k/average_l0_62
+    neuronpedia: gemma-2-2b/20-gemmascope-att-16k
+  - id: layer_21/width_16k/canonical
+    path: layer_21/width_16k/average_l0_65
+    neuronpedia: gemma-2-2b/21-gemmascope-att-16k
+  - id: layer_22/width_16k/canonical
+    path: layer_22/width_16k/average_l0_106
+    neuronpedia: gemma-2-2b/22-gemmascope-att-16k
+  - id: layer_23/width_16k/canonical
+    path: layer_23/width_16k/average_l0_73
+    neuronpedia: gemma-2-2b/23-gemmascope-att-16k
+  - id: layer_24/width_16k/canonical
+    path: layer_24/width_16k/average_l0_96
+    neuronpedia: gemma-2-2b/24-gemmascope-att-16k
+  - id: layer_25/width_16k/canonical
+    path: layer_25/width_16k/average_l0_77
+    neuronpedia: gemma-2-2b/25-gemmascope-att-16k
+  - id: layer_0/width_65k/canonical
+    path: layer_0/width_65k/average_l0_75
+    neuronpedia: gemma-2-2b/0-gemmascope-att-65k
+  - id: layer_1/width_65k/canonical
+    path: layer_1/width_65k/average_l0_98
+    neuronpedia: gemma-2-2b/1-gemmascope-att-65k
+  - id: layer_2/width_65k/canonical
+    path: layer_2/width_65k/average_l0_125
+    neuronpedia: gemma-2-2b/2-gemmascope-att-65k
+  - id: layer_3/width_65k/canonical
+    path: layer_3/width_65k/average_l0_83
+    neuronpedia: gemma-2-2b/3-gemmascope-att-65k
+  - id: layer_4/width_65k/canonical
+    path: layer_4/width_65k/average_l0_87
+    neuronpedia: gemma-2-2b/4-gemmascope-att-65k
+  - id: layer_5/width_65k/canonical
+    path: layer_5/width_65k/average_l0_99
+    neuronpedia: gemma-2-2b/5-gemmascope-att-65k
+  - id: layer_6/width_65k/canonical
+    path: layer_6/width_65k/average_l0_112
+    neuronpedia: gemma-2-2b/6-gemmascope-att-65k
+  - id: layer_7/width_65k/canonical
+    path: layer_7/width_65k/average_l0_96
+    neuronpedia: gemma-2-2b/7-gemmascope-att-65k
+  - id: layer_8/width_65k/canonical
+    path: layer_8/width_65k/average_l0_112
+    neuronpedia: gemma-2-2b/8-gemmascope-att-65k
+  - id: layer_9/width_65k/canonical
+    path: layer_9/width_65k/average_l0_107
+    neuronpedia: gemma-2-2b/9-gemmascope-att-65k
+  - id: layer_10/width_65k/canonical
+    path: layer_10/width_65k/average_l0_67
+    neuronpedia: gemma-2-2b/10-gemmascope-att-65k
+  - id: layer_11/width_65k/canonical
+    path: layer_11/width_65k/average_l0_75
+    neuronpedia: gemma-2-2b/11-gemmascope-att-65k
+  - id: layer_12/width_65k/canonical
+    path: layer_12/width_65k/average_l0_79
+    neuronpedia: gemma-2-2b/12-gemmascope-att-65k
+  - id: layer_13/width_65k/canonical
+    path: layer_13/width_65k/average_l0_87
+    neuronpedia: gemma-2-2b/13-gemmascope-att-65k
+  - id: layer_14/width_65k/canonical
+    path: layer_14/width_65k/average_l0_66
+    neuronpedia: gemma-2-2b/14-gemmascope-att-65k
+  - id: layer_15/width_65k/canonical
+    path: layer_15/width_65k/average_l0_90
+    neuronpedia: gemma-2-2b/15-gemmascope-att-65k
+  - id: layer_16/width_65k/canonical
+    path: layer_16/width_65k/average_l0_129
+    neuronpedia: gemma-2-2b/16-gemmascope-att-65k
+  - id: layer_17/width_65k/canonical
+    path: layer_17/width_65k/average_l0_70
+    neuronpedia: gemma-2-2b/17-gemmascope-att-65k
+  - id: layer_18/width_65k/canonical
+    path: layer_18/width_65k/average_l0_123
+    neuronpedia: gemma-2-2b/18-gemmascope-att-65k
+  - id: layer_19/width_65k/canonical
+    path: layer_19/width_65k/average_l0_106
+    neuronpedia: gemma-2-2b/19-gemmascope-att-65k
+  - id: layer_20/width_65k/canonical
+    path: layer_20/width_65k/average_l0_102
+    neuronpedia: gemma-2-2b/20-gemmascope-att-65k
+  - id: layer_21/width_65k/canonical
+    path: layer_21/width_65k/average_l0_118
+    neuronpedia: gemma-2-2b/21-gemmascope-att-65k
+  - id: layer_22/width_65k/canonical
+    path: layer_22/width_65k/average_l0_112
+    neuronpedia: gemma-2-2b/22-gemmascope-att-65k
+  - id: layer_23/width_65k/canonical
+    path: layer_23/width_65k/average_l0_140
+    neuronpedia: gemma-2-2b/23-gemmascope-att-65k
+  - id: layer_24/width_65k/canonical
+    path: layer_24/width_65k/average_l0_77
+    neuronpedia: gemma-2-2b/24-gemmascope-att-65k
+  - id: layer_25/width_65k/canonical
+    path: layer_25/width_65k/average_l0_63
+    neuronpedia: gemma-2-2b/25-gemmascope-att-65k
+gemma-scope-9b-pt-res:
+  repo_id: google/gemma-scope-9b-pt-res
+  model: gemma-2-9b
+  conversion_func: gemma_2
+  saes:
+  - id: layer_0/width_131k/average_l0_11
+    path: layer_0/width_131k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_0/width_131k/average_l0_15
+    path: layer_0/width_131k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_0/width_131k/average_l0_21
+    path: layer_0/width_131k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_0/width_131k/average_l0_30
+    path: layer_0/width_131k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_0/width_131k/average_l0_41
+    path: layer_0/width_131k/average_l0_41/params.npz
+    l0: 41
+  - id: layer_0/width_131k/average_l0_8
+    path: layer_0/width_131k/average_l0_8/params.npz
+    l0: 8
+  - id: layer_0/width_16k/average_l0_11
+    path: layer_0/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_0/width_16k/average_l0_129
+    path: layer_0/width_16k/average_l0_129/params.npz
+    l0: 129
+  - id: layer_0/width_16k/average_l0_17
+    path: layer_0/width_16k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_0/width_16k/average_l0_35
+    path: layer_0/width_16k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_0/width_16k/average_l0_68
+    path: layer_0/width_16k/average_l0_68/params.npz
+    l0: 68
+  - id: layer_1/width_131k/average_l0_13
+    path: layer_1/width_131k/average_l0_13/params.npz
+    l0: 13
+  - id: layer_1/width_131k/average_l0_20
+    path: layer_1/width_131k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_1/width_131k/average_l0_33
+    path: layer_1/width_131k/average_l0_33/params.npz
+    l0: 33
+  - id: layer_1/width_131k/average_l0_56
+    path: layer_1/width_131k/average_l0_56/params.npz
+    l0: 56
+  - id: layer_1/width_131k/average_l0_6
+    path: layer_1/width_131k/average_l0_6/params.npz
+    l0: 6
+  - id: layer_1/width_131k/average_l0_9
+    path: layer_1/width_131k/average_l0_9/params.npz
+    l0: 9
+  - id: layer_1/width_16k/average_l0_15
+    path: layer_1/width_16k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_1/width_16k/average_l0_175
+    path: layer_1/width_16k/average_l0_175/params.npz
+    l0: 175
+  - id: layer_1/width_16k/average_l0_31
+    path: layer_1/width_16k/average_l0_31/params.npz
+    l0: 31
+  - id: layer_1/width_16k/average_l0_69
+    path: layer_1/width_16k/average_l0_69/params.npz
+    l0: 69
+  - id: layer_1/width_16k/average_l0_9
+    path: layer_1/width_16k/average_l0_9/params.npz
+    l0: 9
+  - id: layer_10/width_131k/average_l0_15
+    path: layer_10/width_131k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_10/width_131k/average_l0_151
+    path: layer_10/width_131k/average_l0_151/params.npz
+    l0: 151
+  - id: layer_10/width_131k/average_l0_27
+    path: layer_10/width_131k/average_l0_27/params.npz
+    l0: 27
+  - id: layer_10/width_131k/average_l0_47
+    path: layer_10/width_131k/average_l0_47/params.npz
+    l0: 47
+  - id: layer_10/width_131k/average_l0_84
+    path: layer_10/width_131k/average_l0_84/params.npz
+    l0: 84
+  - id: layer_10/width_131k/average_l0_9
+    path: layer_10/width_131k/average_l0_9/params.npz
+    l0: 9
+  - id: layer_10/width_16k/average_l0_10
+    path: layer_10/width_16k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_10/width_16k/average_l0_113
+    path: layer_10/width_16k/average_l0_113/params.npz
+    l0: 113
+  - id: layer_10/width_16k/average_l0_17
+    path: layer_10/width_16k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_10/width_16k/average_l0_243
+    path: layer_10/width_16k/average_l0_243/params.npz
+    l0: 243
+  - id: layer_10/width_16k/average_l0_31
+    path: layer_10/width_16k/average_l0_31/params.npz
+    l0: 31
+  - id: layer_10/width_16k/average_l0_57
+    path: layer_10/width_16k/average_l0_57/params.npz
+    l0: 57
+  - id: layer_11/width_131k/average_l0_16
+    path: layer_11/width_131k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_11/width_131k/average_l0_162
+    path: layer_11/width_131k/average_l0_162/params.npz
+    l0: 162
+  - id: layer_11/width_131k/average_l0_27
+    path: layer_11/width_131k/average_l0_27/params.npz
+    l0: 27
+  - id: layer_11/width_131k/average_l0_49
+    path: layer_11/width_131k/average_l0_49/params.npz
+    l0: 49
+  - id: layer_11/width_131k/average_l0_88
+    path: layer_11/width_131k/average_l0_88/params.npz
+    l0: 88
+  - id: layer_11/width_131k/average_l0_9
+    path: layer_11/width_131k/average_l0_9/params.npz
+    l0: 9
+  - id: layer_11/width_16k/average_l0_10
+    path: layer_11/width_16k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_11/width_16k/average_l0_118
+    path: layer_11/width_16k/average_l0_118/params.npz
+    l0: 118
+  - id: layer_11/width_16k/average_l0_18
+    path: layer_11/width_16k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_11/width_16k/average_l0_255
+    path: layer_11/width_16k/average_l0_255/params.npz
+    l0: 255
+  - id: layer_11/width_16k/average_l0_32
+    path: layer_11/width_16k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_11/width_16k/average_l0_60
+    path: layer_11/width_16k/average_l0_60/params.npz
+    l0: 60
+  - id: layer_12/width_131k/average_l0_10
+    path: layer_12/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_12/width_131k/average_l0_17
+    path: layer_12/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_12/width_131k/average_l0_183
+    path: layer_12/width_131k/average_l0_183/params.npz
+    l0: 183
+  - id: layer_12/width_131k/average_l0_29
+    path: layer_12/width_131k/average_l0_29/params.npz
+    l0: 29
+  - id: layer_12/width_131k/average_l0_52
+    path: layer_12/width_131k/average_l0_52/params.npz
+    l0: 52
+  - id: layer_12/width_131k/average_l0_96
+    path: layer_12/width_131k/average_l0_96/params.npz
+    l0: 96
+  - id: layer_12/width_16k/average_l0_10
+    path: layer_12/width_16k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_12/width_16k/average_l0_130
+    path: layer_12/width_16k/average_l0_130/params.npz
+    l0: 130
+  - id: layer_12/width_16k/average_l0_19
+    path: layer_12/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_12/width_16k/average_l0_287
+    path: layer_12/width_16k/average_l0_287/params.npz
+    l0: 287
+  - id: layer_12/width_16k/average_l0_33
+    path: layer_12/width_16k/average_l0_33/params.npz
+    l0: 33
+  - id: layer_12/width_16k/average_l0_64
+    path: layer_12/width_16k/average_l0_64/params.npz
+    l0: 64
+  - id: layer_13/width_131k/average_l0_10
+    path: layer_13/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_13/width_131k/average_l0_17
+    path: layer_13/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_13/width_131k/average_l0_189
+    path: layer_13/width_131k/average_l0_189/params.npz
+    l0: 189
+  - id: layer_13/width_131k/average_l0_30
+    path: layer_13/width_131k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_13/width_131k/average_l0_54
+    path: layer_13/width_131k/average_l0_54/params.npz
+    l0: 54
+  - id: layer_13/width_131k/average_l0_99
+    path: layer_13/width_131k/average_l0_99/params.npz
+    l0: 99
+  - id: layer_13/width_16k/average_l0_11
+    path: layer_13/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_13/width_16k/average_l0_132
+    path: layer_13/width_16k/average_l0_132/params.npz
+    l0: 132
+  - id: layer_13/width_16k/average_l0_19
+    path: layer_13/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_13/width_16k/average_l0_285
+    path: layer_13/width_16k/average_l0_285/params.npz
+    l0: 285
+  - id: layer_13/width_16k/average_l0_34
+    path: layer_13/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_13/width_16k/average_l0_65
+    path: layer_13/width_16k/average_l0_65/params.npz
+    l0: 65
+  - id: layer_14/width_131k/average_l0_10
+    path: layer_14/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_14/width_131k/average_l0_105
+    path: layer_14/width_131k/average_l0_105/params.npz
+    l0: 105
+  - id: layer_14/width_131k/average_l0_18
+    path: layer_14/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_14/width_131k/average_l0_197
+    path: layer_14/width_131k/average_l0_197/params.npz
+    l0: 197
+  - id: layer_14/width_131k/average_l0_31
+    path: layer_14/width_131k/average_l0_31/params.npz
+    l0: 31
+  - id: layer_14/width_131k/average_l0_56
+    path: layer_14/width_131k/average_l0_56/params.npz
+    l0: 56
+  - id: layer_14/width_16k/average_l0_11
+    path: layer_14/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_14/width_16k/average_l0_137
+    path: layer_14/width_16k/average_l0_137/params.npz
+    l0: 137
+  - id: layer_14/width_16k/average_l0_19
+    path: layer_14/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_14/width_16k/average_l0_294
+    path: layer_14/width_16k/average_l0_294/params.npz
+    l0: 294
+  - id: layer_14/width_16k/average_l0_35
+    path: layer_14/width_16k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_14/width_16k/average_l0_67
+    path: layer_14/width_16k/average_l0_67/params.npz
+    l0: 67
+  - id: layer_15/width_131k/average_l0_10
+    path: layer_15/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_15/width_131k/average_l0_103
+    path: layer_15/width_131k/average_l0_103/params.npz
+    l0: 103
+  - id: layer_15/width_131k/average_l0_17
+    path: layer_15/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_15/width_131k/average_l0_198
+    path: layer_15/width_131k/average_l0_198/params.npz
+    l0: 198
+  - id: layer_15/width_131k/average_l0_30
+    path: layer_15/width_131k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_15/width_131k/average_l0_55
+    path: layer_15/width_131k/average_l0_55/params.npz
+    l0: 55
+  - id: layer_15/width_16k/average_l0_10
+    path: layer_15/width_16k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_15/width_16k/average_l0_131
+    path: layer_15/width_16k/average_l0_131/params.npz
+    l0: 131
+  - id: layer_15/width_16k/average_l0_18
+    path: layer_15/width_16k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_15/width_16k/average_l0_290
+    path: layer_15/width_16k/average_l0_290/params.npz
+    l0: 290
+  - id: layer_15/width_16k/average_l0_34
+    path: layer_15/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_15/width_16k/average_l0_65
+    path: layer_15/width_16k/average_l0_65/params.npz
+    l0: 65
+  - id: layer_16/width_131k/average_l0_11
+    path: layer_16/width_131k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_16/width_131k/average_l0_121
+    path: layer_16/width_131k/average_l0_121/params.npz
+    l0: 121
+  - id: layer_16/width_131k/average_l0_20
+    path: layer_16/width_131k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_16/width_131k/average_l0_232
+    path: layer_16/width_131k/average_l0_232/params.npz
+    l0: 232
+  - id: layer_16/width_131k/average_l0_35
+    path: layer_16/width_131k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_16/width_131k/average_l0_65
+    path: layer_16/width_131k/average_l0_65/params.npz
+    l0: 65
+  - id: layer_16/width_16k/average_l0_11
+    path: layer_16/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_16/width_16k/average_l0_152
+    path: layer_16/width_16k/average_l0_152/params.npz
+    l0: 152
+  - id: layer_16/width_16k/average_l0_21
+    path: layer_16/width_16k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_16/width_16k/average_l0_346
+    path: layer_16/width_16k/average_l0_346/params.npz
+    l0: 346
+  - id: layer_16/width_16k/average_l0_39
+    path: layer_16/width_16k/average_l0_39/params.npz
+    l0: 39
+  - id: layer_16/width_16k/average_l0_75
+    path: layer_16/width_16k/average_l0_75/params.npz
+    l0: 75
+  - id: layer_17/width_131k/average_l0_11
+    path: layer_17/width_131k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_17/width_131k/average_l0_117
+    path: layer_17/width_131k/average_l0_117/params.npz
+    l0: 117
+  - id: layer_17/width_131k/average_l0_19
+    path: layer_17/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_17/width_131k/average_l0_221
+    path: layer_17/width_131k/average_l0_221/params.npz
+    l0: 221
+  - id: layer_17/width_131k/average_l0_35
+    path: layer_17/width_131k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_17/width_131k/average_l0_64
+    path: layer_17/width_131k/average_l0_64/params.npz
+    l0: 64
+  - id: layer_17/width_16k/average_l0_12
+    path: layer_17/width_16k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_17/width_16k/average_l0_144
+    path: layer_17/width_16k/average_l0_144/params.npz
+    l0: 144
+  - id: layer_17/width_16k/average_l0_21
+    path: layer_17/width_16k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_17/width_16k/average_l0_317
+    path: layer_17/width_16k/average_l0_317/params.npz
+    l0: 317
+  - id: layer_17/width_16k/average_l0_38
+    path: layer_17/width_16k/average_l0_38/params.npz
+    l0: 38
+  - id: layer_17/width_16k/average_l0_73
+    path: layer_17/width_16k/average_l0_73/params.npz
+    l0: 73
+  - id: layer_18/width_131k/average_l0_11
+    path: layer_18/width_131k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_18/width_131k/average_l0_113
+    path: layer_18/width_131k/average_l0_113/params.npz
+    l0: 113
+  - id: layer_18/width_131k/average_l0_19
+    path: layer_18/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_18/width_131k/average_l0_221
+    path: layer_18/width_131k/average_l0_221/params.npz
+    l0: 221
+  - id: layer_18/width_131k/average_l0_34
+    path: layer_18/width_131k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_18/width_131k/average_l0_62
+    path: layer_18/width_131k/average_l0_62/params.npz
+    l0: 62
+  - id: layer_18/width_16k/average_l0_11
+    path: layer_18/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_18/width_16k/average_l0_140
+    path: layer_18/width_16k/average_l0_140/params.npz
+    l0: 140
+  - id: layer_18/width_16k/average_l0_20
+    path: layer_18/width_16k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_18/width_16k/average_l0_309
+    path: layer_18/width_16k/average_l0_309/params.npz
+    l0: 309
+  - id: layer_18/width_16k/average_l0_37
+    path: layer_18/width_16k/average_l0_37/params.npz
+    l0: 37
+  - id: layer_18/width_16k/average_l0_71
+    path: layer_18/width_16k/average_l0_71/params.npz
+    l0: 71
+  - id: layer_19/width_131k/average_l0_10
+    path: layer_19/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_19/width_131k/average_l0_110
+    path: layer_19/width_131k/average_l0_110/params.npz
+    l0: 110
+  - id: layer_19/width_131k/average_l0_18
+    path: layer_19/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_19/width_131k/average_l0_210
+    path: layer_19/width_131k/average_l0_210/params.npz
+    l0: 210
+  - id: layer_19/width_131k/average_l0_32
+    path: layer_19/width_131k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_19/width_131k/average_l0_60
+    path: layer_19/width_131k/average_l0_60/params.npz
+    l0: 60
+  - id: layer_19/width_16k/average_l0_11
+    path: layer_19/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_19/width_16k/average_l0_132
+    path: layer_19/width_16k/average_l0_132/params.npz
+    l0: 132
+  - id: layer_19/width_16k/average_l0_19
+    path: layer_19/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_19/width_16k/average_l0_293
+    path: layer_19/width_16k/average_l0_293/params.npz
+    l0: 293
+  - id: layer_19/width_16k/average_l0_35
+    path: layer_19/width_16k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_19/width_16k/average_l0_67
+    path: layer_19/width_16k/average_l0_67/params.npz
+    l0: 67
+  - id: layer_2/width_131k/average_l0_12
+    path: layer_2/width_131k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_2/width_131k/average_l0_19
+    path: layer_2/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_2/width_131k/average_l0_36
+    path: layer_2/width_131k/average_l0_36/params.npz
+    l0: 36
+  - id: layer_2/width_131k/average_l0_5
+    path: layer_2/width_131k/average_l0_5/params.npz
+    l0: 5
+  - id: layer_2/width_131k/average_l0_70
+    path: layer_2/width_131k/average_l0_70/params.npz
+    l0: 70
+  - id: layer_2/width_131k/average_l0_8
+    path: layer_2/width_131k/average_l0_8/params.npz
+    l0: 8
+  - id: layer_2/width_16k/average_l0_14
+    path: layer_2/width_16k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_2/width_16k/average_l0_189
+    path: layer_2/width_16k/average_l0_189/params.npz
+    l0: 189
+  - id: layer_2/width_16k/average_l0_29
+    path: layer_2/width_16k/average_l0_29/params.npz
+    l0: 29
+  - id: layer_2/width_16k/average_l0_67
+    path: layer_2/width_16k/average_l0_67/params.npz
+    l0: 67
+  - id: layer_2/width_16k/average_l0_8
+    path: layer_2/width_16k/average_l0_8/params.npz
+    l0: 8
+  - id: layer_20/width_131k/average_l0_10
+    path: layer_20/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_20/width_131k/average_l0_11
+    path: layer_20/width_131k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_20/width_131k/average_l0_114
+    path: layer_20/width_131k/average_l0_114/params.npz
+    l0: 114
+  - id: layer_20/width_131k/average_l0_12
+    path: layer_20/width_131k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_20/width_131k/average_l0_19
+    path: layer_20/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_20/width_131k/average_l0_221
+    path: layer_20/width_131k/average_l0_221/params.npz
+    l0: 221
+  - id: layer_20/width_131k/average_l0_269
+    path: layer_20/width_131k/average_l0_269/params.npz
+    l0: 269
+  - id: layer_20/width_131k/average_l0_276
+    path: layer_20/width_131k/average_l0_276/params.npz
+    l0: 276
+  - id: layer_20/width_131k/average_l0_288
+    path: layer_20/width_131k/average_l0_288/params.npz
+    l0: 288
+  - id: layer_20/width_131k/average_l0_34
+    path: layer_20/width_131k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_20/width_131k/average_l0_51
+    path: layer_20/width_131k/average_l0_51/params.npz
+    l0: 51
+  - id: layer_20/width_131k/average_l0_53
+    path: layer_20/width_131k/average_l0_53/params.npz
+    l0: 53
+  - id: layer_20/width_131k/average_l0_54
+    path: layer_20/width_131k/average_l0_54/params.npz
+    l0: 54
+  - id: layer_20/width_131k/average_l0_62
+    path: layer_20/width_131k/average_l0_62/params.npz
+    l0: 62
+  - id: layer_20/width_16k/average_l0_11
+    path: layer_20/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_20/width_16k/average_l0_138
+    path: layer_20/width_16k/average_l0_138/params.npz
+    l0: 138
+  - id: layer_20/width_16k/average_l0_20
+    path: layer_20/width_16k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_20/width_16k/average_l0_310
+    path: layer_20/width_16k/average_l0_310/params.npz
+    l0: 310
+  - id: layer_20/width_16k/average_l0_36
+    path: layer_20/width_16k/average_l0_36/params.npz
+    l0: 36
+  - id: layer_20/width_16k/average_l0_393
+    path: layer_20/width_16k/average_l0_393/params.npz
+    l0: 393
+  - id: layer_20/width_16k/average_l0_408
+    path: layer_20/width_16k/average_l0_408/params.npz
+    l0: 408
+  - id: layer_20/width_16k/average_l0_427
+    path: layer_20/width_16k/average_l0_427/params.npz
+    l0: 427
+  - id: layer_20/width_16k/average_l0_57
+    path: layer_20/width_16k/average_l0_57/params.npz
+    l0: 57
+  - id: layer_20/width_16k/average_l0_58
+    path: layer_20/width_16k/average_l0_58/params.npz
+    l0: 58
+  - id: layer_20/width_16k/average_l0_68
+    path: layer_20/width_16k/average_l0_68/params.npz
+    l0: 68
+  - id: layer_20/width_1m/average_l0_101
+    path: layer_20/width_1m/average_l0_101/params.npz
+    l0: 101
+  - id: layer_20/width_1m/average_l0_11
+    path: layer_20/width_1m/average_l0_11/params.npz
+    l0: 11
+  - id: layer_20/width_1m/average_l0_19
+    path: layer_20/width_1m/average_l0_19/params.npz
+    l0: 19
+  - id: layer_20/width_1m/average_l0_193
+    path: layer_20/width_1m/average_l0_193/params.npz
+    l0: 193
+  - id: layer_20/width_1m/average_l0_34
+    path: layer_20/width_1m/average_l0_34/params.npz
+    l0: 34
+  - id: layer_20/width_1m/average_l0_57
+    path: layer_20/width_1m/average_l0_57/params.npz
+    l0: 57
+  - id: layer_20/width_262k/average_l0_10
+    path: layer_20/width_262k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_20/width_262k/average_l0_11
+    path: layer_20/width_262k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_20/width_262k/average_l0_13
+    path: layer_20/width_262k/average_l0_13/params.npz
+    l0: 13
+  - id: layer_20/width_262k/average_l0_249
+    path: layer_20/width_262k/average_l0_249/params.npz
+    l0: 249
+  - id: layer_20/width_262k/average_l0_259
+    path: layer_20/width_262k/average_l0_259/params.npz
+    l0: 259
+  - id: layer_20/width_262k/average_l0_276
+    path: layer_20/width_262k/average_l0_276/params.npz
+    l0: 276
+  - id: layer_20/width_262k/average_l0_49
+    path: layer_20/width_262k/average_l0_49/params.npz
+    l0: 49
+  - id: layer_20/width_262k/average_l0_50
+    path: layer_20/width_262k/average_l0_50/params.npz
+    l0: 50
+  - id: layer_20/width_262k/average_l0_64
+    path: layer_20/width_262k/average_l0_64/params.npz
+    l0: 64
+  - id: layer_20/width_32k/average_l0_11
+    path: layer_20/width_32k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_20/width_32k/average_l0_334
+    path: layer_20/width_32k/average_l0_334/params.npz
+    l0: 334
+  - id: layer_20/width_32k/average_l0_344
+    path: layer_20/width_32k/average_l0_344/params.npz
+    l0: 344
+  - id: layer_20/width_32k/average_l0_357
+    path: layer_20/width_32k/average_l0_357/params.npz
+    l0: 357
+  - id: layer_20/width_32k/average_l0_55
+    path: layer_20/width_32k/average_l0_55/params.npz
+    l0: 55
+  - id: layer_20/width_32k/average_l0_57
+    path: layer_20/width_32k/average_l0_57/params.npz
+    l0: 57
+  - id: layer_20/width_524k/average_l0_10
+    path: layer_20/width_524k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_20/width_524k/average_l0_229
+    path: layer_20/width_524k/average_l0_229/params.npz
+    l0: 229
+  - id: layer_20/width_524k/average_l0_24
+    path: layer_20/width_524k/average_l0_24/params.npz
+    l0: 24
+  - id: layer_20/width_524k/average_l0_241
+    path: layer_20/width_524k/average_l0_241/params.npz
+    l0: 241
+  - id: layer_20/width_524k/average_l0_298
+    path: layer_20/width_524k/average_l0_298/params.npz
+    l0: 298
+  - id: layer_20/width_524k/average_l0_46
+    path: layer_20/width_524k/average_l0_46/params.npz
+    l0: 46
+  - id: layer_20/width_524k/average_l0_48
+    path: layer_20/width_524k/average_l0_48/params.npz
+    l0: 48
+  - id: layer_20/width_524k/average_l0_78
+    path: layer_20/width_524k/average_l0_78/params.npz
+    l0: 78
+  - id: layer_20/width_65k/average_l0_11
+    path: layer_20/width_65k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_20/width_65k/average_l0_292
+    path: layer_20/width_65k/average_l0_292/params.npz
+    l0: 292
+  - id: layer_20/width_65k/average_l0_298
+    path: layer_20/width_65k/average_l0_298/params.npz
+    l0: 298
+  - id: layer_20/width_65k/average_l0_309
+    path: layer_20/width_65k/average_l0_309/params.npz
+    l0: 309
+  - id: layer_20/width_65k/average_l0_54
+    path: layer_20/width_65k/average_l0_54/params.npz
+    l0: 54
+  - id: layer_20/width_65k/average_l0_55
+    path: layer_20/width_65k/average_l0_55/params.npz
+    l0: 55
+  - id: layer_21/width_131k/average_l0_109
+    path: layer_21/width_131k/average_l0_109/params.npz
+    l0: 109
+  - id: layer_21/width_131k/average_l0_11
+    path: layer_21/width_131k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_21/width_131k/average_l0_19
+    path: layer_21/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_21/width_131k/average_l0_204
+    path: layer_21/width_131k/average_l0_204/params.npz
+    l0: 204
+  - id: layer_21/width_131k/average_l0_33
+    path: layer_21/width_131k/average_l0_33/params.npz
+    l0: 33
+  - id: layer_21/width_131k/average_l0_58
+    path: layer_21/width_131k/average_l0_58/params.npz
+    l0: 58
+  - id: layer_21/width_16k/average_l0_11
+    path: layer_21/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_21/width_16k/average_l0_129
+    path: layer_21/width_16k/average_l0_129/params.npz
+    l0: 129
+  - id: layer_21/width_16k/average_l0_19
+    path: layer_21/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_21/width_16k/average_l0_278
+    path: layer_21/width_16k/average_l0_278/params.npz
+    l0: 278
+  - id: layer_21/width_16k/average_l0_36
+    path: layer_21/width_16k/average_l0_36/params.npz
+    l0: 36
+  - id: layer_21/width_16k/average_l0_66
+    path: layer_21/width_16k/average_l0_66/params.npz
+    l0: 66
+  - id: layer_22/width_131k/average_l0_10
+    path: layer_22/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_22/width_131k/average_l0_105
+    path: layer_22/width_131k/average_l0_105/params.npz
+    l0: 105
+  - id: layer_22/width_131k/average_l0_18
+    path: layer_22/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_22/width_131k/average_l0_197
+    path: layer_22/width_131k/average_l0_197/params.npz
+    l0: 197
+  - id: layer_22/width_131k/average_l0_32
+    path: layer_22/width_131k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_22/width_131k/average_l0_58
+    path: layer_22/width_131k/average_l0_58/params.npz
+    l0: 58
+  - id: layer_22/width_16k/average_l0_11
+    path: layer_22/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_22/width_16k/average_l0_123
+    path: layer_22/width_16k/average_l0_123/params.npz
+    l0: 123
+  - id: layer_22/width_16k/average_l0_19
+    path: layer_22/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_22/width_16k/average_l0_268
+    path: layer_22/width_16k/average_l0_268/params.npz
+    l0: 268
+  - id: layer_22/width_16k/average_l0_35
+    path: layer_22/width_16k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_22/width_16k/average_l0_65
+    path: layer_22/width_16k/average_l0_65/params.npz
+    l0: 65
+  - id: layer_23/width_131k/average_l0_10
+    path: layer_23/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_23/width_131k/average_l0_101
+    path: layer_23/width_131k/average_l0_101/params.npz
+    l0: 101
+  - id: layer_23/width_131k/average_l0_18
+    path: layer_23/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_23/width_131k/average_l0_187
+    path: layer_23/width_131k/average_l0_187/params.npz
+    l0: 187
+  - id: layer_23/width_131k/average_l0_32
+    path: layer_23/width_131k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_23/width_131k/average_l0_56
+    path: layer_23/width_131k/average_l0_56/params.npz
+    l0: 56
+  - id: layer_23/width_16k/average_l0_11
+    path: layer_23/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_23/width_16k/average_l0_120
+    path: layer_23/width_16k/average_l0_120/params.npz
+    l0: 120
+  - id: layer_23/width_16k/average_l0_19
+    path: layer_23/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_23/width_16k/average_l0_248
+    path: layer_23/width_16k/average_l0_248/params.npz
+    l0: 248
+  - id: layer_23/width_16k/average_l0_35
+    path: layer_23/width_16k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_23/width_16k/average_l0_63
+    path: layer_23/width_16k/average_l0_63/params.npz
+    l0: 63
+  - id: layer_24/width_131k/average_l0_10
+    path: layer_24/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_24/width_131k/average_l0_17
+    path: layer_24/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_24/width_131k/average_l0_180
+    path: layer_24/width_131k/average_l0_180/params.npz
+    l0: 180
+  - id: layer_24/width_131k/average_l0_30
+    path: layer_24/width_131k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_24/width_131k/average_l0_55
+    path: layer_24/width_131k/average_l0_55/params.npz
+    l0: 55
+  - id: layer_24/width_131k/average_l0_97
+    path: layer_24/width_131k/average_l0_97/params.npz
+    l0: 97
+  - id: layer_24/width_16k/average_l0_10
+    path: layer_24/width_16k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_24/width_16k/average_l0_114
+    path: layer_24/width_16k/average_l0_114/params.npz
+    l0: 114
+  - id: layer_24/width_16k/average_l0_19
+    path: layer_24/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_24/width_16k/average_l0_234
+    path: layer_24/width_16k/average_l0_234/params.npz
+    l0: 234
+  - id: layer_24/width_16k/average_l0_34
+    path: layer_24/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_24/width_16k/average_l0_61
+    path: layer_24/width_16k/average_l0_61/params.npz
+    l0: 61
+  - id: layer_25/width_131k/average_l0_10
+    path: layer_25/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_25/width_131k/average_l0_177
+    path: layer_25/width_131k/average_l0_177/params.npz
+    l0: 177
+  - id: layer_25/width_131k/average_l0_18
+    path: layer_25/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_25/width_131k/average_l0_31
+    path: layer_25/width_131k/average_l0_31/params.npz
+    l0: 31
+  - id: layer_25/width_131k/average_l0_54
+    path: layer_25/width_131k/average_l0_54/params.npz
+    l0: 54
+  - id: layer_25/width_131k/average_l0_96
+    path: layer_25/width_131k/average_l0_96/params.npz
+    l0: 96
+  - id: layer_25/width_16k/average_l0_11
+    path: layer_25/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_25/width_16k/average_l0_114
+    path: layer_25/width_16k/average_l0_114/params.npz
+    l0: 114
+  - id: layer_25/width_16k/average_l0_19
+    path: layer_25/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_25/width_16k/average_l0_231
+    path: layer_25/width_16k/average_l0_231/params.npz
+    l0: 231
+  - id: layer_25/width_16k/average_l0_34
+    path: layer_25/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_25/width_16k/average_l0_61
+    path: layer_25/width_16k/average_l0_61/params.npz
+    l0: 61
+  - id: layer_26/width_131k/average_l0_10
+    path: layer_26/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_26/width_131k/average_l0_176
+    path: layer_26/width_131k/average_l0_176/params.npz
+    l0: 176
+  - id: layer_26/width_131k/average_l0_18
+    path: layer_26/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_26/width_131k/average_l0_32
+    path: layer_26/width_131k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_26/width_131k/average_l0_55
+    path: layer_26/width_131k/average_l0_55/params.npz
+    l0: 55
+  - id: layer_26/width_131k/average_l0_97
+    path: layer_26/width_131k/average_l0_97/params.npz
+    l0: 97
+  - id: layer_26/width_16k/average_l0_11
+    path: layer_26/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_26/width_16k/average_l0_116
+    path: layer_26/width_16k/average_l0_116/params.npz
+    l0: 116
+  - id: layer_26/width_16k/average_l0_20
+    path: layer_26/width_16k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_26/width_16k/average_l0_233
+    path: layer_26/width_16k/average_l0_233/params.npz
+    l0: 233
+  - id: layer_26/width_16k/average_l0_35
+    path: layer_26/width_16k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_26/width_16k/average_l0_63
+    path: layer_26/width_16k/average_l0_63/params.npz
+    l0: 63
+  - id: layer_27/width_131k/average_l0_11
+    path: layer_27/width_131k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_27/width_131k/average_l0_171
+    path: layer_27/width_131k/average_l0_171/params.npz
+    l0: 171
+  - id: layer_27/width_131k/average_l0_19
+    path: layer_27/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_27/width_131k/average_l0_33
+    path: layer_27/width_131k/average_l0_33/params.npz
+    l0: 33
+  - id: layer_27/width_131k/average_l0_56
+    path: layer_27/width_131k/average_l0_56/params.npz
+    l0: 56
+  - id: layer_27/width_131k/average_l0_96
+    path: layer_27/width_131k/average_l0_96/params.npz
+    l0: 96
+  - id: layer_27/width_16k/average_l0_118
+    path: layer_27/width_16k/average_l0_118/params.npz
+    l0: 118
+  - id: layer_27/width_16k/average_l0_12
+    path: layer_27/width_16k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_27/width_16k/average_l0_21
+    path: layer_27/width_16k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_27/width_16k/average_l0_230
+    path: layer_27/width_16k/average_l0_230/params.npz
+    l0: 230
+  - id: layer_27/width_16k/average_l0_36
+    path: layer_27/width_16k/average_l0_36/params.npz
+    l0: 36
+  - id: layer_27/width_16k/average_l0_65
+    path: layer_27/width_16k/average_l0_65/params.npz
+    l0: 65
+  - id: layer_28/width_131k/average_l0_11
+    path: layer_28/width_131k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_28/width_131k/average_l0_171
+    path: layer_28/width_131k/average_l0_171/params.npz
+    l0: 171
+  - id: layer_28/width_131k/average_l0_19
+    path: layer_28/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_28/width_131k/average_l0_32
+    path: layer_28/width_131k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_28/width_131k/average_l0_57
+    path: layer_28/width_131k/average_l0_57/params.npz
+    l0: 57
+  - id: layer_28/width_131k/average_l0_98
+    path: layer_28/width_131k/average_l0_98/params.npz
+    l0: 98
+  - id: layer_28/width_16k/average_l0_119
+    path: layer_28/width_16k/average_l0_119/params.npz
+    l0: 119
+  - id: layer_28/width_16k/average_l0_12
+    path: layer_28/width_16k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_28/width_16k/average_l0_21
+    path: layer_28/width_16k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_28/width_16k/average_l0_229
+    path: layer_28/width_16k/average_l0_229/params.npz
+    l0: 229
+  - id: layer_28/width_16k/average_l0_37
+    path: layer_28/width_16k/average_l0_37/params.npz
+    l0: 37
+  - id: layer_28/width_16k/average_l0_65
+    path: layer_28/width_16k/average_l0_65/params.npz
+    l0: 65
+  - id: layer_29/width_131k/average_l0_11
+    path: layer_29/width_131k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_29/width_131k/average_l0_171
+    path: layer_29/width_131k/average_l0_171/params.npz
+    l0: 171
+  - id: layer_29/width_131k/average_l0_19
+    path: layer_29/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_29/width_131k/average_l0_33
+    path: layer_29/width_131k/average_l0_33/params.npz
+    l0: 33
+  - id: layer_29/width_131k/average_l0_56
+    path: layer_29/width_131k/average_l0_56/params.npz
+    l0: 56
+  - id: layer_29/width_131k/average_l0_97
+    path: layer_29/width_131k/average_l0_97/params.npz
+    l0: 97
+  - id: layer_29/width_16k/average_l0_119
+    path: layer_29/width_16k/average_l0_119/params.npz
+    l0: 119
+  - id: layer_29/width_16k/average_l0_12
+    path: layer_29/width_16k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_29/width_16k/average_l0_21
+    path: layer_29/width_16k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_29/width_16k/average_l0_224
+    path: layer_29/width_16k/average_l0_224/params.npz
+    l0: 224
+  - id: layer_29/width_16k/average_l0_38
+    path: layer_29/width_16k/average_l0_38/params.npz
+    l0: 38
+  - id: layer_29/width_16k/average_l0_66
+    path: layer_29/width_16k/average_l0_66/params.npz
+    l0: 66
+  - id: layer_3/width_131k/average_l0_103
+    path: layer_3/width_131k/average_l0_103/params.npz
+    l0: 103
+  - id: layer_3/width_131k/average_l0_14
+    path: layer_3/width_131k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_3/width_131k/average_l0_25
+    path: layer_3/width_131k/average_l0_25/params.npz
+    l0: 25
+  - id: layer_3/width_131k/average_l0_46
+    path: layer_3/width_131k/average_l0_46/params.npz
+    l0: 46
+  - id: layer_3/width_131k/average_l0_6
+    path: layer_3/width_131k/average_l0_6/params.npz
+    l0: 6
+  - id: layer_3/width_131k/average_l0_9
+    path: layer_3/width_131k/average_l0_9/params.npz
+    l0: 9
+  - id: layer_3/width_16k/average_l0_10
+    path: layer_3/width_16k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_3/width_16k/average_l0_17
+    path: layer_3/width_16k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_3/width_16k/average_l0_229
+    path: layer_3/width_16k/average_l0_229/params.npz
+    l0: 229
+  - id: layer_3/width_16k/average_l0_37
+    path: layer_3/width_16k/average_l0_37/params.npz
+    l0: 37
+  - id: layer_3/width_16k/average_l0_90
+    path: layer_3/width_16k/average_l0_90/params.npz
+    l0: 90
+  - id: layer_30/width_131k/average_l0_11
+    path: layer_30/width_131k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_30/width_131k/average_l0_170
+    path: layer_30/width_131k/average_l0_170/params.npz
+    l0: 170
+  - id: layer_30/width_131k/average_l0_18
+    path: layer_30/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_30/width_131k/average_l0_32
+    path: layer_30/width_131k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_30/width_131k/average_l0_56
+    path: layer_30/width_131k/average_l0_56/params.npz
+    l0: 56
+  - id: layer_30/width_131k/average_l0_95
+    path: layer_30/width_131k/average_l0_95/params.npz
+    l0: 95
+  - id: layer_30/width_16k/average_l0_12
+    path: layer_30/width_16k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_30/width_16k/average_l0_120
+    path: layer_30/width_16k/average_l0_120/params.npz
+    l0: 120
+  - id: layer_30/width_16k/average_l0_21
+    path: layer_30/width_16k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_30/width_16k/average_l0_226
+    path: layer_30/width_16k/average_l0_226/params.npz
+    l0: 226
+  - id: layer_30/width_16k/average_l0_37
+    path: layer_30/width_16k/average_l0_37/params.npz
+    l0: 37
+  - id: layer_30/width_16k/average_l0_66
+    path: layer_30/width_16k/average_l0_66/params.npz
+    l0: 66
+  - id: layer_31/width_131k/average_l0_10
+    path: layer_31/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_31/width_131k/average_l0_160
+    path: layer_31/width_131k/average_l0_160/params.npz
+    l0: 160
+  - id: layer_31/width_131k/average_l0_18
+    path: layer_31/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_31/width_131k/average_l0_31
+    path: layer_31/width_131k/average_l0_31/params.npz
+    l0: 31
+  - id: layer_31/width_131k/average_l0_52
+    path: layer_31/width_131k/average_l0_52/params.npz
+    l0: 52
+  - id: layer_31/width_131k/average_l0_92
+    path: layer_31/width_131k/average_l0_92/params.npz
+    l0: 92
+  - id: layer_31/width_16k/average_l0_11
+    path: layer_31/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_31/width_16k/average_l0_114
+    path: layer_31/width_16k/average_l0_114/params.npz
+    l0: 114
+  - id: layer_31/width_16k/average_l0_20
+    path: layer_31/width_16k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_31/width_16k/average_l0_218
+    path: layer_31/width_16k/average_l0_218/params.npz
+    l0: 218
+  - id: layer_31/width_16k/average_l0_35
+    path: layer_31/width_16k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_31/width_16k/average_l0_63
+    path: layer_31/width_16k/average_l0_63/params.npz
+    l0: 63
+  - id: layer_31/width_1m/average_l0_11
+    path: layer_31/width_1m/average_l0_11/params.npz
+    l0: 11
+  - id: layer_31/width_1m/average_l0_132
+    path: layer_31/width_1m/average_l0_132/params.npz
+    l0: 132
+  - id: layer_31/width_1m/average_l0_25
+    path: layer_31/width_1m/average_l0_25/params.npz
+    l0: 25
+  - id: layer_31/width_1m/average_l0_27
+    path: layer_31/width_1m/average_l0_27/params.npz
+    l0: 27
+  - id: layer_31/width_1m/average_l0_45
+    path: layer_31/width_1m/average_l0_45/params.npz
+    l0: 45
+  - id: layer_31/width_1m/average_l0_77
+    path: layer_31/width_1m/average_l0_77/params.npz
+    l0: 77
+  - id: layer_32/width_131k/average_l0_10
+    path: layer_32/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_32/width_131k/average_l0_158
+    path: layer_32/width_131k/average_l0_158/params.npz
+    l0: 158
+  - id: layer_32/width_131k/average_l0_18
+    path: layer_32/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_32/width_131k/average_l0_30
+    path: layer_32/width_131k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_32/width_131k/average_l0_51
+    path: layer_32/width_131k/average_l0_51/params.npz
+    l0: 51
+  - id: layer_32/width_131k/average_l0_88
+    path: layer_32/width_131k/average_l0_88/params.npz
+    l0: 88
+  - id: layer_32/width_16k/average_l0_11
+    path: layer_32/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_32/width_16k/average_l0_111
+    path: layer_32/width_16k/average_l0_111/params.npz
+    l0: 111
+  - id: layer_32/width_16k/average_l0_20
+    path: layer_32/width_16k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_32/width_16k/average_l0_219
+    path: layer_32/width_16k/average_l0_219/params.npz
+    l0: 219
+  - id: layer_32/width_16k/average_l0_34
+    path: layer_32/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_32/width_16k/average_l0_61
+    path: layer_32/width_16k/average_l0_61/params.npz
+    l0: 61
+  - id: layer_33/width_131k/average_l0_10
+    path: layer_33/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_33/width_131k/average_l0_165
+    path: layer_33/width_131k/average_l0_165/params.npz
+    l0: 165
+  - id: layer_33/width_131k/average_l0_18
+    path: layer_33/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_33/width_131k/average_l0_30
+    path: layer_33/width_131k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_33/width_131k/average_l0_51
+    path: layer_33/width_131k/average_l0_51/params.npz
+    l0: 51
+  - id: layer_33/width_131k/average_l0_91
+    path: layer_33/width_131k/average_l0_91/params.npz
+    l0: 91
+  - id: layer_33/width_16k/average_l0_11
+    path: layer_33/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_33/width_16k/average_l0_114
+    path: layer_33/width_16k/average_l0_114/params.npz
+    l0: 114
+  - id: layer_33/width_16k/average_l0_20
+    path: layer_33/width_16k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_33/width_16k/average_l0_228
+    path: layer_33/width_16k/average_l0_228/params.npz
+    l0: 228
+  - id: layer_33/width_16k/average_l0_34
+    path: layer_33/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_33/width_16k/average_l0_63
+    path: layer_33/width_16k/average_l0_63/params.npz
+    l0: 63
+  - id: layer_34/width_131k/average_l0_10
+    path: layer_34/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_34/width_131k/average_l0_163
+    path: layer_34/width_131k/average_l0_163/params.npz
+    l0: 163
+  - id: layer_34/width_131k/average_l0_17
+    path: layer_34/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_34/width_131k/average_l0_30
+    path: layer_34/width_131k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_34/width_131k/average_l0_51
+    path: layer_34/width_131k/average_l0_51/params.npz
+    l0: 51
+  - id: layer_34/width_131k/average_l0_89
+    path: layer_34/width_131k/average_l0_89/params.npz
+    l0: 89
+  - id: layer_34/width_16k/average_l0_11
+    path: layer_34/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_34/width_16k/average_l0_114
+    path: layer_34/width_16k/average_l0_114/params.npz
+    l0: 114
+  - id: layer_34/width_16k/average_l0_19
+    path: layer_34/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_34/width_16k/average_l0_229
+    path: layer_34/width_16k/average_l0_229/params.npz
+    l0: 229
+  - id: layer_34/width_16k/average_l0_34
+    path: layer_34/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_34/width_16k/average_l0_60
+    path: layer_34/width_16k/average_l0_60/params.npz
+    l0: 60
+  - id: layer_35/width_131k/average_l0_10
+    path: layer_35/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_35/width_131k/average_l0_17
+    path: layer_35/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_35/width_131k/average_l0_171
+    path: layer_35/width_131k/average_l0_171/params.npz
+    l0: 171
+  - id: layer_35/width_131k/average_l0_30
+    path: layer_35/width_131k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_35/width_131k/average_l0_51
+    path: layer_35/width_131k/average_l0_51/params.npz
+    l0: 51
+  - id: layer_35/width_131k/average_l0_94
+    path: layer_35/width_131k/average_l0_94/params.npz
+    l0: 94
+  - id: layer_35/width_16k/average_l0_11
+    path: layer_35/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_35/width_16k/average_l0_120
+    path: layer_35/width_16k/average_l0_120/params.npz
+    l0: 120
+  - id: layer_35/width_16k/average_l0_19
+    path: layer_35/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_35/width_16k/average_l0_246
+    path: layer_35/width_16k/average_l0_246/params.npz
+    l0: 246
+  - id: layer_35/width_16k/average_l0_34
+    path: layer_35/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_35/width_16k/average_l0_61
+    path: layer_35/width_16k/average_l0_61/params.npz
+    l0: 61
+  - id: layer_36/width_131k/average_l0_10
+    path: layer_36/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_36/width_131k/average_l0_17
+    path: layer_36/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_36/width_131k/average_l0_180
+    path: layer_36/width_131k/average_l0_180/params.npz
+    l0: 180
+  - id: layer_36/width_131k/average_l0_30
+    path: layer_36/width_131k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_36/width_131k/average_l0_51
+    path: layer_36/width_131k/average_l0_51/params.npz
+    l0: 51
+  - id: layer_36/width_131k/average_l0_93
+    path: layer_36/width_131k/average_l0_93/params.npz
+    l0: 93
+  - id: layer_36/width_16k/average_l0_11
+    path: layer_36/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_36/width_16k/average_l0_120
+    path: layer_36/width_16k/average_l0_120/params.npz
+    l0: 120
+  - id: layer_36/width_16k/average_l0_19
+    path: layer_36/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_36/width_16k/average_l0_252
+    path: layer_36/width_16k/average_l0_252/params.npz
+    l0: 252
+  - id: layer_36/width_16k/average_l0_34
+    path: layer_36/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_36/width_16k/average_l0_61
+    path: layer_36/width_16k/average_l0_61/params.npz
+    l0: 61
+  - id: layer_37/width_131k/average_l0_10
+    path: layer_37/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_37/width_131k/average_l0_18
+    path: layer_37/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_37/width_131k/average_l0_184
+    path: layer_37/width_131k/average_l0_184/params.npz
+    l0: 184
+  - id: layer_37/width_131k/average_l0_30
+    path: layer_37/width_131k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_37/width_131k/average_l0_53
+    path: layer_37/width_131k/average_l0_53/params.npz
+    l0: 53
+  - id: layer_37/width_131k/average_l0_96
+    path: layer_37/width_131k/average_l0_96/params.npz
+    l0: 96
+  - id: layer_37/width_16k/average_l0_11
+    path: layer_37/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_37/width_16k/average_l0_124
+    path: layer_37/width_16k/average_l0_124/params.npz
+    l0: 124
+  - id: layer_37/width_16k/average_l0_20
+    path: layer_37/width_16k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_37/width_16k/average_l0_266
+    path: layer_37/width_16k/average_l0_266/params.npz
+    l0: 266
+  - id: layer_37/width_16k/average_l0_34
+    path: layer_37/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_37/width_16k/average_l0_63
+    path: layer_37/width_16k/average_l0_63/params.npz
+    l0: 63
+  - id: layer_38/width_131k/average_l0_10
+    path: layer_38/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_38/width_131k/average_l0_101
+    path: layer_38/width_131k/average_l0_101/params.npz
+    l0: 101
+  - id: layer_38/width_131k/average_l0_18
+    path: layer_38/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_38/width_131k/average_l0_194
+    path: layer_38/width_131k/average_l0_194/params.npz
+    l0: 194
+  - id: layer_38/width_131k/average_l0_30
+    path: layer_38/width_131k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_38/width_131k/average_l0_53
+    path: layer_38/width_131k/average_l0_53/params.npz
+    l0: 53
+  - id: layer_38/width_16k/average_l0_11
+    path: layer_38/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_38/width_16k/average_l0_128
+    path: layer_38/width_16k/average_l0_128/params.npz
+    l0: 128
+  - id: layer_38/width_16k/average_l0_20
+    path: layer_38/width_16k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_38/width_16k/average_l0_286
+    path: layer_38/width_16k/average_l0_286/params.npz
+    l0: 286
+  - id: layer_38/width_16k/average_l0_34
+    path: layer_38/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_38/width_16k/average_l0_64
+    path: layer_38/width_16k/average_l0_64/params.npz
+    l0: 64
+  - id: layer_39/width_131k/average_l0_10
+    path: layer_39/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_39/width_131k/average_l0_18
+    path: layer_39/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_39/width_131k/average_l0_199
+    path: layer_39/width_131k/average_l0_199/params.npz
+    l0: 199
+  - id: layer_39/width_131k/average_l0_30
+    path: layer_39/width_131k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_39/width_131k/average_l0_54
+    path: layer_39/width_131k/average_l0_54/params.npz
+    l0: 54
+  - id: layer_39/width_131k/average_l0_99
+    path: layer_39/width_131k/average_l0_99/params.npz
+    l0: 99
+  - id: layer_39/width_16k/average_l0_11
+    path: layer_39/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_39/width_16k/average_l0_131
+    path: layer_39/width_16k/average_l0_131/params.npz
+    l0: 131
+  - id: layer_39/width_16k/average_l0_19
+    path: layer_39/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_39/width_16k/average_l0_298
+    path: layer_39/width_16k/average_l0_298/params.npz
+    l0: 298
+  - id: layer_39/width_16k/average_l0_34
+    path: layer_39/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_39/width_16k/average_l0_64
+    path: layer_39/width_16k/average_l0_64/params.npz
+    l0: 64
+  - id: layer_4/width_131k/average_l0_101
+    path: layer_4/width_131k/average_l0_101/params.npz
+    l0: 101
+  - id: layer_4/width_131k/average_l0_16
+    path: layer_4/width_131k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_4/width_131k/average_l0_28
+    path: layer_4/width_131k/average_l0_28/params.npz
+    l0: 28
+  - id: layer_4/width_131k/average_l0_51
+    path: layer_4/width_131k/average_l0_51/params.npz
+    l0: 51
+  - id: layer_4/width_131k/average_l0_6
+    path: layer_4/width_131k/average_l0_6/params.npz
+    l0: 6
+  - id: layer_4/width_131k/average_l0_9
+    path: layer_4/width_131k/average_l0_9/params.npz
+    l0: 9
+  - id: layer_4/width_16k/average_l0_10
+    path: layer_4/width_16k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_4/width_16k/average_l0_18
+    path: layer_4/width_16k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_4/width_16k/average_l0_234
+    path: layer_4/width_16k/average_l0_234/params.npz
+    l0: 234
+  - id: layer_4/width_16k/average_l0_37
+    path: layer_4/width_16k/average_l0_37/params.npz
+    l0: 37
+  - id: layer_4/width_16k/average_l0_91
+    path: layer_4/width_16k/average_l0_91/params.npz
+    l0: 91
+  - id: layer_40/width_131k/average_l0_10
+    path: layer_40/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_40/width_131k/average_l0_17
+    path: layer_40/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_40/width_131k/average_l0_193
+    path: layer_40/width_131k/average_l0_193/params.npz
+    l0: 193
+  - id: layer_40/width_131k/average_l0_29
+    path: layer_40/width_131k/average_l0_29/params.npz
+    l0: 29
+  - id: layer_40/width_131k/average_l0_49
+    path: layer_40/width_131k/average_l0_49/params.npz
+    l0: 49
+  - id: layer_40/width_131k/average_l0_94
+    path: layer_40/width_131k/average_l0_94/params.npz
+    l0: 94
+  - id: layer_40/width_16k/average_l0_10
+    path: layer_40/width_16k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_40/width_16k/average_l0_125
+    path: layer_40/width_16k/average_l0_125/params.npz
+    l0: 125
+  - id: layer_40/width_16k/average_l0_18
+    path: layer_40/width_16k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_40/width_16k/average_l0_292
+    path: layer_40/width_16k/average_l0_292/params.npz
+    l0: 292
+  - id: layer_40/width_16k/average_l0_32
+    path: layer_40/width_16k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_40/width_16k/average_l0_61
+    path: layer_40/width_16k/average_l0_61/params.npz
+    l0: 61
+  - id: layer_41/width_131k/average_l0_10
+    path: layer_41/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_41/width_131k/average_l0_15
+    path: layer_41/width_131k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_41/width_131k/average_l0_175
+    path: layer_41/width_131k/average_l0_175/params.npz
+    l0: 175
+  - id: layer_41/width_131k/average_l0_26
+    path: layer_41/width_131k/average_l0_26/params.npz
+    l0: 26
+  - id: layer_41/width_131k/average_l0_45
+    path: layer_41/width_131k/average_l0_45/params.npz
+    l0: 45
+  - id: layer_41/width_131k/average_l0_84
+    path: layer_41/width_131k/average_l0_84/params.npz
+    l0: 84
+  - id: layer_41/width_16k/average_l0_10
+    path: layer_41/width_16k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_41/width_16k/average_l0_113
+    path: layer_41/width_16k/average_l0_113/params.npz
+    l0: 113
+  - id: layer_41/width_16k/average_l0_16
+    path: layer_41/width_16k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_41/width_16k/average_l0_270
+    path: layer_41/width_16k/average_l0_270/params.npz
+    l0: 270
+  - id: layer_41/width_16k/average_l0_28
+    path: layer_41/width_16k/average_l0_28/params.npz
+    l0: 28
+  - id: layer_41/width_16k/average_l0_52
+    path: layer_41/width_16k/average_l0_52/params.npz
+    l0: 52
+  - id: layer_5/width_131k/average_l0_10
+    path: layer_5/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_5/width_131k/average_l0_16
+    path: layer_5/width_131k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_5/width_131k/average_l0_29
+    path: layer_5/width_131k/average_l0_29/params.npz
+    l0: 29
+  - id: layer_5/width_131k/average_l0_51
+    path: layer_5/width_131k/average_l0_51/params.npz
+    l0: 51
+  - id: layer_5/width_131k/average_l0_6
+    path: layer_5/width_131k/average_l0_6/params.npz
+    l0: 6
+  - id: layer_5/width_131k/average_l0_94
+    path: layer_5/width_131k/average_l0_94/params.npz
+    l0: 94
+  - id: layer_5/width_16k/average_l0_11
+    path: layer_5/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_5/width_16k/average_l0_193
+    path: layer_5/width_16k/average_l0_193/params.npz
+    l0: 193
+  - id: layer_5/width_16k/average_l0_20
+    path: layer_5/width_16k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_5/width_16k/average_l0_37
+    path: layer_5/width_16k/average_l0_37/params.npz
+    l0: 37
+  - id: layer_5/width_16k/average_l0_77
+    path: layer_5/width_16k/average_l0_77/params.npz
+    l0: 77
+  - id: layer_6/width_131k/average_l0_12
+    path: layer_6/width_131k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_6/width_131k/average_l0_120
+    path: layer_6/width_131k/average_l0_120/params.npz
+    l0: 120
+  - id: layer_6/width_131k/average_l0_21
+    path: layer_6/width_131k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_6/width_131k/average_l0_36
+    path: layer_6/width_131k/average_l0_36/params.npz
+    l0: 36
+  - id: layer_6/width_131k/average_l0_66
+    path: layer_6/width_131k/average_l0_66/params.npz
+    l0: 66
+  - id: layer_6/width_131k/average_l0_7
+    path: layer_6/width_131k/average_l0_7/params.npz
+    l0: 7
+  - id: layer_6/width_16k/average_l0_14
+    path: layer_6/width_16k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_6/width_16k/average_l0_224
+    path: layer_6/width_16k/average_l0_224/params.npz
+    l0: 224
+  - id: layer_6/width_16k/average_l0_25
+    path: layer_6/width_16k/average_l0_25/params.npz
+    l0: 25
+  - id: layer_6/width_16k/average_l0_47
+    path: layer_6/width_16k/average_l0_47/params.npz
+    l0: 47
+  - id: layer_6/width_16k/average_l0_8
+    path: layer_6/width_16k/average_l0_8/params.npz
+    l0: 8
+  - id: layer_6/width_16k/average_l0_93
+    path: layer_6/width_16k/average_l0_93/params.npz
+    l0: 93
+  - id: layer_7/width_131k/average_l0_119
+    path: layer_7/width_131k/average_l0_119/params.npz
+    l0: 119
+  - id: layer_7/width_131k/average_l0_13
+    path: layer_7/width_131k/average_l0_13/params.npz
+    l0: 13
+  - id: layer_7/width_131k/average_l0_21
+    path: layer_7/width_131k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_7/width_131k/average_l0_38
+    path: layer_7/width_131k/average_l0_38/params.npz
+    l0: 38
+  - id: layer_7/width_131k/average_l0_65
+    path: layer_7/width_131k/average_l0_65/params.npz
+    l0: 65
+  - id: layer_7/width_131k/average_l0_8
+    path: layer_7/width_131k/average_l0_8/params.npz
+    l0: 8
+  - id: layer_7/width_16k/average_l0_14
+    path: layer_7/width_16k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_7/width_16k/average_l0_198
+    path: layer_7/width_16k/average_l0_198/params.npz
+    l0: 198
+  - id: layer_7/width_16k/average_l0_25
+    path: layer_7/width_16k/average_l0_25/params.npz
+    l0: 25
+  - id: layer_7/width_16k/average_l0_46
+    path: layer_7/width_16k/average_l0_46/params.npz
+    l0: 46
+  - id: layer_7/width_16k/average_l0_8
+    path: layer_7/width_16k/average_l0_8/params.npz
+    l0: 8
+  - id: layer_7/width_16k/average_l0_92
+    path: layer_7/width_16k/average_l0_92/params.npz
+    l0: 92
+  - id: layer_8/width_131k/average_l0_129
+    path: layer_8/width_131k/average_l0_129/params.npz
+    l0: 129
+  - id: layer_8/width_131k/average_l0_14
+    path: layer_8/width_131k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_8/width_131k/average_l0_24
+    path: layer_8/width_131k/average_l0_24/params.npz
+    l0: 24
+  - id: layer_8/width_131k/average_l0_41
+    path: layer_8/width_131k/average_l0_41/params.npz
+    l0: 41
+  - id: layer_8/width_131k/average_l0_72
+    path: layer_8/width_131k/average_l0_72/params.npz
+    l0: 72
+  - id: layer_8/width_131k/average_l0_8
+    path: layer_8/width_131k/average_l0_8/params.npz
+    l0: 8
+  - id: layer_8/width_16k/average_l0_16
+    path: layer_8/width_16k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_8/width_16k/average_l0_207
+    path: layer_8/width_16k/average_l0_207/params.npz
+    l0: 207
+  - id: layer_8/width_16k/average_l0_28
+    path: layer_8/width_16k/average_l0_28/params.npz
+    l0: 28
+  - id: layer_8/width_16k/average_l0_51
+    path: layer_8/width_16k/average_l0_51/params.npz
+    l0: 51
+  - id: layer_8/width_16k/average_l0_9
+    path: layer_8/width_16k/average_l0_9/params.npz
+    l0: 9
+  - id: layer_8/width_16k/average_l0_99
+    path: layer_8/width_16k/average_l0_99/params.npz
+    l0: 99
+  - id: layer_9/width_131k/average_l0_134
+    path: layer_9/width_131k/average_l0_134/params.npz
+    l0: 134
+  - id: layer_9/width_131k/average_l0_14
+    path: layer_9/width_131k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_9/width_131k/average_l0_25
+    path: layer_9/width_131k/average_l0_25/params.npz
+    l0: 25
+  - id: layer_9/width_131k/average_l0_42
+    path: layer_9/width_131k/average_l0_42/params.npz
+    l0: 42
+  - id: layer_9/width_131k/average_l0_75
+    path: layer_9/width_131k/average_l0_75/params.npz
+    l0: 75
+  - id: layer_9/width_131k/average_l0_8
+    path: layer_9/width_131k/average_l0_8/params.npz
+    l0: 8
+  - id: layer_9/width_16k/average_l0_100
+    path: layer_9/width_16k/average_l0_100/params.npz
+    l0: 100
+  - id: layer_9/width_16k/average_l0_16
+    path: layer_9/width_16k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_9/width_16k/average_l0_209
+    path: layer_9/width_16k/average_l0_209/params.npz
+    l0: 209
+  - id: layer_9/width_16k/average_l0_28
+    path: layer_9/width_16k/average_l0_28/params.npz
+    l0: 28
+  - id: layer_9/width_16k/average_l0_51
+    path: layer_9/width_16k/average_l0_51/params.npz
+    l0: 51
+  - id: layer_9/width_16k/average_l0_9
+    path: layer_9/width_16k/average_l0_9/params.npz
+    l0: 9
+  - id: layer_9/width_1m/average_l0_122
+    path: layer_9/width_1m/average_l0_122/params.npz
+    l0: 122
+  - id: layer_9/width_1m/average_l0_14
+    path: layer_9/width_1m/average_l0_14/params.npz
+    l0: 14
+  - id: layer_9/width_1m/average_l0_24
+    path: layer_9/width_1m/average_l0_24/params.npz
+    l0: 24
+  - id: layer_9/width_1m/average_l0_41
+    path: layer_9/width_1m/average_l0_41/params.npz
+    l0: 41
+  - id: layer_9/width_1m/average_l0_70
+    path: layer_9/width_1m/average_l0_70/params.npz
+    l0: 70
+  - id: layer_9/width_1m/average_l0_9
+    path: layer_9/width_1m/average_l0_9/params.npz
+    l0: 9
+gemma-scope-9b-pt-res-canonical:
+  repo_id: google/gemma-scope-9b-pt-res
+  model: gemma-2-9b
+  conversion_func: gemma_2
+  saes:
+  - id: layer_0/width_131k/canonical
+    path: layer_0/width_131k/average_l0_41
+    neuronpedia: gemma-2-9b/0-gemmascope-res-131k
+  - id: layer_1/width_131k/canonical
+    path: layer_1/width_131k/average_l0_56
+    neuronpedia: gemma-2-9b/1-gemmascope-res-131k
+  - id: layer_2/width_131k/canonical
+    path: layer_2/width_131k/average_l0_70
+    neuronpedia: gemma-2-9b/2-gemmascope-res-131k
+  - id: layer_3/width_131k/canonical
+    path: layer_3/width_131k/average_l0_103
+    neuronpedia: gemma-2-9b/3-gemmascope-res-131k
+  - id: layer_4/width_131k/canonical
+    path: layer_4/width_131k/average_l0_101
+    neuronpedia: gemma-2-9b/4-gemmascope-res-131k
+  - id: layer_5/width_131k/canonical
+    path: layer_5/width_131k/average_l0_94
+    neuronpedia: gemma-2-9b/5-gemmascope-res-131k
+  - id: layer_6/width_131k/canonical
+    path: layer_6/width_131k/average_l0_120
+    neuronpedia: gemma-2-9b/6-gemmascope-res-131k
+  - id: layer_7/width_131k/canonical
+    path: layer_7/width_131k/average_l0_119
+    neuronpedia: gemma-2-9b/7-gemmascope-res-131k
+  - id: layer_8/width_131k/canonical
+    path: layer_8/width_131k/average_l0_72
+    neuronpedia: gemma-2-9b/8-gemmascope-res-131k
+  - id: layer_9/width_131k/canonical
+    path: layer_9/width_131k/average_l0_75
+    neuronpedia: gemma-2-9b/9-gemmascope-res-131k
+  - id: layer_10/width_131k/canonical
+    path: layer_10/width_131k/average_l0_84
+    neuronpedia: gemma-2-9b/10-gemmascope-res-131k
+  - id: layer_11/width_131k/canonical
+    path: layer_11/width_131k/average_l0_88
+    neuronpedia: gemma-2-9b/11-gemmascope-res-131k
+  - id: layer_12/width_131k/canonical
+    path: layer_12/width_131k/average_l0_96
+    neuronpedia: gemma-2-9b/12-gemmascope-res-131k
+  - id: layer_13/width_131k/canonical
+    path: layer_13/width_131k/average_l0_99
+    neuronpedia: gemma-2-9b/13-gemmascope-res-131k
+  - id: layer_14/width_131k/canonical
+    path: layer_14/width_131k/average_l0_105
+    neuronpedia: gemma-2-9b/14-gemmascope-res-131k
+  - id: layer_15/width_131k/canonical
+    path: layer_15/width_131k/average_l0_103
+    neuronpedia: gemma-2-9b/15-gemmascope-res-131k
+  - id: layer_16/width_131k/canonical
+    path: layer_16/width_131k/average_l0_121
+    neuronpedia: gemma-2-9b/16-gemmascope-res-131k
+  - id: layer_17/width_131k/canonical
+    path: layer_17/width_131k/average_l0_117
+    neuronpedia: gemma-2-9b/17-gemmascope-res-131k
+  - id: layer_18/width_131k/canonical
+    path: layer_18/width_131k/average_l0_113
+    neuronpedia: gemma-2-9b/18-gemmascope-res-131k
+  - id: layer_19/width_131k/canonical
+    path: layer_19/width_131k/average_l0_110
+    neuronpedia: gemma-2-9b/19-gemmascope-res-131k
+  - id: layer_20/width_131k/canonical
+    path: layer_20/width_131k/average_l0_114
+    neuronpedia: gemma-2-9b/20-gemmascope-res-131k
+  - id: layer_21/width_131k/canonical
+    path: layer_21/width_131k/average_l0_109
+    neuronpedia: gemma-2-9b/21-gemmascope-res-131k
+  - id: layer_22/width_131k/canonical
+    path: layer_22/width_131k/average_l0_105
+    neuronpedia: gemma-2-9b/22-gemmascope-res-131k
+  - id: layer_23/width_131k/canonical
+    path: layer_23/width_131k/average_l0_101
+    neuronpedia: gemma-2-9b/23-gemmascope-res-131k
+  - id: layer_24/width_131k/canonical
+    path: layer_24/width_131k/average_l0_97
+    neuronpedia: gemma-2-9b/24-gemmascope-res-131k
+  - id: layer_25/width_131k/canonical
+    path: layer_25/width_131k/average_l0_96
+    neuronpedia: gemma-2-9b/25-gemmascope-res-131k
+  - id: layer_26/width_131k/canonical
+    path: layer_26/width_131k/average_l0_97
+    neuronpedia: gemma-2-9b/26-gemmascope-res-131k
+  - id: layer_27/width_131k/canonical
+    path: layer_27/width_131k/average_l0_96
+    neuronpedia: gemma-2-9b/27-gemmascope-res-131k
+  - id: layer_28/width_131k/canonical
+    path: layer_28/width_131k/average_l0_98
+    neuronpedia: gemma-2-9b/28-gemmascope-res-131k
+  - id: layer_29/width_131k/canonical
+    path: layer_29/width_131k/average_l0_97
+    neuronpedia: gemma-2-9b/29-gemmascope-res-131k
+  - id: layer_30/width_131k/canonical
+    path: layer_30/width_131k/average_l0_95
+    neuronpedia: gemma-2-9b/30-gemmascope-res-131k
+  - id: layer_31/width_131k/canonical
+    path: layer_31/width_131k/average_l0_92
+    neuronpedia: gemma-2-9b/31-gemmascope-res-131k
+  - id: layer_32/width_131k/canonical
+    path: layer_32/width_131k/average_l0_88
+    neuronpedia: gemma-2-9b/32-gemmascope-res-131k
+  - id: layer_33/width_131k/canonical
+    path: layer_33/width_131k/average_l0_91
+    neuronpedia: gemma-2-9b/33-gemmascope-res-131k
+  - id: layer_34/width_131k/canonical
+    path: layer_34/width_131k/average_l0_89
+    neuronpedia: gemma-2-9b/34-gemmascope-res-131k
+  - id: layer_35/width_131k/canonical
+    path: layer_35/width_131k/average_l0_94
+    neuronpedia: gemma-2-9b/35-gemmascope-res-131k
+  - id: layer_36/width_131k/canonical
+    path: layer_36/width_131k/average_l0_93
+    neuronpedia: gemma-2-9b/36-gemmascope-res-131k
+  - id: layer_37/width_131k/canonical
+    path: layer_37/width_131k/average_l0_96
+    neuronpedia: gemma-2-9b/37-gemmascope-res-131k
+  - id: layer_38/width_131k/canonical
+    path: layer_38/width_131k/average_l0_101
+    neuronpedia: gemma-2-9b/38-gemmascope-res-131k
+  - id: layer_39/width_131k/canonical
+    path: layer_39/width_131k/average_l0_99
+    neuronpedia: gemma-2-9b/39-gemmascope-res-131k
+  - id: layer_40/width_131k/canonical
+    path: layer_40/width_131k/average_l0_94
+    neuronpedia: gemma-2-9b/40-gemmascope-res-131k
+  - id: layer_41/width_131k/canonical
+    path: layer_41/width_131k/average_l0_84
+    neuronpedia: gemma-2-9b/41-gemmascope-res-131k
+gemma-scope-9b-pt-att:
+  repo_id: google/gemma-scope-9b-pt-att
+  model: gemma-2-9b
+  conversion_func: gemma_2
+  saes:
+  - id: layer_0/width_131k/average_l0_55
+    path: layer_0/width_131k/average_l0_55
+    l0: 55
+  - id: layer_1/width_131k/average_l0_116
+    path: layer_1/width_131k/average_l0_116
+    l0: 116
+  - id: layer_2/width_131k/average_l0_11
+    path: layer_2/width_131k/average_l0_11
+    l0: 11
+  - id: layer_3/width_131k/average_l0_10
+    path: layer_3/width_131k/average_l0_10
+    l0: 10
+  - id: layer_4/width_131k/average_l0_12
+    path: layer_4/width_131k/average_l0_12
+    l0: 12
+  - id: layer_5/width_131k/average_l0_12
+    path: layer_5/width_131k/average_l0_12
+    l0: 12
+  - id: layer_6/width_131k/average_l0_14
+    path: layer_6/width_131k/average_l0_14
+    l0: 14
+  - id: layer_6/width_131k/average_l0_148
+    path: layer_6/width_131k/average_l0_148
+    l0: 148
+  - id: layer_7/width_131k/average_l0_106
+    path: layer_7/width_131k/average_l0_106
+    l0: 106
+  - id: layer_8/width_131k/average_l0_16
+    path: layer_8/width_131k/average_l0_16
+    l0: 16
+  - id: layer_9/width_131k/average_l0_111
+    path: layer_9/width_131k/average_l0_111
+    l0: 111
+  - id: layer_10/width_131k/average_l0_16
+    path: layer_10/width_131k/average_l0_16
+    l0: 16
+  - id: layer_11/width_131k/average_l0_104
+    path: layer_11/width_131k/average_l0_104
+    l0: 104
+  - id: layer_12/width_131k/average_l0_110
+    path: layer_12/width_131k/average_l0_110
+    l0: 110
+  - id: layer_13/width_131k/average_l0_126
+    path: layer_13/width_131k/average_l0_126
+    l0: 126
+  - id: layer_14/width_131k/average_l0_131
+    path: layer_14/width_131k/average_l0_131
+    l0: 131
+  - id: layer_15/width_131k/average_l0_130
+    path: layer_15/width_131k/average_l0_130
+    l0: 130
+  - id: layer_16/width_131k/average_l0_140
+    path: layer_16/width_131k/average_l0_140
+    l0: 140
+  - id: layer_17/width_131k/average_l0_191
+    path: layer_17/width_131k/average_l0_191
+    l0: 191
+  - id: layer_18/width_131k/average_l0_133
+    path: layer_18/width_131k/average_l0_133
+    l0: 133
+  - id: layer_19/width_131k/average_l0_152
+    path: layer_19/width_131k/average_l0_152
+    l0: 152
+  - id: layer_20/width_131k/average_l0_125
+    path: layer_20/width_131k/average_l0_125
+    l0: 125
+  - id: layer_21/width_131k/average_l0_150
+    path: layer_21/width_131k/average_l0_150
+    l0: 150
+  - id: layer_22/width_131k/average_l0_115
+    path: layer_22/width_131k/average_l0_115
+    l0: 115
+  - id: layer_23/width_131k/average_l0_134
+    path: layer_23/width_131k/average_l0_134
+    l0: 134
+  - id: layer_24/width_131k/average_l0_130
+    path: layer_24/width_131k/average_l0_130
+    l0: 130
+  - id: layer_25/width_131k/average_l0_115
+    path: layer_25/width_131k/average_l0_115
+    l0: 115
+  - id: layer_26/width_131k/average_l0_120
+    path: layer_26/width_131k/average_l0_120
+    l0: 120
+  - id: layer_27/width_131k/average_l0_102
+    path: layer_27/width_131k/average_l0_102
+    l0: 102
+  - id: layer_28/width_131k/average_l0_115
+    path: layer_28/width_131k/average_l0_115
+    l0: 115
+  - id: layer_29/width_131k/average_l0_128
+    path: layer_29/width_131k/average_l0_128
+    l0: 128
+  - id: layer_30/width_131k/average_l0_109
+    path: layer_30/width_131k/average_l0_109
+    l0: 109
+  - id: layer_31/width_131k/average_l0_117
+    path: layer_31/width_131k/average_l0_117
+    l0: 117
+  - id: layer_32/width_131k/average_l0_117
+    path: layer_32/width_131k/average_l0_117
+    l0: 117
+  - id: layer_33/width_131k/average_l0_128
+    path: layer_33/width_131k/average_l0_128
+    l0: 128
+  - id: layer_34/width_131k/average_l0_15
+    path: layer_34/width_131k/average_l0_15
+    l0: 15
+  - id: layer_35/width_131k/average_l0_124
+    path: layer_35/width_131k/average_l0_124
+    l0: 124
+  - id: layer_36/width_131k/average_l0_105
+    path: layer_36/width_131k/average_l0_105
+    l0: 105
+  - id: layer_37/width_131k/average_l0_124
+    path: layer_37/width_131k/average_l0_124
+    l0: 124
+  - id: layer_38/width_131k/average_l0_135
+    path: layer_38/width_131k/average_l0_135
+    l0: 135
+  - id: layer_39/width_131k/average_l0_120
+    path: layer_39/width_131k/average_l0_120
+    l0: 120
+  - id: layer_40/width_131k/average_l0_144
+    path: layer_40/width_131k/average_l0_144
+    l0: 144
+  - id: layer_41/width_131k/average_l0_13
+    path: layer_41/width_131k/average_l0_13
+    l0: 13
+  - id: layer_0/width_16k/average_l0_12
+    path: layer_0/width_16k/average_l0_12
+    l0: 12
+  - id: layer_1/width_16k/average_l0_147
+    path: layer_1/width_16k/average_l0_147
+    l0: 147
+  - id: layer_2/width_16k/average_l0_15
+    path: layer_2/width_16k/average_l0_15
+    l0: 15
+  - id: layer_3/width_16k/average_l0_102
+    path: layer_3/width_16k/average_l0_102
+    l0: 102
+  - id: layer_4/width_16k/average_l0_126
+    path: layer_4/width_16k/average_l0_126
+    l0: 126
+  - id: layer_5/width_16k/average_l0_125
+    path: layer_5/width_16k/average_l0_125
+    l0: 125
+  - id: layer_6/width_16k/average_l0_108
+    path: layer_6/width_16k/average_l0_108
+    l0: 108
+  - id: layer_7/width_16k/average_l0_70
+    path: layer_7/width_16k/average_l0_70
+    l0: 70
+  - id: layer_8/width_16k/average_l0_150
+    path: layer_8/width_16k/average_l0_150
+    l0: 150
+  - id: layer_9/width_16k/average_l0_172
+    path: layer_9/width_16k/average_l0_172
+    l0: 172
+  - id: layer_10/width_16k/average_l0_132
+    path: layer_10/width_16k/average_l0_132
+    l0: 132
+  - id: layer_11/width_16k/average_l0_153
+    path: layer_11/width_16k/average_l0_153
+    l0: 153
+  - id: layer_12/width_16k/average_l0_149
+    path: layer_12/width_16k/average_l0_149
+    l0: 149
+  - id: layer_13/width_16k/average_l0_170
+    path: layer_13/width_16k/average_l0_170
+    l0: 170
+  - id: layer_14/width_16k/average_l0_179
+    path: layer_14/width_16k/average_l0_179
+    l0: 179
+  - id: layer_15/width_16k/average_l0_168
+    path: layer_15/width_16k/average_l0_168
+    l0: 168
+  - id: layer_16/width_16k/average_l0_172
+    path: layer_16/width_16k/average_l0_172
+    l0: 172
+  - id: layer_17/width_16k/average_l0_110
+    path: layer_17/width_16k/average_l0_110
+    l0: 110
+  - id: layer_18/width_16k/average_l0_171
+    path: layer_18/width_16k/average_l0_171
+    l0: 171
+  - id: layer_19/width_16k/average_l0_186
+    path: layer_19/width_16k/average_l0_186
+    l0: 186
+  - id: layer_20/width_16k/average_l0_158
+    path: layer_20/width_16k/average_l0_158
+    l0: 158
+  - id: layer_21/width_16k/average_l0_195
+    path: layer_21/width_16k/average_l0_195
+    l0: 195
+  - id: layer_22/width_16k/average_l0_141
+    path: layer_22/width_16k/average_l0_141
+    l0: 141
+  - id: layer_23/width_16k/average_l0_173
+    path: layer_23/width_16k/average_l0_173
+    l0: 173
+  - id: layer_24/width_16k/average_l0_167
+    path: layer_24/width_16k/average_l0_167
+    l0: 167
+  - id: layer_25/width_16k/average_l0_156
+    path: layer_25/width_16k/average_l0_156
+    l0: 156
+  - id: layer_26/width_16k/average_l0_159
+    path: layer_26/width_16k/average_l0_159
+    l0: 159
+  - id: layer_27/width_16k/average_l0_136
+    path: layer_27/width_16k/average_l0_136
+    l0: 136
+  - id: layer_28/width_16k/average_l0_143
+    path: layer_28/width_16k/average_l0_143
+    l0: 143
+  - id: layer_29/width_16k/average_l0_171
+    path: layer_29/width_16k/average_l0_171
+    l0: 171
+  - id: layer_30/width_16k/average_l0_157
+    path: layer_30/width_16k/average_l0_157
+    l0: 157
+  - id: layer_31/width_16k/average_l0_168
+    path: layer_31/width_16k/average_l0_168
+    l0: 168
+  - id: layer_32/width_16k/average_l0_158
+    path: layer_32/width_16k/average_l0_158
+    l0: 158
+  - id: layer_33/width_16k/average_l0_158
+    path: layer_33/width_16k/average_l0_158
+    l0: 158
+  - id: layer_34/width_16k/average_l0_17
+    path: layer_34/width_16k/average_l0_17
+    l0: 17
+  - id: layer_35/width_16k/average_l0_14
+    path: layer_35/width_16k/average_l0_14
+    l0: 14
+  - id: layer_36/width_16k/average_l0_144
+    path: layer_36/width_16k/average_l0_144
+    l0: 144
+  - id: layer_37/width_16k/average_l0_17
+    path: layer_37/width_16k/average_l0_17
+    l0: 17
+  - id: layer_37/width_16k/average_l0_172
+    path: layer_37/width_16k/average_l0_172
+    l0: 172
+  - id: layer_38/width_16k/average_l0_175
+    path: layer_38/width_16k/average_l0_175
+    l0: 175
+  - id: layer_39/width_16k/average_l0_15
+    path: layer_39/width_16k/average_l0_15
+    l0: 15
+  - id: layer_40/width_16k/average_l0_18
+    path: layer_40/width_16k/average_l0_18
+    l0: 18
+  - id: layer_40/width_16k/average_l0_189
+    path: layer_40/width_16k/average_l0_189
+    l0: 189
+  - id: layer_41/width_16k/average_l0_129
+    path: layer_41/width_16k/average_l0_129
+    l0: 129
+gemma-scope-9b-pt-att-canonical:
+  repo_id: google/gemma-scope-9b-pt-att
+  model: gemma-2-9b
+  conversion_func: gemma_2
+  saes:
+  - id: layer_0/width_131k/canonical
+    path: layer_0/width_131k/average_l0_55
+    neuronpedia: gemma-2-9b/0-gemmascope-att-131k
+  - id: layer_1/width_131k/canonical
+    path: layer_1/width_131k/average_l0_116
+    neuronpedia: gemma-2-9b/1-gemmascope-att-131k
+  - id: layer_2/width_131k/canonical
+    path: layer_2/width_131k/average_l0_11
+    neuronpedia: gemma-2-9b/2-gemmascope-att-131k
+  - id: layer_3/width_131k/canonical
+    path: layer_3/width_131k/average_l0_10
+    neuronpedia: gemma-2-9b/3-gemmascope-att-131k
+  - id: layer_4/width_131k/canonical
+    path: layer_4/width_131k/average_l0_12
+    neuronpedia: gemma-2-9b/4-gemmascope-att-131k
+  - id: layer_5/width_131k/canonical
+    path: layer_5/width_131k/average_l0_12
+    neuronpedia: gemma-2-9b/5-gemmascope-att-131k
+  - id: layer_6/width_131k/canonical
+    path: layer_6/width_131k/average_l0_148
+    neuronpedia: gemma-2-9b/6-gemmascope-att-131k
+  - id: layer_7/width_131k/canonical
+    path: layer_7/width_131k/average_l0_106
+    neuronpedia: gemma-2-9b/7-gemmascope-att-131k
+  - id: layer_8/width_131k/canonical
+    path: layer_8/width_131k/average_l0_16
+    neuronpedia: gemma-2-9b/8-gemmascope-att-131k
+  - id: layer_9/width_131k/canonical
+    path: layer_9/width_131k/average_l0_111
+    neuronpedia: gemma-2-9b/9-gemmascope-att-131k
+  - id: layer_10/width_131k/canonical
+    path: layer_10/width_131k/average_l0_16
+    neuronpedia: gemma-2-9b/10-gemmascope-att-131k
+  - id: layer_11/width_131k/canonical
+    path: layer_11/width_131k/average_l0_104
+    neuronpedia: gemma-2-9b/11-gemmascope-att-131k
+  - id: layer_12/width_131k/canonical
+    path: layer_12/width_131k/average_l0_110
+    neuronpedia: gemma-2-9b/12-gemmascope-att-131k
+  - id: layer_13/width_131k/canonical
+    path: layer_13/width_131k/average_l0_126
+    neuronpedia: gemma-2-9b/13-gemmascope-att-131k
+  - id: layer_14/width_131k/canonical
+    path: layer_14/width_131k/average_l0_131
+    neuronpedia: gemma-2-9b/14-gemmascope-att-131k
+  - id: layer_15/width_131k/canonical
+    path: layer_15/width_131k/average_l0_130
+    neuronpedia: gemma-2-9b/15-gemmascope-att-131k
+  - id: layer_16/width_131k/canonical
+    path: layer_16/width_131k/average_l0_140
+    neuronpedia: gemma-2-9b/16-gemmascope-att-131k
+  - id: layer_17/width_131k/canonical
+    path: layer_17/width_131k/average_l0_191
+    neuronpedia: gemma-2-9b/17-gemmascope-att-131k
+  - id: layer_18/width_131k/canonical
+    path: layer_18/width_131k/average_l0_133
+    neuronpedia: gemma-2-9b/18-gemmascope-att-131k
+  - id: layer_19/width_131k/canonical
+    path: layer_19/width_131k/average_l0_152
+    neuronpedia: gemma-2-9b/19-gemmascope-att-131k
+  - id: layer_20/width_131k/canonical
+    path: layer_20/width_131k/average_l0_125
+    neuronpedia: gemma-2-9b/20-gemmascope-att-131k
+  - id: layer_21/width_131k/canonical
+    path: layer_21/width_131k/average_l0_150
+    neuronpedia: gemma-2-9b/21-gemmascope-att-131k
+  - id: layer_22/width_131k/canonical
+    path: layer_22/width_131k/average_l0_115
+    neuronpedia: gemma-2-9b/22-gemmascope-att-131k
+  - id: layer_23/width_131k/canonical
+    path: layer_23/width_131k/average_l0_134
+    neuronpedia: gemma-2-9b/23-gemmascope-att-131k
+  - id: layer_24/width_131k/canonical
+    path: layer_24/width_131k/average_l0_130
+    neuronpedia: gemma-2-9b/24-gemmascope-att-131k
+  - id: layer_25/width_131k/canonical
+    path: layer_25/width_131k/average_l0_115
+    neuronpedia: gemma-2-9b/25-gemmascope-att-131k
+  - id: layer_26/width_131k/canonical
+    path: layer_26/width_131k/average_l0_120
+    neuronpedia: gemma-2-9b/26-gemmascope-att-131k
+  - id: layer_27/width_131k/canonical
+    path: layer_27/width_131k/average_l0_102
+    neuronpedia: gemma-2-9b/27-gemmascope-att-131k
+  - id: layer_28/width_131k/canonical
+    path: layer_28/width_131k/average_l0_115
+    neuronpedia: gemma-2-9b/28-gemmascope-att-131k
+  - id: layer_29/width_131k/canonical
+    path: layer_29/width_131k/average_l0_128
+    neuronpedia: gemma-2-9b/29-gemmascope-att-131k
+  - id: layer_30/width_131k/canonical
+    path: layer_30/width_131k/average_l0_109
+    neuronpedia: gemma-2-9b/30-gemmascope-att-131k
+  - id: layer_31/width_131k/canonical
+    path: layer_31/width_131k/average_l0_117
+    neuronpedia: gemma-2-9b/31-gemmascope-att-131k
+  - id: layer_32/width_131k/canonical
+    path: layer_32/width_131k/average_l0_117
+    neuronpedia: gemma-2-9b/32-gemmascope-att-131k
+  - id: layer_33/width_131k/canonical
+    path: layer_33/width_131k/average_l0_128
+    neuronpedia: gemma-2-9b/33-gemmascope-att-131k
+  - id: layer_34/width_131k/canonical
+    path: layer_34/width_131k/average_l0_15
+    neuronpedia: gemma-2-9b/34-gemmascope-att-131k
+  - id: layer_35/width_131k/canonical
+    path: layer_35/width_131k/average_l0_124
+    neuronpedia: gemma-2-9b/35-gemmascope-att-131k
+  - id: layer_36/width_131k/canonical
+    path: layer_36/width_131k/average_l0_105
+    neuronpedia: gemma-2-9b/36-gemmascope-att-131k
+  - id: layer_37/width_131k/canonical
+    path: layer_37/width_131k/average_l0_124
+    neuronpedia: gemma-2-9b/37-gemmascope-att-131k
+  - id: layer_38/width_131k/canonical
+    path: layer_38/width_131k/average_l0_135
+    neuronpedia: gemma-2-9b/38-gemmascope-att-131k
+  - id: layer_39/width_131k/canonical
+    path: layer_39/width_131k/average_l0_120
+    neuronpedia: gemma-2-9b/39-gemmascope-att-131k
+  - id: layer_40/width_131k/canonical
+    path: layer_40/width_131k/average_l0_144
+    neuronpedia: gemma-2-9b/40-gemmascope-att-131k
+  - id: layer_41/width_131k/canonical
+    path: layer_41/width_131k/average_l0_13
+    neuronpedia: gemma-2-9b/41-gemmascope-att-131k
+gemma-scope-9b-pt-mlp:
+  repo_id: google/gemma-scope-9b-pt-mlp
+  model: gemma-2-9b
+  conversion_func: gemma_2
+  saes:
+  - id: layer_0/width_131k/average_l0_11
+    path: layer_0/width_131k/average_l0_11
+    l0: 11
+  - id: layer_1/width_131k/average_l0_10
+    path: layer_1/width_131k/average_l0_10
+    l0: 10
+  - id: layer_1/width_131k/average_l0_106
+    path: layer_1/width_131k/average_l0_106
+    l0: 106
+  - id: layer_2/width_131k/average_l0_12
+    path: layer_2/width_131k/average_l0_12
+    l0: 12
+  - id: layer_3/width_131k/average_l0_109
+    path: layer_3/width_131k/average_l0_109
+    l0: 109
+  - id: layer_4/width_131k/average_l0_14
+    path: layer_4/width_131k/average_l0_14
+    l0: 14
+  - id: layer_5/width_131k/average_l0_12
+    path: layer_5/width_131k/average_l0_12
+    l0: 12
+  - id: layer_6/width_131k/average_l0_12
+    path: layer_6/width_131k/average_l0_12
+    l0: 12
+  - id: layer_7/width_131k/average_l0_13
+    path: layer_7/width_131k/average_l0_13
+    l0: 13
+  - id: layer_8/width_131k/average_l0_15
+    path: layer_8/width_131k/average_l0_15
+    l0: 15
+  - id: layer_9/width_131k/average_l0_12
+    path: layer_9/width_131k/average_l0_12
+    l0: 12
+  - id: layer_9/width_131k/average_l0_129
+    path: layer_9/width_131k/average_l0_129
+    l0: 129
+  - id: layer_10/width_131k/average_l0_12
+    path: layer_10/width_131k/average_l0_12
+    l0: 12
+  - id: layer_11/width_131k/average_l0_120
+    path: layer_11/width_131k/average_l0_120
+    l0: 120
+  - id: layer_12/width_131k/average_l0_159
+    path: layer_12/width_131k/average_l0_159
+    l0: 159
+  - id: layer_13/width_131k/average_l0_160
+    path: layer_13/width_131k/average_l0_160
+    l0: 160
+  - id: layer_14/width_131k/average_l0_174
+    path: layer_14/width_131k/average_l0_174
+    l0: 174
+  - id: layer_15/width_131k/average_l0_194
+    path: layer_15/width_131k/average_l0_194
+    l0: 194
+  - id: layer_16/width_131k/average_l0_17
+    path: layer_16/width_131k/average_l0_17
+    l0: 17
+  - id: layer_16/width_131k/average_l0_175
+    path: layer_16/width_131k/average_l0_175
+    l0: 175
+  - id: layer_17/width_131k/average_l0_207
+    path: layer_17/width_131k/average_l0_207
+    l0: 207
+  - id: layer_18/width_131k/average_l0_174
+    path: layer_18/width_131k/average_l0_174
+    l0: 174
+  - id: layer_19/width_131k/average_l0_189
+    path: layer_19/width_131k/average_l0_189
+    l0: 189
+  - id: layer_20/width_131k/average_l0_20
+    path: layer_20/width_131k/average_l0_20
+    l0: 20
+  - id: layer_21/width_131k/average_l0_16
+    path: layer_21/width_131k/average_l0_16
+    l0: 16
+  - id: layer_22/width_131k/average_l0_17
+    path: layer_22/width_131k/average_l0_17
+    l0: 17
+  - id: layer_22/width_131k/average_l0_172
+    path: layer_22/width_131k/average_l0_172
+    l0: 172
+  - id: layer_23/width_131k/average_l0_146
+    path: layer_23/width_131k/average_l0_146
+    l0: 146
+  - id: layer_24/width_131k/average_l0_147
+    path: layer_24/width_131k/average_l0_147
+    l0: 147
+  - id: layer_25/width_131k/average_l0_139
+    path: layer_25/width_131k/average_l0_139
+    l0: 139
+  - id: layer_26/width_131k/average_l0_110
+    path: layer_26/width_131k/average_l0_110
+    l0: 110
+  - id: layer_27/width_131k/average_l0_14
+    path: layer_27/width_131k/average_l0_14
+    l0: 14
+  - id: layer_28/width_131k/average_l0_15
+    path: layer_28/width_131k/average_l0_15
+    l0: 15
+  - id: layer_29/width_131k/average_l0_15
+    path: layer_29/width_131k/average_l0_15
+    l0: 15
+  - id: layer_30/width_131k/average_l0_14
+    path: layer_30/width_131k/average_l0_14
+    l0: 14
+  - id: layer_31/width_131k/average_l0_12
+    path: layer_31/width_131k/average_l0_12
+    l0: 12
+  - id: layer_32/width_131k/average_l0_12
+    path: layer_32/width_131k/average_l0_12
+    l0: 12
+  - id: layer_33/width_131k/average_l0_12
+    path: layer_33/width_131k/average_l0_12
+    l0: 12
+  - id: layer_34/width_131k/average_l0_10
+    path: layer_34/width_131k/average_l0_10
+    l0: 10
+  - id: layer_35/width_131k/average_l0_10
+    path: layer_35/width_131k/average_l0_10
+    l0: 10
+  - id: layer_36/width_131k/average_l0_11
+    path: layer_36/width_131k/average_l0_11
+    l0: 11
+  - id: layer_37/width_131k/average_l0_12
+    path: layer_37/width_131k/average_l0_12
+    l0: 12
+  - id: layer_38/width_131k/average_l0_11
+    path: layer_38/width_131k/average_l0_11
+    l0: 11
+  - id: layer_39/width_131k/average_l0_11
+    path: layer_39/width_131k/average_l0_11
+    l0: 11
+  - id: layer_40/width_131k/average_l0_11
+    path: layer_40/width_131k/average_l0_11
+    l0: 11
+  - id: layer_41/width_131k/average_l0_14
+    path: layer_41/width_131k/average_l0_14
+    l0: 14
+  - id: layer_3/width_16k/average_l0_126
+    path: layer_3/width_16k/average_l0_126
+    l0: 126
+  - id: layer_10/width_16k/average_l0_114
+    path: layer_10/width_16k/average_l0_114
+    l0: 114
+  - id: layer_20/width_16k/average_l0_146
+    path: layer_20/width_16k/average_l0_146
+    l0: 146
+  - id: layer_20/width_16k/average_l0_1522
+    path: layer_20/width_16k/average_l0_1522
+    l0: 1522
+  - id: layer_20/width_16k/average_l0_23
+    path: layer_20/width_16k/average_l0_23
+    l0: 23
+  - id: layer_20/width_16k/average_l0_384
+    path: layer_20/width_16k/average_l0_384
+    l0: 384
+  - id: layer_20/width_16k/average_l0_56
+    path: layer_20/width_16k/average_l0_56
+    l0: 56
+  - id: layer_20/width_16k/average_l0_868
+    path: layer_20/width_16k/average_l0_868
+    l0: 868
+  - id: layer_26/width_16k/average_l0_14
+    path: layer_26/width_16k/average_l0_14
+    l0: 14
+  - id: layer_26/width_16k/average_l0_142
+    path: layer_26/width_16k/average_l0_142
+    l0: 142
+  - id: layer_31/width_16k/average_l0_12
+    path: layer_31/width_16k/average_l0_12
+    l0: 12
+gemma-scope-9b-pt-mlp-canonical:
+  repo_id: google/gemma-scope-9b-pt-mlp
+  model: gemma-2-9b
+  conversion_func: gemma_2
+  saes:
+  - id: layer_0/width_131k/canonical
+    path: layer_0/width_131k/average_l0_11
+    neuronpedia: gemma-2-9b/0-gemmascope-mlp-131k
+  - id: layer_1/width_131k/canonical
+    path: layer_1/width_131k/average_l0_106
+    neuronpedia: gemma-2-9b/1-gemmascope-mlp-131k
+  - id: layer_2/width_131k/canonical
+    path: layer_2/width_131k/average_l0_12
+    neuronpedia: gemma-2-9b/2-gemmascope-mlp-131k
+  - id: layer_3/width_131k/canonical
+    path: layer_3/width_131k/average_l0_109
+    neuronpedia: gemma-2-9b/3-gemmascope-mlp-131k
+  - id: layer_4/width_131k/canonical
+    path: layer_4/width_131k/average_l0_14
+    neuronpedia: gemma-2-9b/4-gemmascope-mlp-131k
+  - id: layer_5/width_131k/canonical
+    path: layer_5/width_131k/average_l0_12
+    neuronpedia: gemma-2-9b/5-gemmascope-mlp-131k
+  - id: layer_6/width_131k/canonical
+    path: layer_6/width_131k/average_l0_12
+    neuronpedia: gemma-2-9b/6-gemmascope-mlp-131k
+  - id: layer_7/width_131k/canonical
+    path: layer_7/width_131k/average_l0_13
+    neuronpedia: gemma-2-9b/7-gemmascope-mlp-131k
+  - id: layer_8/width_131k/canonical
+    path: layer_8/width_131k/average_l0_15
+    neuronpedia: gemma-2-9b/8-gemmascope-mlp-131k
+  - id: layer_9/width_131k/canonical
+    path: layer_9/width_131k/average_l0_129
+    neuronpedia: gemma-2-9b/9-gemmascope-mlp-131k
+  - id: layer_10/width_131k/canonical
+    path: layer_10/width_131k/average_l0_12
+    neuronpedia: gemma-2-9b/10-gemmascope-mlp-131k
+  - id: layer_11/width_131k/canonical
+    path: layer_11/width_131k/average_l0_120
+    neuronpedia: gemma-2-9b/11-gemmascope-mlp-131k
+  - id: layer_12/width_131k/canonical
+    path: layer_12/width_131k/average_l0_159
+    neuronpedia: gemma-2-9b/12-gemmascope-mlp-131k
+  - id: layer_13/width_131k/canonical
+    path: layer_13/width_131k/average_l0_160
+    neuronpedia: gemma-2-9b/13-gemmascope-mlp-131k
+  - id: layer_14/width_131k/canonical
+    path: layer_14/width_131k/average_l0_174
+    neuronpedia: gemma-2-9b/14-gemmascope-mlp-131k
+  - id: layer_15/width_131k/canonical
+    path: layer_15/width_131k/average_l0_194
+    neuronpedia: gemma-2-9b/15-gemmascope-mlp-131k
+  - id: layer_16/width_131k/canonical
+    path: layer_16/width_131k/average_l0_175
+    neuronpedia: gemma-2-9b/16-gemmascope-mlp-131k
+  - id: layer_17/width_131k/canonical
+    path: layer_17/width_131k/average_l0_207
+    neuronpedia: gemma-2-9b/17-gemmascope-mlp-131k
+  - id: layer_18/width_131k/canonical
+    path: layer_18/width_131k/average_l0_174
+    neuronpedia: gemma-2-9b/18-gemmascope-mlp-131k
+  - id: layer_19/width_131k/canonical
+    path: layer_19/width_131k/average_l0_189
+    neuronpedia: gemma-2-9b/19-gemmascope-mlp-131k
+  - id: layer_20/width_131k/canonical
+    path: layer_20/width_131k/average_l0_20
+    neuronpedia: gemma-2-9b/20-gemmascope-mlp-131k
+  - id: layer_21/width_131k/canonical
+    path: layer_21/width_131k/average_l0_16
+    neuronpedia: gemma-2-9b/21-gemmascope-mlp-131k
+  - id: layer_22/width_131k/canonical
+    path: layer_22/width_131k/average_l0_172
+    neuronpedia: gemma-2-9b/22-gemmascope-mlp-131k
+  - id: layer_23/width_131k/canonical
+    path: layer_23/width_131k/average_l0_146
+    neuronpedia: gemma-2-9b/23-gemmascope-mlp-131k
+  - id: layer_24/width_131k/canonical
+    path: layer_24/width_131k/average_l0_147
+    neuronpedia: gemma-2-9b/24-gemmascope-mlp-131k
+  - id: layer_25/width_131k/canonical
+    path: layer_25/width_131k/average_l0_139
+    neuronpedia: gemma-2-9b/25-gemmascope-mlp-131k
+  - id: layer_26/width_131k/canonical
+    path: layer_26/width_131k/average_l0_110
+    neuronpedia: gemma-2-9b/26-gemmascope-mlp-131k
+  - id: layer_27/width_131k/canonical
+    path: layer_27/width_131k/average_l0_14
+    neuronpedia: gemma-2-9b/27-gemmascope-mlp-131k
+  - id: layer_28/width_131k/canonical
+    path: layer_28/width_131k/average_l0_15
+    neuronpedia: gemma-2-9b/28-gemmascope-mlp-131k
+  - id: layer_29/width_131k/canonical
+    path: layer_29/width_131k/average_l0_15
+    neuronpedia: gemma-2-9b/29-gemmascope-mlp-131k
+  - id: layer_30/width_131k/canonical
+    path: layer_30/width_131k/average_l0_14
+    neuronpedia: gemma-2-9b/30-gemmascope-mlp-131k
+  - id: layer_31/width_131k/canonical
+    path: layer_31/width_131k/average_l0_12
+    neuronpedia: gemma-2-9b/31-gemmascope-mlp-131k
+  - id: layer_32/width_131k/canonical
+    path: layer_32/width_131k/average_l0_12
+    neuronpedia: gemma-2-9b/32-gemmascope-mlp-131k
+  - id: layer_33/width_131k/canonical
+    path: layer_33/width_131k/average_l0_12
+    neuronpedia: gemma-2-9b/33-gemmascope-mlp-131k
+  - id: layer_34/width_131k/canonical
+    path: layer_34/width_131k/average_l0_10
+    neuronpedia: gemma-2-9b/34-gemmascope-mlp-131k
+  - id: layer_35/width_131k/canonical
+    path: layer_35/width_131k/average_l0_10
+    neuronpedia: gemma-2-9b/35-gemmascope-mlp-131k
+  - id: layer_36/width_131k/canonical
+    path: layer_36/width_131k/average_l0_11
+    neuronpedia: gemma-2-9b/36-gemmascope-mlp-131k
+  - id: layer_37/width_131k/canonical
+    path: layer_37/width_131k/average_l0_12
+    neuronpedia: gemma-2-9b/37-gemmascope-mlp-131k
+  - id: layer_38/width_131k/canonical
+    path: layer_38/width_131k/average_l0_11
+    neuronpedia: gemma-2-9b/38-gemmascope-mlp-131k
+  - id: layer_39/width_131k/canonical
+    path: layer_39/width_131k/average_l0_11
+    neuronpedia: gemma-2-9b/39-gemmascope-mlp-131k
+  - id: layer_40/width_131k/canonical
+    path: layer_40/width_131k/average_l0_11
+    neuronpedia: gemma-2-9b/40-gemmascope-mlp-131k
+  - id: layer_41/width_131k/canonical
+    path: layer_41/width_131k/average_l0_14
+    neuronpedia: gemma-2-9b/41-gemmascope-mlp-131k
+gemma-scope-9b-it-res:
+  repo_id: google/gemma-scope-9b-it-res
+  model: gemma-2-9b
+  conversion_func: gemma_2
+  saes:
+  - id: layer_20/width_131k/average_l0_13
+    path: layer_20/width_131k/average_l0_13/params.npz
+    l0: 13
+  - id: layer_20/width_131k/average_l0_153
+    path: layer_20/width_131k/average_l0_153/params.npz
+    l0: 153
+  - id: layer_20/width_131k/average_l0_24
+    path: layer_20/width_131k/average_l0_24/params.npz
+    l0: 24
+  - id: layer_20/width_131k/average_l0_43
+    path: layer_20/width_131k/average_l0_43/params.npz
+    l0: 43
+  - id: layer_20/width_131k/average_l0_81
+    path: layer_20/width_131k/average_l0_81/params.npz
+    l0: 81
+  - id: layer_20/width_16k/average_l0_14
+    path: layer_20/width_16k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_20/width_16k/average_l0_189
+    path: layer_20/width_16k/average_l0_189/params.npz
+    l0: 189
+  - id: layer_20/width_16k/average_l0_25
+    path: layer_20/width_16k/average_l0_25/params.npz
+    l0: 25
+  - id: layer_20/width_16k/average_l0_47
+    path: layer_20/width_16k/average_l0_47/params.npz
+    l0: 47
+  - id: layer_20/width_16k/average_l0_91
+    path: layer_20/width_16k/average_l0_91/params.npz
+    l0: 91
+  - id: layer_31/width_131k/average_l0_109
+    path: layer_31/width_131k/average_l0_109/params.npz
+    l0: 109
+  - id: layer_31/width_131k/average_l0_13
+    path: layer_31/width_131k/average_l0_13/params.npz
+    l0: 13
+  - id: layer_31/width_131k/average_l0_22
+    path: layer_31/width_131k/average_l0_22/params.npz
+    l0: 22
+  - id: layer_31/width_131k/average_l0_37
+    path: layer_31/width_131k/average_l0_37/params.npz
+    l0: 37
+  - id: layer_31/width_131k/average_l0_63
+    path: layer_31/width_131k/average_l0_63/params.npz
+    l0: 63
+  - id: layer_31/width_16k/average_l0_14
+    path: layer_31/width_16k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_31/width_16k/average_l0_142
+    path: layer_31/width_16k/average_l0_142/params.npz
+    l0: 142
+  - id: layer_31/width_16k/average_l0_24
+    path: layer_31/width_16k/average_l0_24/params.npz
+    l0: 24
+  - id: layer_31/width_16k/average_l0_43
+    path: layer_31/width_16k/average_l0_43/params.npz
+    l0: 43
+  - id: layer_31/width_16k/average_l0_76
+    path: layer_31/width_16k/average_l0_76/params.npz
+    l0: 76
+  - id: layer_9/width_131k/average_l0_121
+    path: layer_9/width_131k/average_l0_121/params.npz
+    l0: 121
+  - id: layer_9/width_131k/average_l0_13
+    path: layer_9/width_131k/average_l0_13/params.npz
+    l0: 13
+  - id: layer_9/width_131k/average_l0_22
+    path: layer_9/width_131k/average_l0_22/params.npz
+    l0: 22
+  - id: layer_9/width_131k/average_l0_39
+    path: layer_9/width_131k/average_l0_39/params.npz
+    l0: 39
+  - id: layer_9/width_131k/average_l0_67
+    path: layer_9/width_131k/average_l0_67/params.npz
+    l0: 67
+  - id: layer_9/width_16k/average_l0_14
+    path: layer_9/width_16k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_9/width_16k/average_l0_186
+    path: layer_9/width_16k/average_l0_186/params.npz
+    l0: 186
+  - id: layer_9/width_16k/average_l0_26
+    path: layer_9/width_16k/average_l0_26/params.npz
+    l0: 26
+  - id: layer_9/width_16k/average_l0_47
+    path: layer_9/width_16k/average_l0_47/params.npz
+    l0: 47
+  - id: layer_9/width_16k/average_l0_88
+    path: layer_9/width_16k/average_l0_88/params.npz
+    l0: 88
+gemma-scope-9b-it-res-canonical:
+  repo_id: google/gemma-scope-9b-it-res
+  model: gemma-2-9b
+  conversion_func: gemma_2
+  saes:
+  - id: layer_9/width_131k/canonical
+    path: layer_9/width_131k/average_l0_121/params.npz
+    neuronpedia: gemma-2-9b/9-gemmascope-res-131k
+  - id: layer_20/width_131k/canonical
+    path: layer_20/width_131k/average_l0_81/params.npz
+    neuronpedia: gemma-2-9b/20-gemmascope-res-131k
+  - id: layer_31/width_131k/canonical
+    path: layer_31/width_131k/average_l0_109/params.npz
+    neuronpedia: gemma-2-9b/31-gemmascope-res-131k
+gemma-scope-27b-pt-res:
+  repo_id: google/gemma-scope-27b-pt-res
+  model: gemma-2-2b
+  conversion_func: gemma_2
+  saes:
+  - id: layer_10/width_131k/average_l0_106
+    path: layer_10/width_131k/average_l0_106
+    l0: 106
+  - id: layer_10/width_131k/average_l0_15
+    path: layer_10/width_131k/average_l0_15
+    l0: 15
+  - id: layer_10/width_131k/average_l0_200
+    path: layer_10/width_131k/average_l0_200
+    l0: 200
+  - id: layer_10/width_131k/average_l0_24
+    path: layer_10/width_131k/average_l0_24
+    l0: 24
+  - id: layer_10/width_131k/average_l0_37
+    path: layer_10/width_131k/average_l0_37
+    l0: 37
+  - id: layer_10/width_131k/average_l0_64
+    path: layer_10/width_131k/average_l0_64
+    l0: 64
+  - id: layer_22/width_131k/average_l0_150
+    path: layer_22/width_131k/average_l0_150
+    l0: 150
+  - id: layer_22/width_131k/average_l0_20
+    path: layer_22/width_131k/average_l0_20
+    l0: 20
+  - id: layer_22/width_131k/average_l0_290
+    path: layer_22/width_131k/average_l0_290
+    l0: 290
+  - id: layer_22/width_131k/average_l0_31
+    path: layer_22/width_131k/average_l0_31
+    l0: 31
+  - id: layer_22/width_131k/average_l0_48
+    path: layer_22/width_131k/average_l0_48
+    l0: 48
+  - id: layer_22/width_131k/average_l0_82
+    path: layer_22/width_131k/average_l0_82
+    l0: 82
+  - id: layer_34/width_131k/average_l0_155
+    path: layer_34/width_131k/average_l0_155
+    l0: 155
+  - id: layer_34/width_131k/average_l0_21
+    path: layer_34/width_131k/average_l0_21
+    l0: 21
+  - id: layer_34/width_131k/average_l0_333
+    path: layer_34/width_131k/average_l0_333
+    l0: 333
+  - id: layer_34/width_131k/average_l0_38
+    path: layer_34/width_131k/average_l0_38
+    l0: 38
+  - id: layer_34/width_131k/average_l0_72
+    path: layer_34/width_131k/average_l0_72
+    l0: 72
+  - id: layer_34/width_131k/average_l0_785
+    path: layer_34/width_131k/average_l0_785
+    l0: 785
+gemma-scope-27b-pt-res-canonical:
+  repo_id: google/gemma-scope-27b-pt-res
+  model: gemma-2-2b
+  conversion_func: gemma_2
+  saes:
+  - id: layer_10/width_131k/canonical
+    path: layer_10/width_131k/average_l0_106
+    neuronpedia: gemma-2-2b/10-gemmascope-res-131k
+  - id: layer_22/width_131k/canonical
+    path: layer_22/width_131k/average_l0_82
+    neuronpedia: gemma-2-2b/22-gemmascope-res-131k
+  - id: layer_34/width_131k/canonical
+    path: layer_34/width_131k/average_l0_72
+    neuronpedia: gemma-2-2b/34-gemmascope-res-131k
+pythia-70m-deduped-res-sm:
+  repo_id: ctigges/pythia-70m-deduped__res-sm_processed
+  model: pythia-70m-deduped
+  conversion_func: null
+  links:
+    model: https://huggingface.co/EleutherAI/pythia-70m-deduped
+    dashboards: https://www.neuronpedia.org/pythia-70m-deduped
+  saes:
+  - id: blocks.0.hook_resid_pre
+    path: e-res-sm
+    neuronpedia: pythia-70m-deduped/e-att-sm
+  - id: blocks.0.hook_resid_post
+    path: 0-res-sm
+    neuronpedia: pythia-70m-deduped/0-res-sm
+  - id: blocks.1.hook_resid_post
+    path: 1-res-sm
+    neuronpedia: pythia-70m-deduped/1-res-sm
+  - id: blocks.2.hook_resid_post
+    path: 2-res-sm
+    neuronpedia: pythia-70m-deduped/2-res-sm
+  - id: blocks.3.hook_resid_post
+    path: 3-res-sm
+    neuronpedia: pythia-70m-deduped/3-res-sm
+  - id: blocks.4.hook_resid_post
+    path: 4-res-sm
+    neuronpedia: pythia-70m-deduped/4-res-sm
+  - id: blocks.5.hook_resid_post
+    path: 5-res-sm
+    neuronpedia: pythia-70m-deduped/5-res-sm
+pythia-70m-deduped-mlp-sm:
+  repo_id: ctigges/pythia-70m-deduped__mlp-sm_processed
+  model: pythia-70m-deduped
+  conversion_func: null
+  links:
+    model: https://huggingface.co/EleutherAI/pythia-70m-deduped
+    dashboards: https://www.neuronpedia.org/pythia-70m-deduped
+  saes:
+  - id: blocks.0.hook_mlp_out
+    path: 0-mlp-sm
+    neuronpedia: pythia-70m-deduped/0-mlp-sm
+  - id: blocks.1.hook_mlp_out
+    path: 1-mlp-sm
+    neuronpedia: pythia-70m-deduped/1-mlp-sm
+  - id: blocks.2.hook_mlp_out
+    path: 2-mlp-sm
+    neuronpedia: pythia-70m-deduped/2-mlp-sm
+  - id: blocks.3.hook_mlp_out
+    path: 3-mlp-sm
+    neuronpedia: pythia-70m-deduped/3-mlp-sm
+  - id: blocks.4.hook_mlp_out
+    path: 4-mlp-sm
+    neuronpedia: pythia-70m-deduped/4-mlp-sm
+  - id: blocks.5.hook_mlp_out
+    path: 5-mlp-sm
+    neuronpedia: pythia-70m-deduped/5-mlp-sm
+pythia-70m-deduped-att-sm:
+  repo_id: ctigges/pythia-70m-deduped__att-sm_processed
+  model: pythia-70m-deduped
+  conversion_func: null
+  links:
+    model: https://huggingface.co/EleutherAI/pythia-70m-deduped
+    dashboards: https://www.neuronpedia.org/pythia-70m-deduped
+  saes:
+  - id: blocks.0.hook_attn_out
+    path: 0-att-sm
+    neuronpedia: pythia-70m-deduped/0-att-sm
+  - id: blocks.1.hook_attn_out
+    path: 1-att-sm
+    neuronpedia: pythia-70m-deduped/1-att-sm
+  - id: blocks.2.hook_attn_out
+    path: 2-att-sm
+    neuronpedia: pythia-70m-deduped/2-att-sm
+  - id: blocks.3.hook_attn_out
+    path: 3-att-sm
+    neuronpedia: pythia-70m-deduped/3-att-sm
+  - id: blocks.4.hook_attn_out
+    path: 4-att-sm
+    neuronpedia: pythia-70m-deduped/4-att-sm
+  - id: blocks.5.hook_attn_out
+    path: 5-att-sm
+    neuronpedia: pythia-70m-deduped/5-att-sm
+gpt2-small-res_sll-ajt:
+  repo_id: neuronpedia/gpt2-small__res_sll-ajt
+  model: gpt2-small
+  conversion_func: null
+  links:
+    model: https://huggingface.co/gpt2
+    dashboards: https://www.neuronpedia.org/gpt2-small/res_sll-ajt
+  saes:
+  - id: blocks.2.hook_resid_pre
+    path: 2-res_sll-ajt
+    neuronpedia: gpt2-small/2-res_sll-ajt
+  - id: blocks.6.hook_resid_pre
+    path: 6-res_sll-ajt
+    neuronpedia: gpt2-small/6-res_sll-ajt
+  - id: blocks.10.hook_resid_pre
+    path: 10-res_sll-ajt
+    neuronpedia: gpt2-small/10-res_sll-ajt
+gpt2-small-res_slefr-ajt:
+  repo_id: neuronpedia/gpt2-small__res_slefr-ajt
+  model: gpt2-small
+  conversion_func: null
+  links:
+    model: https://huggingface.co/gpt2
+    dashboards: https://www.neuronpedia.org/gpt2-small/res_slefr-ajt
+  saes:
+  - id: blocks.2.hook_resid_pre
+    path: 2-res_slefr-ajt
+    neuronpedia: gpt2-small/2-res_slefr-ajt
+  - id: blocks.6.hook_resid_pre
+    path: 6-res_slefr-ajt
+    neuronpedia: gpt2-small/6-res_slefr-ajt
+  - id: blocks.10.hook_resid_pre
+    path: 10-res_slefr-ajt
+    neuronpedia: gpt2-small/10-res_slefr-ajt
+gpt2-small-res_scl-ajt:
+  repo_id: neuronpedia/gpt2-small__res_scl-ajt
+  model: gpt2-small
+  conversion_func: null
+  links:
+    model: https://huggingface.co/gpt2
+    dashboards: https://www.neuronpedia.org/gpt2-small/res_scl-ajt
+  saes:
+  - id: blocks.2.hook_resid_pre
+    path: 2-res_scl-ajt
+    neuronpedia: gpt2-small/2-res_scl-ajt
+  - id: blocks.6.hook_resid_pre
+    path: 6-res_scl-ajt
+    neuronpedia: gpt2-small/6-res_scl-ajt
+  - id: blocks.10.hook_resid_pre
+    path: 10-res_scl-ajt
+    neuronpedia: gpt2-small/10-res_scl-ajt
+gpt2-small-res_sle-ajt:
+  repo_id: neuronpedia/gpt2-small__res_sle-ajt
+  model: gpt2-small
+  conversion_func: null
+  links:
+    model: https://huggingface.co/gpt2
+    dashboards: https://www.neuronpedia.org/gpt2-small/res_sle-ajt
+  saes:
+  - id: blocks.2.hook_resid_pre
+    path: 2-res_sle-ajt
+    neuronpedia: gpt2-small/2-res_sle-ajt
+  - id: blocks.6.hook_resid_pre
+    path: 6-res_sle-ajt
+    neuronpedia: gpt2-small/6-res_sle-ajt
+  - id: blocks.10.hook_resid_pre
+    path: 10-res_sle-ajt
+    neuronpedia: gpt2-small/10-res_sle-ajt
+gpt2-small-res_sce-ajt:
+  repo_id: neuronpedia/gpt2-small__res_sce-ajt
+  model: gpt2-small
+  conversion_func: null
+  links:
+    model: https://huggingface.co/gpt2
+    dashboards: https://www.neuronpedia.org/gpt2-small/res_sce-ajt
+  saes:
+  - id: blocks.2.hook_resid_pre
+    path: 2-res_sce-ajt
+    neuronpedia: gpt2-small/2-res_sce-ajt
+  - id: blocks.6.hook_resid_pre
+    path: 6-res_sce-ajt
+    neuronpedia: gpt2-small/6-res_sce-ajt
+  - id: blocks.10.hook_resid_pre
+    path: 10-res_sce-ajt
+    neuronpedia: gpt2-small/10-res_sce-ajt
+gpt2-small-res_scefr-ajt:
+  repo_id: neuronpedia/gpt2-small__res_scefr-ajt
+  model: gpt2-small
+  conversion_func: null
+  links:
+    model: https://huggingface.co/gpt2
+    dashboards: https://www.neuronpedia.org/gpt2-small/res_scefr-ajt
+  saes:
+  - id: blocks.2.hook_resid_pre
+    path: 2-res_scefr-ajt
+    neuronpedia: gpt2-small/2-res_scefr-ajt
+  - id: blocks.6.hook_resid_pre
+    path: 6-res_scefr-ajt
+    neuronpedia: gpt2-small/6-res_scefr-ajt
+  - id: blocks.10.hook_resid_pre
+    path: 10-res_scefr-ajt
+    neuronpedia: gpt2-small/10-res_scefr-ajt
 
-      - id: layer_1/width_16k/canonical
-        path: layer_1/width_16k/canonical
-
-      - id: layer_2/width_16k/canonical
-        path: layer_2/width_16k/canonical
-
-      - id: layer_3/width_16k/canonical
-        path: layer_3/width_16k/canonical
-
-      - id: layer_4/width_16k/canonical
-        path: layer_4/width_16k/canonical
-
-      - id: layer_5/width_16k/canonical
-        path: layer_5/width_16k/canonical
-
-      - id: layer_6/width_16k/canonical
-        path: layer_6/width_16k/canonical
-
-      - id: layer_7/width_16k/canonical
-        path: layer_7/width_16k/canonical
-
-      - id: layer_8/width_16k/canonical
-        path: layer_8/width_16k/canonical
-
-      - id: layer_9/width_16k/canonical
-        path: layer_9/width_16k/canonical
-
-      - id: layer_10/width_16k/canonical
-        path: layer_10/width_16k/canonical
-
-      - id: layer_11/width_16k/canonical
-        path: layer_11/width_16k/canonical
-
-      - id: layer_12/width_16k/canonical
-        path: layer_12/width_16k/canonical
-
-      - id: layer_13/width_16k/canonical
-        path: layer_13/width_16k/canonical
-
-      - id: layer_14/width_16k/canonical
-        path: layer_14/width_16k/canonical
-
-      - id: layer_15/width_16k/canonical
-        path: layer_15/width_16k/canonical
-
-      - id: layer_16/width_16k/canonical
-        path: layer_16/width_16k/canonical
-
-      - id: layer_17/width_16k/canonical
-        path: layer_17/width_16k/canonical
-
-      - id: layer_18/width_16k/canonical
-        path: layer_18/width_16k/canonical
-
-      - id: layer_19/width_16k/canonical
-        path: layer_19/width_16k/canonical
-
-      - id: layer_20/width_16k/canonical
-        path: layer_20/width_16k/canonical
-
-      - id: layer_21/width_16k/canonical
-        path: layer_21/width_16k/canonical
-
-      - id: layer_22/width_16k/canonical
-        path: layer_22/width_16k/canonical
-
-      - id: layer_23/width_16k/canonical
-        path: layer_23/width_16k/canonical
-
-      - id: layer_24/width_16k/canonical
-        path: layer_24/width_16k/canonical
-
-      - id: layer_25/width_16k/canonical
-        path: layer_25/width_16k/canonical
-
-      - id: layer_5/width_1m/canonical
-        path: layer_5/width_1m/canonical
-
-      - id: layer_12/width_1m/canonical
-        path: layer_12/width_1m/canonical
-
-      - id: layer_19/width_1m/canonical
-        path: layer_19/width_1m/canonical
-
-      - id: layer_12/width_262k/canonical
-        path: layer_12/width_262k/canonical
-
-      - id: layer_12/width_32k/canonical
-        path: layer_12/width_32k/canonical
-
-      - id: layer_12/width_524k/canonical
-        path: layer_12/width_524k/canonical
-
-      - id: layer_0/width_65k/canonical
-        path: layer_0/width_65k/canonical
-
-      - id: layer_1/width_65k/canonical
-        path: layer_1/width_65k/canonical
-
-      - id: layer_2/width_65k/canonical
-        path: layer_2/width_65k/canonical
-
-      - id: layer_3/width_65k/canonical
-        path: layer_3/width_65k/canonical
-
-      - id: layer_4/width_65k/canonical
-        path: layer_4/width_65k/canonical
-
-      - id: layer_5/width_65k/canonical
-        path: layer_5/width_65k/canonical
-
-      - id: layer_6/width_65k/canonical
-        path: layer_6/width_65k/canonical
-
-      - id: layer_7/width_65k/canonical
-        path: layer_7/width_65k/canonical
-
-      - id: layer_8/width_65k/canonical
-        path: layer_8/width_65k/canonical
-
-      - id: layer_9/width_65k/canonical
-        path: layer_9/width_65k/canonical
-
-      - id: layer_10/width_65k/canonical
-        path: layer_10/width_65k/canonical
-
-      - id: layer_11/width_65k/canonical
-        path: layer_11/width_65k/canonical
-
-      - id: layer_12/width_65k/canonical
-        path: layer_12/width_65k/canonical
-
-      - id: layer_13/width_65k/canonical
-        path: layer_13/width_65k/canonical
-
-      - id: layer_14/width_65k/canonical
-        path: layer_14/width_65k/canonical
-
-      - id: layer_15/width_65k/canonical
-        path: layer_15/width_65k/canonical
-
-      - id: layer_16/width_65k/canonical
-        path: layer_16/width_65k/canonical
-
-      - id: layer_17/width_65k/canonical
-        path: layer_17/width_65k/canonical
-
-      - id: layer_18/width_65k/canonical
-        path: layer_18/width_65k/canonical
-
-      - id: layer_19/width_65k/canonical
-        path: layer_19/width_65k/canonical
-
-      - id: layer_20/width_65k/canonical
-        path: layer_20/width_65k/canonical
-
-      - id: layer_21/width_65k/canonical
-        path: layer_21/width_65k/canonical
-
-      - id: layer_22/width_65k/canonical
-        path: layer_22/width_65k/canonical
-
-      - id: layer_23/width_65k/canonical
-        path: layer_23/width_65k/canonical
-
-      - id: layer_24/width_65k/canonical
-        path: layer_24/width_65k/canonical
-
-      - id: layer_25/width_65k/canonical
-        path: layer_25/width_65k/canonical
-  gemma-scope-2b-pt-res:
-    repo_id: google/gemma-scope-2b-pt-res
-    model: gemma-2-2b
-    conversion_func: gemma_2
-    saes:
-      - id: layer_0/width_16k/average_l0_105
-        path: layer_0/width_16k/average_l0_105
-        l0: 105
-
-      - id: layer_0/width_16k/average_l0_13
-        path: layer_0/width_16k/average_l0_13
-        l0: 13
-
-      - id: layer_0/width_16k/average_l0_226
-        path: layer_0/width_16k/average_l0_226
-        l0: 226
-
-      - id: layer_0/width_16k/average_l0_25
-        path: layer_0/width_16k/average_l0_25
-        l0: 25
-
-      - id: layer_0/width_16k/average_l0_46
-        path: layer_0/width_16k/average_l0_46
-        l0: 46
-
-      - id: layer_1/width_16k/average_l0_10
-        path: layer_1/width_16k/average_l0_10
-        l0: 10
-
-      - id: layer_1/width_16k/average_l0_102
-        path: layer_1/width_16k/average_l0_102
-        l0: 102
-
-      - id: layer_1/width_16k/average_l0_20
-        path: layer_1/width_16k/average_l0_20
-        l0: 20
-
-      - id: layer_1/width_16k/average_l0_250
-        path: layer_1/width_16k/average_l0_250
-        l0: 250
-
-      - id: layer_1/width_16k/average_l0_40
-        path: layer_1/width_16k/average_l0_40
-        l0: 40
-
-      - id: layer_2/width_16k/average_l0_13
-        path: layer_2/width_16k/average_l0_13
-        l0: 13
-
-      - id: layer_2/width_16k/average_l0_141
-        path: layer_2/width_16k/average_l0_141
-        l0: 141
-
-      - id: layer_2/width_16k/average_l0_142
-        path: layer_2/width_16k/average_l0_142
-        l0: 142
-
-      - id: layer_2/width_16k/average_l0_24
-        path: layer_2/width_16k/average_l0_24
-        l0: 24
-
-      - id: layer_2/width_16k/average_l0_304
-        path: layer_2/width_16k/average_l0_304
-        l0: 304
-
-      - id: layer_2/width_16k/average_l0_53
-        path: layer_2/width_16k/average_l0_53
-        l0: 53
-
-      - id: layer_3/width_16k/average_l0_14
-        path: layer_3/width_16k/average_l0_14
-        l0: 14
-
-      - id: layer_3/width_16k/average_l0_142
-        path: layer_3/width_16k/average_l0_142
-        l0: 142
-
-      - id: layer_3/width_16k/average_l0_28
-        path: layer_3/width_16k/average_l0_28
-        l0: 28
-
-      - id: layer_3/width_16k/average_l0_315
-        path: layer_3/width_16k/average_l0_315
-        l0: 315
-
-      - id: layer_3/width_16k/average_l0_59
-        path: layer_3/width_16k/average_l0_59
-        l0: 59
-
-      - id: layer_4/width_16k/average_l0_124
-        path: layer_4/width_16k/average_l0_124
-        l0: 124
-
-      - id: layer_4/width_16k/average_l0_125
-        path: layer_4/width_16k/average_l0_125
-        l0: 125
-
-      - id: layer_4/width_16k/average_l0_17
-        path: layer_4/width_16k/average_l0_17
-        l0: 17
-
-      - id: layer_4/width_16k/average_l0_281
-        path: layer_4/width_16k/average_l0_281
-        l0: 281
-
-      - id: layer_4/width_16k/average_l0_31
-        path: layer_4/width_16k/average_l0_31
-        l0: 31
-
-      - id: layer_4/width_16k/average_l0_60
-        path: layer_4/width_16k/average_l0_60
-        l0: 60
-
-      - id: layer_5/width_16k/average_l0_143
-        path: layer_5/width_16k/average_l0_143
-        l0: 143
-
-      - id: layer_5/width_16k/average_l0_18
-        path: layer_5/width_16k/average_l0_18
-        l0: 18
-
-      - id: layer_5/width_16k/average_l0_309
-        path: layer_5/width_16k/average_l0_309
-        l0: 309
-
-      - id: layer_5/width_16k/average_l0_34
-        path: layer_5/width_16k/average_l0_34
-        l0: 34
-
-      - id: layer_5/width_16k/average_l0_68
-        path: layer_5/width_16k/average_l0_68
-        l0: 68
-
-      - id: layer_6/width_16k/average_l0_144
-        path: layer_6/width_16k/average_l0_144
-        l0: 144
-
-      - id: layer_6/width_16k/average_l0_19
-        path: layer_6/width_16k/average_l0_19
-        l0: 19
-
-      - id: layer_6/width_16k/average_l0_301
-        path: layer_6/width_16k/average_l0_301
-        l0: 301
-
-      - id: layer_6/width_16k/average_l0_36
-        path: layer_6/width_16k/average_l0_36
-        l0: 36
-
-      - id: layer_6/width_16k/average_l0_70
-        path: layer_6/width_16k/average_l0_70
-        l0: 70
-
-      - id: layer_7/width_16k/average_l0_137
-        path: layer_7/width_16k/average_l0_137
-        l0: 137
-
-      - id: layer_7/width_16k/average_l0_20
-        path: layer_7/width_16k/average_l0_20
-        l0: 20
-
-      - id: layer_7/width_16k/average_l0_285
-        path: layer_7/width_16k/average_l0_285
-        l0: 285
-
-      - id: layer_7/width_16k/average_l0_36
-        path: layer_7/width_16k/average_l0_36
-        l0: 36
-
-      - id: layer_7/width_16k/average_l0_69
-        path: layer_7/width_16k/average_l0_69
-        l0: 69
-
-      - id: layer_8/width_16k/average_l0_142
-        path: layer_8/width_16k/average_l0_142
-        l0: 142
-
-      - id: layer_8/width_16k/average_l0_20
-        path: layer_8/width_16k/average_l0_20
-        l0: 20
-
-      - id: layer_8/width_16k/average_l0_301
-        path: layer_8/width_16k/average_l0_301
-        l0: 301
-
-      - id: layer_8/width_16k/average_l0_37
-        path: layer_8/width_16k/average_l0_37
-        l0: 37
-
-      - id: layer_8/width_16k/average_l0_71
-        path: layer_8/width_16k/average_l0_71
-        l0: 71
-
-      - id: layer_9/width_16k/average_l0_151
-        path: layer_9/width_16k/average_l0_151
-        l0: 151
-
-      - id: layer_9/width_16k/average_l0_21
-        path: layer_9/width_16k/average_l0_21
-        l0: 21
-
-      - id: layer_9/width_16k/average_l0_340
-        path: layer_9/width_16k/average_l0_340
-        l0: 340
-
-      - id: layer_9/width_16k/average_l0_37
-        path: layer_9/width_16k/average_l0_37
-        l0: 37
-
-      - id: layer_9/width_16k/average_l0_73
-        path: layer_9/width_16k/average_l0_73
-        l0: 73
-
-      - id: layer_10/width_16k/average_l0_166
-        path: layer_10/width_16k/average_l0_166
-        l0: 166
-
-      - id: layer_10/width_16k/average_l0_21
-        path: layer_10/width_16k/average_l0_21
-        l0: 21
-
-      - id: layer_10/width_16k/average_l0_39
-        path: layer_10/width_16k/average_l0_39
-        l0: 39
-
-      - id: layer_10/width_16k/average_l0_395
-        path: layer_10/width_16k/average_l0_395
-        l0: 395
-
-      - id: layer_10/width_16k/average_l0_77
-        path: layer_10/width_16k/average_l0_77
-        l0: 77
-
-      - id: layer_11/width_16k/average_l0_168
-        path: layer_11/width_16k/average_l0_168
-        l0: 168
-
-      - id: layer_11/width_16k/average_l0_22
-        path: layer_11/width_16k/average_l0_22
-        l0: 22
-
-      - id: layer_11/width_16k/average_l0_393
-        path: layer_11/width_16k/average_l0_393
-        l0: 393
-
-      - id: layer_11/width_16k/average_l0_41
-        path: layer_11/width_16k/average_l0_41
-        l0: 41
-
-      - id: layer_11/width_16k/average_l0_79
-        path: layer_11/width_16k/average_l0_79
-        l0: 79
-
-      - id: layer_11/width_16k/average_l0_80
-        path: layer_11/width_16k/average_l0_80
-        l0: 80
-
-      - id: layer_12/width_16k/average_l0_176
-        path: layer_12/width_16k/average_l0_176
-        l0: 176
-
-      - id: layer_12/width_16k/average_l0_22
-        path: layer_12/width_16k/average_l0_22
-        l0: 22
-
-      - id: layer_12/width_16k/average_l0_41
-        path: layer_12/width_16k/average_l0_41
-        l0: 41
-
-      - id: layer_12/width_16k/average_l0_445
-        path: layer_12/width_16k/average_l0_445
-        l0: 445
-
-      - id: layer_12/width_16k/average_l0_82
-        path: layer_12/width_16k/average_l0_82
-        l0: 82
-
-      - id: layer_13/width_16k/average_l0_173
-        path: layer_13/width_16k/average_l0_173
-        l0: 173
-
-      - id: layer_13/width_16k/average_l0_23
-        path: layer_13/width_16k/average_l0_23
-        l0: 23
-
-      - id: layer_13/width_16k/average_l0_403
-        path: layer_13/width_16k/average_l0_403
-        l0: 403
-
-      - id: layer_13/width_16k/average_l0_43
-        path: layer_13/width_16k/average_l0_43
-        l0: 43
-
-      - id: layer_13/width_16k/average_l0_83
-        path: layer_13/width_16k/average_l0_83
-        l0: 83
-
-      - id: layer_13/width_16k/average_l0_84
-        path: layer_13/width_16k/average_l0_84
-        l0: 84
-
-      - id: layer_14/width_16k/average_l0_173
-        path: layer_14/width_16k/average_l0_173
-        l0: 173
-
-      - id: layer_14/width_16k/average_l0_23
-        path: layer_14/width_16k/average_l0_23
-        l0: 23
-
-      - id: layer_14/width_16k/average_l0_388
-        path: layer_14/width_16k/average_l0_388
-        l0: 388
-
-      - id: layer_14/width_16k/average_l0_43
-        path: layer_14/width_16k/average_l0_43
-        l0: 43
-
-      - id: layer_14/width_16k/average_l0_83
-        path: layer_14/width_16k/average_l0_83
-        l0: 83
-
-      - id: layer_14/width_16k/average_l0_84
-        path: layer_14/width_16k/average_l0_84
-        l0: 84
-
-      - id: layer_15/width_16k/average_l0_150
-        path: layer_15/width_16k/average_l0_150
-        l0: 150
-
-      - id: layer_15/width_16k/average_l0_23
-        path: layer_15/width_16k/average_l0_23
-        l0: 23
-
-      - id: layer_15/width_16k/average_l0_308
-        path: layer_15/width_16k/average_l0_308
-        l0: 308
-
-      - id: layer_15/width_16k/average_l0_41
-        path: layer_15/width_16k/average_l0_41
-        l0: 41
-
-      - id: layer_15/width_16k/average_l0_78
-        path: layer_15/width_16k/average_l0_78
-        l0: 78
-
-      - id: layer_16/width_16k/average_l0_154
-        path: layer_16/width_16k/average_l0_154
-        l0: 154
-
-      - id: layer_16/width_16k/average_l0_23
-        path: layer_16/width_16k/average_l0_23
-        l0: 23
-
-      - id: layer_16/width_16k/average_l0_335
-        path: layer_16/width_16k/average_l0_335
-        l0: 335
-
-      - id: layer_16/width_16k/average_l0_42
-        path: layer_16/width_16k/average_l0_42
-        l0: 42
-
-      - id: layer_16/width_16k/average_l0_78
-        path: layer_16/width_16k/average_l0_78
-        l0: 78
-
-      - id: layer_17/width_16k/average_l0_150
-        path: layer_17/width_16k/average_l0_150
-        l0: 150
-
-      - id: layer_17/width_16k/average_l0_23
-        path: layer_17/width_16k/average_l0_23
-        l0: 23
-
-      - id: layer_17/width_16k/average_l0_304
-        path: layer_17/width_16k/average_l0_304
-        l0: 304
-
-      - id: layer_17/width_16k/average_l0_42
-        path: layer_17/width_16k/average_l0_42
-        l0: 42
-
-      - id: layer_17/width_16k/average_l0_77
-        path: layer_17/width_16k/average_l0_77
-        l0: 77
-
-      - id: layer_18/width_16k/average_l0_138
-        path: layer_18/width_16k/average_l0_138
-        l0: 138
-
-      - id: layer_18/width_16k/average_l0_23
-        path: layer_18/width_16k/average_l0_23
-        l0: 23
-
-      - id: layer_18/width_16k/average_l0_280
-        path: layer_18/width_16k/average_l0_280
-        l0: 280
-
-      - id: layer_18/width_16k/average_l0_40
-        path: layer_18/width_16k/average_l0_40
-        l0: 40
-
-      - id: layer_18/width_16k/average_l0_74
-        path: layer_18/width_16k/average_l0_74
-        l0: 74
-
-      - id: layer_19/width_16k/average_l0_137
-        path: layer_19/width_16k/average_l0_137
-        l0: 137
-
-      - id: layer_19/width_16k/average_l0_23
-        path: layer_19/width_16k/average_l0_23
-        l0: 23
-
-      - id: layer_19/width_16k/average_l0_279
-        path: layer_19/width_16k/average_l0_279
-        l0: 279
-
-      - id: layer_19/width_16k/average_l0_40
-        path: layer_19/width_16k/average_l0_40
-        l0: 40
-
-      - id: layer_19/width_16k/average_l0_73
-        path: layer_19/width_16k/average_l0_73
-        l0: 73
-
-      - id: layer_20/width_16k/average_l0_139
-        path: layer_20/width_16k/average_l0_139
-        l0: 139
-
-      - id: layer_20/width_16k/average_l0_22
-        path: layer_20/width_16k/average_l0_22
-        l0: 22
-
-      - id: layer_20/width_16k/average_l0_294
-        path: layer_20/width_16k/average_l0_294
-        l0: 294
-
-      - id: layer_20/width_16k/average_l0_38
-        path: layer_20/width_16k/average_l0_38
-        l0: 38
-
-      - id: layer_20/width_16k/average_l0_71
-        path: layer_20/width_16k/average_l0_71
-        l0: 71
-
-      - id: layer_21/width_16k/average_l0_139
-        path: layer_21/width_16k/average_l0_139
-        l0: 139
-
-      - id: layer_21/width_16k/average_l0_22
-        path: layer_21/width_16k/average_l0_22
-        l0: 22
-
-      - id: layer_21/width_16k/average_l0_301
-        path: layer_21/width_16k/average_l0_301
-        l0: 301
-
-      - id: layer_21/width_16k/average_l0_38
-        path: layer_21/width_16k/average_l0_38
-        l0: 38
-
-      - id: layer_21/width_16k/average_l0_70
-        path: layer_21/width_16k/average_l0_70
-        l0: 70
-
-      - id: layer_22/width_16k/average_l0_147
-        path: layer_22/width_16k/average_l0_147
-        l0: 147
-
-      - id: layer_22/width_16k/average_l0_21
-        path: layer_22/width_16k/average_l0_21
-        l0: 21
-
-      - id: layer_22/width_16k/average_l0_349
-        path: layer_22/width_16k/average_l0_349
-        l0: 349
-
-      - id: layer_22/width_16k/average_l0_38
-        path: layer_22/width_16k/average_l0_38
-        l0: 38
-
-      - id: layer_22/width_16k/average_l0_72
-        path: layer_22/width_16k/average_l0_72
-        l0: 72
-
-      - id: layer_23/width_16k/average_l0_157
-        path: layer_23/width_16k/average_l0_157
-        l0: 157
-
-      - id: layer_23/width_16k/average_l0_21
-        path: layer_23/width_16k/average_l0_21
-        l0: 21
-
-      - id: layer_23/width_16k/average_l0_38
-        path: layer_23/width_16k/average_l0_38
-        l0: 38
-
-      - id: layer_23/width_16k/average_l0_404
-        path: layer_23/width_16k/average_l0_404
-        l0: 404
-
-      - id: layer_23/width_16k/average_l0_74
-        path: layer_23/width_16k/average_l0_74
-        l0: 74
-
-      - id: layer_23/width_16k/average_l0_75
-        path: layer_23/width_16k/average_l0_75
-        l0: 75
-
-      - id: layer_24/width_16k/average_l0_158
-        path: layer_24/width_16k/average_l0_158
-        l0: 158
-
-      - id: layer_24/width_16k/average_l0_20
-        path: layer_24/width_16k/average_l0_20
-        l0: 20
-
-      - id: layer_24/width_16k/average_l0_38
-        path: layer_24/width_16k/average_l0_38
-        l0: 38
-
-      - id: layer_24/width_16k/average_l0_457
-        path: layer_24/width_16k/average_l0_457
-        l0: 457
-
-      - id: layer_24/width_16k/average_l0_73
-        path: layer_24/width_16k/average_l0_73
-        l0: 73
-
-      - id: layer_25/width_16k/average_l0_116
-        path: layer_25/width_16k/average_l0_116
-        l0: 116
-
-      - id: layer_25/width_16k/average_l0_16
-        path: layer_25/width_16k/average_l0_16
-        l0: 16
-
-      - id: layer_25/width_16k/average_l0_28
-        path: layer_25/width_16k/average_l0_28
-        l0: 28
-
-      - id: layer_25/width_16k/average_l0_285
-        path: layer_25/width_16k/average_l0_285
-        l0: 285
-
-      - id: layer_25/width_16k/average_l0_55
-        path: layer_25/width_16k/average_l0_55
-        l0: 55
-
-      - id: layer_5/width_1m/average_l0_114
-        path: layer_5/width_1m/average_l0_114
-        l0: 114
-
-      - id: layer_5/width_1m/average_l0_13
-        path: layer_5/width_1m/average_l0_13
-        l0: 13
-
-      - id: layer_5/width_1m/average_l0_21
-        path: layer_5/width_1m/average_l0_21
-        l0: 21
-
-      - id: layer_5/width_1m/average_l0_36
-        path: layer_5/width_1m/average_l0_36
-        l0: 36
-
-      - id: layer_5/width_1m/average_l0_63
-        path: layer_5/width_1m/average_l0_63
-        l0: 63
-
-      - id: layer_5/width_1m/average_l0_9
-        path: layer_5/width_1m/average_l0_9
-        l0: 9
-
-      - id: layer_12/width_1m/average_l0_107
-        path: layer_12/width_1m/average_l0_107
-        l0: 107
-
-      - id: layer_12/width_1m/average_l0_19
-        path: layer_12/width_1m/average_l0_19
-        l0: 19
-
-      - id: layer_12/width_1m/average_l0_207
-        path: layer_12/width_1m/average_l0_207
-        l0: 207
-
-      - id: layer_12/width_1m/average_l0_26
-        path: layer_12/width_1m/average_l0_26
-        l0: 26
-
-      - id: layer_12/width_1m/average_l0_58
-        path: layer_12/width_1m/average_l0_58
-        l0: 58
-
-      - id: layer_12/width_1m/average_l0_73
-        path: layer_12/width_1m/average_l0_73
-        l0: 73
-
-      - id: layer_19/width_1m/average_l0_157
-        path: layer_19/width_1m/average_l0_157
-        l0: 157
-
-      - id: layer_19/width_1m/average_l0_16
-        path: layer_19/width_1m/average_l0_16
-        l0: 16
-
-      - id: layer_19/width_1m/average_l0_18
-        path: layer_19/width_1m/average_l0_18
-        l0: 18
-
-      - id: layer_19/width_1m/average_l0_29
-        path: layer_19/width_1m/average_l0_29
-        l0: 29
-
-      - id: layer_19/width_1m/average_l0_50
-        path: layer_19/width_1m/average_l0_50
-        l0: 50
-
-      - id: layer_19/width_1m/average_l0_88
-        path: layer_19/width_1m/average_l0_88
-        l0: 88
-
-      - id: layer_12/width_262k/average_l0_11
-        path: layer_12/width_262k/average_l0_11
-        l0: 11
-
-      - id: layer_12/width_262k/average_l0_121
-        path: layer_12/width_262k/average_l0_121
-        l0: 121
-
-      - id: layer_12/width_262k/average_l0_21
-        path: layer_12/width_262k/average_l0_21
-        l0: 21
-
-      - id: layer_12/width_262k/average_l0_243
-        path: layer_12/width_262k/average_l0_243
-        l0: 243
-
-      - id: layer_12/width_262k/average_l0_36
-        path: layer_12/width_262k/average_l0_36
-        l0: 36
-
-      - id: layer_12/width_262k/average_l0_67
-        path: layer_12/width_262k/average_l0_67
-        l0: 67
-
-      - id: layer_12/width_32k/average_l0_12
-        path: layer_12/width_32k/average_l0_12
-        l0: 12
-
-      - id: layer_12/width_32k/average_l0_155
-        path: layer_12/width_32k/average_l0_155
-        l0: 155
-
-      - id: layer_12/width_32k/average_l0_22
-        path: layer_12/width_32k/average_l0_22
-        l0: 22
-
-      - id: layer_12/width_32k/average_l0_360
-        path: layer_12/width_32k/average_l0_360
-        l0: 360
-
-      - id: layer_12/width_32k/average_l0_40
-        path: layer_12/width_32k/average_l0_40
-        l0: 40
-
-      - id: layer_12/width_32k/average_l0_76
-        path: layer_12/width_32k/average_l0_76
-        l0: 76
-
-      - id: layer_12/width_524k/average_l0_115
-        path: layer_12/width_524k/average_l0_115
-        l0: 115
-
-      - id: layer_12/width_524k/average_l0_22
-        path: layer_12/width_524k/average_l0_22
-        l0: 22
-
-      - id: layer_12/width_524k/average_l0_227
-        path: layer_12/width_524k/average_l0_227
-        l0: 227
-
-      - id: layer_12/width_524k/average_l0_29
-        path: layer_12/width_524k/average_l0_29
-        l0: 29
-
-      - id: layer_12/width_524k/average_l0_46
-        path: layer_12/width_524k/average_l0_46
-        l0: 46
-
-      - id: layer_12/width_524k/average_l0_65
-        path: layer_12/width_524k/average_l0_65
-        l0: 65
-
-      - id: layer_0/width_65k/average_l0_11
-        path: layer_0/width_65k/average_l0_11
-        l0: 11
-
-      - id: layer_0/width_65k/average_l0_17
-        path: layer_0/width_65k/average_l0_17
-        l0: 17
-
-      - id: layer_0/width_65k/average_l0_27
-        path: layer_0/width_65k/average_l0_27
-        l0: 27
-
-      - id: layer_0/width_65k/average_l0_43
-        path: layer_0/width_65k/average_l0_43
-        l0: 43
-
-      - id: layer_0/width_65k/average_l0_73
-        path: layer_0/width_65k/average_l0_73
-        l0: 73
-
-      - id: layer_1/width_65k/average_l0_121
-        path: layer_1/width_65k/average_l0_121
-        l0: 121
-
-      - id: layer_1/width_65k/average_l0_16
-        path: layer_1/width_65k/average_l0_16
-        l0: 16
-
-      - id: layer_1/width_65k/average_l0_30
-        path: layer_1/width_65k/average_l0_30
-        l0: 30
-
-      - id: layer_1/width_65k/average_l0_54
-        path: layer_1/width_65k/average_l0_54
-        l0: 54
-
-      - id: layer_1/width_65k/average_l0_9
-        path: layer_1/width_65k/average_l0_9
-        l0: 9
-
-      - id: layer_2/width_65k/average_l0_11
-        path: layer_2/width_65k/average_l0_11
-        l0: 11
-
-      - id: layer_2/width_65k/average_l0_169
-        path: layer_2/width_65k/average_l0_169
-        l0: 169
-
-      - id: layer_2/width_65k/average_l0_20
-        path: layer_2/width_65k/average_l0_20
-        l0: 20
-
-      - id: layer_2/width_65k/average_l0_37
-        path: layer_2/width_65k/average_l0_37
-        l0: 37
-
-      - id: layer_2/width_65k/average_l0_77
-        path: layer_2/width_65k/average_l0_77
-        l0: 77
-
-      - id: layer_3/width_65k/average_l0_13
-        path: layer_3/width_65k/average_l0_13
-        l0: 13
-
-      - id: layer_3/width_65k/average_l0_193
-        path: layer_3/width_65k/average_l0_193
-        l0: 193
-
-      - id: layer_3/width_65k/average_l0_23
-        path: layer_3/width_65k/average_l0_23
-        l0: 23
-
-      - id: layer_3/width_65k/average_l0_42
-        path: layer_3/width_65k/average_l0_42
-        l0: 42
-
-      - id: layer_3/width_65k/average_l0_89
-        path: layer_3/width_65k/average_l0_89
-        l0: 89
-
-      - id: layer_4/width_65k/average_l0_14
-        path: layer_4/width_65k/average_l0_14
-        l0: 14
-
-      - id: layer_4/width_65k/average_l0_177
-        path: layer_4/width_65k/average_l0_177
-        l0: 177
-
-      - id: layer_4/width_65k/average_l0_25
-        path: layer_4/width_65k/average_l0_25
-        l0: 25
-
-      - id: layer_4/width_65k/average_l0_46
-        path: layer_4/width_65k/average_l0_46
-        l0: 46
-
-      - id: layer_4/width_65k/average_l0_89
-        path: layer_4/width_65k/average_l0_89
-        l0: 89
-
-      - id: layer_5/width_65k/average_l0_105
-        path: layer_5/width_65k/average_l0_105
-        l0: 105
-
-      - id: layer_5/width_65k/average_l0_17
-        path: layer_5/width_65k/average_l0_17
-        l0: 17
-
-      - id: layer_5/width_65k/average_l0_211
-        path: layer_5/width_65k/average_l0_211
-        l0: 211
-
-      - id: layer_5/width_65k/average_l0_29
-        path: layer_5/width_65k/average_l0_29
-        l0: 29
-
-      - id: layer_5/width_65k/average_l0_53
-        path: layer_5/width_65k/average_l0_53
-        l0: 53
-
-      - id: layer_6/width_65k/average_l0_107
-        path: layer_6/width_65k/average_l0_107
-        l0: 107
-
-      - id: layer_6/width_65k/average_l0_17
-        path: layer_6/width_65k/average_l0_17
-        l0: 17
-
-      - id: layer_6/width_65k/average_l0_208
-        path: layer_6/width_65k/average_l0_208
-        l0: 208
-
-      - id: layer_6/width_65k/average_l0_30
-        path: layer_6/width_65k/average_l0_30
-        l0: 30
-
-      - id: layer_6/width_65k/average_l0_56
-        path: layer_6/width_65k/average_l0_56
-        l0: 56
-
-      - id: layer_7/width_65k/average_l0_107
-        path: layer_7/width_65k/average_l0_107
-        l0: 107
-
-      - id: layer_7/width_65k/average_l0_18
-        path: layer_7/width_65k/average_l0_18
-        l0: 18
-
-      - id: layer_7/width_65k/average_l0_203
-        path: layer_7/width_65k/average_l0_203
-        l0: 203
-
-      - id: layer_7/width_65k/average_l0_31
-        path: layer_7/width_65k/average_l0_31
-        l0: 31
-
-      - id: layer_7/width_65k/average_l0_57
-        path: layer_7/width_65k/average_l0_57
-        l0: 57
-
-      - id: layer_8/width_65k/average_l0_111
-        path: layer_8/width_65k/average_l0_111
-        l0: 111
-
-      - id: layer_8/width_65k/average_l0_19
-        path: layer_8/width_65k/average_l0_19
-        l0: 19
-
-      - id: layer_8/width_65k/average_l0_213
-        path: layer_8/width_65k/average_l0_213
-        l0: 213
-
-      - id: layer_8/width_65k/average_l0_33
-        path: layer_8/width_65k/average_l0_33
-        l0: 33
-
-      - id: layer_8/width_65k/average_l0_59
-        path: layer_8/width_65k/average_l0_59
-        l0: 59
-
-      - id: layer_9/width_65k/average_l0_118
-        path: layer_9/width_65k/average_l0_118
-        l0: 118
-
-      - id: layer_9/width_65k/average_l0_19
-        path: layer_9/width_65k/average_l0_19
-        l0: 19
-
-      - id: layer_9/width_65k/average_l0_240
-        path: layer_9/width_65k/average_l0_240
-        l0: 240
-
-      - id: layer_9/width_65k/average_l0_34
-        path: layer_9/width_65k/average_l0_34
-        l0: 34
-
-      - id: layer_9/width_65k/average_l0_61
-        path: layer_9/width_65k/average_l0_61
-        l0: 61
-
-      - id: layer_10/width_65k/average_l0_128
-        path: layer_10/width_65k/average_l0_128
-        l0: 128
-
-      - id: layer_10/width_65k/average_l0_20
-        path: layer_10/width_65k/average_l0_20
-        l0: 20
-
-      - id: layer_10/width_65k/average_l0_265
-        path: layer_10/width_65k/average_l0_265
-        l0: 265
-
-      - id: layer_10/width_65k/average_l0_36
-        path: layer_10/width_65k/average_l0_36
-        l0: 36
-
-      - id: layer_10/width_65k/average_l0_66
-        path: layer_10/width_65k/average_l0_66
-        l0: 66
-
-      - id: layer_11/width_65k/average_l0_134
-        path: layer_11/width_65k/average_l0_134
-        l0: 134
-
-      - id: layer_11/width_65k/average_l0_21
-        path: layer_11/width_65k/average_l0_21
-        l0: 21
-
-      - id: layer_11/width_65k/average_l0_273
-        path: layer_11/width_65k/average_l0_273
-        l0: 273
-
-      - id: layer_11/width_65k/average_l0_37
-        path: layer_11/width_65k/average_l0_37
-        l0: 37
-
-      - id: layer_11/width_65k/average_l0_70
-        path: layer_11/width_65k/average_l0_70
-        l0: 70
-
-      - id: layer_12/width_65k/average_l0_141
-        path: layer_12/width_65k/average_l0_141
-        l0: 141
-
-      - id: layer_12/width_65k/average_l0_21
-        path: layer_12/width_65k/average_l0_21
-        l0: 21
-
-      - id: layer_12/width_65k/average_l0_297
-        path: layer_12/width_65k/average_l0_297
-        l0: 297
-
-      - id: layer_12/width_65k/average_l0_38
-        path: layer_12/width_65k/average_l0_38
-        l0: 38
-
-      - id: layer_12/width_65k/average_l0_72
-        path: layer_12/width_65k/average_l0_72
-        l0: 72
-
-      - id: layer_13/width_65k/average_l0_142
-        path: layer_13/width_65k/average_l0_142
-        l0: 142
-
-      - id: layer_13/width_65k/average_l0_22
-        path: layer_13/width_65k/average_l0_22
-        l0: 22
-
-      - id: layer_13/width_65k/average_l0_288
-        path: layer_13/width_65k/average_l0_288
-        l0: 288
-
-      - id: layer_13/width_65k/average_l0_40
-        path: layer_13/width_65k/average_l0_40
-        l0: 40
-
-      - id: layer_13/width_65k/average_l0_74
-        path: layer_13/width_65k/average_l0_74
-        l0: 74
-
-      - id: layer_13/width_65k/average_l0_75
-        path: layer_13/width_65k/average_l0_75
-        l0: 75
-
-      - id: layer_14/width_65k/average_l0_144
-        path: layer_14/width_65k/average_l0_144
-        l0: 144
-
-      - id: layer_14/width_65k/average_l0_21
-        path: layer_14/width_65k/average_l0_21
-        l0: 21
-
-      - id: layer_14/width_65k/average_l0_284
-        path: layer_14/width_65k/average_l0_284
-        l0: 284
-
-      - id: layer_14/width_65k/average_l0_40
-        path: layer_14/width_65k/average_l0_40
-        l0: 40
-
-      - id: layer_14/width_65k/average_l0_73
-        path: layer_14/width_65k/average_l0_73
-        l0: 73
-
-      - id: layer_15/width_65k/average_l0_127
-        path: layer_15/width_65k/average_l0_127
-        l0: 127
-
-      - id: layer_15/width_65k/average_l0_21
-        path: layer_15/width_65k/average_l0_21
-        l0: 21
-
-      - id: layer_15/width_65k/average_l0_240
-        path: layer_15/width_65k/average_l0_240
-        l0: 240
-
-      - id: layer_15/width_65k/average_l0_38
-        path: layer_15/width_65k/average_l0_38
-        l0: 38
-
-      - id: layer_15/width_65k/average_l0_68
-        path: layer_15/width_65k/average_l0_68
-        l0: 68
-
-      - id: layer_16/width_65k/average_l0_128
-        path: layer_16/width_65k/average_l0_128
-        l0: 128
-
-      - id: layer_16/width_65k/average_l0_21
-        path: layer_16/width_65k/average_l0_21
-        l0: 21
-
-      - id: layer_16/width_65k/average_l0_244
-        path: layer_16/width_65k/average_l0_244
-        l0: 244
-
-      - id: layer_16/width_65k/average_l0_38
-        path: layer_16/width_65k/average_l0_38
-        l0: 38
-
-      - id: layer_16/width_65k/average_l0_69
-        path: layer_16/width_65k/average_l0_69
-        l0: 69
-
-      - id: layer_17/width_65k/average_l0_125
-        path: layer_17/width_65k/average_l0_125
-        l0: 125
-
-      - id: layer_17/width_65k/average_l0_21
-        path: layer_17/width_65k/average_l0_21
-        l0: 21
-
-      - id: layer_17/width_65k/average_l0_233
-        path: layer_17/width_65k/average_l0_233
-        l0: 233
-
-      - id: layer_17/width_65k/average_l0_38
-        path: layer_17/width_65k/average_l0_38
-        l0: 38
-
-      - id: layer_17/width_65k/average_l0_68
-        path: layer_17/width_65k/average_l0_68
-        l0: 68
-
-      - id: layer_18/width_65k/average_l0_116
-        path: layer_18/width_65k/average_l0_116
-        l0: 116
-
-      - id: layer_18/width_65k/average_l0_117
-        path: layer_18/width_65k/average_l0_117
-        l0: 117
-
-      - id: layer_18/width_65k/average_l0_21
-        path: layer_18/width_65k/average_l0_21
-        l0: 21
-
-      - id: layer_18/width_65k/average_l0_216
-        path: layer_18/width_65k/average_l0_216
-        l0: 216
-
-      - id: layer_18/width_65k/average_l0_36
-        path: layer_18/width_65k/average_l0_36
-        l0: 36
-
-      - id: layer_18/width_65k/average_l0_64
-        path: layer_18/width_65k/average_l0_64
-        l0: 64
-
-      - id: layer_19/width_65k/average_l0_115
-        path: layer_19/width_65k/average_l0_115
-        l0: 115
-
-      - id: layer_19/width_65k/average_l0_21
-        path: layer_19/width_65k/average_l0_21
-        l0: 21
-
-      - id: layer_19/width_65k/average_l0_216
-        path: layer_19/width_65k/average_l0_216
-        l0: 216
-
-      - id: layer_19/width_65k/average_l0_35
-        path: layer_19/width_65k/average_l0_35
-        l0: 35
-
-      - id: layer_19/width_65k/average_l0_63
-        path: layer_19/width_65k/average_l0_63
-        l0: 63
-
-      - id: layer_20/width_65k/average_l0_114
-        path: layer_20/width_65k/average_l0_114
-        l0: 114
-
-      - id: layer_20/width_65k/average_l0_20
-        path: layer_20/width_65k/average_l0_20
-        l0: 20
-
-      - id: layer_20/width_65k/average_l0_221
-        path: layer_20/width_65k/average_l0_221
-        l0: 221
-
-      - id: layer_20/width_65k/average_l0_34
-        path: layer_20/width_65k/average_l0_34
-        l0: 34
-
-      - id: layer_20/width_65k/average_l0_61
-        path: layer_20/width_65k/average_l0_61
-        l0: 61
-
-      - id: layer_21/width_65k/average_l0_111
-        path: layer_21/width_65k/average_l0_111
-        l0: 111
-
-      - id: layer_21/width_65k/average_l0_112
-        path: layer_21/width_65k/average_l0_112
-        l0: 112
-
-      - id: layer_21/width_65k/average_l0_20
-        path: layer_21/width_65k/average_l0_20
-        l0: 20
-
-      - id: layer_21/width_65k/average_l0_225
-        path: layer_21/width_65k/average_l0_225
-        l0: 225
-
-      - id: layer_21/width_65k/average_l0_33
-        path: layer_21/width_65k/average_l0_33
-        l0: 33
-
-      - id: layer_21/width_65k/average_l0_61
-        path: layer_21/width_65k/average_l0_61
-        l0: 61
-
-      - id: layer_22/width_65k/average_l0_116
-        path: layer_22/width_65k/average_l0_116
-        l0: 116
-
-      - id: layer_22/width_65k/average_l0_117
-        path: layer_22/width_65k/average_l0_117
-        l0: 117
-
-      - id: layer_22/width_65k/average_l0_20
-        path: layer_22/width_65k/average_l0_20
-        l0: 20
-
-      - id: layer_22/width_65k/average_l0_248
-        path: layer_22/width_65k/average_l0_248
-        l0: 248
-
-      - id: layer_22/width_65k/average_l0_33
-        path: layer_22/width_65k/average_l0_33
-        l0: 33
-
-      - id: layer_22/width_65k/average_l0_62
-        path: layer_22/width_65k/average_l0_62
-        l0: 62
-
-      - id: layer_23/width_65k/average_l0_123
-        path: layer_23/width_65k/average_l0_123
-        l0: 123
-
-      - id: layer_23/width_65k/average_l0_124
-        path: layer_23/width_65k/average_l0_124
-        l0: 124
-
-      - id: layer_23/width_65k/average_l0_20
-        path: layer_23/width_65k/average_l0_20
-        l0: 20
-
-      - id: layer_23/width_65k/average_l0_272
-        path: layer_23/width_65k/average_l0_272
-        l0: 272
-
-      - id: layer_23/width_65k/average_l0_35
-        path: layer_23/width_65k/average_l0_35
-        l0: 35
-
-      - id: layer_23/width_65k/average_l0_64
-        path: layer_23/width_65k/average_l0_64
-        l0: 64
-
-      - id: layer_24/width_65k/average_l0_124
-        path: layer_24/width_65k/average_l0_124
-        l0: 124
-
-      - id: layer_24/width_65k/average_l0_19
-        path: layer_24/width_65k/average_l0_19
-        l0: 19
-
-      - id: layer_24/width_65k/average_l0_273
-        path: layer_24/width_65k/average_l0_273
-        l0: 273
-
-      - id: layer_24/width_65k/average_l0_34
-        path: layer_24/width_65k/average_l0_34
-        l0: 34
-
-      - id: layer_24/width_65k/average_l0_63
-        path: layer_24/width_65k/average_l0_63
-        l0: 63
-
-      - id: layer_25/width_65k/average_l0_15
-        path: layer_25/width_65k/average_l0_15
-        l0: 15
-
-      - id: layer_25/width_65k/average_l0_197
-        path: layer_25/width_65k/average_l0_197
-        l0: 197
-
-      - id: layer_25/width_65k/average_l0_26
-        path: layer_25/width_65k/average_l0_26
-        l0: 26
-
-      - id: layer_25/width_65k/average_l0_48
-        path: layer_25/width_65k/average_l0_48
-        l0: 48
-
-      - id: layer_25/width_65k/average_l0_93
-        path: layer_25/width_65k/average_l0_93
-        l0: 93
-  gemma-scope-2b-pt-mlp-canonical:
-    repo_id: google/gemma-scope-2b-pt-mlp
-    model: gemma-2-2b
-    conversion_func: gemma_2
-    saes:
-      - id: layer_0/width_16k/canonical
-        path: layer_0/width_16k/canonical
-
-      - id: layer_1/width_16k/canonical
-        path: layer_1/width_16k/canonical
-
-      - id: layer_2/width_16k/canonical
-        path: layer_2/width_16k/canonical
-
-      - id: layer_3/width_16k/canonical
-        path: layer_3/width_16k/canonical
-
-      - id: layer_4/width_16k/canonical
-        path: layer_4/width_16k/canonical
-
-      - id: layer_5/width_16k/canonical
-        path: layer_5/width_16k/canonical
-
-      - id: layer_6/width_16k/canonical
-        path: layer_6/width_16k/canonical
-
-      - id: layer_7/width_16k/canonical
-        path: layer_7/width_16k/canonical
-
-      - id: layer_8/width_16k/canonical
-        path: layer_8/width_16k/canonical
-
-      - id: layer_9/width_16k/canonical
-        path: layer_9/width_16k/canonical
-
-      - id: layer_10/width_16k/canonical
-        path: layer_10/width_16k/canonical
-
-      - id: layer_11/width_16k/canonical
-        path: layer_11/width_16k/canonical
-
-      - id: layer_12/width_16k/canonical
-        path: layer_12/width_16k/canonical
-
-      - id: layer_13/width_16k/canonical
-        path: layer_13/width_16k/canonical
-
-      - id: layer_14/width_16k/canonical
-        path: layer_14/width_16k/canonical
-
-      - id: layer_15/width_16k/canonical
-        path: layer_15/width_16k/canonical
-
-      - id: layer_16/width_16k/canonical
-        path: layer_16/width_16k/canonical
-
-      - id: layer_17/width_16k/canonical
-        path: layer_17/width_16k/canonical
-
-      - id: layer_18/width_16k/canonical
-        path: layer_18/width_16k/canonical
-
-      - id: layer_19/width_16k/canonical
-        path: layer_19/width_16k/canonical
-
-      - id: layer_20/width_16k/canonical
-        path: layer_20/width_16k/canonical
-
-      - id: layer_21/width_16k/canonical
-        path: layer_21/width_16k/canonical
-
-      - id: layer_22/width_16k/canonical
-        path: layer_22/width_16k/canonical
-
-      - id: layer_23/width_16k/canonical
-        path: layer_23/width_16k/canonical
-
-      - id: layer_24/width_16k/canonical
-        path: layer_24/width_16k/canonical
-
-      - id: layer_25/width_16k/canonical
-        path: layer_25/width_16k/canonical
-
-      - id: layer_0/width_65k/canonical
-        path: layer_0/width_65k/canonical
-
-      - id: layer_1/width_65k/canonical
-        path: layer_1/width_65k/canonical
-
-      - id: layer_2/width_65k/canonical
-        path: layer_2/width_65k/canonical
-
-      - id: layer_3/width_65k/canonical
-        path: layer_3/width_65k/canonical
-
-      - id: layer_4/width_65k/canonical
-        path: layer_4/width_65k/canonical
-
-      - id: layer_5/width_65k/canonical
-        path: layer_5/width_65k/canonical
-
-      - id: layer_6/width_65k/canonical
-        path: layer_6/width_65k/canonical
-
-      - id: layer_7/width_65k/canonical
-        path: layer_7/width_65k/canonical
-
-      - id: layer_8/width_65k/canonical
-        path: layer_8/width_65k/canonical
-
-      - id: layer_9/width_65k/canonical
-        path: layer_9/width_65k/canonical
-
-      - id: layer_10/width_65k/canonical
-        path: layer_10/width_65k/canonical
-
-      - id: layer_11/width_65k/canonical
-        path: layer_11/width_65k/canonical
-
-      - id: layer_12/width_65k/canonical
-        path: layer_12/width_65k/canonical
-
-      - id: layer_13/width_65k/canonical
-        path: layer_13/width_65k/canonical
-
-      - id: layer_14/width_65k/canonical
-        path: layer_14/width_65k/canonical
-
-      - id: layer_15/width_65k/canonical
-        path: layer_15/width_65k/canonical
-
-      - id: layer_16/width_65k/canonical
-        path: layer_16/width_65k/canonical
-
-      - id: layer_17/width_65k/canonical
-        path: layer_17/width_65k/canonical
-
-      - id: layer_18/width_65k/canonical
-        path: layer_18/width_65k/canonical
-
-      - id: layer_19/width_65k/canonical
-        path: layer_19/width_65k/canonical
-
-      - id: layer_20/width_65k/canonical
-        path: layer_20/width_65k/canonical
-
-      - id: layer_21/width_65k/canonical
-        path: layer_21/width_65k/canonical
-
-      - id: layer_22/width_65k/canonical
-        path: layer_22/width_65k/canonical
-
-      - id: layer_23/width_65k/canonical
-        path: layer_23/width_65k/canonical
-
-      - id: layer_24/width_65k/canonical
-        path: layer_24/width_65k/canonical
-
-      - id: layer_25/width_65k/canonical
-        path: layer_25/width_65k/canonical
-  gemma-scope-2b-pt-mlp:
-    repo_id: google/gemma-scope-2b-pt-mlp
-    model: gemma-2-2b
-    conversion_func: gemma_2
-    saes:
-      - id: layer_0/width_16k/average_l0_119
-        path: layer_0/width_16k/average_l0_119
-        l0: 119
-
-      - id: layer_0/width_16k/average_l0_16
-        path: layer_0/width_16k/average_l0_16
-        l0: 16
-
-      - id: layer_0/width_16k/average_l0_30
-        path: layer_0/width_16k/average_l0_30
-        l0: 30
-
-      - id: layer_0/width_16k/average_l0_60
-        path: layer_0/width_16k/average_l0_60
-        l0: 60
-
-      - id: layer_0/width_16k/average_l0_9
-        path: layer_0/width_16k/average_l0_9
-        l0: 9
-
-      - id: layer_1/width_16k/average_l0_105
-        path: layer_1/width_16k/average_l0_105
-        l0: 105
-
-      - id: layer_1/width_16k/average_l0_12
-        path: layer_1/width_16k/average_l0_12
-        l0: 12
-
-      - id: layer_1/width_16k/average_l0_239
-        path: layer_1/width_16k/average_l0_239
-        l0: 239
-
-      - id: layer_1/width_16k/average_l0_24
-        path: layer_1/width_16k/average_l0_24
-        l0: 24
-
-      - id: layer_1/width_16k/average_l0_50
-        path: layer_1/width_16k/average_l0_50
-        l0: 50
-
-      - id: layer_2/width_16k/average_l0_19
-        path: layer_2/width_16k/average_l0_19
-        l0: 19
-
-      - id: layer_2/width_16k/average_l0_213
-        path: layer_2/width_16k/average_l0_213
-        l0: 213
-
-      - id: layer_2/width_16k/average_l0_41
-        path: layer_2/width_16k/average_l0_41
-        l0: 41
-
-      - id: layer_2/width_16k/average_l0_434
-        path: layer_2/width_16k/average_l0_434
-        l0: 434
-
-      - id: layer_2/width_16k/average_l0_95
-        path: layer_2/width_16k/average_l0_95
-        l0: 95
-
-      - id: layer_3/width_16k/average_l0_195
-        path: layer_3/width_16k/average_l0_195
-        l0: 195
-
-      - id: layer_3/width_16k/average_l0_21
-        path: layer_3/width_16k/average_l0_21
-        l0: 21
-
-      - id: layer_3/width_16k/average_l0_377
-        path: layer_3/width_16k/average_l0_377
-        l0: 377
-
-      - id: layer_3/width_16k/average_l0_44
-        path: layer_3/width_16k/average_l0_44
-        l0: 44
-
-      - id: layer_3/width_16k/average_l0_95
-        path: layer_3/width_16k/average_l0_95
-        l0: 95
-
-      - id: layer_4/width_16k/average_l0_18
-        path: layer_4/width_16k/average_l0_18
-        l0: 18
-
-      - id: layer_4/width_16k/average_l0_198
-        path: layer_4/width_16k/average_l0_198
-        l0: 198
-
-      - id: layer_4/width_16k/average_l0_38
-        path: layer_4/width_16k/average_l0_38
-        l0: 38
-
-      - id: layer_4/width_16k/average_l0_433
-        path: layer_4/width_16k/average_l0_433
-        l0: 433
-
-      - id: layer_4/width_16k/average_l0_85
-        path: layer_4/width_16k/average_l0_85
-        l0: 85
-
-      - id: layer_5/width_16k/average_l0_114
-        path: layer_5/width_16k/average_l0_114
-        l0: 114
-
-      - id: layer_5/width_16k/average_l0_23
-        path: layer_5/width_16k/average_l0_23
-        l0: 23
-
-      - id: layer_5/width_16k/average_l0_269
-        path: layer_5/width_16k/average_l0_269
-        l0: 269
-
-      - id: layer_5/width_16k/average_l0_48
-        path: layer_5/width_16k/average_l0_48
-        l0: 48
-
-      - id: layer_5/width_16k/average_l0_575
-        path: layer_5/width_16k/average_l0_575
-        l0: 575
-
-      - id: layer_6/width_16k/average_l0_133
-        path: layer_6/width_16k/average_l0_133
-        l0: 133
-
-      - id: layer_6/width_16k/average_l0_25
-        path: layer_6/width_16k/average_l0_25
-        l0: 25
-
-      - id: layer_6/width_16k/average_l0_328
-        path: layer_6/width_16k/average_l0_328
-        l0: 328
-
-      - id: layer_6/width_16k/average_l0_55
-        path: layer_6/width_16k/average_l0_55
-        l0: 55
-
-      - id: layer_6/width_16k/average_l0_699
-        path: layer_6/width_16k/average_l0_699
-        l0: 699
-
-      - id: layer_7/width_16k/average_l0_146
-        path: layer_7/width_16k/average_l0_146
-        l0: 146
-
-      - id: layer_7/width_16k/average_l0_28
-        path: layer_7/width_16k/average_l0_28
-        l0: 28
-
-      - id: layer_7/width_16k/average_l0_355
-        path: layer_7/width_16k/average_l0_355
-        l0: 355
-
-      - id: layer_7/width_16k/average_l0_60
-        path: layer_7/width_16k/average_l0_60
-        l0: 60
-
-      - id: layer_7/width_16k/average_l0_731
-        path: layer_7/width_16k/average_l0_731
-        l0: 731
-
-      - id: layer_8/width_16k/average_l0_136
-        path: layer_8/width_16k/average_l0_136
-        l0: 136
-
-      - id: layer_8/width_16k/average_l0_27
-        path: layer_8/width_16k/average_l0_27
-        l0: 27
-
-      - id: layer_8/width_16k/average_l0_351
-        path: layer_8/width_16k/average_l0_351
-        l0: 351
-
-      - id: layer_8/width_16k/average_l0_56
-        path: layer_8/width_16k/average_l0_56
-        l0: 56
-
-      - id: layer_8/width_16k/average_l0_739
-        path: layer_8/width_16k/average_l0_739
-        l0: 739
-
-      - id: layer_9/width_16k/average_l0_216
-        path: layer_9/width_16k/average_l0_216
-        l0: 216
-
-      - id: layer_9/width_16k/average_l0_38
-        path: layer_9/width_16k/average_l0_38
-        l0: 38
-
-      - id: layer_9/width_16k/average_l0_482
-        path: layer_9/width_16k/average_l0_482
-        l0: 482
-
-      - id: layer_9/width_16k/average_l0_861
-        path: layer_9/width_16k/average_l0_861
-        l0: 861
-
-      - id: layer_9/width_16k/average_l0_88
-        path: layer_9/width_16k/average_l0_88
-        l0: 88
-
-      - id: layer_10/width_16k/average_l0_110
-        path: layer_10/width_16k/average_l0_110
-        l0: 110
-
-      - id: layer_10/width_16k/average_l0_266
-        path: layer_10/width_16k/average_l0_266
-        l0: 266
-
-      - id: layer_10/width_16k/average_l0_45
-        path: layer_10/width_16k/average_l0_45
-        l0: 45
-
-      - id: layer_10/width_16k/average_l0_568
-        path: layer_10/width_16k/average_l0_568
-        l0: 568
-
-      - id: layer_10/width_16k/average_l0_908
-        path: layer_10/width_16k/average_l0_908
-        l0: 908
-
-      - id: layer_11/width_16k/average_l0_234
-        path: layer_11/width_16k/average_l0_234
-        l0: 234
-
-      - id: layer_11/width_16k/average_l0_42
-        path: layer_11/width_16k/average_l0_42
-        l0: 42
-
-      - id: layer_11/width_16k/average_l0_499
-        path: layer_11/width_16k/average_l0_499
-        l0: 499
-
-      - id: layer_11/width_16k/average_l0_847
-        path: layer_11/width_16k/average_l0_847
-        l0: 847
-
-      - id: layer_11/width_16k/average_l0_98
-        path: layer_11/width_16k/average_l0_98
-        l0: 98
-
-      - id: layer_12/width_16k/average_l0_108
-        path: layer_12/width_16k/average_l0_108
-        l0: 108
-
-      - id: layer_12/width_16k/average_l0_262
-        path: layer_12/width_16k/average_l0_262
-        l0: 262
-
-      - id: layer_12/width_16k/average_l0_44
-        path: layer_12/width_16k/average_l0_44
-        l0: 44
-
-      - id: layer_12/width_16k/average_l0_548
-        path: layer_12/width_16k/average_l0_548
-        l0: 548
-
-      - id: layer_12/width_16k/average_l0_879
-        path: layer_12/width_16k/average_l0_879
-        l0: 879
-
-      - id: layer_13/width_16k/average_l0_112
-        path: layer_13/width_16k/average_l0_112
-        l0: 112
-
-      - id: layer_13/width_16k/average_l0_267
-        path: layer_13/width_16k/average_l0_267
-        l0: 267
-
-      - id: layer_13/width_16k/average_l0_47
-        path: layer_13/width_16k/average_l0_47
-        l0: 47
-
-      - id: layer_13/width_16k/average_l0_553
-        path: layer_13/width_16k/average_l0_553
-        l0: 553
-
-      - id: layer_13/width_16k/average_l0_892
-        path: layer_13/width_16k/average_l0_892
-        l0: 892
-
-      - id: layer_14/width_16k/average_l0_246
-        path: layer_14/width_16k/average_l0_246
-        l0: 246
-
-      - id: layer_14/width_16k/average_l0_41
-        path: layer_14/width_16k/average_l0_41
-        l0: 41
-
-      - id: layer_14/width_16k/average_l0_536
-        path: layer_14/width_16k/average_l0_536
-        l0: 536
-
-      - id: layer_14/width_16k/average_l0_894
-        path: layer_14/width_16k/average_l0_894
-        l0: 894
-
-      - id: layer_14/width_16k/average_l0_97
-        path: layer_14/width_16k/average_l0_97
-        l0: 97
-
-      - id: layer_15/width_16k/average_l0_207
-        path: layer_15/width_16k/average_l0_207
-        l0: 207
-
-      - id: layer_15/width_16k/average_l0_35
-        path: layer_15/width_16k/average_l0_35
-        l0: 35
-
-      - id: layer_15/width_16k/average_l0_492
-        path: layer_15/width_16k/average_l0_492
-        l0: 492
-
-      - id: layer_15/width_16k/average_l0_80
-        path: layer_15/width_16k/average_l0_80
-        l0: 80
-
-      - id: layer_15/width_16k/average_l0_879
-        path: layer_15/width_16k/average_l0_879
-        l0: 879
-
-      - id: layer_16/width_16k/average_l0_185
-        path: layer_16/width_16k/average_l0_185
-        l0: 185
-
-      - id: layer_16/width_16k/average_l0_33
-        path: layer_16/width_16k/average_l0_33
-        l0: 33
-
-      - id: layer_16/width_16k/average_l0_452
-        path: layer_16/width_16k/average_l0_452
-        l0: 452
-
-      - id: layer_16/width_16k/average_l0_72
-        path: layer_16/width_16k/average_l0_72
-        l0: 72
-
-      - id: layer_16/width_16k/average_l0_847
-        path: layer_16/width_16k/average_l0_847
-        l0: 847
-
-      - id: layer_17/width_16k/average_l0_179
-        path: layer_17/width_16k/average_l0_179
-        l0: 179
-
-      - id: layer_17/width_16k/average_l0_31
-        path: layer_17/width_16k/average_l0_31
-        l0: 31
-
-      - id: layer_17/width_16k/average_l0_453
-        path: layer_17/width_16k/average_l0_453
-        l0: 453
-
-      - id: layer_17/width_16k/average_l0_68
-        path: layer_17/width_16k/average_l0_68
-        l0: 68
-
-      - id: layer_17/width_16k/average_l0_853
-        path: layer_17/width_16k/average_l0_853
-        l0: 853
-
-      - id: layer_18/width_16k/average_l0_106
-        path: layer_18/width_16k/average_l0_106
-        l0: 106
-
-      - id: layer_18/width_16k/average_l0_24
-        path: layer_18/width_16k/average_l0_24
-        l0: 24
-
-      - id: layer_18/width_16k/average_l0_292
-        path: layer_18/width_16k/average_l0_292
-        l0: 292
-
-      - id: layer_18/width_16k/average_l0_47
-        path: layer_18/width_16k/average_l0_47
-        l0: 47
-
-      - id: layer_18/width_16k/average_l0_672
-        path: layer_18/width_16k/average_l0_672
-        l0: 672
-
-      - id: layer_19/width_16k/average_l0_109
-        path: layer_19/width_16k/average_l0_109
-        l0: 109
-
-      - id: layer_19/width_16k/average_l0_25
-        path: layer_19/width_16k/average_l0_25
-        l0: 25
-
-      - id: layer_19/width_16k/average_l0_295
-        path: layer_19/width_16k/average_l0_295
-        l0: 295
-
-      - id: layer_19/width_16k/average_l0_50
-        path: layer_19/width_16k/average_l0_50
-        l0: 50
-
-      - id: layer_19/width_16k/average_l0_673
-        path: layer_19/width_16k/average_l0_673
-        l0: 673
-
-      - id: layer_20/width_16k/average_l0_109
-        path: layer_20/width_16k/average_l0_109
-        l0: 109
-
-      - id: layer_20/width_16k/average_l0_24
-        path: layer_20/width_16k/average_l0_24
-        l0: 24
-
-      - id: layer_20/width_16k/average_l0_289
-        path: layer_20/width_16k/average_l0_289
-        l0: 289
-
-      - id: layer_20/width_16k/average_l0_49
-        path: layer_20/width_16k/average_l0_49
-        l0: 49
-
-      - id: layer_20/width_16k/average_l0_658
-        path: layer_20/width_16k/average_l0_658
-        l0: 658
-
-      - id: layer_21/width_16k/average_l0_113
-        path: layer_21/width_16k/average_l0_113
-        l0: 113
-
-      - id: layer_21/width_16k/average_l0_23
-        path: layer_21/width_16k/average_l0_23
-        l0: 23
-
-      - id: layer_21/width_16k/average_l0_279
-        path: layer_21/width_16k/average_l0_279
-        l0: 279
-
-      - id: layer_21/width_16k/average_l0_48
-        path: layer_21/width_16k/average_l0_48
-        l0: 48
-
-      - id: layer_21/width_16k/average_l0_633
-        path: layer_21/width_16k/average_l0_633
-        l0: 633
-
-      - id: layer_22/width_16k/average_l0_121
-        path: layer_22/width_16k/average_l0_121
-        l0: 121
-
-      - id: layer_22/width_16k/average_l0_24
-        path: layer_22/width_16k/average_l0_24
-        l0: 24
-
-      - id: layer_22/width_16k/average_l0_290
-        path: layer_22/width_16k/average_l0_290
-        l0: 290
-
-      - id: layer_22/width_16k/average_l0_51
-        path: layer_22/width_16k/average_l0_51
-        l0: 51
-
-      - id: layer_22/width_16k/average_l0_624
-        path: layer_22/width_16k/average_l0_624
-        l0: 624
-
-      - id: layer_23/width_16k/average_l0_128
-        path: layer_23/width_16k/average_l0_128
-        l0: 128
-
-      - id: layer_23/width_16k/average_l0_27
-        path: layer_23/width_16k/average_l0_27
-        l0: 27
-
-      - id: layer_23/width_16k/average_l0_287
-        path: layer_23/width_16k/average_l0_287
-        l0: 287
-
-      - id: layer_23/width_16k/average_l0_57
-        path: layer_23/width_16k/average_l0_57
-        l0: 57
-
-      - id: layer_23/width_16k/average_l0_627
-        path: layer_23/width_16k/average_l0_627
-        l0: 627
-
-      - id: layer_24/width_16k/average_l0_158
-        path: layer_24/width_16k/average_l0_158
-        l0: 158
-
-      - id: layer_24/width_16k/average_l0_19
-        path: layer_24/width_16k/average_l0_19
-        l0: 19
-
-      - id: layer_24/width_16k/average_l0_35
-        path: layer_24/width_16k/average_l0_35
-        l0: 35
-
-      - id: layer_24/width_16k/average_l0_357
-        path: layer_24/width_16k/average_l0_357
-        l0: 357
-
-      - id: layer_24/width_16k/average_l0_73
-        path: layer_24/width_16k/average_l0_73
-        l0: 73
-
-      - id: layer_25/width_16k/average_l0_126
-        path: layer_25/width_16k/average_l0_126
-        l0: 126
-
-      - id: layer_25/width_16k/average_l0_15
-        path: layer_25/width_16k/average_l0_15
-        l0: 15
-
-      - id: layer_25/width_16k/average_l0_277
-        path: layer_25/width_16k/average_l0_277
-        l0: 277
-
-      - id: layer_25/width_16k/average_l0_29
-        path: layer_25/width_16k/average_l0_29
-        l0: 29
-
-      - id: layer_25/width_16k/average_l0_59
-        path: layer_25/width_16k/average_l0_59
-        l0: 59
-
-      - id: layer_0/width_65k/average_l0_12
-        path: layer_0/width_65k/average_l0_12
-        l0: 12
-
-      - id: layer_0/width_65k/average_l0_21
-        path: layer_0/width_65k/average_l0_21
-        l0: 21
-
-      - id: layer_0/width_65k/average_l0_39
-        path: layer_0/width_65k/average_l0_39
-        l0: 39
-
-      - id: layer_0/width_65k/average_l0_7
-        path: layer_0/width_65k/average_l0_7
-        l0: 7
-
-      - id: layer_0/width_65k/average_l0_72
-        path: layer_0/width_65k/average_l0_72
-        l0: 72
-
-      - id: layer_1/width_65k/average_l0_11
-        path: layer_1/width_65k/average_l0_11
-        l0: 11
-
-      - id: layer_1/width_65k/average_l0_127
-        path: layer_1/width_65k/average_l0_127
-        l0: 127
-
-      - id: layer_1/width_65k/average_l0_20
-        path: layer_1/width_65k/average_l0_20
-        l0: 20
-
-      - id: layer_1/width_65k/average_l0_37
-        path: layer_1/width_65k/average_l0_37
-        l0: 37
-
-      - id: layer_1/width_65k/average_l0_67
-        path: layer_1/width_65k/average_l0_67
-        l0: 67
-
-      - id: layer_2/width_65k/average_l0_134
-        path: layer_2/width_65k/average_l0_134
-        l0: 134
-
-      - id: layer_2/width_65k/average_l0_16
-        path: layer_2/width_65k/average_l0_16
-        l0: 16
-
-      - id: layer_2/width_65k/average_l0_265
-        path: layer_2/width_65k/average_l0_265
-        l0: 265
-
-      - id: layer_2/width_65k/average_l0_31
-        path: layer_2/width_65k/average_l0_31
-        l0: 31
-
-      - id: layer_2/width_65k/average_l0_60
-        path: layer_2/width_65k/average_l0_60
-        l0: 60
-
-      - id: layer_3/width_65k/average_l0_144
-        path: layer_3/width_65k/average_l0_144
-        l0: 144
-
-      - id: layer_3/width_65k/average_l0_18
-        path: layer_3/width_65k/average_l0_18
-        l0: 18
-
-      - id: layer_3/width_65k/average_l0_279
-        path: layer_3/width_65k/average_l0_279
-        l0: 279
-
-      - id: layer_3/width_65k/average_l0_33
-        path: layer_3/width_65k/average_l0_33
-        l0: 33
-
-      - id: layer_3/width_65k/average_l0_68
-        path: layer_3/width_65k/average_l0_68
-        l0: 68
-
-      - id: layer_4/width_65k/average_l0_138
-        path: layer_4/width_65k/average_l0_138
-        l0: 138
-
-      - id: layer_4/width_65k/average_l0_17
-        path: layer_4/width_65k/average_l0_17
-        l0: 17
-
-      - id: layer_4/width_65k/average_l0_299
-        path: layer_4/width_65k/average_l0_299
-        l0: 299
-
-      - id: layer_4/width_65k/average_l0_32
-        path: layer_4/width_65k/average_l0_32
-        l0: 32
-
-      - id: layer_4/width_65k/average_l0_66
-        path: layer_4/width_65k/average_l0_66
-        l0: 66
-
-      - id: layer_5/width_65k/average_l0_186
-        path: layer_5/width_65k/average_l0_186
-        l0: 186
-
-      - id: layer_5/width_65k/average_l0_22
-        path: layer_5/width_65k/average_l0_22
-        l0: 22
-
-      - id: layer_5/width_65k/average_l0_407
-        path: layer_5/width_65k/average_l0_407
-        l0: 407
-
-      - id: layer_5/width_65k/average_l0_43
-        path: layer_5/width_65k/average_l0_43
-        l0: 43
-
-      - id: layer_5/width_65k/average_l0_86
-        path: layer_5/width_65k/average_l0_86
-        l0: 86
-
-      - id: layer_6/width_65k/average_l0_101
-        path: layer_6/width_65k/average_l0_101
-        l0: 101
-
-      - id: layer_6/width_65k/average_l0_224
-        path: layer_6/width_65k/average_l0_224
-        l0: 224
-
-      - id: layer_6/width_65k/average_l0_24
-        path: layer_6/width_65k/average_l0_24
-        l0: 24
-
-      - id: layer_6/width_65k/average_l0_47
-        path: layer_6/width_65k/average_l0_47
-        l0: 47
-
-      - id: layer_6/width_65k/average_l0_515
-        path: layer_6/width_65k/average_l0_515
-        l0: 515
-
-      - id: layer_7/width_65k/average_l0_115
-        path: layer_7/width_65k/average_l0_115
-        l0: 115
-
-      - id: layer_7/width_65k/average_l0_266
-        path: layer_7/width_65k/average_l0_266
-        l0: 266
-
-      - id: layer_7/width_65k/average_l0_28
-        path: layer_7/width_65k/average_l0_28
-        l0: 28
-
-      - id: layer_7/width_65k/average_l0_56
-        path: layer_7/width_65k/average_l0_56
-        l0: 56
-
-      - id: layer_7/width_65k/average_l0_571
-        path: layer_7/width_65k/average_l0_571
-        l0: 571
-
-      - id: layer_8/width_65k/average_l0_110
-        path: layer_8/width_65k/average_l0_110
-        l0: 110
-
-      - id: layer_8/width_65k/average_l0_256
-        path: layer_8/width_65k/average_l0_256
-        l0: 256
-
-      - id: layer_8/width_65k/average_l0_31
-        path: layer_8/width_65k/average_l0_31
-        l0: 31
-
-      - id: layer_8/width_65k/average_l0_547
-        path: layer_8/width_65k/average_l0_547
-        l0: 547
-
-      - id: layer_8/width_65k/average_l0_55
-        path: layer_8/width_65k/average_l0_55
-        l0: 55
-
-      - id: layer_9/width_65k/average_l0_168
-        path: layer_9/width_65k/average_l0_168
-        l0: 168
-
-      - id: layer_9/width_65k/average_l0_38
-        path: layer_9/width_65k/average_l0_38
-        l0: 38
-
-      - id: layer_9/width_65k/average_l0_387
-        path: layer_9/width_65k/average_l0_387
-        l0: 387
-
-      - id: layer_9/width_65k/average_l0_745
-        path: layer_9/width_65k/average_l0_745
-        l0: 745
-
-      - id: layer_9/width_65k/average_l0_77
-        path: layer_9/width_65k/average_l0_77
-        l0: 77
-
-      - id: layer_10/width_65k/average_l0_218
-        path: layer_10/width_65k/average_l0_218
-        l0: 218
-
-      - id: layer_10/width_65k/average_l0_43
-        path: layer_10/width_65k/average_l0_43
-        l0: 43
-
-      - id: layer_10/width_65k/average_l0_474
-        path: layer_10/width_65k/average_l0_474
-        l0: 474
-
-      - id: layer_10/width_65k/average_l0_851
-        path: layer_10/width_65k/average_l0_851
-        l0: 851
-
-      - id: layer_10/width_65k/average_l0_95
-        path: layer_10/width_65k/average_l0_95
-        l0: 95
-
-      - id: layer_11/width_65k/average_l0_200
-        path: layer_11/width_65k/average_l0_200
-        l0: 200
-
-      - id: layer_11/width_65k/average_l0_41
-        path: layer_11/width_65k/average_l0_41
-        l0: 41
-
-      - id: layer_11/width_65k/average_l0_436
-        path: layer_11/width_65k/average_l0_436
-        l0: 436
-
-      - id: layer_11/width_65k/average_l0_771
-        path: layer_11/width_65k/average_l0_771
-        l0: 771
-
-      - id: layer_11/width_65k/average_l0_88
-        path: layer_11/width_65k/average_l0_88
-        l0: 88
-
-      - id: layer_12/width_65k/average_l0_222
-        path: layer_12/width_65k/average_l0_222
-        l0: 222
-
-      - id: layer_12/width_65k/average_l0_44
-        path: layer_12/width_65k/average_l0_44
-        l0: 44
-
-      - id: layer_12/width_65k/average_l0_482
-        path: layer_12/width_65k/average_l0_482
-        l0: 482
-
-      - id: layer_12/width_65k/average_l0_848
-        path: layer_12/width_65k/average_l0_848
-        l0: 848
-
-      - id: layer_12/width_65k/average_l0_96
-        path: layer_12/width_65k/average_l0_96
-        l0: 96
-
-      - id: layer_13/width_65k/average_l0_228
-        path: layer_13/width_65k/average_l0_228
-        l0: 228
-
-      - id: layer_13/width_65k/average_l0_44
-        path: layer_13/width_65k/average_l0_44
-        l0: 44
-
-      - id: layer_13/width_65k/average_l0_480
-        path: layer_13/width_65k/average_l0_480
-        l0: 480
-
-      - id: layer_13/width_65k/average_l0_841
-        path: layer_13/width_65k/average_l0_841
-        l0: 841
-
-      - id: layer_13/width_65k/average_l0_98
-        path: layer_13/width_65k/average_l0_98
-        l0: 98
-
-      - id: layer_14/width_65k/average_l0_204
-        path: layer_14/width_65k/average_l0_204
-        l0: 204
-
-      - id: layer_14/width_65k/average_l0_39
-        path: layer_14/width_65k/average_l0_39
-        l0: 39
-
-      - id: layer_14/width_65k/average_l0_463
-        path: layer_14/width_65k/average_l0_463
-        l0: 463
-
-      - id: layer_14/width_65k/average_l0_816
-        path: layer_14/width_65k/average_l0_816
-        l0: 816
-
-      - id: layer_14/width_65k/average_l0_89
-        path: layer_14/width_65k/average_l0_89
-        l0: 89
-
-      - id: layer_15/width_65k/average_l0_164
-        path: layer_15/width_65k/average_l0_164
-        l0: 164
-
-      - id: layer_15/width_65k/average_l0_35
-        path: layer_15/width_65k/average_l0_35
-        l0: 35
-
-      - id: layer_15/width_65k/average_l0_405
-        path: layer_15/width_65k/average_l0_405
-        l0: 405
-
-      - id: layer_15/width_65k/average_l0_72
-        path: layer_15/width_65k/average_l0_72
-        l0: 72
-
-      - id: layer_15/width_65k/average_l0_754
-        path: layer_15/width_65k/average_l0_754
-        l0: 754
-
-      - id: layer_16/width_65k/average_l0_142
-        path: layer_16/width_65k/average_l0_142
-        l0: 142
-
-      - id: layer_16/width_65k/average_l0_32
-        path: layer_16/width_65k/average_l0_32
-        l0: 32
-
-      - id: layer_16/width_65k/average_l0_348
-        path: layer_16/width_65k/average_l0_348
-        l0: 348
-
-      - id: layer_16/width_65k/average_l0_66
-        path: layer_16/width_65k/average_l0_66
-        l0: 66
-
-      - id: layer_16/width_65k/average_l0_695
-        path: layer_16/width_65k/average_l0_695
-        l0: 695
-
-      - id: layer_17/width_65k/average_l0_136
-        path: layer_17/width_65k/average_l0_136
-        l0: 136
-
-      - id: layer_17/width_65k/average_l0_30
-        path: layer_17/width_65k/average_l0_30
-        l0: 30
-
-      - id: layer_17/width_65k/average_l0_342
-        path: layer_17/width_65k/average_l0_342
-        l0: 342
-
-      - id: layer_17/width_65k/average_l0_61
-        path: layer_17/width_65k/average_l0_61
-        l0: 61
-
-      - id: layer_17/width_65k/average_l0_666
-        path: layer_17/width_65k/average_l0_666
-        l0: 666
-
-      - id: layer_18/width_65k/average_l0_191
-        path: layer_18/width_65k/average_l0_191
-        l0: 191
-
-      - id: layer_18/width_65k/average_l0_24
-        path: layer_18/width_65k/average_l0_24
-        l0: 24
-
-      - id: layer_18/width_65k/average_l0_44
-        path: layer_18/width_65k/average_l0_44
-        l0: 44
-
-      - id: layer_18/width_65k/average_l0_491
-        path: layer_18/width_65k/average_l0_491
-        l0: 491
-
-      - id: layer_18/width_65k/average_l0_88
-        path: layer_18/width_65k/average_l0_88
-        l0: 88
-
-      - id: layer_19/width_65k/average_l0_192
-        path: layer_19/width_65k/average_l0_192
-        l0: 192
-
-      - id: layer_19/width_65k/average_l0_25
-        path: layer_19/width_65k/average_l0_25
-        l0: 25
-
-      - id: layer_19/width_65k/average_l0_45
-        path: layer_19/width_65k/average_l0_45
-        l0: 45
-
-      - id: layer_19/width_65k/average_l0_470
-        path: layer_19/width_65k/average_l0_470
-        l0: 470
-
-      - id: layer_19/width_65k/average_l0_88
-        path: layer_19/width_65k/average_l0_88
-        l0: 88
-
-      - id: layer_20/width_65k/average_l0_189
-        path: layer_20/width_65k/average_l0_189
-        l0: 189
-
-      - id: layer_20/width_65k/average_l0_23
-        path: layer_20/width_65k/average_l0_23
-        l0: 23
-
-      - id: layer_20/width_65k/average_l0_44
-        path: layer_20/width_65k/average_l0_44
-        l0: 44
-
-      - id: layer_20/width_65k/average_l0_446
-        path: layer_20/width_65k/average_l0_446
-        l0: 446
-
-      - id: layer_20/width_65k/average_l0_88
-        path: layer_20/width_65k/average_l0_88
-        l0: 88
-
-      - id: layer_21/width_65k/average_l0_192
-        path: layer_21/width_65k/average_l0_192
-        l0: 192
-
-      - id: layer_21/width_65k/average_l0_23
-        path: layer_21/width_65k/average_l0_23
-        l0: 23
-
-      - id: layer_21/width_65k/average_l0_42
-        path: layer_21/width_65k/average_l0_42
-        l0: 42
-
-      - id: layer_21/width_65k/average_l0_472
-        path: layer_21/width_65k/average_l0_472
-        l0: 472
-
-      - id: layer_21/width_65k/average_l0_86
-        path: layer_21/width_65k/average_l0_86
-        l0: 86
-
-      - id: layer_22/width_65k/average_l0_203
-        path: layer_22/width_65k/average_l0_203
-        l0: 203
-
-      - id: layer_22/width_65k/average_l0_23
-        path: layer_22/width_65k/average_l0_23
-        l0: 23
-
-      - id: layer_22/width_65k/average_l0_46
-        path: layer_22/width_65k/average_l0_46
-        l0: 46
-
-      - id: layer_22/width_65k/average_l0_487
-        path: layer_22/width_65k/average_l0_487
-        l0: 487
-
-      - id: layer_22/width_65k/average_l0_92
-        path: layer_22/width_65k/average_l0_92
-        l0: 92
-
-      - id: layer_23/width_65k/average_l0_102
-        path: layer_23/width_65k/average_l0_102
-        l0: 102
-
-      - id: layer_23/width_65k/average_l0_218
-        path: layer_23/width_65k/average_l0_218
-        l0: 218
-
-      - id: layer_23/width_65k/average_l0_25
-        path: layer_23/width_65k/average_l0_25
-        l0: 25
-
-      - id: layer_23/width_65k/average_l0_49
-        path: layer_23/width_65k/average_l0_49
-        l0: 49
-
-      - id: layer_23/width_65k/average_l0_497
-        path: layer_23/width_65k/average_l0_497
-        l0: 497
-
-      - id: layer_24/width_65k/average_l0_128
-        path: layer_24/width_65k/average_l0_128
-        l0: 128
-
-      - id: layer_24/width_65k/average_l0_18
-        path: layer_24/width_65k/average_l0_18
-        l0: 18
-
-      - id: layer_24/width_65k/average_l0_268
-        path: layer_24/width_65k/average_l0_268
-        l0: 268
-
-      - id: layer_24/width_65k/average_l0_32
-        path: layer_24/width_65k/average_l0_32
-        l0: 32
-
-      - id: layer_24/width_65k/average_l0_62
-        path: layer_24/width_65k/average_l0_62
-        l0: 62
-
-      - id: layer_25/width_65k/average_l0_107
-        path: layer_25/width_65k/average_l0_107
-        l0: 107
-
-      - id: layer_25/width_65k/average_l0_14
-        path: layer_25/width_65k/average_l0_14
-        l0: 14
-
-      - id: layer_25/width_65k/average_l0_215
-        path: layer_25/width_65k/average_l0_215
-        l0: 215
-
-      - id: layer_25/width_65k/average_l0_26
-        path: layer_25/width_65k/average_l0_26
-        l0: 26
-
-      - id: layer_25/width_65k/average_l0_52
-        path: layer_25/width_65k/average_l0_52
-        l0: 52
-  gemma-scope-2b-pt-att:
-    repo_id: google/gemma-scope-2b-pt-att
-    model: gemma-2-2b
-    conversion_func: gemma_2
-    saes:
-      - id: layer_0/width_16k/average_l0_104
-        path: layer_0/width_16k/average_l0_104
-        l0: 104
-
-      - id: layer_0/width_16k/average_l0_12
-        path: layer_0/width_16k/average_l0_12
-        l0: 12
-
-      - id: layer_0/width_16k/average_l0_18
-        path: layer_0/width_16k/average_l0_18
-        l0: 18
-
-      - id: layer_0/width_16k/average_l0_30
-        path: layer_0/width_16k/average_l0_30
-        l0: 30
-
-      - id: layer_0/width_16k/average_l0_57
-        path: layer_0/width_16k/average_l0_57
-        l0: 57
-
-      - id: layer_1/width_16k/average_l0_146
-        path: layer_1/width_16k/average_l0_146
-        l0: 146
-
-      - id: layer_1/width_16k/average_l0_20
-        path: layer_1/width_16k/average_l0_20
-        l0: 20
-
-      - id: layer_1/width_16k/average_l0_251
-        path: layer_1/width_16k/average_l0_251
-        l0: 251
-
-      - id: layer_1/width_16k/average_l0_40
-        path: layer_1/width_16k/average_l0_40
-        l0: 40
-
-      - id: layer_1/width_16k/average_l0_79
-        path: layer_1/width_16k/average_l0_79
-        l0: 79
-
-      - id: layer_2/width_16k/average_l0_174
-        path: layer_2/width_16k/average_l0_174
-        l0: 174
-
-      - id: layer_2/width_16k/average_l0_19
-        path: layer_2/width_16k/average_l0_19
-        l0: 19
-
-      - id: layer_2/width_16k/average_l0_297
-        path: layer_2/width_16k/average_l0_297
-        l0: 297
-
-      - id: layer_2/width_16k/average_l0_43
-        path: layer_2/width_16k/average_l0_43
-        l0: 43
-
-      - id: layer_2/width_16k/average_l0_93
-        path: layer_2/width_16k/average_l0_93
-        l0: 93
-
-      - id: layer_3/width_16k/average_l0_117
-        path: layer_3/width_16k/average_l0_117
-        l0: 117
-
-      - id: layer_3/width_16k/average_l0_219
-        path: layer_3/width_16k/average_l0_219
-        l0: 219
-
-      - id: layer_3/width_16k/average_l0_24
-        path: layer_3/width_16k/average_l0_24
-        l0: 24
-
-      - id: layer_3/width_16k/average_l0_386
-        path: layer_3/width_16k/average_l0_386
-        l0: 386
-
-      - id: layer_3/width_16k/average_l0_55
-        path: layer_3/width_16k/average_l0_55
-        l0: 55
-
-      - id: layer_4/width_16k/average_l0_116
-        path: layer_4/width_16k/average_l0_116
-        l0: 116
-
-      - id: layer_4/width_16k/average_l0_249
-        path: layer_4/width_16k/average_l0_249
-        l0: 249
-
-      - id: layer_4/width_16k/average_l0_26
-        path: layer_4/width_16k/average_l0_26
-        l0: 26
-
-      - id: layer_4/width_16k/average_l0_454
-        path: layer_4/width_16k/average_l0_454
-        l0: 454
-
-      - id: layer_4/width_16k/average_l0_53
-        path: layer_4/width_16k/average_l0_53
-        l0: 53
-
-      - id: layer_5/width_16k/average_l0_135
-        path: layer_5/width_16k/average_l0_135
-        l0: 135
-
-      - id: layer_5/width_16k/average_l0_268
-        path: layer_5/width_16k/average_l0_268
-        l0: 268
-
-      - id: layer_5/width_16k/average_l0_30
-        path: layer_5/width_16k/average_l0_30
-        l0: 30
-
-      - id: layer_5/width_16k/average_l0_449
-        path: layer_5/width_16k/average_l0_449
-        l0: 449
-
-      - id: layer_5/width_16k/average_l0_59
-        path: layer_5/width_16k/average_l0_59
-        l0: 59
-
-      - id: layer_6/width_16k/average_l0_143
-        path: layer_6/width_16k/average_l0_143
-        l0: 143
-
-      - id: layer_6/width_16k/average_l0_292
-        path: layer_6/width_16k/average_l0_292
-        l0: 292
-
-      - id: layer_6/width_16k/average_l0_30
-        path: layer_6/width_16k/average_l0_30
-        l0: 30
-
-      - id: layer_6/width_16k/average_l0_479
-        path: layer_6/width_16k/average_l0_479
-        l0: 479
-
-      - id: layer_6/width_16k/average_l0_61
-        path: layer_6/width_16k/average_l0_61
-        l0: 61
-
-      - id: layer_7/width_16k/average_l0_184
-        path: layer_7/width_16k/average_l0_184
-        l0: 184
-
-      - id: layer_7/width_16k/average_l0_331
-        path: layer_7/width_16k/average_l0_331
-        l0: 331
-
-      - id: layer_7/width_16k/average_l0_46
-        path: layer_7/width_16k/average_l0_46
-        l0: 46
-
-      - id: layer_7/width_16k/average_l0_537
-        path: layer_7/width_16k/average_l0_537
-        l0: 537
-
-      - id: layer_7/width_16k/average_l0_99
-        path: layer_7/width_16k/average_l0_99
-        l0: 99
-
-      - id: layer_8/width_16k/average_l0_129
-        path: layer_8/width_16k/average_l0_129
-        l0: 129
-
-      - id: layer_8/width_16k/average_l0_282
-        path: layer_8/width_16k/average_l0_282
-        l0: 282
-
-      - id: layer_8/width_16k/average_l0_32
-        path: layer_8/width_16k/average_l0_32
-        l0: 32
-
-      - id: layer_8/width_16k/average_l0_482
-        path: layer_8/width_16k/average_l0_482
-        l0: 482
-
-      - id: layer_8/width_16k/average_l0_64
-        path: layer_8/width_16k/average_l0_64
-        l0: 64
-
-      - id: layer_9/width_16k/average_l0_127
-        path: layer_9/width_16k/average_l0_127
-        l0: 127
-
-      - id: layer_9/width_16k/average_l0_270
-        path: layer_9/width_16k/average_l0_270
-        l0: 270
-
-      - id: layer_9/width_16k/average_l0_34
-        path: layer_9/width_16k/average_l0_34
-        l0: 34
-
-      - id: layer_9/width_16k/average_l0_499
-        path: layer_9/width_16k/average_l0_499
-        l0: 499
-
-      - id: layer_9/width_16k/average_l0_64
-        path: layer_9/width_16k/average_l0_64
-        l0: 64
-
-      - id: layer_10/width_16k/average_l0_148
-        path: layer_10/width_16k/average_l0_148
-        l0: 148
-
-      - id: layer_10/width_16k/average_l0_307
-        path: layer_10/width_16k/average_l0_307
-        l0: 307
-
-      - id: layer_10/width_16k/average_l0_36
-        path: layer_10/width_16k/average_l0_36
-        l0: 36
-
-      - id: layer_10/width_16k/average_l0_541
-        path: layer_10/width_16k/average_l0_541
-        l0: 541
-
-      - id: layer_10/width_16k/average_l0_70
-        path: layer_10/width_16k/average_l0_70
-        l0: 70
-
-      - id: layer_11/width_16k/average_l0_170
-        path: layer_11/width_16k/average_l0_170
-        l0: 170
-
-      - id: layer_11/width_16k/average_l0_350
-        path: layer_11/width_16k/average_l0_350
-        l0: 350
-
-      - id: layer_11/width_16k/average_l0_41
-        path: layer_11/width_16k/average_l0_41
-        l0: 41
-
-      - id: layer_11/width_16k/average_l0_593
-        path: layer_11/width_16k/average_l0_593
-        l0: 593
-
-      - id: layer_11/width_16k/average_l0_80
-        path: layer_11/width_16k/average_l0_80
-        l0: 80
-
-      - id: layer_12/width_16k/average_l0_184
-        path: layer_12/width_16k/average_l0_184
-        l0: 184
-
-      - id: layer_12/width_16k/average_l0_328
-        path: layer_12/width_16k/average_l0_328
-        l0: 328
-
-      - id: layer_12/width_16k/average_l0_41
-        path: layer_12/width_16k/average_l0_41
-        l0: 41
-
-      - id: layer_12/width_16k/average_l0_514
-        path: layer_12/width_16k/average_l0_514
-        l0: 514
-
-      - id: layer_12/width_16k/average_l0_85
-        path: layer_12/width_16k/average_l0_85
-        l0: 85
-
-      - id: layer_13/width_16k/average_l0_203
-        path: layer_13/width_16k/average_l0_203
-        l0: 203
-
-      - id: layer_13/width_16k/average_l0_372
-        path: layer_13/width_16k/average_l0_372
-        l0: 372
-
-      - id: layer_13/width_16k/average_l0_43
-        path: layer_13/width_16k/average_l0_43
-        l0: 43
-
-      - id: layer_13/width_16k/average_l0_570
-        path: layer_13/width_16k/average_l0_570
-        l0: 570
-
-      - id: layer_13/width_16k/average_l0_92
-        path: layer_13/width_16k/average_l0_92
-        l0: 92
-
-      - id: layer_14/width_16k/average_l0_161
-        path: layer_14/width_16k/average_l0_161
-        l0: 161
-
-      - id: layer_14/width_16k/average_l0_298
-        path: layer_14/width_16k/average_l0_298
-        l0: 298
-
-      - id: layer_14/width_16k/average_l0_37
-        path: layer_14/width_16k/average_l0_37
-        l0: 37
-
-      - id: layer_14/width_16k/average_l0_468
-        path: layer_14/width_16k/average_l0_468
-        l0: 468
-
-      - id: layer_14/width_16k/average_l0_71
-        path: layer_14/width_16k/average_l0_71
-        l0: 71
-
-      - id: layer_15/width_16k/average_l0_195
-        path: layer_15/width_16k/average_l0_195
-        l0: 195
-
-      - id: layer_15/width_16k/average_l0_342
-        path: layer_15/width_16k/average_l0_342
-        l0: 342
-
-      - id: layer_15/width_16k/average_l0_44
-        path: layer_15/width_16k/average_l0_44
-        l0: 44
-
-      - id: layer_15/width_16k/average_l0_535
-        path: layer_15/width_16k/average_l0_535
-        l0: 535
-
-      - id: layer_15/width_16k/average_l0_98
-        path: layer_15/width_16k/average_l0_98
-        l0: 98
-
-      - id: layer_16/width_16k/average_l0_144
-        path: layer_16/width_16k/average_l0_144
-        l0: 144
-
-      - id: layer_16/width_16k/average_l0_293
-        path: layer_16/width_16k/average_l0_293
-        l0: 293
-
-      - id: layer_16/width_16k/average_l0_37
-        path: layer_16/width_16k/average_l0_37
-        l0: 37
-
-      - id: layer_16/width_16k/average_l0_527
-        path: layer_16/width_16k/average_l0_527
-        l0: 527
-
-      - id: layer_16/width_16k/average_l0_71
-        path: layer_16/width_16k/average_l0_71
-        l0: 71
-
-      - id: layer_17/width_16k/average_l0_176
-        path: layer_17/width_16k/average_l0_176
-        l0: 176
-
-      - id: layer_17/width_16k/average_l0_316
-        path: layer_17/width_16k/average_l0_316
-        l0: 316
-
-      - id: layer_17/width_16k/average_l0_38
-        path: layer_17/width_16k/average_l0_38
-        l0: 38
-
-      - id: layer_17/width_16k/average_l0_509
-        path: layer_17/width_16k/average_l0_509
-        l0: 509
-
-      - id: layer_17/width_16k/average_l0_79
-        path: layer_17/width_16k/average_l0_79
-        l0: 79
-
-      - id: layer_18/width_16k/average_l0_144
-        path: layer_18/width_16k/average_l0_144
-        l0: 144
-
-      - id: layer_18/width_16k/average_l0_292
-        path: layer_18/width_16k/average_l0_292
-        l0: 292
-
-      - id: layer_18/width_16k/average_l0_34
-        path: layer_18/width_16k/average_l0_34
-        l0: 34
-
-      - id: layer_18/width_16k/average_l0_491
-        path: layer_18/width_16k/average_l0_491
-        l0: 491
-
-      - id: layer_18/width_16k/average_l0_72
-        path: layer_18/width_16k/average_l0_72
-        l0: 72
-
-      - id: layer_19/width_16k/average_l0_122
-        path: layer_19/width_16k/average_l0_122
-        l0: 122
-
-      - id: layer_19/width_16k/average_l0_249
-        path: layer_19/width_16k/average_l0_249
-        l0: 249
-
-      - id: layer_19/width_16k/average_l0_28
-        path: layer_19/width_16k/average_l0_28
-        l0: 28
-
-      - id: layer_19/width_16k/average_l0_423
-        path: layer_19/width_16k/average_l0_423
-        l0: 423
-
-      - id: layer_19/width_16k/average_l0_56
-        path: layer_19/width_16k/average_l0_56
-        l0: 56
-
-      - id: layer_20/width_16k/average_l0_141
-        path: layer_20/width_16k/average_l0_141
-        l0: 141
-
-      - id: layer_20/width_16k/average_l0_274
-        path: layer_20/width_16k/average_l0_274
-        l0: 274
-
-      - id: layer_20/width_16k/average_l0_31
-        path: layer_20/width_16k/average_l0_31
-        l0: 31
-
-      - id: layer_20/width_16k/average_l0_446
-        path: layer_20/width_16k/average_l0_446
-        l0: 446
-
-      - id: layer_20/width_16k/average_l0_62
-        path: layer_20/width_16k/average_l0_62
-        l0: 62
-
-      - id: layer_21/width_16k/average_l0_142
-        path: layer_21/width_16k/average_l0_142
-        l0: 142
-
-      - id: layer_21/width_16k/average_l0_301
-        path: layer_21/width_16k/average_l0_301
-        l0: 301
-
-      - id: layer_21/width_16k/average_l0_32
-        path: layer_21/width_16k/average_l0_32
-        l0: 32
-
-      - id: layer_21/width_16k/average_l0_505
-        path: layer_21/width_16k/average_l0_505
-        l0: 505
-
-      - id: layer_21/width_16k/average_l0_65
-        path: layer_21/width_16k/average_l0_65
-        l0: 65
-
-      - id: layer_22/width_16k/average_l0_106
-        path: layer_22/width_16k/average_l0_106
-        l0: 106
-
-      - id: layer_22/width_16k/average_l0_215
-        path: layer_22/width_16k/average_l0_215
-        l0: 215
-
-      - id: layer_22/width_16k/average_l0_22
-        path: layer_22/width_16k/average_l0_22
-        l0: 22
-
-      - id: layer_22/width_16k/average_l0_373
-        path: layer_22/width_16k/average_l0_373
-        l0: 373
-
-      - id: layer_22/width_16k/average_l0_47
-        path: layer_22/width_16k/average_l0_47
-        l0: 47
-
-      - id: layer_23/width_16k/average_l0_161
-        path: layer_23/width_16k/average_l0_161
-        l0: 161
-
-      - id: layer_23/width_16k/average_l0_30
-        path: layer_23/width_16k/average_l0_30
-        l0: 30
-
-      - id: layer_23/width_16k/average_l0_300
-        path: layer_23/width_16k/average_l0_300
-        l0: 300
-
-      - id: layer_23/width_16k/average_l0_474
-        path: layer_23/width_16k/average_l0_474
-        l0: 474
-
-      - id: layer_23/width_16k/average_l0_73
-        path: layer_23/width_16k/average_l0_73
-        l0: 73
-
-      - id: layer_24/width_16k/average_l0_212
-        path: layer_24/width_16k/average_l0_212
-        l0: 212
-
-      - id: layer_24/width_16k/average_l0_372
-        path: layer_24/width_16k/average_l0_372
-        l0: 372
-
-      - id: layer_24/width_16k/average_l0_39
-        path: layer_24/width_16k/average_l0_39
-        l0: 39
-
-      - id: layer_24/width_16k/average_l0_558
-        path: layer_24/width_16k/average_l0_558
-        l0: 558
-
-      - id: layer_24/width_16k/average_l0_96
-        path: layer_24/width_16k/average_l0_96
-        l0: 96
-
-      - id: layer_25/width_16k/average_l0_177
-        path: layer_25/width_16k/average_l0_177
-        l0: 177
-
-      - id: layer_25/width_16k/average_l0_313
-        path: layer_25/width_16k/average_l0_313
-        l0: 313
-
-      - id: layer_25/width_16k/average_l0_35
-        path: layer_25/width_16k/average_l0_35
-        l0: 35
-
-      - id: layer_25/width_16k/average_l0_492
-        path: layer_25/width_16k/average_l0_492
-        l0: 492
-
-      - id: layer_25/width_16k/average_l0_77
-        path: layer_25/width_16k/average_l0_77
-        l0: 77
-
-      - id: layer_0/width_65k/average_l0_10
-        path: layer_0/width_65k/average_l0_10
-        l0: 10
-
-      - id: layer_0/width_65k/average_l0_16
-        path: layer_0/width_65k/average_l0_16
-        l0: 16
-
-      - id: layer_0/width_65k/average_l0_24
-        path: layer_0/width_65k/average_l0_24
-        l0: 24
-
-      - id: layer_0/width_65k/average_l0_43
-        path: layer_0/width_65k/average_l0_43
-        l0: 43
-
-      - id: layer_0/width_65k/average_l0_75
-        path: layer_0/width_65k/average_l0_75
-        l0: 75
-
-      - id: layer_1/width_65k/average_l0_15
-        path: layer_1/width_65k/average_l0_15
-        l0: 15
-
-      - id: layer_1/width_65k/average_l0_181
-        path: layer_1/width_65k/average_l0_181
-        l0: 181
-
-      - id: layer_1/width_65k/average_l0_28
-        path: layer_1/width_65k/average_l0_28
-        l0: 28
-
-      - id: layer_1/width_65k/average_l0_55
-        path: layer_1/width_65k/average_l0_55
-        l0: 55
-
-      - id: layer_1/width_65k/average_l0_98
-        path: layer_1/width_65k/average_l0_98
-        l0: 98
-
-      - id: layer_2/width_65k/average_l0_125
-        path: layer_2/width_65k/average_l0_125
-        l0: 125
-
-      - id: layer_2/width_65k/average_l0_14
-        path: layer_2/width_65k/average_l0_14
-        l0: 14
-
-      - id: layer_2/width_65k/average_l0_228
-        path: layer_2/width_65k/average_l0_228
-        l0: 228
-
-      - id: layer_2/width_65k/average_l0_28
-        path: layer_2/width_65k/average_l0_28
-        l0: 28
-
-      - id: layer_2/width_65k/average_l0_59
-        path: layer_2/width_65k/average_l0_59
-        l0: 59
-
-      - id: layer_3/width_65k/average_l0_174
-        path: layer_3/width_65k/average_l0_174
-        l0: 174
-
-      - id: layer_3/width_65k/average_l0_19
-        path: layer_3/width_65k/average_l0_19
-        l0: 19
-
-      - id: layer_3/width_65k/average_l0_320
-        path: layer_3/width_65k/average_l0_320
-        l0: 320
-
-      - id: layer_3/width_65k/average_l0_39
-        path: layer_3/width_65k/average_l0_39
-        l0: 39
-
-      - id: layer_3/width_65k/average_l0_83
-        path: layer_3/width_65k/average_l0_83
-        l0: 83
-
-      - id: layer_4/width_65k/average_l0_188
-        path: layer_4/width_65k/average_l0_188
-        l0: 188
-
-      - id: layer_4/width_65k/average_l0_22
-        path: layer_4/width_65k/average_l0_22
-        l0: 22
-
-      - id: layer_4/width_65k/average_l0_382
-        path: layer_4/width_65k/average_l0_382
-        l0: 382
-
-      - id: layer_4/width_65k/average_l0_43
-        path: layer_4/width_65k/average_l0_43
-        l0: 43
-
-      - id: layer_4/width_65k/average_l0_87
-        path: layer_4/width_65k/average_l0_87
-        l0: 87
-
-      - id: layer_5/width_65k/average_l0_227
-        path: layer_5/width_65k/average_l0_227
-        l0: 227
-
-      - id: layer_5/width_65k/average_l0_28
-        path: layer_5/width_65k/average_l0_28
-        l0: 28
-
-      - id: layer_5/width_65k/average_l0_400
-        path: layer_5/width_65k/average_l0_400
-        l0: 400
-
-      - id: layer_5/width_65k/average_l0_51
-        path: layer_5/width_65k/average_l0_51
-        l0: 51
-
-      - id: layer_5/width_65k/average_l0_99
-        path: layer_5/width_65k/average_l0_99
-        l0: 99
-
-      - id: layer_6/width_65k/average_l0_112
-        path: layer_6/width_65k/average_l0_112
-        l0: 112
-
-      - id: layer_6/width_65k/average_l0_261
-        path: layer_6/width_65k/average_l0_261
-        l0: 261
-
-      - id: layer_6/width_65k/average_l0_30
-        path: layer_6/width_65k/average_l0_30
-        l0: 30
-
-      - id: layer_6/width_65k/average_l0_449
-        path: layer_6/width_65k/average_l0_449
-        l0: 449
-
-      - id: layer_6/width_65k/average_l0_55
-        path: layer_6/width_65k/average_l0_55
-        l0: 55
-
-      - id: layer_7/width_65k/average_l0_176
-        path: layer_7/width_65k/average_l0_176
-        l0: 176
-
-      - id: layer_7/width_65k/average_l0_311
-        path: layer_7/width_65k/average_l0_311
-        l0: 311
-
-      - id: layer_7/width_65k/average_l0_519
-        path: layer_7/width_65k/average_l0_519
-        l0: 519
-
-      - id: layer_7/width_65k/average_l0_52
-        path: layer_7/width_65k/average_l0_52
-        l0: 52
-
-      - id: layer_7/width_65k/average_l0_96
-        path: layer_7/width_65k/average_l0_96
-        l0: 96
-
-      - id: layer_8/width_65k/average_l0_112
-        path: layer_8/width_65k/average_l0_112
-        l0: 112
-
-      - id: layer_8/width_65k/average_l0_246
-        path: layer_8/width_65k/average_l0_246
-        l0: 246
-
-      - id: layer_8/width_65k/average_l0_35
-        path: layer_8/width_65k/average_l0_35
-        l0: 35
-
-      - id: layer_8/width_65k/average_l0_454
-        path: layer_8/width_65k/average_l0_454
-        l0: 454
-
-      - id: layer_8/width_65k/average_l0_56
-        path: layer_8/width_65k/average_l0_56
-        l0: 56
-
-      - id: layer_9/width_65k/average_l0_107
-        path: layer_9/width_65k/average_l0_107
-        l0: 107
-
-      - id: layer_9/width_65k/average_l0_231
-        path: layer_9/width_65k/average_l0_231
-        l0: 231
-
-      - id: layer_9/width_65k/average_l0_31
-        path: layer_9/width_65k/average_l0_31
-        l0: 31
-
-      - id: layer_9/width_65k/average_l0_454
-        path: layer_9/width_65k/average_l0_454
-        l0: 454
-
-      - id: layer_9/width_65k/average_l0_57
-        path: layer_9/width_65k/average_l0_57
-        l0: 57
-
-      - id: layer_10/width_65k/average_l0_134
-        path: layer_10/width_65k/average_l0_134
-        l0: 134
-
-      - id: layer_10/width_65k/average_l0_292
-        path: layer_10/width_65k/average_l0_292
-        l0: 292
-
-      - id: layer_10/width_65k/average_l0_35
-        path: layer_10/width_65k/average_l0_35
-        l0: 35
-
-      - id: layer_10/width_65k/average_l0_521
-        path: layer_10/width_65k/average_l0_521
-        l0: 521
-
-      - id: layer_10/width_65k/average_l0_67
-        path: layer_10/width_65k/average_l0_67
-        l0: 67
-
-      - id: layer_11/width_65k/average_l0_154
-        path: layer_11/width_65k/average_l0_154
-        l0: 154
-
-      - id: layer_11/width_65k/average_l0_330
-        path: layer_11/width_65k/average_l0_330
-        l0: 330
-
-      - id: layer_11/width_65k/average_l0_41
-        path: layer_11/width_65k/average_l0_41
-        l0: 41
-
-      - id: layer_11/width_65k/average_l0_576
-        path: layer_11/width_65k/average_l0_576
-        l0: 576
-
-      - id: layer_11/width_65k/average_l0_75
-        path: layer_11/width_65k/average_l0_75
-        l0: 75
-
-      - id: layer_12/width_65k/average_l0_172
-        path: layer_12/width_65k/average_l0_172
-        l0: 172
-
-      - id: layer_12/width_65k/average_l0_320
-        path: layer_12/width_65k/average_l0_320
-        l0: 320
-
-      - id: layer_12/width_65k/average_l0_39
-        path: layer_12/width_65k/average_l0_39
-        l0: 39
-
-      - id: layer_12/width_65k/average_l0_503
-        path: layer_12/width_65k/average_l0_503
-        l0: 503
-
-      - id: layer_12/width_65k/average_l0_79
-        path: layer_12/width_65k/average_l0_79
-        l0: 79
-
-      - id: layer_13/width_65k/average_l0_191
-        path: layer_13/width_65k/average_l0_191
-        l0: 191
-
-      - id: layer_13/width_65k/average_l0_363
-        path: layer_13/width_65k/average_l0_363
-        l0: 363
-
-      - id: layer_13/width_65k/average_l0_41
-        path: layer_13/width_65k/average_l0_41
-        l0: 41
-
-      - id: layer_13/width_65k/average_l0_556
-        path: layer_13/width_65k/average_l0_556
-        l0: 556
-
-      - id: layer_13/width_65k/average_l0_87
-        path: layer_13/width_65k/average_l0_87
-        l0: 87
-
-      - id: layer_14/width_65k/average_l0_138
-        path: layer_14/width_65k/average_l0_138
-        l0: 138
-
-      - id: layer_14/width_65k/average_l0_283
-        path: layer_14/width_65k/average_l0_283
-        l0: 283
-
-      - id: layer_14/width_65k/average_l0_37
-        path: layer_14/width_65k/average_l0_37
-        l0: 37
-
-      - id: layer_14/width_65k/average_l0_453
-        path: layer_14/width_65k/average_l0_453
-        l0: 453
-
-      - id: layer_14/width_65k/average_l0_66
-        path: layer_14/width_65k/average_l0_66
-        l0: 66
-
-      - id: layer_15/width_65k/average_l0_182
-        path: layer_15/width_65k/average_l0_182
-        l0: 182
-
-      - id: layer_15/width_65k/average_l0_327
-        path: layer_15/width_65k/average_l0_327
-        l0: 327
-
-      - id: layer_15/width_65k/average_l0_42
-        path: layer_15/width_65k/average_l0_42
-        l0: 42
-
-      - id: layer_15/width_65k/average_l0_517
-        path: layer_15/width_65k/average_l0_517
-        l0: 517
-
-      - id: layer_15/width_65k/average_l0_90
-        path: layer_15/width_65k/average_l0_90
-        l0: 90
-
-      - id: layer_16/width_65k/average_l0_129
-        path: layer_16/width_65k/average_l0_129
-        l0: 129
-
-      - id: layer_16/width_65k/average_l0_260
-        path: layer_16/width_65k/average_l0_260
-        l0: 260
-
-      - id: layer_16/width_65k/average_l0_35
-        path: layer_16/width_65k/average_l0_35
-        l0: 35
-
-      - id: layer_16/width_65k/average_l0_502
-        path: layer_16/width_65k/average_l0_502
-        l0: 502
-
-      - id: layer_16/width_65k/average_l0_64
-        path: layer_16/width_65k/average_l0_64
-        l0: 64
-
-      - id: layer_17/width_65k/average_l0_157
-        path: layer_17/width_65k/average_l0_157
-        l0: 157
-
-      - id: layer_17/width_65k/average_l0_293
-        path: layer_17/width_65k/average_l0_293
-        l0: 293
-
-      - id: layer_17/width_65k/average_l0_35
-        path: layer_17/width_65k/average_l0_35
-        l0: 35
-
-      - id: layer_17/width_65k/average_l0_489
-        path: layer_17/width_65k/average_l0_489
-        l0: 489
-
-      - id: layer_17/width_65k/average_l0_70
-        path: layer_17/width_65k/average_l0_70
-        l0: 70
-
-      - id: layer_18/width_65k/average_l0_123
-        path: layer_18/width_65k/average_l0_123
-        l0: 123
-
-      - id: layer_18/width_65k/average_l0_255
-        path: layer_18/width_65k/average_l0_255
-        l0: 255
-
-      - id: layer_18/width_65k/average_l0_29
-        path: layer_18/width_65k/average_l0_29
-        l0: 29
-
-      - id: layer_18/width_65k/average_l0_466
-        path: layer_18/width_65k/average_l0_466
-        l0: 466
-
-      - id: layer_18/width_65k/average_l0_58
-        path: layer_18/width_65k/average_l0_58
-        l0: 58
-
-      - id: layer_19/width_65k/average_l0_106
-        path: layer_19/width_65k/average_l0_106
-        l0: 106
-
-      - id: layer_19/width_65k/average_l0_220
-        path: layer_19/width_65k/average_l0_220
-        l0: 220
-
-      - id: layer_19/width_65k/average_l0_26
-        path: layer_19/width_65k/average_l0_26
-        l0: 26
-
-      - id: layer_19/width_65k/average_l0_411
-        path: layer_19/width_65k/average_l0_411
-        l0: 411
-
-      - id: layer_19/width_65k/average_l0_49
-        path: layer_19/width_65k/average_l0_49
-        l0: 49
-
-      - id: layer_20/width_65k/average_l0_102
-        path: layer_20/width_65k/average_l0_102
-        l0: 102
-
-      - id: layer_20/width_65k/average_l0_242
-        path: layer_20/width_65k/average_l0_242
-        l0: 242
-
-      - id: layer_20/width_65k/average_l0_26
-        path: layer_20/width_65k/average_l0_26
-        l0: 26
-
-      - id: layer_20/width_65k/average_l0_419
-        path: layer_20/width_65k/average_l0_419
-        l0: 419
-
-      - id: layer_20/width_65k/average_l0_49
-        path: layer_20/width_65k/average_l0_49
-        l0: 49
-
-      - id: layer_21/width_65k/average_l0_118
-        path: layer_21/width_65k/average_l0_118
-        l0: 118
-
-      - id: layer_21/width_65k/average_l0_266
-        path: layer_21/width_65k/average_l0_266
-        l0: 266
-
-      - id: layer_21/width_65k/average_l0_29
-        path: layer_21/width_65k/average_l0_29
-        l0: 29
-
-      - id: layer_21/width_65k/average_l0_474
-        path: layer_21/width_65k/average_l0_474
-        l0: 474
-
-      - id: layer_21/width_65k/average_l0_56
-        path: layer_21/width_65k/average_l0_56
-        l0: 56
-
-      - id: layer_22/width_65k/average_l0_112
-        path: layer_22/width_65k/average_l0_112
-        l0: 112
-
-      - id: layer_22/width_65k/average_l0_196
-        path: layer_22/width_65k/average_l0_196
-        l0: 196
-
-      - id: layer_22/width_65k/average_l0_20
-        path: layer_22/width_65k/average_l0_20
-        l0: 20
-
-      - id: layer_22/width_65k/average_l0_361
-        path: layer_22/width_65k/average_l0_361
-        l0: 361
-
-      - id: layer_22/width_65k/average_l0_37
-        path: layer_22/width_65k/average_l0_37
-        l0: 37
-
-      - id: layer_23/width_65k/average_l0_140
-        path: layer_23/width_65k/average_l0_140
-        l0: 140
-
-      - id: layer_23/width_65k/average_l0_27
-        path: layer_23/width_65k/average_l0_27
-        l0: 27
-
-      - id: layer_23/width_65k/average_l0_276
-        path: layer_23/width_65k/average_l0_276
-        l0: 276
-
-      - id: layer_23/width_65k/average_l0_457
-        path: layer_23/width_65k/average_l0_457
-        l0: 457
-
-      - id: layer_23/width_65k/average_l0_56
-        path: layer_23/width_65k/average_l0_56
-        l0: 56
-
-      - id: layer_24/width_65k/average_l0_186
-        path: layer_24/width_65k/average_l0_186
-        l0: 186
-
-      - id: layer_24/width_65k/average_l0_32
-        path: layer_24/width_65k/average_l0_32
-        l0: 32
-
-      - id: layer_24/width_65k/average_l0_347
-        path: layer_24/width_65k/average_l0_347
-        l0: 347
-
-      - id: layer_24/width_65k/average_l0_537
-        path: layer_24/width_65k/average_l0_537
-        l0: 537
-
-      - id: layer_24/width_65k/average_l0_77
-        path: layer_24/width_65k/average_l0_77
-        l0: 77
-
-      - id: layer_25/width_65k/average_l0_153
-        path: layer_25/width_65k/average_l0_153
-        l0: 153
-
-      - id: layer_25/width_65k/average_l0_290
-        path: layer_25/width_65k/average_l0_290
-        l0: 290
-
-      - id: layer_25/width_65k/average_l0_30
-        path: layer_25/width_65k/average_l0_30
-        l0: 30
-
-      - id: layer_25/width_65k/average_l0_465
-        path: layer_25/width_65k/average_l0_465
-        l0: 465
-
-      - id: layer_25/width_65k/average_l0_63
-        path: layer_25/width_65k/average_l0_63
-        l0: 63
-  gemma-scope-2b-pt-att-canonical:
-    repo_id: google/gemma-scope-2b-pt-att
-    model: gemma-2-2b
-    conversion_func: gemma_2
-    saes:
-      - id: layer_0/width_16k/canonical
-        path: layer_0/width_16k/average_l0_104
-      - id: layer_1/width_16k/canonical
-        path: layer_1/width_16k/average_l0_79
-      - id: layer_2/width_16k/canonical
-        path: layer_2/width_16k/average_l0_93
-      - id: layer_3/width_16k/canonical
-        path: layer_3/width_16k/average_l0_117
-      - id: layer_4/width_16k/canonical
-        path: layer_4/width_16k/average_l0_116
-      - id: layer_5/width_16k/canonical
-        path: layer_5/width_16k/average_l0_135
-      - id: layer_6/width_16k/canonical
-        path: layer_6/width_16k/average_l0_61
-      - id: layer_7/width_16k/canonical
-        path: layer_7/width_16k/average_l0_99
-      - id: layer_8/width_16k/canonical
-        path: layer_8/width_16k/average_l0_129
-      - id: layer_9/width_16k/canonical
-        path: layer_9/width_16k/average_l0_127
-      - id: layer_10/width_16k/canonical
-        path: layer_10/width_16k/average_l0_70
-      - id: layer_11/width_16k/canonical
-        path: layer_11/width_16k/average_l0_80
-      - id: layer_12/width_16k/canonical
-        path: layer_12/width_16k/average_l0_85
-      - id: layer_13/width_16k/canonical
-        path: layer_13/width_16k/average_l0_92
-      - id: layer_14/width_16k/canonical
-        path: layer_14/width_16k/average_l0_71
-      - id: layer_15/width_16k/canonical
-        path: layer_15/width_16k/average_l0_98
-      - id: layer_16/width_16k/canonical
-        path: layer_16/width_16k/average_l0_71
-      - id: layer_17/width_16k/canonical
-        path: layer_17/width_16k/average_l0_79
-      - id: layer_18/width_16k/canonical
-        path: layer_18/width_16k/average_l0_72
-      - id: layer_19/width_16k/canonical
-        path: layer_19/width_16k/average_l0_122
-      - id: layer_20/width_16k/canonical
-        path: layer_20/width_16k/average_l0_62
-      - id: layer_21/width_16k/canonical
-        path: layer_21/width_16k/average_l0_65
-      - id: layer_22/width_16k/canonical
-        path: layer_22/width_16k/average_l0_106
-      - id: layer_23/width_16k/canonical
-        path: layer_23/width_16k/average_l0_73
-      - id: layer_24/width_16k/canonical
-        path: layer_24/width_16k/average_l0_96
-      - id: layer_25/width_16k/canonical
-        path: layer_25/width_16k/average_l0_77
-      - id: layer_0/width_65k/canonical
-        path: layer_0/width_65k/average_l0_75
-      - id: layer_1/width_65k/canonical
-        path: layer_1/width_65k/average_l0_98
-      - id: layer_2/width_65k/canonical
-        path: layer_2/width_65k/average_l0_125
-      - id: layer_3/width_65k/canonical
-        path: layer_3/width_65k/average_l0_83
-      - id: layer_4/width_65k/canonical
-        path: layer_4/width_65k/average_l0_87
-      - id: layer_5/width_65k/canonical
-        path: layer_5/width_65k/average_l0_99
-      - id: layer_6/width_65k/canonical
-        path: layer_6/width_65k/average_l0_112
-      - id: layer_7/width_65k/canonical
-        path: layer_7/width_65k/average_l0_96
-      - id: layer_8/width_65k/canonical
-        path: layer_8/width_65k/average_l0_112
-      - id: layer_9/width_65k/canonical
-        path: layer_9/width_65k/average_l0_107
-      - id: layer_10/width_65k/canonical
-        path: layer_10/width_65k/average_l0_67
-      - id: layer_11/width_65k/canonical
-        path: layer_11/width_65k/average_l0_75
-      - id: layer_12/width_65k/canonical
-        path: layer_12/width_65k/average_l0_79
-      - id: layer_13/width_65k/canonical
-        path: layer_13/width_65k/average_l0_87
-      - id: layer_14/width_65k/canonical
-        path: layer_14/width_65k/average_l0_66
-      - id: layer_15/width_65k/canonical
-        path: layer_15/width_65k/average_l0_90
-      - id: layer_16/width_65k/canonical
-        path: layer_16/width_65k/average_l0_129
-      - id: layer_17/width_65k/canonical
-        path: layer_17/width_65k/average_l0_70
-      - id: layer_18/width_65k/canonical
-        path: layer_18/width_65k/average_l0_123
-      - id: layer_19/width_65k/canonical
-        path: layer_19/width_65k/average_l0_106
-      - id: layer_20/width_65k/canonical
-        path: layer_20/width_65k/average_l0_102
-      - id: layer_21/width_65k/canonical
-        path: layer_21/width_65k/average_l0_118
-      - id: layer_22/width_65k/canonical
-        path: layer_22/width_65k/average_l0_112
-      - id: layer_23/width_65k/canonical
-        path: layer_23/width_65k/average_l0_140
-      - id: layer_24/width_65k/canonical
-        path: layer_24/width_65k/average_l0_77
-      - id: layer_25/width_65k/canonical
-        path: layer_25/width_65k/average_l0_63
-  gemma-scope-9b-pt-att:
-    repo_id: google/gemma-scope-9b-pt-att
-    model: gemma-2-2b
-    conversion_func: gemma_2
-    saes:
-      - id: layer_0/width_131k/average_l0_55
-        path: layer_0/width_131k/average_l0_55
-        l0: 55
-
-      - id: layer_1/width_131k/average_l0_116
-        path: layer_1/width_131k/average_l0_116
-        l0: 116
-
-      - id: layer_2/width_131k/average_l0_11
-        path: layer_2/width_131k/average_l0_11
-        l0: 11
-
-      - id: layer_3/width_131k/average_l0_10
-        path: layer_3/width_131k/average_l0_10
-        l0: 10
-
-      - id: layer_4/width_131k/average_l0_12
-        path: layer_4/width_131k/average_l0_12
-        l0: 12
-
-      - id: layer_5/width_131k/average_l0_12
-        path: layer_5/width_131k/average_l0_12
-        l0: 12
-
-      - id: layer_6/width_131k/average_l0_14
-        path: layer_6/width_131k/average_l0_14
-        l0: 14
-
-      - id: layer_6/width_131k/average_l0_148
-        path: layer_6/width_131k/average_l0_148
-        l0: 148
-
-      - id: layer_7/width_131k/average_l0_106
-        path: layer_7/width_131k/average_l0_106
-        l0: 106
-
-      - id: layer_8/width_131k/average_l0_16
-        path: layer_8/width_131k/average_l0_16
-        l0: 16
-
-      - id: layer_9/width_131k/average_l0_111
-        path: layer_9/width_131k/average_l0_111
-        l0: 111
-
-      - id: layer_10/width_131k/average_l0_16
-        path: layer_10/width_131k/average_l0_16
-        l0: 16
-
-      - id: layer_11/width_131k/average_l0_104
-        path: layer_11/width_131k/average_l0_104
-        l0: 104
-
-      - id: layer_12/width_131k/average_l0_110
-        path: layer_12/width_131k/average_l0_110
-        l0: 110
-
-      - id: layer_13/width_131k/average_l0_126
-        path: layer_13/width_131k/average_l0_126
-        l0: 126
-
-      - id: layer_14/width_131k/average_l0_131
-        path: layer_14/width_131k/average_l0_131
-        l0: 131
-
-      - id: layer_15/width_131k/average_l0_130
-        path: layer_15/width_131k/average_l0_130
-        l0: 130
-
-      - id: layer_16/width_131k/average_l0_140
-        path: layer_16/width_131k/average_l0_140
-        l0: 140
-
-      - id: layer_17/width_131k/average_l0_191
-        path: layer_17/width_131k/average_l0_191
-        l0: 191
-
-      - id: layer_18/width_131k/average_l0_133
-        path: layer_18/width_131k/average_l0_133
-        l0: 133
-
-      - id: layer_19/width_131k/average_l0_152
-        path: layer_19/width_131k/average_l0_152
-        l0: 152
-
-      - id: layer_20/width_131k/average_l0_125
-        path: layer_20/width_131k/average_l0_125
-        l0: 125
-
-      - id: layer_21/width_131k/average_l0_150
-        path: layer_21/width_131k/average_l0_150
-        l0: 150
-
-      - id: layer_22/width_131k/average_l0_115
-        path: layer_22/width_131k/average_l0_115
-        l0: 115
-
-      - id: layer_23/width_131k/average_l0_134
-        path: layer_23/width_131k/average_l0_134
-        l0: 134
-
-      - id: layer_24/width_131k/average_l0_130
-        path: layer_24/width_131k/average_l0_130
-        l0: 130
-
-      - id: layer_25/width_131k/average_l0_115
-        path: layer_25/width_131k/average_l0_115
-        l0: 115
-
-      - id: layer_26/width_131k/average_l0_120
-        path: layer_26/width_131k/average_l0_120
-        l0: 120
-
-      - id: layer_27/width_131k/average_l0_102
-        path: layer_27/width_131k/average_l0_102
-        l0: 102
-
-      - id: layer_28/width_131k/average_l0_115
-        path: layer_28/width_131k/average_l0_115
-        l0: 115
-
-      - id: layer_29/width_131k/average_l0_128
-        path: layer_29/width_131k/average_l0_128
-        l0: 128
-
-      - id: layer_30/width_131k/average_l0_109
-        path: layer_30/width_131k/average_l0_109
-        l0: 109
-
-      - id: layer_31/width_131k/average_l0_117
-        path: layer_31/width_131k/average_l0_117
-        l0: 117
-
-      - id: layer_32/width_131k/average_l0_117
-        path: layer_32/width_131k/average_l0_117
-        l0: 117
-
-      - id: layer_33/width_131k/average_l0_128
-        path: layer_33/width_131k/average_l0_128
-        l0: 128
-
-      - id: layer_34/width_131k/average_l0_15
-        path: layer_34/width_131k/average_l0_15
-        l0: 15
-
-      - id: layer_35/width_131k/average_l0_124
-        path: layer_35/width_131k/average_l0_124
-        l0: 124
-
-      - id: layer_36/width_131k/average_l0_105
-        path: layer_36/width_131k/average_l0_105
-        l0: 105
-
-      - id: layer_37/width_131k/average_l0_124
-        path: layer_37/width_131k/average_l0_124
-        l0: 124
-
-      - id: layer_38/width_131k/average_l0_135
-        path: layer_38/width_131k/average_l0_135
-        l0: 135
-
-      - id: layer_39/width_131k/average_l0_120
-        path: layer_39/width_131k/average_l0_120
-        l0: 120
-
-      - id: layer_40/width_131k/average_l0_144
-        path: layer_40/width_131k/average_l0_144
-        l0: 144
-
-      - id: layer_41/width_131k/average_l0_13
-        path: layer_41/width_131k/average_l0_13
-        l0: 13
-
-      - id: layer_0/width_16k/average_l0_12
-        path: layer_0/width_16k/average_l0_12
-        l0: 12
-
-      - id: layer_1/width_16k/average_l0_147
-        path: layer_1/width_16k/average_l0_147
-        l0: 147
-
-      - id: layer_2/width_16k/average_l0_15
-        path: layer_2/width_16k/average_l0_15
-        l0: 15
-
-      - id: layer_3/width_16k/average_l0_102
-        path: layer_3/width_16k/average_l0_102
-        l0: 102
-
-      - id: layer_4/width_16k/average_l0_126
-        path: layer_4/width_16k/average_l0_126
-        l0: 126
-
-      - id: layer_5/width_16k/average_l0_125
-        path: layer_5/width_16k/average_l0_125
-        l0: 125
-
-      - id: layer_6/width_16k/average_l0_108
-        path: layer_6/width_16k/average_l0_108
-        l0: 108
-
-      - id: layer_7/width_16k/average_l0_70
-        path: layer_7/width_16k/average_l0_70
-        l0: 70
-
-      - id: layer_8/width_16k/average_l0_150
-        path: layer_8/width_16k/average_l0_150
-        l0: 150
-
-      - id: layer_9/width_16k/average_l0_172
-        path: layer_9/width_16k/average_l0_172
-        l0: 172
-
-      - id: layer_10/width_16k/average_l0_132
-        path: layer_10/width_16k/average_l0_132
-        l0: 132
-
-      - id: layer_11/width_16k/average_l0_153
-        path: layer_11/width_16k/average_l0_153
-        l0: 153
-
-      - id: layer_12/width_16k/average_l0_149
-        path: layer_12/width_16k/average_l0_149
-        l0: 149
-
-      - id: layer_13/width_16k/average_l0_170
-        path: layer_13/width_16k/average_l0_170
-        l0: 170
-
-      - id: layer_14/width_16k/average_l0_179
-        path: layer_14/width_16k/average_l0_179
-        l0: 179
-
-      - id: layer_15/width_16k/average_l0_168
-        path: layer_15/width_16k/average_l0_168
-        l0: 168
-
-      - id: layer_16/width_16k/average_l0_172
-        path: layer_16/width_16k/average_l0_172
-        l0: 172
-
-      - id: layer_17/width_16k/average_l0_110
-        path: layer_17/width_16k/average_l0_110
-        l0: 110
-
-      - id: layer_18/width_16k/average_l0_171
-        path: layer_18/width_16k/average_l0_171
-        l0: 171
-
-      - id: layer_19/width_16k/average_l0_186
-        path: layer_19/width_16k/average_l0_186
-        l0: 186
-
-      - id: layer_20/width_16k/average_l0_158
-        path: layer_20/width_16k/average_l0_158
-        l0: 158
-
-      - id: layer_21/width_16k/average_l0_195
-        path: layer_21/width_16k/average_l0_195
-        l0: 195
-
-      - id: layer_22/width_16k/average_l0_141
-        path: layer_22/width_16k/average_l0_141
-        l0: 141
-
-      - id: layer_23/width_16k/average_l0_173
-        path: layer_23/width_16k/average_l0_173
-        l0: 173
-
-      - id: layer_24/width_16k/average_l0_167
-        path: layer_24/width_16k/average_l0_167
-        l0: 167
-
-      - id: layer_25/width_16k/average_l0_156
-        path: layer_25/width_16k/average_l0_156
-        l0: 156
-
-      - id: layer_26/width_16k/average_l0_159
-        path: layer_26/width_16k/average_l0_159
-        l0: 159
-
-      - id: layer_27/width_16k/average_l0_136
-        path: layer_27/width_16k/average_l0_136
-        l0: 136
-
-      - id: layer_28/width_16k/average_l0_143
-        path: layer_28/width_16k/average_l0_143
-        l0: 143
-
-      - id: layer_29/width_16k/average_l0_171
-        path: layer_29/width_16k/average_l0_171
-        l0: 171
-
-      - id: layer_30/width_16k/average_l0_157
-        path: layer_30/width_16k/average_l0_157
-        l0: 157
-
-      - id: layer_31/width_16k/average_l0_168
-        path: layer_31/width_16k/average_l0_168
-        l0: 168
-
-      - id: layer_32/width_16k/average_l0_158
-        path: layer_32/width_16k/average_l0_158
-        l0: 158
-
-      - id: layer_33/width_16k/average_l0_158
-        path: layer_33/width_16k/average_l0_158
-        l0: 158
-
-      - id: layer_34/width_16k/average_l0_17
-        path: layer_34/width_16k/average_l0_17
-        l0: 17
-
-      - id: layer_35/width_16k/average_l0_14
-        path: layer_35/width_16k/average_l0_14
-        l0: 14
-
-      - id: layer_36/width_16k/average_l0_144
-        path: layer_36/width_16k/average_l0_144
-        l0: 144
-
-      - id: layer_37/width_16k/average_l0_17
-        path: layer_37/width_16k/average_l0_17
-        l0: 17
-
-      - id: layer_37/width_16k/average_l0_172
-        path: layer_37/width_16k/average_l0_172
-        l0: 172
-
-      - id: layer_38/width_16k/average_l0_175
-        path: layer_38/width_16k/average_l0_175
-        l0: 175
-
-      - id: layer_39/width_16k/average_l0_15
-        path: layer_39/width_16k/average_l0_15
-        l0: 15
-
-      - id: layer_40/width_16k/average_l0_18
-        path: layer_40/width_16k/average_l0_18
-        l0: 18
-
-      - id: layer_40/width_16k/average_l0_189
-        path: layer_40/width_16k/average_l0_189
-        l0: 189
-
-      - id: layer_41/width_16k/average_l0_129
-        path: layer_41/width_16k/average_l0_129
-        l0: 129
-  gemma-scope-9b-pt-mlp:
-    repo_id: google/gemma-scope-9b-pt-mlp
-    model: gemma-2-2b
-    conversion_func: gemma_2
-    saes:
-      - id: layer_0/width_131k/average_l0_11
-        path: layer_0/width_131k/average_l0_11
-        l0: 11
-
-      - id: layer_1/width_131k/average_l0_10
-        path: layer_1/width_131k/average_l0_10
-        l0: 10
-
-      - id: layer_1/width_131k/average_l0_106
-        path: layer_1/width_131k/average_l0_106
-        l0: 106
-
-      - id: layer_2/width_131k/average_l0_12
-        path: layer_2/width_131k/average_l0_12
-        l0: 12
-
-      - id: layer_3/width_131k/average_l0_109
-        path: layer_3/width_131k/average_l0_109
-        l0: 109
-
-      - id: layer_4/width_131k/average_l0_14
-        path: layer_4/width_131k/average_l0_14
-        l0: 14
-
-      - id: layer_5/width_131k/average_l0_12
-        path: layer_5/width_131k/average_l0_12
-        l0: 12
-
-      - id: layer_6/width_131k/average_l0_12
-        path: layer_6/width_131k/average_l0_12
-        l0: 12
-
-      - id: layer_7/width_131k/average_l0_13
-        path: layer_7/width_131k/average_l0_13
-        l0: 13
-
-      - id: layer_8/width_131k/average_l0_15
-        path: layer_8/width_131k/average_l0_15
-        l0: 15
-
-      - id: layer_9/width_131k/average_l0_12
-        path: layer_9/width_131k/average_l0_12
-        l0: 12
-
-      - id: layer_9/width_131k/average_l0_129
-        path: layer_9/width_131k/average_l0_129
-        l0: 129
-
-      - id: layer_10/width_131k/average_l0_12
-        path: layer_10/width_131k/average_l0_12
-        l0: 12
-
-      - id: layer_11/width_131k/average_l0_120
-        path: layer_11/width_131k/average_l0_120
-        l0: 120
-
-      - id: layer_12/width_131k/average_l0_159
-        path: layer_12/width_131k/average_l0_159
-        l0: 159
-
-      - id: layer_13/width_131k/average_l0_160
-        path: layer_13/width_131k/average_l0_160
-        l0: 160
-
-      - id: layer_14/width_131k/average_l0_174
-        path: layer_14/width_131k/average_l0_174
-        l0: 174
-
-      - id: layer_15/width_131k/average_l0_194
-        path: layer_15/width_131k/average_l0_194
-        l0: 194
-
-      - id: layer_16/width_131k/average_l0_17
-        path: layer_16/width_131k/average_l0_17
-        l0: 17
-
-      - id: layer_16/width_131k/average_l0_175
-        path: layer_16/width_131k/average_l0_175
-        l0: 175
-
-      - id: layer_17/width_131k/average_l0_207
-        path: layer_17/width_131k/average_l0_207
-        l0: 207
-
-      - id: layer_18/width_131k/average_l0_174
-        path: layer_18/width_131k/average_l0_174
-        l0: 174
-
-      - id: layer_19/width_131k/average_l0_189
-        path: layer_19/width_131k/average_l0_189
-        l0: 189
-
-      - id: layer_20/width_131k/average_l0_20
-        path: layer_20/width_131k/average_l0_20
-        l0: 20
-
-      - id: layer_21/width_131k/average_l0_16
-        path: layer_21/width_131k/average_l0_16
-        l0: 16
-
-      - id: layer_22/width_131k/average_l0_17
-        path: layer_22/width_131k/average_l0_17
-        l0: 17
-
-      - id: layer_22/width_131k/average_l0_172
-        path: layer_22/width_131k/average_l0_172
-        l0: 172
-
-      - id: layer_23/width_131k/average_l0_146
-        path: layer_23/width_131k/average_l0_146
-        l0: 146
-
-      - id: layer_24/width_131k/average_l0_147
-        path: layer_24/width_131k/average_l0_147
-        l0: 147
-
-      - id: layer_25/width_131k/average_l0_139
-        path: layer_25/width_131k/average_l0_139
-        l0: 139
-
-      - id: layer_26/width_131k/average_l0_110
-        path: layer_26/width_131k/average_l0_110
-        l0: 110
-
-      - id: layer_27/width_131k/average_l0_14
-        path: layer_27/width_131k/average_l0_14
-        l0: 14
-
-      - id: layer_28/width_131k/average_l0_15
-        path: layer_28/width_131k/average_l0_15
-        l0: 15
-
-      - id: layer_29/width_131k/average_l0_15
-        path: layer_29/width_131k/average_l0_15
-        l0: 15
-
-      - id: layer_30/width_131k/average_l0_14
-        path: layer_30/width_131k/average_l0_14
-        l0: 14
-
-      - id: layer_31/width_131k/average_l0_12
-        path: layer_31/width_131k/average_l0_12
-        l0: 12
-
-      - id: layer_32/width_131k/average_l0_12
-        path: layer_32/width_131k/average_l0_12
-        l0: 12
-
-      - id: layer_33/width_131k/average_l0_12
-        path: layer_33/width_131k/average_l0_12
-        l0: 12
-
-      - id: layer_34/width_131k/average_l0_10
-        path: layer_34/width_131k/average_l0_10
-        l0: 10
-
-      - id: layer_35/width_131k/average_l0_10
-        path: layer_35/width_131k/average_l0_10
-        l0: 10
-
-      - id: layer_36/width_131k/average_l0_11
-        path: layer_36/width_131k/average_l0_11
-        l0: 11
-
-      - id: layer_37/width_131k/average_l0_12
-        path: layer_37/width_131k/average_l0_12
-        l0: 12
-
-      - id: layer_38/width_131k/average_l0_11
-        path: layer_38/width_131k/average_l0_11
-        l0: 11
-
-      - id: layer_39/width_131k/average_l0_11
-        path: layer_39/width_131k/average_l0_11
-        l0: 11
-
-      - id: layer_40/width_131k/average_l0_11
-        path: layer_40/width_131k/average_l0_11
-        l0: 11
-
-      - id: layer_41/width_131k/average_l0_14
-        path: layer_41/width_131k/average_l0_14
-        l0: 14
-
-      - id: layer_3/width_16k/average_l0_126
-        path: layer_3/width_16k/average_l0_126
-        l0: 126
-
-      - id: layer_10/width_16k/average_l0_114
-        path: layer_10/width_16k/average_l0_114
-        l0: 114
-
-      - id: layer_20/width_16k/average_l0_146
-        path: layer_20/width_16k/average_l0_146
-        l0: 146
-
-      - id: layer_20/width_16k/average_l0_1522
-        path: layer_20/width_16k/average_l0_1522
-        l0: 1522
-
-      - id: layer_20/width_16k/average_l0_23
-        path: layer_20/width_16k/average_l0_23
-        l0: 23
-
-      - id: layer_20/width_16k/average_l0_384
-        path: layer_20/width_16k/average_l0_384
-        l0: 384
-
-      - id: layer_20/width_16k/average_l0_56
-        path: layer_20/width_16k/average_l0_56
-        l0: 56
-
-      - id: layer_20/width_16k/average_l0_868
-        path: layer_20/width_16k/average_l0_868
-        l0: 868
-
-      - id: layer_26/width_16k/average_l0_14
-        path: layer_26/width_16k/average_l0_14
-        l0: 14
-
-      - id: layer_26/width_16k/average_l0_142
-        path: layer_26/width_16k/average_l0_142
-        l0: 142
-
-      - id: layer_31/width_16k/average_l0_12
-        path: layer_31/width_16k/average_l0_12
-        l0: 12
-  gemma-scope-27b-pt-res:
-    repo_id: google/gemma-scope-27b-pt-res
-    model: gemma-2-2b
-    conversion_func: gemma_2
-    saes:
-      - id: layer_10/width_131k/average_l0_106
-        path: layer_10/width_131k/average_l0_106
-        l0: 106
-
-      - id: layer_10/width_131k/average_l0_15
-        path: layer_10/width_131k/average_l0_15
-        l0: 15
-
-      - id: layer_10/width_131k/average_l0_200
-        path: layer_10/width_131k/average_l0_200
-        l0: 200
-
-      - id: layer_10/width_131k/average_l0_24
-        path: layer_10/width_131k/average_l0_24
-        l0: 24
-
-      - id: layer_10/width_131k/average_l0_37
-        path: layer_10/width_131k/average_l0_37
-        l0: 37
-
-      - id: layer_10/width_131k/average_l0_64
-        path: layer_10/width_131k/average_l0_64
-        l0: 64
-
-      - id: layer_22/width_131k/average_l0_150
-        path: layer_22/width_131k/average_l0_150
-        l0: 150
-
-      - id: layer_22/width_131k/average_l0_20
-        path: layer_22/width_131k/average_l0_20
-        l0: 20
-
-      - id: layer_22/width_131k/average_l0_290
-        path: layer_22/width_131k/average_l0_290
-        l0: 290
-
-      - id: layer_22/width_131k/average_l0_31
-        path: layer_22/width_131k/average_l0_31
-        l0: 31
-
-      - id: layer_22/width_131k/average_l0_48
-        path: layer_22/width_131k/average_l0_48
-        l0: 48
-
-      - id: layer_22/width_131k/average_l0_82
-        path: layer_22/width_131k/average_l0_82
-        l0: 82
-
-      - id: layer_34/width_131k/average_l0_155
-        path: layer_34/width_131k/average_l0_155
-        l0: 155
-
-      - id: layer_34/width_131k/average_l0_21
-        path: layer_34/width_131k/average_l0_21
-        l0: 21
-
-      - id: layer_34/width_131k/average_l0_333
-        path: layer_34/width_131k/average_l0_333
-        l0: 333
-
-      - id: layer_34/width_131k/average_l0_38
-        path: layer_34/width_131k/average_l0_38
-        l0: 38
-
-      - id: layer_34/width_131k/average_l0_72
-        path: layer_34/width_131k/average_l0_72
-        l0: 72
-
-      - id: layer_34/width_131k/average_l0_785
-        path: layer_34/width_131k/average_l0_785
-        l0: 785
-
-  pythia-70m-deduped-res-sm:
-    repo_id: ctigges/pythia-70m-deduped__res-sm_processed
-    model: pythia-70m-deduped
-    conversion_func: null
-    links:
-      model: https://huggingface.co/EleutherAI/pythia-70m-deduped
-      dashboards: https://www.neuronpedia.org/pythia-70m-deduped
-    saes:
-    - id: blocks.0.hook_resid_pre
-      path: e-res-sm
-    - id: blocks.0.hook_resid_post
-      path: 0-res-sm
-    - id: blocks.1.hook_resid_post
-      path: 1-res-sm
-    - id: blocks.2.hook_resid_post
-      path: 2-res-sm
-    - id: blocks.3.hook_resid_post
-      path: 3-res-sm
-    - id: blocks.4.hook_resid_post
-      path: 4-res-sm
-    - id: blocks.5.hook_resid_post
-      path: 5-res-sm
-  pythia-70m-deduped-mlp-sm:
-    repo_id: ctigges/pythia-70m-deduped__mlp-sm_processed
-    model: pythia-70m-deduped
-    conversion_func: null
-    links:
-      model: https://huggingface.co/EleutherAI/pythia-70m-deduped
-      dashboards: https://www.neuronpedia.org/pythia-70m-deduped
-    saes:
-    - id: blocks.0.hook_mlp_out
-      path: 0-mlp-sm
-    - id: blocks.1.hook_mlp_out
-      path: 1-mlp-sm
-    - id: blocks.2.hook_mlp_out
-      path: 2-mlp-sm
-    - id: blocks.3.hook_mlp_out
-      path: 3-mlp-sm
-    - id: blocks.4.hook_mlp_out
-      path: 4-mlp-sm
-    - id: blocks.5.hook_mlp_out
-      path: 5-mlp-sm
-  pythia-70m-deduped-att-sm:
-    repo_id: ctigges/pythia-70m-deduped__att-sm_processed
-    model: pythia-70m-deduped
-    conversion_func: null
-    links:
-      model: https://huggingface.co/EleutherAI/pythia-70m-deduped
-      dashboards: https://www.neuronpedia.org/pythia-70m-deduped
-    saes:
-    - id: blocks.0.hook_attn_out
-      path: 0-att-sm
-    - id: blocks.1.hook_attn_out
-      path: 1-att-sm
-    - id: blocks.2.hook_attn_out
-      path: 2-att-sm
-    - id: blocks.3.hook_attn_out
-      path: 3-att-sm
-    - id: blocks.4.hook_attn_out
-      path: 4-att-sm
-    - id: blocks.5.hook_attn_out
-      path: 5-att-sm
-
-  gpt2-small-res_sll-ajt:
-    repo_id: neuronpedia/gpt2-small__res_sll-ajt
-    model: gpt2-small
-    conversion_func: null
-    links:
-      model: https://huggingface.co/gpt2
-      dashboards: https://www.neuronpedia.org/gpt2-small/res_sll-ajt
-    saes:
-    - id: blocks.2.hook_resid_pre
-      path: 2-res_sll-ajt
-    - id: blocks.6.hook_resid_pre
-      path: 6-res_sll-ajt
-    - id: blocks.10.hook_resid_pre
-      path: 10-res_sll-ajt
-
-  gpt2-small-res_slefr-ajt:
-    repo_id: neuronpedia/gpt2-small__res_slefr-ajt
-    model: gpt2-small
-    conversion_func: null
-    links:
-      model: https://huggingface.co/gpt2
-      dashboards: https://www.neuronpedia.org/gpt2-small/res_slefr-ajt
-    saes:
-    - id: blocks.2.hook_resid_pre
-      path: 2-res_slefr-ajt
-    - id: blocks.6.hook_resid_pre
-      path: 6-res_slefr-ajt
-    - id: blocks.10.hook_resid_pre
-      path: 10-res_slefr-ajt
-
-  gpt2-small-res_scl-ajt:
-    repo_id: neuronpedia/gpt2-small__res_scl-ajt
-    model: gpt2-small
-    conversion_func: null
-    links:
-      model: https://huggingface.co/gpt2
-      dashboards: https://www.neuronpedia.org/gpt2-small/res_scl-ajt
-    saes:
-    - id: blocks.2.hook_resid_pre
-      path: 2-res_scl-ajt
-    - id: blocks.6.hook_resid_pre
-      path: 6-res_scl-ajt
-    - id: blocks.10.hook_resid_pre
-      path: 10-res_scl-ajt
-
-  gpt2-small-res_sle-ajt:
-    repo_id: neuronpedia/gpt2-small__res_sle-ajt
-    model: gpt2-small
-    conversion_func: null
-    links:
-      model: https://huggingface.co/gpt2
-      dashboards: https://www.neuronpedia.org/gpt2-small/res_sle-ajt
-    saes:
-    - id: blocks.2.hook_resid_pre
-      path: 2-res_sle-ajt
-    - id: blocks.6.hook_resid_pre
-      path: 6-res_sle-ajt
-    - id: blocks.10.hook_resid_pre
-      path: 10-res_sle-ajt
-
-  gpt2-small-res_sce-ajt:
-    repo_id: neuronpedia/gpt2-small__res_sce-ajt
-    model: gpt2-small
-    conversion_func: null
-    links:
-      model: https://huggingface.co/gpt2
-      dashboards: https://www.neuronpedia.org/gpt2-small/res_sce-ajt
-    saes:
-    - id: blocks.2.hook_resid_pre
-      path: 2-res_sce-ajt
-    - id: blocks.6.hook_resid_pre
-      path: 6-res_sce-ajt
-    - id: blocks.10.hook_resid_pre
-      path: 10-res_sce-ajt
-
-  gpt2-small-res_scefr-ajt:
     repo_id: neuronpedia/gpt2-small__res_scefr-ajt
     model: gpt2-small
     conversion_func: null
@@ -5164,7 +6583,10 @@ SAE_LOOKUP:
     saes:
     - id: blocks.2.hook_resid_pre
       path: 2-res_scefr-ajt
+      neuronpedia: gpt2-small/2-res_scefr-ajt
     - id: blocks.6.hook_resid_pre
       path: 6-res_scefr-ajt
+      neuronpedia: gpt2-small/6-res_scefr-ajt
     - id: blocks.10.hook_resid_pre
       path: 10-res_scefr-ajt
+      neuronpedia: gpt2-small/10-res_scefr-ajt

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -60,6 +60,7 @@ class SAEConfig:
     device: str
     sae_lens_training_version: Optional[str]
     activation_fn_kwargs: dict[str, Any] = field(default_factory=dict)
+    neuronpedia_id: Optional[str] = None
 
     @classmethod
     def from_dict(cls, config_dict: dict[str, Any]) -> "SAEConfig":
@@ -104,6 +105,7 @@ class SAEConfig:
             "dataset_trust_remote_code": self.dataset_trust_remote_code,
             "context_size": self.context_size,
             "normalize_activations": self.normalize_activations,
+            "neuronpedia_id": self.neuronpedia_id,
         }
 
 
@@ -659,6 +661,9 @@ class SAE(HookedRootModule):
         hf_repo_id = sae_info.repo_id if sae_info is not None else release
         hf_path = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
         config_overrides = sae_info.config_overrides if sae_info is not None else None
+        neuronpedia_id = (
+            sae_info.neuronpedia_id[sae_id] if sae_info is not None else None
+        )
 
         conversion_loader_name = "sae_lens"
         if sae_info is not None and sae_info.conversion_func is not None:
@@ -679,6 +684,7 @@ class SAE(HookedRootModule):
 
         sae = cls(SAEConfig.from_dict(cfg_dict))
         sae.load_state_dict(state_dict)
+        sae.cfg.neuronpedia_id = neuronpedia_id
 
         # Check if normalization is 'expected_average_only_in'
         if cfg_dict.get("normalize_activations") == "expected_average_only_in":

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -112,6 +112,7 @@ def handle_config_defaulting(cfg_dict: dict[str, Any]) -> dict[str, Any]:
     cfg_dict.setdefault("sae_lens_training_version", None)
     cfg_dict.setdefault("activation_fn_str", cfg_dict.get("activation_fn", "relu"))
     cfg_dict.setdefault("architecture", "standard")
+    cfg_dict.setdefault("neuronpedia", None)
 
     if "normalize_activations" in cfg_dict and isinstance(
         cfg_dict["normalize_activations"], bool

--- a/tests/benchmark/test_eval_all_loadable_saes.py
+++ b/tests/benchmark/test_eval_all_loadable_saes.py
@@ -4,6 +4,7 @@
 import pytest
 import torch
 
+from sae_lens.analysis.neuronpedia_integration import open_neuronpedia_feature_dashboard
 from sae_lens.evals import all_loadable_saes
 from sae_lens.sae import SAE
 from sae_lens.toolkit.pretrained_sae_loaders import get_sae_config_from_hf
@@ -50,6 +51,25 @@ def test_loading_pretrained_saes(
 
     sae, _, _ = SAE.from_pretrained(release, sae_name, device=device)
     assert isinstance(sae, SAE)
+
+
+@pytest.mark.parametrize(
+    "release, sae_name, expected_var_explained, expected_l0", all_loadable_saes()
+)
+def test_loading_pretrained_saes_open_neuronpedia(
+    release: str, sae_name: str, expected_var_explained: float, expected_l0: float
+):
+    if torch.cuda.is_available():
+        device = "cuda"
+    elif torch.backends.mps.is_available():
+        device = "mps"
+    else:
+        device = "cpu"
+
+    sae, _, _ = SAE.from_pretrained(release, sae_name, device=device)
+    assert isinstance(sae, SAE)
+
+    open_neuronpedia_feature_dashboard(sae, 0)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/toolkit/test_pretrained_saes_directory.py
+++ b/tests/unit/toolkit/test_pretrained_saes_directory.py
@@ -58,6 +58,21 @@ def test_get_pretrained_saes_directory():
             "blocks.11.hook_resid_post": 70.0,
         },
         config_overrides=None,
+        neuronpedia_id={
+            "blocks.0.hook_resid_pre": "gpt2-small/0-res-jb",
+            "blocks.1.hook_resid_pre": "gpt2-small/1-res-jb",
+            "blocks.2.hook_resid_pre": "gpt2-small/2-res-jb",
+            "blocks.3.hook_resid_pre": "gpt2-small/3-res-jb",
+            "blocks.4.hook_resid_pre": "gpt2-small/4-res-jb",
+            "blocks.5.hook_resid_pre": "gpt2-small/0-res-jb",
+            "blocks.6.hook_resid_pre": "gpt2-small/6-res-jb",
+            "blocks.7.hook_resid_pre": "gpt2-small/7-res-jb",
+            "blocks.8.hook_resid_pre": "gpt2-small/8-res-jb",
+            "blocks.9.hook_resid_pre": "gpt2-small/9-res-jb",
+            "blocks.10.hook_resid_pre": "gpt2-small/10-res-jb",
+            "blocks.11.hook_resid_pre": "gpt2-small/11-res-jb",
+            "blocks.11.hook_resid_post": "gpt2-small/12-res-jb",
+        },
     )
 
     assert sae_directory["gpt2-small-res-jb"] == expected_result

--- a/tests/unit/training/test_sae_from_pretrained.py
+++ b/tests/unit/training/test_sae_from_pretrained.py
@@ -13,6 +13,10 @@ def test_SparseAutoencoder_from_pretrained_loads_from_hugginface_using_shorthand
         device="cpu",
     )
 
+    assert (
+        sae.cfg.neuronpedia_id == "gpt2-small/0-res-jb"
+    )  # what we expect from the yml
+
     # it should match what we get when manually loading from hf
     repo_id = "jbloom/GPT2-Small-SAEs-Reformatted"
     hook_point = "blocks.0.hook_resid_pre"


### PR DESCRIPTION
# Description

This PR solves a few problems so that supporting Gemma Scope on Neuronpedia can be more streamlined. 

Specific changes include:
- Using paths in the pretrained_saes.yml that point to the specific SAE for any hookpoint (out of 5 or so different sparsity levels) which we will support on Neuronepedia. We found a few inconsistencies with the "canonical" folder in huggingface and this will make it simpler. 
- We store the neuronpedia id for an SAE in the pretrained_cfg.yaml so that it's always easy to work out which Neuronpedia SAE matches which SAE in SAE Lens. 
- I added Gemma Scope SAEs that were previously not yet in the yaml.