### PR TITLE
fix: gemma scope saes yml. 16k for Gemma 2 9b was missing entries. 

### DIFF
--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -5378,6 +5378,132 @@ gemma-scope-9b-pt-res-canonical:
   model: gemma-2-9b
   conversion_func: gemma_2
   saes:
+  - id: layer_0/width_16k/canonical
+    path: layer_0/width_16k/average_l0_129
+    neuronpedia: gemma-2-9b/0-gemmascope-res-16k
+  - id: layer_1/width_16k/canonical
+    path: layer_1/width_16k/average_l0_69
+    neuronpedia: gemma-2-9b/1-gemmascope-res-16k
+  - id: layer_2/width_16k/canonical
+    path: layer_2/width_16k/average_l0_67
+    neuronpedia: gemma-2-9b/2-gemmascope-res-16k
+  - id: layer_3/width_16k/canonical
+    path: layer_3/width_16k/average_l0_90
+    neuronpedia: gemma-2-9b/3-gemmascope-res-16k
+  - id: layer_4/width_16k/canonical
+    path: layer_4/width_16k/average_l0_91
+    neuronpedia: gemma-2-9b/4-gemmascope-res-16k
+  - id: layer_5/width_16k/canonical
+    path: layer_5/width_16k/average_l0_77
+    neuronpedia: gemma-2-9b/5-gemmascope-res-16k
+  - id: layer_6/width_16k/canonical
+    path: layer_6/width_16k/average_l0_93
+    neuronpedia: gemma-2-9b/6-gemmascope-res-16k
+  - id: layer_7/width_16k/canonical
+    path: layer_7/width_16k/average_l0_92
+    neuronpedia: gemma-2-9b/7-gemmascope-res-16k
+  - id: layer_8/width_16k/canonical
+    path: layer_8/width_16k/average_l0_99
+    neuronpedia: gemma-2-9b/8-gemmascope-res-16k
+  - id: layer_9/width_16k/canonical
+    path: layer_9/width_16k/average_l0_100
+    neuronpedia: gemma-2-9b/9-gemmascope-res-16k
+  - id: layer_10/width_16k/canonical
+    path: layer_10/width_16k/average_l0_113
+    neuronpedia: gemma-2-9b/10-gemmascope-res-16k
+  - id: layer_11/width_16k/canonical
+    path: layer_11/width_16k/average_l0_118
+    neuronpedia: gemma-2-9b/11-gemmascope-res-16k
+  - id: layer_12/width_16k/canonical
+    path: layer_12/width_16k/average_l0_130
+    neuronpedia: gemma-2-9b/12-gemmascope-res-16k
+  - id: layer_13/width_16k/canonical
+    path: layer_13/width_16k/average_l0_132
+    neuronpedia: gemma-2-9b/13-gemmascope-res-16k
+  - id: layer_14/width_16k/canonical
+    path: layer_14/width_16k/average_l0_67
+    neuronpedia: gemma-2-9b/14-gemmascope-res-16k
+  - id: layer_15/width_16k/canonical
+    path: layer_15/width_16k/average_l0_131
+    neuronpedia: gemma-2-9b/15-gemmascope-res-16k
+  - id: layer_16/width_16k/canonical
+    path: layer_16/width_16k/average_l0_75
+    neuronpedia: gemma-2-9b/16-gemmascope-res-16k
+  - id: layer_17/width_16k/canonical
+    path: layer_17/width_16k/average_l0_73
+    neuronpedia: gemma-2-9b/17-gemmascope-res-16k
+  - id: layer_18/width_16k/canonical
+    path: layer_18/width_16k/average_l0_71
+    neuronpedia: gemma-2-9b/18-gemmascope-res-16k
+  - id: layer_19/width_16k/canonical
+    path: layer_19/width_16k/average_l0_132
+    neuronpedia: gemma-2-9b/19-gemmascope-res-16k
+  - id: layer_20/width_16k/canonical
+    path: layer_20/width_16k/average_l0_68
+    neuronpedia: gemma-2-9b/20-gemmascope-res-16k
+  - id: layer_21/width_16k/canonical
+    path: layer_21/width_16k/average_l0_129
+    neuronpedia: gemma-2-9b/21-gemmascope-res-16k
+  - id: layer_22/width_16k/canonical
+    path: layer_22/width_16k/average_l0_123
+    neuronpedia: gemma-2-9b/22-gemmascope-res-16k
+  - id: layer_23/width_16k/canonical
+    path: layer_23/width_16k/average_l0_120
+    neuronpedia: gemma-2-9b/23-gemmascope-res-16k
+  - id: layer_24/width_16k/canonical
+    path: layer_24/width_16k/average_l0_114
+    neuronpedia: gemma-2-9b/24-gemmascope-res-16k
+  - id: layer_25/width_16k/canonical
+    path: layer_25/width_16k/average_l0_114
+    neuronpedia: gemma-2-9b/25-gemmascope-res-16k
+  - id: layer_26/width_16k/canonical
+    path: layer_26/width_16k/average_l0_116
+    neuronpedia: gemma-2-9b/26-gemmascope-res-16k
+  - id: layer_27/width_16k/canonical
+    path: layer_27/width_16k/average_l0_118
+    neuronpedia: gemma-2-9b/27-gemmascope-res-16k
+  - id: layer_28/width_16k/canonical
+    path: layer_28/width_16k/average_l0_119
+    neuronpedia: gemma-2-9b/28-gemmascope-res-16k
+  - id: layer_29/width_16k/canonical
+    path: layer_29/width_16k/average_l0_119
+    neuronpedia: gemma-2-9b/29-gemmascope-res-16k
+  - id: layer_30/width_16k/canonical
+    path: layer_30/width_16k/average_l0_120
+    neuronpedia: gemma-2-9b/30-gemmascope-res-16k
+  - id: layer_31/width_16k/canonical
+    path: layer_31/width_16k/average_l0_114
+    neuronpedia: gemma-2-9b/31-gemmascope-res-16k
+  - id: layer_32/width_16k/canonical
+    path: layer_32/width_16k/average_l0_111
+    neuronpedia: gemma-2-9b/32-gemmascope-res-16k
+  - id: layer_33/width_16k/canonical
+    path: layer_33/width_16k/average_l0_114
+    neuronpedia: gemma-2-9b/33-gemmascope-res-16k
+  - id: layer_34/width_16k/canonical
+    path: layer_34/width_16k/average_l0_114
+    neuronpedia: gemma-2-9b/34-gemmascope-res-16k
+  - id: layer_35/width_16k/canonical
+    path: layer_35/width_16k/average_l0_120
+    neuronpedia: gemma-2-9b/35-gemmascope-res-16k
+  - id: layer_36/width_16k/canonical
+    path: layer_36/width_16k/average_l0_120
+    neuronpedia: gemma-2-9b/36-gemmascope-res-16k
+  - id: layer_37/width_16k/canonical
+    path: layer_37/width_16k/average_l0_124
+    neuronpedia: gemma-2-9b/37-gemmascope-res-16k
+  - id: layer_38/width_16k/canonical
+    path: layer_38/width_16k/average_l0_128
+    neuronpedia: gemma-2-9b/38-gemmascope-res-16k
+  - id: layer_39/width_16k/canonical
+    path: layer_39/width_16k/average_l0_131
+    neuronpedia: gemma-2-9b/39-gemmascope-res-16k
+  - id: layer_40/width_16k/canonical
+    path: layer_40/width_16k/average_l0_125
+    neuronpedia: gemma-2-9b/40-gemmascope-res-16k
+  - id: layer_41/width_16k/canonical
+    path: layer_41/width_16k/average_l0_113
+    neuronpedia: gemma-2-9b/41-gemmascope-res-16k
   - id: layer_0/width_131k/canonical
     path: layer_0/width_131k/average_l0_41
     neuronpedia: gemma-2-9b/0-gemmascope-res-131k
@@ -5509,272 +5635,1613 @@ gemma-scope-9b-pt-att:
   model: gemma-2-9b
   conversion_func: gemma_2
   saes:
-  - id: layer_0/width_131k/average_l0_55
-    path: layer_0/width_131k/average_l0_55
-    l0: 55
-  - id: layer_1/width_131k/average_l0_116
-    path: layer_1/width_131k/average_l0_116
-    l0: 116
-  - id: layer_2/width_131k/average_l0_11
-    path: layer_2/width_131k/average_l0_11
-    l0: 11
-  - id: layer_3/width_131k/average_l0_10
-    path: layer_3/width_131k/average_l0_10
-    l0: 10
-  - id: layer_4/width_131k/average_l0_12
-    path: layer_4/width_131k/average_l0_12
-    l0: 12
-  - id: layer_5/width_131k/average_l0_12
-    path: layer_5/width_131k/average_l0_12
-    l0: 12
-  - id: layer_6/width_131k/average_l0_14
-    path: layer_6/width_131k/average_l0_14
-    l0: 14
-  - id: layer_6/width_131k/average_l0_148
-    path: layer_6/width_131k/average_l0_148
-    l0: 148
-  - id: layer_7/width_131k/average_l0_106
-    path: layer_7/width_131k/average_l0_106
-    l0: 106
-  - id: layer_8/width_131k/average_l0_16
-    path: layer_8/width_131k/average_l0_16
-    l0: 16
-  - id: layer_9/width_131k/average_l0_111
-    path: layer_9/width_131k/average_l0_111
-    l0: 111
-  - id: layer_10/width_131k/average_l0_16
-    path: layer_10/width_131k/average_l0_16
-    l0: 16
-  - id: layer_11/width_131k/average_l0_104
-    path: layer_11/width_131k/average_l0_104
-    l0: 104
-  - id: layer_12/width_131k/average_l0_110
-    path: layer_12/width_131k/average_l0_110
-    l0: 110
-  - id: layer_13/width_131k/average_l0_126
-    path: layer_13/width_131k/average_l0_126
-    l0: 126
-  - id: layer_14/width_131k/average_l0_131
-    path: layer_14/width_131k/average_l0_131
-    l0: 131
-  - id: layer_15/width_131k/average_l0_130
-    path: layer_15/width_131k/average_l0_130
-    l0: 130
-  - id: layer_16/width_131k/average_l0_140
-    path: layer_16/width_131k/average_l0_140
-    l0: 140
-  - id: layer_17/width_131k/average_l0_191
-    path: layer_17/width_131k/average_l0_191
-    l0: 191
-  - id: layer_18/width_131k/average_l0_133
-    path: layer_18/width_131k/average_l0_133
-    l0: 133
-  - id: layer_19/width_131k/average_l0_152
-    path: layer_19/width_131k/average_l0_152
-    l0: 152
-  - id: layer_20/width_131k/average_l0_125
-    path: layer_20/width_131k/average_l0_125
-    l0: 125
-  - id: layer_21/width_131k/average_l0_150
-    path: layer_21/width_131k/average_l0_150
-    l0: 150
-  - id: layer_22/width_131k/average_l0_115
-    path: layer_22/width_131k/average_l0_115
-    l0: 115
-  - id: layer_23/width_131k/average_l0_134
-    path: layer_23/width_131k/average_l0_134
-    l0: 134
-  - id: layer_24/width_131k/average_l0_130
-    path: layer_24/width_131k/average_l0_130
-    l0: 130
-  - id: layer_25/width_131k/average_l0_115
-    path: layer_25/width_131k/average_l0_115
-    l0: 115
-  - id: layer_26/width_131k/average_l0_120
-    path: layer_26/width_131k/average_l0_120
-    l0: 120
-  - id: layer_27/width_131k/average_l0_102
-    path: layer_27/width_131k/average_l0_102
-    l0: 102
-  - id: layer_28/width_131k/average_l0_115
-    path: layer_28/width_131k/average_l0_115
-    l0: 115
-  - id: layer_29/width_131k/average_l0_128
-    path: layer_29/width_131k/average_l0_128
-    l0: 128
-  - id: layer_30/width_131k/average_l0_109
-    path: layer_30/width_131k/average_l0_109
-    l0: 109
-  - id: layer_31/width_131k/average_l0_117
-    path: layer_31/width_131k/average_l0_117
-    l0: 117
-  - id: layer_32/width_131k/average_l0_117
-    path: layer_32/width_131k/average_l0_117
-    l0: 117
-  - id: layer_33/width_131k/average_l0_128
-    path: layer_33/width_131k/average_l0_128
-    l0: 128
-  - id: layer_34/width_131k/average_l0_15
-    path: layer_34/width_131k/average_l0_15
-    l0: 15
-  - id: layer_35/width_131k/average_l0_124
-    path: layer_35/width_131k/average_l0_124
-    l0: 124
-  - id: layer_36/width_131k/average_l0_105
-    path: layer_36/width_131k/average_l0_105
-    l0: 105
-  - id: layer_37/width_131k/average_l0_124
-    path: layer_37/width_131k/average_l0_124
-    l0: 124
-  - id: layer_38/width_131k/average_l0_135
-    path: layer_38/width_131k/average_l0_135
-    l0: 135
-  - id: layer_39/width_131k/average_l0_120
-    path: layer_39/width_131k/average_l0_120
-    l0: 120
-  - id: layer_40/width_131k/average_l0_144
-    path: layer_40/width_131k/average_l0_144
-    l0: 144
-  - id: layer_41/width_131k/average_l0_13
-    path: layer_41/width_131k/average_l0_13
-    l0: 13
   - id: layer_0/width_16k/average_l0_12
-    path: layer_0/width_16k/average_l0_12
+    path: layer_0/width_16k/average_l0_12/params.npz
     l0: 12
+  - id: layer_0/width_16k/average_l0_16
+    path: layer_0/width_16k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_0/width_16k/average_l0_25
+    path: layer_0/width_16k/average_l0_25/params.npz
+    l0: 25
+  - id: layer_0/width_16k/average_l0_38
+    path: layer_0/width_16k/average_l0_38/params.npz
+    l0: 38
+  - id: layer_0/width_16k/average_l0_61
+    path: layer_0/width_16k/average_l0_61/params.npz
+    l0: 61
+  - id: layer_0/width_131k/average_l0_8
+    path: layer_0/width_131k/average_l0_8/params.npz
+    l0: 8
+  - id: layer_0/width_131k/average_l0_11
+    path: layer_0/width_131k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_0/width_131k/average_l0_15
+    path: layer_0/width_131k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_0/width_131k/average_l0_22
+    path: layer_0/width_131k/average_l0_22/params.npz
+    l0: 22
+  - id: layer_0/width_131k/average_l0_33
+    path: layer_0/width_131k/average_l0_33/params.npz
+    l0: 33
+  - id: layer_0/width_131k/average_l0_55
+    path: layer_0/width_131k/average_l0_55/params.npz
+    l0: 55
+  - id: layer_1/width_16k/average_l0_17
+    path: layer_1/width_16k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_1/width_16k/average_l0_34
+    path: layer_1/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_1/width_16k/average_l0_77
+    path: layer_1/width_16k/average_l0_77/params.npz
+    l0: 77
   - id: layer_1/width_16k/average_l0_147
-    path: layer_1/width_16k/average_l0_147
+    path: layer_1/width_16k/average_l0_147/params.npz
     l0: 147
-  - id: layer_2/width_16k/average_l0_15
-    path: layer_2/width_16k/average_l0_15
-    l0: 15
-  - id: layer_3/width_16k/average_l0_102
-    path: layer_3/width_16k/average_l0_102
-    l0: 102
-  - id: layer_4/width_16k/average_l0_126
-    path: layer_4/width_16k/average_l0_126
-    l0: 126
-  - id: layer_5/width_16k/average_l0_125
-    path: layer_5/width_16k/average_l0_125
-    l0: 125
-  - id: layer_6/width_16k/average_l0_108
-    path: layer_6/width_16k/average_l0_108
-    l0: 108
-  - id: layer_7/width_16k/average_l0_70
-    path: layer_7/width_16k/average_l0_70
-    l0: 70
-  - id: layer_8/width_16k/average_l0_150
-    path: layer_8/width_16k/average_l0_150
-    l0: 150
-  - id: layer_9/width_16k/average_l0_172
-    path: layer_9/width_16k/average_l0_172
-    l0: 172
-  - id: layer_10/width_16k/average_l0_132
-    path: layer_10/width_16k/average_l0_132
-    l0: 132
-  - id: layer_11/width_16k/average_l0_153
-    path: layer_11/width_16k/average_l0_153
-    l0: 153
-  - id: layer_12/width_16k/average_l0_149
-    path: layer_12/width_16k/average_l0_149
-    l0: 149
-  - id: layer_13/width_16k/average_l0_170
-    path: layer_13/width_16k/average_l0_170
-    l0: 170
-  - id: layer_14/width_16k/average_l0_179
-    path: layer_14/width_16k/average_l0_179
-    l0: 179
-  - id: layer_15/width_16k/average_l0_168
-    path: layer_15/width_16k/average_l0_168
-    l0: 168
-  - id: layer_16/width_16k/average_l0_172
-    path: layer_16/width_16k/average_l0_172
-    l0: 172
-  - id: layer_17/width_16k/average_l0_110
-    path: layer_17/width_16k/average_l0_110
-    l0: 110
-  - id: layer_18/width_16k/average_l0_171
-    path: layer_18/width_16k/average_l0_171
-    l0: 171
-  - id: layer_19/width_16k/average_l0_186
-    path: layer_19/width_16k/average_l0_186
-    l0: 186
-  - id: layer_20/width_16k/average_l0_158
-    path: layer_20/width_16k/average_l0_158
-    l0: 158
-  - id: layer_21/width_16k/average_l0_195
-    path: layer_21/width_16k/average_l0_195
-    l0: 195
-  - id: layer_22/width_16k/average_l0_141
-    path: layer_22/width_16k/average_l0_141
-    l0: 141
-  - id: layer_23/width_16k/average_l0_173
-    path: layer_23/width_16k/average_l0_173
-    l0: 173
-  - id: layer_24/width_16k/average_l0_167
-    path: layer_24/width_16k/average_l0_167
-    l0: 167
-  - id: layer_25/width_16k/average_l0_156
-    path: layer_25/width_16k/average_l0_156
-    l0: 156
-  - id: layer_26/width_16k/average_l0_159
-    path: layer_26/width_16k/average_l0_159
-    l0: 159
-  - id: layer_27/width_16k/average_l0_136
-    path: layer_27/width_16k/average_l0_136
-    l0: 136
-  - id: layer_28/width_16k/average_l0_143
-    path: layer_28/width_16k/average_l0_143
-    l0: 143
-  - id: layer_29/width_16k/average_l0_171
-    path: layer_29/width_16k/average_l0_171
-    l0: 171
-  - id: layer_30/width_16k/average_l0_157
-    path: layer_30/width_16k/average_l0_157
-    l0: 157
-  - id: layer_31/width_16k/average_l0_168
-    path: layer_31/width_16k/average_l0_168
-    l0: 168
-  - id: layer_32/width_16k/average_l0_158
-    path: layer_32/width_16k/average_l0_158
-    l0: 158
-  - id: layer_33/width_16k/average_l0_158
-    path: layer_33/width_16k/average_l0_158
-    l0: 158
-  - id: layer_34/width_16k/average_l0_17
-    path: layer_34/width_16k/average_l0_17
-    l0: 17
-  - id: layer_35/width_16k/average_l0_14
-    path: layer_35/width_16k/average_l0_14
-    l0: 14
-  - id: layer_36/width_16k/average_l0_144
-    path: layer_36/width_16k/average_l0_144
-    l0: 144
-  - id: layer_37/width_16k/average_l0_17
-    path: layer_37/width_16k/average_l0_17
-    l0: 17
-  - id: layer_37/width_16k/average_l0_172
-    path: layer_37/width_16k/average_l0_172
-    l0: 172
-  - id: layer_38/width_16k/average_l0_175
-    path: layer_38/width_16k/average_l0_175
-    l0: 175
-  - id: layer_39/width_16k/average_l0_15
-    path: layer_39/width_16k/average_l0_15
-    l0: 15
-  - id: layer_40/width_16k/average_l0_18
-    path: layer_40/width_16k/average_l0_18
+  - id: layer_1/width_16k/average_l0_266
+    path: layer_1/width_16k/average_l0_266/params.npz
+    l0: 266
+  - id: layer_1/width_131k/average_l0_8
+    path: layer_1/width_131k/average_l0_8/params.npz
+    l0: 8
+  - id: layer_1/width_131k/average_l0_12
+    path: layer_1/width_131k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_1/width_131k/average_l0_18
+    path: layer_1/width_131k/average_l0_18/params.npz
     l0: 18
+  - id: layer_1/width_131k/average_l0_29
+    path: layer_1/width_131k/average_l0_29/params.npz
+    l0: 29
+  - id: layer_1/width_131k/average_l0_63
+    path: layer_1/width_131k/average_l0_63/params.npz
+    l0: 63
+  - id: layer_1/width_131k/average_l0_116
+    path: layer_1/width_131k/average_l0_116/params.npz
+    l0: 116
+  - id: layer_10/width_16k/average_l0_18
+    path: layer_10/width_16k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_10/width_16k/average_l0_33
+    path: layer_10/width_16k/average_l0_33/params.npz
+    l0: 33
+  - id: layer_10/width_16k/average_l0_63
+    path: layer_10/width_16k/average_l0_63/params.npz
+    l0: 63
+  - id: layer_10/width_16k/average_l0_132
+    path: layer_10/width_16k/average_l0_132/params.npz
+    l0: 132
+  - id: layer_10/width_16k/average_l0_301
+    path: layer_10/width_16k/average_l0_301/params.npz
+    l0: 301
+  - id: layer_10/width_131k/average_l0_16
+    path: layer_10/width_131k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_10/width_131k/average_l0_28
+    path: layer_10/width_131k/average_l0_28/params.npz
+    l0: 28
+  - id: layer_10/width_131k/average_l0_51
+    path: layer_10/width_131k/average_l0_51/params.npz
+    l0: 51
+  - id: layer_10/width_131k/average_l0_97
+    path: layer_10/width_131k/average_l0_97/params.npz
+    l0: 97
+  - id: layer_10/width_131k/average_l0_199
+    path: layer_10/width_131k/average_l0_199/params.npz
+    l0: 199
+  - id: layer_10/width_131k/average_l0_440
+    path: layer_10/width_131k/average_l0_440/params.npz
+    l0: 440
+  - id: layer_11/width_16k/average_l0_18
+    path: layer_11/width_16k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_11/width_16k/average_l0_34
+    path: layer_11/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_11/width_16k/average_l0_67
+    path: layer_11/width_16k/average_l0_67/params.npz
+    l0: 67
+  - id: layer_11/width_16k/average_l0_153
+    path: layer_11/width_16k/average_l0_153/params.npz
+    l0: 153
+  - id: layer_11/width_16k/average_l0_366
+    path: layer_11/width_16k/average_l0_366/params.npz
+    l0: 366
+  - id: layer_11/width_131k/average_l0_17
+    path: layer_11/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_11/width_131k/average_l0_29
+    path: layer_11/width_131k/average_l0_29/params.npz
+    l0: 29
+  - id: layer_11/width_131k/average_l0_54
+    path: layer_11/width_131k/average_l0_54/params.npz
+    l0: 54
+  - id: layer_11/width_131k/average_l0_104
+    path: layer_11/width_131k/average_l0_104/params.npz
+    l0: 104
+  - id: layer_11/width_131k/average_l0_241
+    path: layer_11/width_131k/average_l0_241/params.npz
+    l0: 241
+  - id: layer_11/width_131k/average_l0_552
+    path: layer_11/width_131k/average_l0_552/params.npz
+    l0: 552
+  - id: layer_12/width_16k/average_l0_19
+    path: layer_12/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_12/width_16k/average_l0_35
+    path: layer_12/width_16k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_12/width_16k/average_l0_68
+    path: layer_12/width_16k/average_l0_68/params.npz
+    l0: 68
+  - id: layer_12/width_16k/average_l0_149
+    path: layer_12/width_16k/average_l0_149/params.npz
+    l0: 149
+  - id: layer_12/width_16k/average_l0_337
+    path: layer_12/width_16k/average_l0_337/params.npz
+    l0: 337
+  - id: layer_12/width_16k/average_l0_654
+    path: layer_12/width_16k/average_l0_654/params.npz
+    l0: 654
+  - id: layer_12/width_131k/average_l0_17
+    path: layer_12/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_12/width_131k/average_l0_29
+    path: layer_12/width_131k/average_l0_29/params.npz
+    l0: 29
+  - id: layer_12/width_131k/average_l0_55
+    path: layer_12/width_131k/average_l0_55/params.npz
+    l0: 55
+  - id: layer_12/width_131k/average_l0_110
+    path: layer_12/width_131k/average_l0_110/params.npz
+    l0: 110
+  - id: layer_12/width_131k/average_l0_237
+    path: layer_12/width_131k/average_l0_237/params.npz
+    l0: 237
+  - id: layer_12/width_131k/average_l0_525
+    path: layer_12/width_131k/average_l0_525/params.npz
+    l0: 525
+  - id: layer_13/width_16k/average_l0_20
+    path: layer_13/width_16k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_13/width_16k/average_l0_38
+    path: layer_13/width_16k/average_l0_38/params.npz
+    l0: 38
+  - id: layer_13/width_16k/average_l0_77
+    path: layer_13/width_16k/average_l0_77/params.npz
+    l0: 77
+  - id: layer_13/width_16k/average_l0_170
+    path: layer_13/width_16k/average_l0_170/params.npz
+    l0: 170
+  - id: layer_13/width_16k/average_l0_380
+    path: layer_13/width_16k/average_l0_380/params.npz
+    l0: 380
+  - id: layer_13/width_16k/average_l0_675
+    path: layer_13/width_16k/average_l0_675/params.npz
+    l0: 675
+  - id: layer_13/width_131k/average_l0_18
+    path: layer_13/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_13/width_131k/average_l0_33
+    path: layer_13/width_131k/average_l0_33/params.npz
+    l0: 33
+  - id: layer_13/width_131k/average_l0_64
+    path: layer_13/width_131k/average_l0_64/params.npz
+    l0: 64
+  - id: layer_13/width_131k/average_l0_126
+    path: layer_13/width_131k/average_l0_126/params.npz
+    l0: 126
+  - id: layer_13/width_131k/average_l0_283
+    path: layer_13/width_131k/average_l0_283/params.npz
+    l0: 283
+  - id: layer_13/width_131k/average_l0_611
+    path: layer_13/width_131k/average_l0_611/params.npz
+    l0: 611
+  - id: layer_14/width_16k/average_l0_21
+    path: layer_14/width_16k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_14/width_16k/average_l0_40
+    path: layer_14/width_16k/average_l0_40/params.npz
+    l0: 40
+  - id: layer_14/width_16k/average_l0_81
+    path: layer_14/width_16k/average_l0_81/params.npz
+    l0: 81
+  - id: layer_14/width_16k/average_l0_179
+    path: layer_14/width_16k/average_l0_179/params.npz
+    l0: 179
+  - id: layer_14/width_16k/average_l0_411
+    path: layer_14/width_16k/average_l0_411/params.npz
+    l0: 411
+  - id: layer_14/width_16k/average_l0_767
+    path: layer_14/width_16k/average_l0_767/params.npz
+    l0: 767
+  - id: layer_14/width_131k/average_l0_18
+    path: layer_14/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_14/width_131k/average_l0_35
+    path: layer_14/width_131k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_14/width_131k/average_l0_67
+    path: layer_14/width_131k/average_l0_67/params.npz
+    l0: 67
+  - id: layer_14/width_131k/average_l0_131
+    path: layer_14/width_131k/average_l0_131/params.npz
+    l0: 131
+  - id: layer_14/width_131k/average_l0_306
+    path: layer_14/width_131k/average_l0_306/params.npz
+    l0: 306
+  - id: layer_14/width_131k/average_l0_650
+    path: layer_14/width_131k/average_l0_650/params.npz
+    l0: 650
+  - id: layer_15/width_16k/average_l0_21
+    path: layer_15/width_16k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_15/width_16k/average_l0_40
+    path: layer_15/width_16k/average_l0_40/params.npz
+    l0: 40
+  - id: layer_15/width_16k/average_l0_79
+    path: layer_15/width_16k/average_l0_79/params.npz
+    l0: 79
+  - id: layer_15/width_16k/average_l0_168
+    path: layer_15/width_16k/average_l0_168/params.npz
+    l0: 168
+  - id: layer_15/width_16k/average_l0_344
+    path: layer_15/width_16k/average_l0_344/params.npz
+    l0: 344
+  - id: layer_15/width_16k/average_l0_638
+    path: layer_15/width_16k/average_l0_638/params.npz
+    l0: 638
+  - id: layer_15/width_131k/average_l0_19
+    path: layer_15/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_15/width_131k/average_l0_35
+    path: layer_15/width_131k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_15/width_131k/average_l0_67
+    path: layer_15/width_131k/average_l0_67/params.npz
+    l0: 67
+  - id: layer_15/width_131k/average_l0_130
+    path: layer_15/width_131k/average_l0_130/params.npz
+    l0: 130
+  - id: layer_15/width_131k/average_l0_283
+    path: layer_15/width_131k/average_l0_283/params.npz
+    l0: 283
+  - id: layer_15/width_131k/average_l0_540
+    path: layer_15/width_131k/average_l0_540/params.npz
+    l0: 540
+  - id: layer_16/width_16k/average_l0_21
+    path: layer_16/width_16k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_16/width_16k/average_l0_40
+    path: layer_16/width_16k/average_l0_40/params.npz
+    l0: 40
+  - id: layer_16/width_16k/average_l0_81
+    path: layer_16/width_16k/average_l0_81/params.npz
+    l0: 81
+  - id: layer_16/width_16k/average_l0_172
+    path: layer_16/width_16k/average_l0_172/params.npz
+    l0: 172
+  - id: layer_16/width_16k/average_l0_376
+    path: layer_16/width_16k/average_l0_376/params.npz
+    l0: 376
+  - id: layer_16/width_16k/average_l0_705
+    path: layer_16/width_16k/average_l0_705/params.npz
+    l0: 705
+  - id: layer_16/width_131k/average_l0_19
+    path: layer_16/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_16/width_131k/average_l0_36
+    path: layer_16/width_131k/average_l0_36/params.npz
+    l0: 36
+  - id: layer_16/width_131k/average_l0_71
+    path: layer_16/width_131k/average_l0_71/params.npz
+    l0: 71
+  - id: layer_16/width_131k/average_l0_140
+    path: layer_16/width_131k/average_l0_140/params.npz
+    l0: 140
+  - id: layer_16/width_131k/average_l0_298
+    path: layer_16/width_131k/average_l0_298/params.npz
+    l0: 298
+  - id: layer_16/width_131k/average_l0_621
+    path: layer_16/width_131k/average_l0_621/params.npz
+    l0: 621
+  - id: layer_17/width_16k/average_l0_24
+    path: layer_17/width_16k/average_l0_24/params.npz
+    l0: 24
+  - id: layer_17/width_16k/average_l0_50
+    path: layer_17/width_16k/average_l0_50/params.npz
+    l0: 50
+  - id: layer_17/width_16k/average_l0_110
+    path: layer_17/width_16k/average_l0_110/params.npz
+    l0: 110
+  - id: layer_17/width_16k/average_l0_227
+    path: layer_17/width_16k/average_l0_227/params.npz
+    l0: 227
+  - id: layer_17/width_16k/average_l0_435
+    path: layer_17/width_16k/average_l0_435/params.npz
+    l0: 435
+  - id: layer_17/width_16k/average_l0_719
+    path: layer_17/width_16k/average_l0_719/params.npz
+    l0: 719
+  - id: layer_17/width_131k/average_l0_22
+    path: layer_17/width_131k/average_l0_22/params.npz
+    l0: 22
+  - id: layer_17/width_131k/average_l0_44
+    path: layer_17/width_131k/average_l0_44/params.npz
+    l0: 44
+  - id: layer_17/width_131k/average_l0_90
+    path: layer_17/width_131k/average_l0_90/params.npz
+    l0: 90
+  - id: layer_17/width_131k/average_l0_191
+    path: layer_17/width_131k/average_l0_191/params.npz
+    l0: 191
+  - id: layer_17/width_131k/average_l0_380
+    path: layer_17/width_131k/average_l0_380/params.npz
+    l0: 380
+  - id: layer_17/width_131k/average_l0_672
+    path: layer_17/width_131k/average_l0_672/params.npz
+    l0: 672
+  - id: layer_18/width_16k/average_l0_21
+    path: layer_18/width_16k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_18/width_16k/average_l0_40
+    path: layer_18/width_16k/average_l0_40/params.npz
+    l0: 40
+  - id: layer_18/width_16k/average_l0_80
+    path: layer_18/width_16k/average_l0_80/params.npz
+    l0: 80
+  - id: layer_18/width_16k/average_l0_171
+    path: layer_18/width_16k/average_l0_171/params.npz
+    l0: 171
+  - id: layer_18/width_16k/average_l0_352
+    path: layer_18/width_16k/average_l0_352/params.npz
+    l0: 352
+  - id: layer_18/width_16k/average_l0_646
+    path: layer_18/width_16k/average_l0_646/params.npz
+    l0: 646
+  - id: layer_18/width_131k/average_l0_19
+    path: layer_18/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_18/width_131k/average_l0_35
+    path: layer_18/width_131k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_18/width_131k/average_l0_69
+    path: layer_18/width_131k/average_l0_69/params.npz
+    l0: 69
+  - id: layer_18/width_131k/average_l0_133
+    path: layer_18/width_131k/average_l0_133/params.npz
+    l0: 133
+  - id: layer_18/width_131k/average_l0_294
+    path: layer_18/width_131k/average_l0_294/params.npz
+    l0: 294
+  - id: layer_18/width_131k/average_l0_557
+    path: layer_18/width_131k/average_l0_557/params.npz
+    l0: 557
+  - id: layer_19/width_16k/average_l0_21
+    path: layer_19/width_16k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_19/width_16k/average_l0_41
+    path: layer_19/width_16k/average_l0_41/params.npz
+    l0: 41
+  - id: layer_19/width_16k/average_l0_86
+    path: layer_19/width_16k/average_l0_86/params.npz
+    l0: 86
+  - id: layer_19/width_16k/average_l0_186
+    path: layer_19/width_16k/average_l0_186/params.npz
+    l0: 186
+  - id: layer_19/width_16k/average_l0_360
+    path: layer_19/width_16k/average_l0_360/params.npz
+    l0: 360
+  - id: layer_19/width_16k/average_l0_661
+    path: layer_19/width_16k/average_l0_661/params.npz
+    l0: 661
+  - id: layer_19/width_131k/average_l0_19
+    path: layer_19/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_19/width_131k/average_l0_38
+    path: layer_19/width_131k/average_l0_38/params.npz
+    l0: 38
+  - id: layer_19/width_131k/average_l0_71
+    path: layer_19/width_131k/average_l0_71/params.npz
+    l0: 71
+  - id: layer_19/width_131k/average_l0_152
+    path: layer_19/width_131k/average_l0_152/params.npz
+    l0: 152
+  - id: layer_19/width_131k/average_l0_307
+    path: layer_19/width_131k/average_l0_307/params.npz
+    l0: 307
+  - id: layer_19/width_131k/average_l0_571
+    path: layer_19/width_131k/average_l0_571/params.npz
+    l0: 571
+  - id: layer_2/width_16k/average_l0_15
+    path: layer_2/width_16k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_2/width_16k/average_l0_30
+    path: layer_2/width_16k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_2/width_16k/average_l0_69
+    path: layer_2/width_16k/average_l0_69/params.npz
+    l0: 69
+  - id: layer_2/width_16k/average_l0_180
+    path: layer_2/width_16k/average_l0_180/params.npz
+    l0: 180
+  - id: layer_2/width_16k/average_l0_384
+    path: layer_2/width_16k/average_l0_384/params.npz
+    l0: 384
+  - id: layer_2/width_131k/average_l0_7
+    path: layer_2/width_131k/average_l0_7/params.npz
+    l0: 7
+  - id: layer_2/width_131k/average_l0_11
+    path: layer_2/width_131k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_2/width_131k/average_l0_18
+    path: layer_2/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_2/width_131k/average_l0_32
+    path: layer_2/width_131k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_2/width_131k/average_l0_62
+    path: layer_2/width_131k/average_l0_62/params.npz
+    l0: 62
+  - id: layer_2/width_131k/average_l0_135
+    path: layer_2/width_131k/average_l0_135/params.npz
+    l0: 135
+  - id: layer_20/width_16k/average_l0_20
+    path: layer_20/width_16k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_20/width_16k/average_l0_39
+    path: layer_20/width_16k/average_l0_39/params.npz
+    l0: 39
+  - id: layer_20/width_16k/average_l0_76
+    path: layer_20/width_16k/average_l0_76/params.npz
+    l0: 76
+  - id: layer_20/width_16k/average_l0_158
+    path: layer_20/width_16k/average_l0_158/params.npz
+    l0: 158
+  - id: layer_20/width_16k/average_l0_342
+    path: layer_20/width_16k/average_l0_342/params.npz
+    l0: 342
+  - id: layer_20/width_16k/average_l0_674
+    path: layer_20/width_16k/average_l0_674/params.npz
+    l0: 674
+  - id: layer_20/width_131k/average_l0_18
+    path: layer_20/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_20/width_131k/average_l0_34
+    path: layer_20/width_131k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_20/width_131k/average_l0_65
+    path: layer_20/width_131k/average_l0_65/params.npz
+    l0: 65
+  - id: layer_20/width_131k/average_l0_125
+    path: layer_20/width_131k/average_l0_125/params.npz
+    l0: 125
+  - id: layer_20/width_131k/average_l0_270
+    path: layer_20/width_131k/average_l0_270/params.npz
+    l0: 270
+  - id: layer_20/width_131k/average_l0_558
+    path: layer_20/width_131k/average_l0_558/params.npz
+    l0: 558
+  - id: layer_21/width_16k/average_l0_21
+    path: layer_21/width_16k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_21/width_16k/average_l0_41
+    path: layer_21/width_16k/average_l0_41/params.npz
+    l0: 41
+  - id: layer_21/width_16k/average_l0_86
+    path: layer_21/width_16k/average_l0_86/params.npz
+    l0: 86
+  - id: layer_21/width_16k/average_l0_195
+    path: layer_21/width_16k/average_l0_195/params.npz
+    l0: 195
+  - id: layer_21/width_16k/average_l0_420
+    path: layer_21/width_16k/average_l0_420/params.npz
+    l0: 420
+  - id: layer_21/width_16k/average_l0_792
+    path: layer_21/width_16k/average_l0_792/params.npz
+    l0: 792
+  - id: layer_21/width_131k/average_l0_18
+    path: layer_21/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_21/width_131k/average_l0_35
+    path: layer_21/width_131k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_21/width_131k/average_l0_71
+    path: layer_21/width_131k/average_l0_71/params.npz
+    l0: 71
+  - id: layer_21/width_131k/average_l0_150
+    path: layer_21/width_131k/average_l0_150/params.npz
+    l0: 150
+  - id: layer_21/width_131k/average_l0_333
+    path: layer_21/width_131k/average_l0_333/params.npz
+    l0: 333
+  - id: layer_21/width_131k/average_l0_665
+    path: layer_21/width_131k/average_l0_665/params.npz
+    l0: 665
+  - id: layer_22/width_16k/average_l0_20
+    path: layer_22/width_16k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_22/width_16k/average_l0_36
+    path: layer_22/width_16k/average_l0_36/params.npz
+    l0: 36
+  - id: layer_22/width_16k/average_l0_70
+    path: layer_22/width_16k/average_l0_70/params.npz
+    l0: 70
+  - id: layer_22/width_16k/average_l0_141
+    path: layer_22/width_16k/average_l0_141/params.npz
+    l0: 141
+  - id: layer_22/width_16k/average_l0_289
+    path: layer_22/width_16k/average_l0_289/params.npz
+    l0: 289
+  - id: layer_22/width_16k/average_l0_569
+    path: layer_22/width_16k/average_l0_569/params.npz
+    l0: 569
+  - id: layer_22/width_131k/average_l0_17
+    path: layer_22/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_22/width_131k/average_l0_32
+    path: layer_22/width_131k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_22/width_131k/average_l0_59
+    path: layer_22/width_131k/average_l0_59/params.npz
+    l0: 59
+  - id: layer_22/width_131k/average_l0_115
+    path: layer_22/width_131k/average_l0_115/params.npz
+    l0: 115
+  - id: layer_22/width_131k/average_l0_231
+    path: layer_22/width_131k/average_l0_231/params.npz
+    l0: 231
+  - id: layer_22/width_131k/average_l0_446
+    path: layer_22/width_131k/average_l0_446/params.npz
+    l0: 446
+  - id: layer_23/width_16k/average_l0_21
+    path: layer_23/width_16k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_23/width_16k/average_l0_41
+    path: layer_23/width_16k/average_l0_41/params.npz
+    l0: 41
+  - id: layer_23/width_16k/average_l0_80
+    path: layer_23/width_16k/average_l0_80/params.npz
+    l0: 80
+  - id: layer_23/width_16k/average_l0_173
+    path: layer_23/width_16k/average_l0_173/params.npz
+    l0: 173
+  - id: layer_23/width_16k/average_l0_356
+    path: layer_23/width_16k/average_l0_356/params.npz
+    l0: 356
+  - id: layer_23/width_16k/average_l0_649
+    path: layer_23/width_16k/average_l0_649/params.npz
+    l0: 649
+  - id: layer_23/width_131k/average_l0_19
+    path: layer_23/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_23/width_131k/average_l0_36
+    path: layer_23/width_131k/average_l0_36/params.npz
+    l0: 36
+  - id: layer_23/width_131k/average_l0_66
+    path: layer_23/width_131k/average_l0_66/params.npz
+    l0: 66
+  - id: layer_23/width_131k/average_l0_134
+    path: layer_23/width_131k/average_l0_134/params.npz
+    l0: 134
+  - id: layer_23/width_131k/average_l0_288
+    path: layer_23/width_131k/average_l0_288/params.npz
+    l0: 288
+  - id: layer_23/width_131k/average_l0_568
+    path: layer_23/width_131k/average_l0_568/params.npz
+    l0: 568
+  - id: layer_24/width_16k/average_l0_21
+    path: layer_24/width_16k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_24/width_16k/average_l0_40
+    path: layer_24/width_16k/average_l0_40/params.npz
+    l0: 40
+  - id: layer_24/width_16k/average_l0_79
+    path: layer_24/width_16k/average_l0_79/params.npz
+    l0: 79
+  - id: layer_24/width_16k/average_l0_167
+    path: layer_24/width_16k/average_l0_167/params.npz
+    l0: 167
+  - id: layer_24/width_16k/average_l0_348
+    path: layer_24/width_16k/average_l0_348/params.npz
+    l0: 348
+  - id: layer_24/width_16k/average_l0_615
+    path: layer_24/width_16k/average_l0_615/params.npz
+    l0: 615
+  - id: layer_24/width_131k/average_l0_19
+    path: layer_24/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_24/width_131k/average_l0_35
+    path: layer_24/width_131k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_24/width_131k/average_l0_66
+    path: layer_24/width_131k/average_l0_66/params.npz
+    l0: 66
+  - id: layer_24/width_131k/average_l0_130
+    path: layer_24/width_131k/average_l0_130/params.npz
+    l0: 130
+  - id: layer_24/width_131k/average_l0_273
+    path: layer_24/width_131k/average_l0_273/params.npz
+    l0: 273
+  - id: layer_24/width_131k/average_l0_542
+    path: layer_24/width_131k/average_l0_542/params.npz
+    l0: 542
+  - id: layer_25/width_16k/average_l0_19
+    path: layer_25/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_25/width_16k/average_l0_36
+    path: layer_25/width_16k/average_l0_36/params.npz
+    l0: 36
+  - id: layer_25/width_16k/average_l0_73
+    path: layer_25/width_16k/average_l0_73/params.npz
+    l0: 73
+  - id: layer_25/width_16k/average_l0_156
+    path: layer_25/width_16k/average_l0_156/params.npz
+    l0: 156
+  - id: layer_25/width_16k/average_l0_371
+    path: layer_25/width_16k/average_l0_371/params.npz
+    l0: 371
+  - id: layer_25/width_16k/average_l0_686
+    path: layer_25/width_16k/average_l0_686/params.npz
+    l0: 686
+  - id: layer_25/width_131k/average_l0_17
+    path: layer_25/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_25/width_131k/average_l0_31
+    path: layer_25/width_131k/average_l0_31/params.npz
+    l0: 31
+  - id: layer_25/width_131k/average_l0_59
+    path: layer_25/width_131k/average_l0_59/params.npz
+    l0: 59
+  - id: layer_25/width_131k/average_l0_115
+    path: layer_25/width_131k/average_l0_115/params.npz
+    l0: 115
+  - id: layer_25/width_131k/average_l0_261
+    path: layer_25/width_131k/average_l0_261/params.npz
+    l0: 261
+  - id: layer_25/width_131k/average_l0_605
+    path: layer_25/width_131k/average_l0_605/params.npz
+    l0: 605
+  - id: layer_26/width_16k/average_l0_20
+    path: layer_26/width_16k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_26/width_16k/average_l0_38
+    path: layer_26/width_16k/average_l0_38/params.npz
+    l0: 38
+  - id: layer_26/width_16k/average_l0_75
+    path: layer_26/width_16k/average_l0_75/params.npz
+    l0: 75
+  - id: layer_26/width_16k/average_l0_159
+    path: layer_26/width_16k/average_l0_159/params.npz
+    l0: 159
+  - id: layer_26/width_16k/average_l0_336
+    path: layer_26/width_16k/average_l0_336/params.npz
+    l0: 336
+  - id: layer_26/width_16k/average_l0_634
+    path: layer_26/width_16k/average_l0_634/params.npz
+    l0: 634
+  - id: layer_26/width_131k/average_l0_18
+    path: layer_26/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_26/width_131k/average_l0_32
+    path: layer_26/width_131k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_26/width_131k/average_l0_62
+    path: layer_26/width_131k/average_l0_62/params.npz
+    l0: 62
+  - id: layer_26/width_131k/average_l0_120
+    path: layer_26/width_131k/average_l0_120/params.npz
+    l0: 120
+  - id: layer_26/width_131k/average_l0_267
+    path: layer_26/width_131k/average_l0_267/params.npz
+    l0: 267
+  - id: layer_26/width_131k/average_l0_525
+    path: layer_26/width_131k/average_l0_525/params.npz
+    l0: 525
+  - id: layer_27/width_16k/average_l0_18
+    path: layer_27/width_16k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_27/width_16k/average_l0_33
+    path: layer_27/width_16k/average_l0_33/params.npz
+    l0: 33
+  - id: layer_27/width_16k/average_l0_64
+    path: layer_27/width_16k/average_l0_64/params.npz
+    l0: 64
+  - id: layer_27/width_16k/average_l0_136
+    path: layer_27/width_16k/average_l0_136/params.npz
+    l0: 136
+  - id: layer_27/width_16k/average_l0_306
+    path: layer_27/width_16k/average_l0_306/params.npz
+    l0: 306
+  - id: layer_27/width_16k/average_l0_613
+    path: layer_27/width_16k/average_l0_613/params.npz
+    l0: 613
+  - id: layer_27/width_131k/average_l0_16
+    path: layer_27/width_131k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_27/width_131k/average_l0_28
+    path: layer_27/width_131k/average_l0_28/params.npz
+    l0: 28
+  - id: layer_27/width_131k/average_l0_53
+    path: layer_27/width_131k/average_l0_53/params.npz
+    l0: 53
+  - id: layer_27/width_131k/average_l0_102
+    path: layer_27/width_131k/average_l0_102/params.npz
+    l0: 102
+  - id: layer_27/width_131k/average_l0_211
+    path: layer_27/width_131k/average_l0_211/params.npz
+    l0: 211
+  - id: layer_27/width_131k/average_l0_458
+    path: layer_27/width_131k/average_l0_458/params.npz
+    l0: 458
+  - id: layer_28/width_16k/average_l0_20
+    path: layer_28/width_16k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_28/width_16k/average_l0_37
+    path: layer_28/width_16k/average_l0_37/params.npz
+    l0: 37
+  - id: layer_28/width_16k/average_l0_71
+    path: layer_28/width_16k/average_l0_71/params.npz
+    l0: 71
+  - id: layer_28/width_16k/average_l0_143
+    path: layer_28/width_16k/average_l0_143/params.npz
+    l0: 143
+  - id: layer_28/width_16k/average_l0_279
+    path: layer_28/width_16k/average_l0_279/params.npz
+    l0: 279
+  - id: layer_28/width_16k/average_l0_498
+    path: layer_28/width_16k/average_l0_498/params.npz
+    l0: 498
+  - id: layer_28/width_131k/average_l0_19
+    path: layer_28/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_28/width_131k/average_l0_32
+    path: layer_28/width_131k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_28/width_131k/average_l0_59
+    path: layer_28/width_131k/average_l0_59/params.npz
+    l0: 59
+  - id: layer_28/width_131k/average_l0_115
+    path: layer_28/width_131k/average_l0_115/params.npz
+    l0: 115
+  - id: layer_28/width_131k/average_l0_230
+    path: layer_28/width_131k/average_l0_230/params.npz
+    l0: 230
+  - id: layer_28/width_131k/average_l0_452
+    path: layer_28/width_131k/average_l0_452/params.npz
+    l0: 452
+  - id: layer_29/width_16k/average_l0_18
+    path: layer_29/width_16k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_29/width_16k/average_l0_35
+    path: layer_29/width_16k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_29/width_16k/average_l0_76
+    path: layer_29/width_16k/average_l0_76/params.npz
+    l0: 76
+  - id: layer_29/width_16k/average_l0_171
+    path: layer_29/width_16k/average_l0_171/params.npz
+    l0: 171
+  - id: layer_29/width_16k/average_l0_308
+    path: layer_29/width_16k/average_l0_308/params.npz
+    l0: 308
+  - id: layer_29/width_16k/average_l0_559
+    path: layer_29/width_16k/average_l0_559/params.npz
+    l0: 559
+  - id: layer_29/width_131k/average_l0_17
+    path: layer_29/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_29/width_131k/average_l0_30
+    path: layer_29/width_131k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_29/width_131k/average_l0_57
+    path: layer_29/width_131k/average_l0_57/params.npz
+    l0: 57
+  - id: layer_29/width_131k/average_l0_128
+    path: layer_29/width_131k/average_l0_128/params.npz
+    l0: 128
+  - id: layer_29/width_131k/average_l0_265
+    path: layer_29/width_131k/average_l0_265/params.npz
+    l0: 265
+  - id: layer_29/width_131k/average_l0_446
+    path: layer_29/width_131k/average_l0_446/params.npz
+    l0: 446
+  - id: layer_3/width_16k/average_l0_23
+    path: layer_3/width_16k/average_l0_23/params.npz
+    l0: 23
+  - id: layer_3/width_16k/average_l0_44
+    path: layer_3/width_16k/average_l0_44/params.npz
+    l0: 44
+  - id: layer_3/width_16k/average_l0_102
+    path: layer_3/width_16k/average_l0_102/params.npz
+    l0: 102
+  - id: layer_3/width_16k/average_l0_221
+    path: layer_3/width_16k/average_l0_221/params.npz
+    l0: 221
+  - id: layer_3/width_16k/average_l0_435
+    path: layer_3/width_16k/average_l0_435/params.npz
+    l0: 435
+  - id: layer_3/width_131k/average_l0_10
+    path: layer_3/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_3/width_131k/average_l0_17
+    path: layer_3/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_3/width_131k/average_l0_31
+    path: layer_3/width_131k/average_l0_31/params.npz
+    l0: 31
+  - id: layer_3/width_131k/average_l0_58
+    path: layer_3/width_131k/average_l0_58/params.npz
+    l0: 58
+  - id: layer_3/width_131k/average_l0_119
+    path: layer_3/width_131k/average_l0_119/params.npz
+    l0: 119
+  - id: layer_3/width_131k/average_l0_252
+    path: layer_3/width_131k/average_l0_252/params.npz
+    l0: 252
+  - id: layer_30/width_16k/average_l0_19
+    path: layer_30/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_30/width_16k/average_l0_36
+    path: layer_30/width_16k/average_l0_36/params.npz
+    l0: 36
+  - id: layer_30/width_16k/average_l0_73
+    path: layer_30/width_16k/average_l0_73/params.npz
+    l0: 73
+  - id: layer_30/width_16k/average_l0_157
+    path: layer_30/width_16k/average_l0_157/params.npz
+    l0: 157
+  - id: layer_30/width_16k/average_l0_313
+    path: layer_30/width_16k/average_l0_313/params.npz
+    l0: 313
+  - id: layer_30/width_16k/average_l0_558
+    path: layer_30/width_16k/average_l0_558/params.npz
+    l0: 558
+  - id: layer_30/width_131k/average_l0_17
+    path: layer_30/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_30/width_131k/average_l0_29
+    path: layer_30/width_131k/average_l0_29/params.npz
+    l0: 29
+  - id: layer_30/width_131k/average_l0_55
+    path: layer_30/width_131k/average_l0_55/params.npz
+    l0: 55
+  - id: layer_30/width_131k/average_l0_109
+    path: layer_30/width_131k/average_l0_109/params.npz
+    l0: 109
+  - id: layer_30/width_131k/average_l0_236
+    path: layer_30/width_131k/average_l0_236/params.npz
+    l0: 236
+  - id: layer_30/width_131k/average_l0_491
+    path: layer_30/width_131k/average_l0_491/params.npz
+    l0: 491
+  - id: layer_31/width_16k/average_l0_18
+    path: layer_31/width_16k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_31/width_16k/average_l0_36
+    path: layer_31/width_16k/average_l0_36/params.npz
+    l0: 36
+  - id: layer_31/width_16k/average_l0_73
+    path: layer_31/width_16k/average_l0_73/params.npz
+    l0: 73
+  - id: layer_31/width_16k/average_l0_168
+    path: layer_31/width_16k/average_l0_168/params.npz
+    l0: 168
+  - id: layer_31/width_16k/average_l0_356
+    path: layer_31/width_16k/average_l0_356/params.npz
+    l0: 356
+  - id: layer_31/width_16k/average_l0_630
+    path: layer_31/width_16k/average_l0_630/params.npz
+    l0: 630
+  - id: layer_31/width_131k/average_l0_16
+    path: layer_31/width_131k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_31/width_131k/average_l0_29
+    path: layer_31/width_131k/average_l0_29/params.npz
+    l0: 29
+  - id: layer_31/width_131k/average_l0_56
+    path: layer_31/width_131k/average_l0_56/params.npz
+    l0: 56
+  - id: layer_31/width_131k/average_l0_117
+    path: layer_31/width_131k/average_l0_117/params.npz
+    l0: 117
+  - id: layer_31/width_131k/average_l0_265
+    path: layer_31/width_131k/average_l0_265/params.npz
+    l0: 265
+  - id: layer_31/width_131k/average_l0_543
+    path: layer_31/width_131k/average_l0_543/params.npz
+    l0: 543
+  - id: layer_32/width_16k/average_l0_18
+    path: layer_32/width_16k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_32/width_16k/average_l0_35
+    path: layer_32/width_16k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_32/width_16k/average_l0_74
+    path: layer_32/width_16k/average_l0_74/params.npz
+    l0: 74
+  - id: layer_32/width_16k/average_l0_158
+    path: layer_32/width_16k/average_l0_158/params.npz
+    l0: 158
+  - id: layer_32/width_16k/average_l0_306
+    path: layer_32/width_16k/average_l0_306/params.npz
+    l0: 306
+  - id: layer_32/width_16k/average_l0_534
+    path: layer_32/width_16k/average_l0_534/params.npz
+    l0: 534
+  - id: layer_32/width_131k/average_l0_16
+    path: layer_32/width_131k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_32/width_131k/average_l0_31
+    path: layer_32/width_131k/average_l0_31/params.npz
+    l0: 31
+  - id: layer_32/width_131k/average_l0_56
+    path: layer_32/width_131k/average_l0_56/params.npz
+    l0: 56
+  - id: layer_32/width_131k/average_l0_117
+    path: layer_32/width_131k/average_l0_117/params.npz
+    l0: 117
+  - id: layer_32/width_131k/average_l0_248
+    path: layer_32/width_131k/average_l0_248/params.npz
+    l0: 248
+  - id: layer_32/width_131k/average_l0_464
+    path: layer_32/width_131k/average_l0_464/params.npz
+    l0: 464
+  - id: layer_33/width_16k/average_l0_17
+    path: layer_33/width_16k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_33/width_16k/average_l0_37
+    path: layer_33/width_16k/average_l0_37/params.npz
+    l0: 37
+  - id: layer_33/width_16k/average_l0_78
+    path: layer_33/width_16k/average_l0_78/params.npz
+    l0: 78
+  - id: layer_33/width_16k/average_l0_158
+    path: layer_33/width_16k/average_l0_158/params.npz
+    l0: 158
+  - id: layer_33/width_16k/average_l0_318
+    path: layer_33/width_16k/average_l0_318/params.npz
+    l0: 318
+  - id: layer_33/width_16k/average_l0_531
+    path: layer_33/width_16k/average_l0_531/params.npz
+    l0: 531
+  - id: layer_33/width_131k/average_l0_16
+    path: layer_33/width_131k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_33/width_131k/average_l0_28
+    path: layer_33/width_131k/average_l0_28/params.npz
+    l0: 28
+  - id: layer_33/width_131k/average_l0_58
+    path: layer_33/width_131k/average_l0_58/params.npz
+    l0: 58
+  - id: layer_33/width_131k/average_l0_128
+    path: layer_33/width_131k/average_l0_128/params.npz
+    l0: 128
+  - id: layer_33/width_131k/average_l0_248
+    path: layer_33/width_131k/average_l0_248/params.npz
+    l0: 248
+  - id: layer_33/width_131k/average_l0_471
+    path: layer_33/width_131k/average_l0_471/params.npz
+    l0: 471
+  - id: layer_34/width_16k/average_l0_17
+    path: layer_34/width_16k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_34/width_16k/average_l0_38
+    path: layer_34/width_16k/average_l0_38/params.npz
+    l0: 38
+  - id: layer_34/width_16k/average_l0_91
+    path: layer_34/width_16k/average_l0_91/params.npz
+    l0: 91
+  - id: layer_34/width_16k/average_l0_192
+    path: layer_34/width_16k/average_l0_192/params.npz
+    l0: 192
+  - id: layer_34/width_16k/average_l0_339
+    path: layer_34/width_16k/average_l0_339/params.npz
+    l0: 339
+  - id: layer_34/width_16k/average_l0_527
+    path: layer_34/width_16k/average_l0_527/params.npz
+    l0: 527
+  - id: layer_34/width_131k/average_l0_15
+    path: layer_34/width_131k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_34/width_131k/average_l0_29
+    path: layer_34/width_131k/average_l0_29/params.npz
+    l0: 29
+  - id: layer_34/width_131k/average_l0_63
+    path: layer_34/width_131k/average_l0_63/params.npz
+    l0: 63
+  - id: layer_34/width_131k/average_l0_199
+    path: layer_34/width_131k/average_l0_199/params.npz
+    l0: 199
+  - id: layer_34/width_131k/average_l0_291
+    path: layer_34/width_131k/average_l0_291/params.npz
+    l0: 291
+  - id: layer_34/width_131k/average_l0_483
+    path: layer_34/width_131k/average_l0_483/params.npz
+    l0: 483
+  - id: layer_35/width_16k/average_l0_14
+    path: layer_35/width_16k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_35/width_16k/average_l0_33
+    path: layer_35/width_16k/average_l0_33/params.npz
+    l0: 33
+  - id: layer_35/width_16k/average_l0_77
+    path: layer_35/width_16k/average_l0_77/params.npz
+    l0: 77
+  - id: layer_35/width_16k/average_l0_168
+    path: layer_35/width_16k/average_l0_168/params.npz
+    l0: 168
+  - id: layer_35/width_16k/average_l0_303
+    path: layer_35/width_16k/average_l0_303/params.npz
+    l0: 303
+  - id: layer_35/width_16k/average_l0_488
+    path: layer_35/width_16k/average_l0_488/params.npz
+    l0: 488
+  - id: layer_35/width_131k/average_l0_13
+    path: layer_35/width_131k/average_l0_13/params.npz
+    l0: 13
+  - id: layer_35/width_131k/average_l0_26
+    path: layer_35/width_131k/average_l0_26/params.npz
+    l0: 26
+  - id: layer_35/width_131k/average_l0_54
+    path: layer_35/width_131k/average_l0_54/params.npz
+    l0: 54
+  - id: layer_35/width_131k/average_l0_124
+    path: layer_35/width_131k/average_l0_124/params.npz
+    l0: 124
+  - id: layer_35/width_131k/average_l0_258
+    path: layer_35/width_131k/average_l0_258/params.npz
+    l0: 258
+  - id: layer_35/width_131k/average_l0_427
+    path: layer_35/width_131k/average_l0_427/params.npz
+    l0: 427
+  - id: layer_36/width_16k/average_l0_15
+    path: layer_36/width_16k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_36/width_16k/average_l0_32
+    path: layer_36/width_16k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_36/width_16k/average_l0_69
+    path: layer_36/width_16k/average_l0_69/params.npz
+    l0: 69
+  - id: layer_36/width_16k/average_l0_144
+    path: layer_36/width_16k/average_l0_144/params.npz
+    l0: 144
+  - id: layer_36/width_16k/average_l0_293
+    path: layer_36/width_16k/average_l0_293/params.npz
+    l0: 293
+  - id: layer_36/width_16k/average_l0_544
+    path: layer_36/width_16k/average_l0_544/params.npz
+    l0: 544
+  - id: layer_36/width_131k/average_l0_16
+    path: layer_36/width_131k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_36/width_131k/average_l0_26
+    path: layer_36/width_131k/average_l0_26/params.npz
+    l0: 26
+  - id: layer_36/width_131k/average_l0_51
+    path: layer_36/width_131k/average_l0_51/params.npz
+    l0: 51
+  - id: layer_36/width_131k/average_l0_105
+    path: layer_36/width_131k/average_l0_105/params.npz
+    l0: 105
+  - id: layer_36/width_131k/average_l0_229
+    path: layer_36/width_131k/average_l0_229/params.npz
+    l0: 229
+  - id: layer_36/width_131k/average_l0_455
+    path: layer_36/width_131k/average_l0_455/params.npz
+    l0: 455
+  - id: layer_37/width_16k/average_l0_17
+    path: layer_37/width_16k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_37/width_16k/average_l0_34
+    path: layer_37/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_37/width_16k/average_l0_82
+    path: layer_37/width_16k/average_l0_82/params.npz
+    l0: 82
+  - id: layer_37/width_16k/average_l0_172
+    path: layer_37/width_16k/average_l0_172/params.npz
+    l0: 172
+  - id: layer_37/width_16k/average_l0_309
+    path: layer_37/width_16k/average_l0_309/params.npz
+    l0: 309
+  - id: layer_37/width_16k/average_l0_519
+    path: layer_37/width_16k/average_l0_519/params.npz
+    l0: 519
+  - id: layer_37/width_131k/average_l0_15
+    path: layer_37/width_131k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_37/width_131k/average_l0_28
+    path: layer_37/width_131k/average_l0_28/params.npz
+    l0: 28
+  - id: layer_37/width_131k/average_l0_55
+    path: layer_37/width_131k/average_l0_55/params.npz
+    l0: 55
+  - id: layer_37/width_131k/average_l0_124
+    path: layer_37/width_131k/average_l0_124/params.npz
+    l0: 124
+  - id: layer_37/width_131k/average_l0_248
+    path: layer_37/width_131k/average_l0_248/params.npz
+    l0: 248
+  - id: layer_37/width_131k/average_l0_450
+    path: layer_37/width_131k/average_l0_450/params.npz
+    l0: 450
+  - id: layer_38/width_16k/average_l0_18
+    path: layer_38/width_16k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_38/width_16k/average_l0_36
+    path: layer_38/width_16k/average_l0_36/params.npz
+    l0: 36
+  - id: layer_38/width_16k/average_l0_81
+    path: layer_38/width_16k/average_l0_81/params.npz
+    l0: 81
+  - id: layer_38/width_16k/average_l0_175
+    path: layer_38/width_16k/average_l0_175/params.npz
+    l0: 175
+  - id: layer_38/width_16k/average_l0_334
+    path: layer_38/width_16k/average_l0_334/params.npz
+    l0: 334
+  - id: layer_38/width_16k/average_l0_547
+    path: layer_38/width_16k/average_l0_547/params.npz
+    l0: 547
+  - id: layer_38/width_131k/average_l0_17
+    path: layer_38/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_38/width_131k/average_l0_30
+    path: layer_38/width_131k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_38/width_131k/average_l0_60
+    path: layer_38/width_131k/average_l0_60/params.npz
+    l0: 60
+  - id: layer_38/width_131k/average_l0_135
+    path: layer_38/width_131k/average_l0_135/params.npz
+    l0: 135
+  - id: layer_38/width_131k/average_l0_284
+    path: layer_38/width_131k/average_l0_284/params.npz
+    l0: 284
+  - id: layer_38/width_131k/average_l0_489
+    path: layer_38/width_131k/average_l0_489/params.npz
+    l0: 489
+  - id: layer_39/width_16k/average_l0_15
+    path: layer_39/width_16k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_39/width_16k/average_l0_33
+    path: layer_39/width_16k/average_l0_33/params.npz
+    l0: 33
+  - id: layer_39/width_16k/average_l0_77
+    path: layer_39/width_16k/average_l0_77/params.npz
+    l0: 77
+  - id: layer_39/width_16k/average_l0_176
+    path: layer_39/width_16k/average_l0_176/params.npz
+    l0: 176
+  - id: layer_39/width_16k/average_l0_391
+    path: layer_39/width_16k/average_l0_391/params.npz
+    l0: 391
+  - id: layer_39/width_16k/average_l0_694
+    path: layer_39/width_16k/average_l0_694/params.npz
+    l0: 694
+  - id: layer_39/width_131k/average_l0_17
+    path: layer_39/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_39/width_131k/average_l0_27
+    path: layer_39/width_131k/average_l0_27/params.npz
+    l0: 27
+  - id: layer_39/width_131k/average_l0_54
+    path: layer_39/width_131k/average_l0_54/params.npz
+    l0: 54
+  - id: layer_39/width_131k/average_l0_120
+    path: layer_39/width_131k/average_l0_120/params.npz
+    l0: 120
+  - id: layer_39/width_131k/average_l0_273
+    path: layer_39/width_131k/average_l0_273/params.npz
+    l0: 273
+  - id: layer_39/width_131k/average_l0_604
+    path: layer_39/width_131k/average_l0_604/params.npz
+    l0: 604
+  - id: layer_4/width_16k/average_l0_26
+    path: layer_4/width_16k/average_l0_26/params.npz
+    l0: 26
+  - id: layer_4/width_16k/average_l0_54
+    path: layer_4/width_16k/average_l0_54/params.npz
+    l0: 54
+  - id: layer_4/width_16k/average_l0_126
+    path: layer_4/width_16k/average_l0_126/params.npz
+    l0: 126
+  - id: layer_4/width_16k/average_l0_274
+    path: layer_4/width_16k/average_l0_274/params.npz
+    l0: 274
+  - id: layer_4/width_16k/average_l0_524
+    path: layer_4/width_16k/average_l0_524/params.npz
+    l0: 524
+  - id: layer_4/width_131k/average_l0_12
+    path: layer_4/width_131k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_4/width_131k/average_l0_21
+    path: layer_4/width_131k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_4/width_131k/average_l0_38
+    path: layer_4/width_131k/average_l0_38/params.npz
+    l0: 38
+  - id: layer_4/width_131k/average_l0_75
+    path: layer_4/width_131k/average_l0_75/params.npz
+    l0: 75
+  - id: layer_4/width_131k/average_l0_163
+    path: layer_4/width_131k/average_l0_163/params.npz
+    l0: 163
+  - id: layer_4/width_131k/average_l0_330
+    path: layer_4/width_131k/average_l0_330/params.npz
+    l0: 330
+  - id: layer_40/width_16k/average_l0_18
+    path: layer_40/width_16k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_40/width_16k/average_l0_38
+    path: layer_40/width_16k/average_l0_38/params.npz
+    l0: 38
+  - id: layer_40/width_16k/average_l0_91
+    path: layer_40/width_16k/average_l0_91/params.npz
+    l0: 91
   - id: layer_40/width_16k/average_l0_189
-    path: layer_40/width_16k/average_l0_189
+    path: layer_40/width_16k/average_l0_189/params.npz
     l0: 189
+  - id: layer_40/width_16k/average_l0_341
+    path: layer_40/width_16k/average_l0_341/params.npz
+    l0: 341
+  - id: layer_40/width_16k/average_l0_603
+    path: layer_40/width_16k/average_l0_603/params.npz
+    l0: 603
+  - id: layer_40/width_131k/average_l0_16
+    path: layer_40/width_131k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_40/width_131k/average_l0_30
+    path: layer_40/width_131k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_40/width_131k/average_l0_64
+    path: layer_40/width_131k/average_l0_64/params.npz
+    l0: 64
+  - id: layer_40/width_131k/average_l0_144
+    path: layer_40/width_131k/average_l0_144/params.npz
+    l0: 144
+  - id: layer_40/width_131k/average_l0_269
+    path: layer_40/width_131k/average_l0_269/params.npz
+    l0: 269
+  - id: layer_40/width_131k/average_l0_493
+    path: layer_40/width_131k/average_l0_493/params.npz
+    l0: 493
+  - id: layer_41/width_16k/average_l0_13
+    path: layer_41/width_16k/average_l0_13/params.npz
+    l0: 13
+  - id: layer_41/width_16k/average_l0_25
+    path: layer_41/width_16k/average_l0_25/params.npz
+    l0: 25
+  - id: layer_41/width_16k/average_l0_56
+    path: layer_41/width_16k/average_l0_56/params.npz
+    l0: 56
   - id: layer_41/width_16k/average_l0_129
-    path: layer_41/width_16k/average_l0_129
+    path: layer_41/width_16k/average_l0_129/params.npz
     l0: 129
+  - id: layer_41/width_16k/average_l0_254
+    path: layer_41/width_16k/average_l0_254/params.npz
+    l0: 254
+  - id: layer_41/width_16k/average_l0_450
+    path: layer_41/width_16k/average_l0_450/params.npz
+    l0: 450
+  - id: layer_41/width_131k/average_l0_13
+    path: layer_41/width_131k/average_l0_13/params.npz
+    l0: 13
+  - id: layer_41/width_131k/average_l0_22
+    path: layer_41/width_131k/average_l0_22/params.npz
+    l0: 22
+  - id: layer_41/width_131k/average_l0_43
+    path: layer_41/width_131k/average_l0_43/params.npz
+    l0: 43
+  - id: layer_41/width_131k/average_l0_92
+    path: layer_41/width_131k/average_l0_92/params.npz
+    l0: 92
+  - id: layer_41/width_131k/average_l0_202
+    path: layer_41/width_131k/average_l0_202/params.npz
+    l0: 202
+  - id: layer_41/width_131k/average_l0_370
+    path: layer_41/width_131k/average_l0_370/params.npz
+    l0: 370
+  - id: layer_5/width_16k/average_l0_25
+    path: layer_5/width_16k/average_l0_25/params.npz
+    l0: 25
+  - id: layer_5/width_16k/average_l0_53
+    path: layer_5/width_16k/average_l0_53/params.npz
+    l0: 53
+  - id: layer_5/width_16k/average_l0_125
+    path: layer_5/width_16k/average_l0_125/params.npz
+    l0: 125
+  - id: layer_5/width_16k/average_l0_270
+    path: layer_5/width_16k/average_l0_270/params.npz
+    l0: 270
+  - id: layer_5/width_16k/average_l0_529
+    path: layer_5/width_16k/average_l0_529/params.npz
+    l0: 529
+  - id: layer_5/width_131k/average_l0_12
+    path: layer_5/width_131k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_5/width_131k/average_l0_21
+    path: layer_5/width_131k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_5/width_131k/average_l0_39
+    path: layer_5/width_131k/average_l0_39/params.npz
+    l0: 39
+  - id: layer_5/width_131k/average_l0_78
+    path: layer_5/width_131k/average_l0_78/params.npz
+    l0: 78
+  - id: layer_5/width_131k/average_l0_160
+    path: layer_5/width_131k/average_l0_160/params.npz
+    l0: 160
+  - id: layer_5/width_131k/average_l0_351
+    path: layer_5/width_131k/average_l0_351/params.npz
+    l0: 351
+  - id: layer_6/width_16k/average_l0_16
+    path: layer_6/width_16k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_6/width_16k/average_l0_28
+    path: layer_6/width_16k/average_l0_28/params.npz
+    l0: 28
+  - id: layer_6/width_16k/average_l0_51
+    path: layer_6/width_16k/average_l0_51/params.npz
+    l0: 51
+  - id: layer_6/width_16k/average_l0_108
+    path: layer_6/width_16k/average_l0_108/params.npz
+    l0: 108
+  - id: layer_6/width_16k/average_l0_258
+    path: layer_6/width_16k/average_l0_258/params.npz
+    l0: 258
+  - id: layer_6/width_131k/average_l0_14
+    path: layer_6/width_131k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_6/width_131k/average_l0_24
+    path: layer_6/width_131k/average_l0_24/params.npz
+    l0: 24
+  - id: layer_6/width_131k/average_l0_41
+    path: layer_6/width_131k/average_l0_41/params.npz
+    l0: 41
+  - id: layer_6/width_131k/average_l0_73
+    path: layer_6/width_131k/average_l0_73/params.npz
+    l0: 73
+  - id: layer_6/width_131k/average_l0_148
+    path: layer_6/width_131k/average_l0_148/params.npz
+    l0: 148
+  - id: layer_6/width_131k/average_l0_353
+    path: layer_6/width_131k/average_l0_353/params.npz
+    l0: 353
+  - id: layer_7/width_16k/average_l0_18
+    path: layer_7/width_16k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_7/width_16k/average_l0_33
+    path: layer_7/width_16k/average_l0_33/params.npz
+    l0: 33
+  - id: layer_7/width_16k/average_l0_70
+    path: layer_7/width_16k/average_l0_70/params.npz
+    l0: 70
+  - id: layer_7/width_16k/average_l0_160
+    path: layer_7/width_16k/average_l0_160/params.npz
+    l0: 160
+  - id: layer_7/width_16k/average_l0_335
+    path: layer_7/width_16k/average_l0_335/params.npz
+    l0: 335
+  - id: layer_7/width_131k/average_l0_16
+    path: layer_7/width_131k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_7/width_131k/average_l0_28
+    path: layer_7/width_131k/average_l0_28/params.npz
+    l0: 28
+  - id: layer_7/width_131k/average_l0_52
+    path: layer_7/width_131k/average_l0_52/params.npz
+    l0: 52
+  - id: layer_7/width_131k/average_l0_106
+    path: layer_7/width_131k/average_l0_106/params.npz
+    l0: 106
+  - id: layer_7/width_131k/average_l0_229
+    path: layer_7/width_131k/average_l0_229/params.npz
+    l0: 229
+  - id: layer_7/width_131k/average_l0_473
+    path: layer_7/width_131k/average_l0_473/params.npz
+    l0: 473
+  - id: layer_8/width_16k/average_l0_17
+    path: layer_8/width_16k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_8/width_16k/average_l0_32
+    path: layer_8/width_16k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_8/width_16k/average_l0_65
+    path: layer_8/width_16k/average_l0_65/params.npz
+    l0: 65
+  - id: layer_8/width_16k/average_l0_150
+    path: layer_8/width_16k/average_l0_150/params.npz
+    l0: 150
+  - id: layer_8/width_16k/average_l0_362
+    path: layer_8/width_16k/average_l0_362/params.npz
+    l0: 362
+  - id: layer_8/width_131k/average_l0_16
+    path: layer_8/width_131k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_8/width_131k/average_l0_27
+    path: layer_8/width_131k/average_l0_27/params.npz
+    l0: 27
+  - id: layer_8/width_131k/average_l0_51
+    path: layer_8/width_131k/average_l0_51/params.npz
+    l0: 51
+  - id: layer_8/width_131k/average_l0_98
+    path: layer_8/width_131k/average_l0_98/params.npz
+    l0: 98
+  - id: layer_8/width_131k/average_l0_222
+    path: layer_8/width_131k/average_l0_222/params.npz
+    l0: 222
+  - id: layer_8/width_131k/average_l0_531
+    path: layer_8/width_131k/average_l0_531/params.npz
+    l0: 531
+  - id: layer_9/width_16k/average_l0_18
+    path: layer_9/width_16k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_9/width_16k/average_l0_34
+    path: layer_9/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_9/width_16k/average_l0_71
+    path: layer_9/width_16k/average_l0_71/params.npz
+    l0: 71
+  - id: layer_9/width_16k/average_l0_172
+    path: layer_9/width_16k/average_l0_172/params.npz
+    l0: 172
+  - id: layer_9/width_16k/average_l0_349
+    path: layer_9/width_16k/average_l0_349/params.npz
+    l0: 349
+  - id: layer_9/width_131k/average_l0_16
+    path: layer_9/width_131k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_9/width_131k/average_l0_30
+    path: layer_9/width_131k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_9/width_131k/average_l0_54
+    path: layer_9/width_131k/average_l0_54/params.npz
+    l0: 54
+  - id: layer_9/width_131k/average_l0_111
+    path: layer_9/width_131k/average_l0_111/params.npz
+    l0: 111
+  - id: layer_9/width_131k/average_l0_263
+    path: layer_9/width_131k/average_l0_263/params.npz
+    l0: 263
+  - id: layer_9/width_131k/average_l0_511
+    path: layer_9/width_131k/average_l0_511/params.npz
+    l0: 511
 gemma-scope-9b-pt-att-canonical:
   repo_id: google/gemma-scope-9b-pt-att
   model: gemma-2-9b
   conversion_func: gemma_2
   saes:
+  - id: layer_0/width_16k/canonical
+    path: layer_0/width_16k/average_l0_61
+    neuronpedia: gemma-2-9b/0-gemmascope-att-16k
+  - id: layer_1/width_16k/canonical
+    path: layer_1/width_16k/average_l0_77
+    neuronpedia: gemma-2-9b/1-gemmascope-att-16k
+  - id: layer_2/width_16k/canonical
+    path: layer_2/width_16k/average_l0_69
+    neuronpedia: gemma-2-9b/2-gemmascope-att-16k
+  - id: layer_3/width_16k/canonical
+    path: layer_3/width_16k/average_l0_102
+    neuronpedia: gemma-2-9b/3-gemmascope-att-16k
+  - id: layer_4/width_16k/canonical
+    path: layer_4/width_16k/average_l0_126
+    neuronpedia: gemma-2-9b/4-gemmascope-att-16k
+  - id: layer_5/width_16k/canonical
+    path: layer_5/width_16k/average_l0_125
+    neuronpedia: gemma-2-9b/5-gemmascope-att-16k
+  - id: layer_6/width_16k/canonical
+    path: layer_6/width_16k/average_l0_108
+    neuronpedia: gemma-2-9b/6-gemmascope-att-16k
+  - id: layer_7/width_16k/canonical
+    path: layer_7/width_16k/average_l0_70
+    neuronpedia: gemma-2-9b/7-gemmascope-att-16k
+  - id: layer_8/width_16k/canonical
+    path: layer_8/width_16k/average_l0_65
+    neuronpedia: gemma-2-9b/8-gemmascope-att-16k
+  - id: layer_9/width_16k/canonical
+    path: layer_9/width_16k/average_l0_71
+    neuronpedia: gemma-2-9b/9-gemmascope-att-16k
+  - id: layer_10/width_16k/canonical
+    path: layer_10/width_16k/average_l0_132
+    neuronpedia: gemma-2-9b/10-gemmascope-att-16k
+  - id: layer_11/width_16k/canonical
+    path: layer_11/width_16k/average_l0_67
+    neuronpedia: gemma-2-9b/11-gemmascope-att-16k
+  - id: layer_12/width_16k/canonical
+    path: layer_12/width_16k/average_l0_68
+    neuronpedia: gemma-2-9b/12-gemmascope-att-16k
+  - id: layer_13/width_16k/canonical
+    path: layer_13/width_16k/average_l0_77
+    neuronpedia: gemma-2-9b/13-gemmascope-att-16k
+  - id: layer_14/width_16k/canonical
+    path: layer_14/width_16k/average_l0_81
+    neuronpedia: gemma-2-9b/14-gemmascope-att-16k
+  - id: layer_15/width_16k/canonical
+    path: layer_15/width_16k/average_l0_79
+    neuronpedia: gemma-2-9b/15-gemmascope-att-16k
+  - id: layer_16/width_16k/canonical
+    path: layer_16/width_16k/average_l0_81
+    neuronpedia: gemma-2-9b/16-gemmascope-att-16k
+  - id: layer_17/width_16k/canonical
+    path: layer_17/width_16k/average_l0_110
+    neuronpedia: gemma-2-9b/17-gemmascope-att-16k
+  - id: layer_18/width_16k/canonical
+    path: layer_18/width_16k/average_l0_80
+    neuronpedia: gemma-2-9b/18-gemmascope-att-16k
+  - id: layer_19/width_16k/canonical
+    path: layer_19/width_16k/average_l0_86
+    neuronpedia: gemma-2-9b/19-gemmascope-att-16k
+  - id: layer_20/width_16k/canonical
+    path: layer_20/width_16k/average_l0_76
+    neuronpedia: gemma-2-9b/20-gemmascope-att-16k
+  - id: layer_21/width_16k/canonical
+    path: layer_21/width_16k/average_l0_86
+    neuronpedia: gemma-2-9b/21-gemmascope-att-16k
+  - id: layer_22/width_16k/canonical
+    path: layer_22/width_16k/average_l0_70
+    neuronpedia: gemma-2-9b/22-gemmascope-att-16k
+  - id: layer_23/width_16k/canonical
+    path: layer_23/width_16k/average_l0_80
+    neuronpedia: gemma-2-9b/23-gemmascope-att-16k
+  - id: layer_24/width_16k/canonical
+    path: layer_24/width_16k/average_l0_79
+    neuronpedia: gemma-2-9b/24-gemmascope-att-16k
+  - id: layer_25/width_16k/canonical
+    path: layer_25/width_16k/average_l0_73
+    neuronpedia: gemma-2-9b/25-gemmascope-att-16k
+  - id: layer_26/width_16k/canonical
+    path: layer_26/width_16k/average_l0_75
+    neuronpedia: gemma-2-9b/26-gemmascope-att-16k
+  - id: layer_27/width_16k/canonical
+    path: layer_27/width_16k/average_l0_136
+    neuronpedia: gemma-2-9b/27-gemmascope-att-16k
+  - id: layer_28/width_16k/canonical
+    path: layer_28/width_16k/average_l0_71
+    neuronpedia: gemma-2-9b/28-gemmascope-att-16k
+  - id: layer_29/width_16k/canonical
+    path: layer_29/width_16k/average_l0_76
+    neuronpedia: gemma-2-9b/29-gemmascope-att-16k
+  - id: layer_30/width_16k/canonical
+    path: layer_30/width_16k/average_l0_73
+    neuronpedia: gemma-2-9b/30-gemmascope-att-16k
+  - id: layer_31/width_16k/canonical
+    path: layer_31/width_16k/average_l0_73
+    neuronpedia: gemma-2-9b/31-gemmascope-att-16k
+  - id: layer_32/width_16k/canonical
+    path: layer_32/width_16k/average_l0_74
+    neuronpedia: gemma-2-9b/32-gemmascope-att-16k
+  - id: layer_33/width_16k/canonical
+    path: layer_33/width_16k/average_l0_78
+    neuronpedia: gemma-2-9b/33-gemmascope-att-16k
+  - id: layer_34/width_16k/canonical
+    path: layer_34/width_16k/average_l0_91
+    neuronpedia: gemma-2-9b/34-gemmascope-att-16k
+  - id: layer_35/width_16k/canonical
+    path: layer_35/width_16k/average_l0_77
+    neuronpedia: gemma-2-9b/35-gemmascope-att-16k
+  - id: layer_36/width_16k/canonical
+    path: layer_36/width_16k/average_l0_69
+    neuronpedia: gemma-2-9b/36-gemmascope-att-16k
+  - id: layer_37/width_16k/canonical
+    path: layer_37/width_16k/average_l0_82
+    neuronpedia: gemma-2-9b/37-gemmascope-att-16k
+  - id: layer_38/width_16k/canonical
+    path: layer_38/width_16k/average_l0_81
+    neuronpedia: gemma-2-9b/38-gemmascope-att-16k
+  - id: layer_39/width_16k/canonical
+    path: layer_39/width_16k/average_l0_77
+    neuronpedia: gemma-2-9b/39-gemmascope-att-16k
+  - id: layer_40/width_16k/canonical
+    path: layer_40/width_16k/average_l0_91
+    neuronpedia: gemma-2-9b/40-gemmascope-att-16k
+  - id: layer_41/width_16k/canonical
+    path: layer_41/width_16k/average_l0_129
+    neuronpedia: gemma-2-9b/41-gemmascope-att-16k
   - id: layer_0/width_131k/canonical
     path: layer_0/width_131k/average_l0_55
     neuronpedia: gemma-2-9b/0-gemmascope-att-131k
@@ -5906,182 +7373,1613 @@ gemma-scope-9b-pt-mlp:
   model: gemma-2-9b
   conversion_func: gemma_2
   saes:
-  - id: layer_0/width_131k/average_l0_11
-    path: layer_0/width_131k/average_l0_11
-    l0: 11
-  - id: layer_1/width_131k/average_l0_10
-    path: layer_1/width_131k/average_l0_10
+  - id: layer_0/width_16k/average_l0_6
+    path: layer_0/width_16k/average_l0_6/params.npz
+    l0: 6
+  - id: layer_0/width_16k/average_l0_10
+    path: layer_0/width_16k/average_l0_10/params.npz
     l0: 10
-  - id: layer_1/width_131k/average_l0_106
-    path: layer_1/width_131k/average_l0_106
-    l0: 106
-  - id: layer_2/width_131k/average_l0_12
-    path: layer_2/width_131k/average_l0_12
-    l0: 12
-  - id: layer_3/width_131k/average_l0_109
-    path: layer_3/width_131k/average_l0_109
-    l0: 109
-  - id: layer_4/width_131k/average_l0_14
-    path: layer_4/width_131k/average_l0_14
-    l0: 14
-  - id: layer_5/width_131k/average_l0_12
-    path: layer_5/width_131k/average_l0_12
-    l0: 12
-  - id: layer_6/width_131k/average_l0_12
-    path: layer_6/width_131k/average_l0_12
-    l0: 12
-  - id: layer_7/width_131k/average_l0_13
-    path: layer_7/width_131k/average_l0_13
-    l0: 13
-  - id: layer_8/width_131k/average_l0_15
-    path: layer_8/width_131k/average_l0_15
-    l0: 15
-  - id: layer_9/width_131k/average_l0_12
-    path: layer_9/width_131k/average_l0_12
-    l0: 12
-  - id: layer_9/width_131k/average_l0_129
-    path: layer_9/width_131k/average_l0_129
-    l0: 129
-  - id: layer_10/width_131k/average_l0_12
-    path: layer_10/width_131k/average_l0_12
-    l0: 12
-  - id: layer_11/width_131k/average_l0_120
-    path: layer_11/width_131k/average_l0_120
-    l0: 120
-  - id: layer_12/width_131k/average_l0_159
-    path: layer_12/width_131k/average_l0_159
-    l0: 159
-  - id: layer_13/width_131k/average_l0_160
-    path: layer_13/width_131k/average_l0_160
-    l0: 160
-  - id: layer_14/width_131k/average_l0_174
-    path: layer_14/width_131k/average_l0_174
-    l0: 174
-  - id: layer_15/width_131k/average_l0_194
-    path: layer_15/width_131k/average_l0_194
-    l0: 194
-  - id: layer_16/width_131k/average_l0_17
-    path: layer_16/width_131k/average_l0_17
-    l0: 17
-  - id: layer_16/width_131k/average_l0_175
-    path: layer_16/width_131k/average_l0_175
-    l0: 175
-  - id: layer_17/width_131k/average_l0_207
-    path: layer_17/width_131k/average_l0_207
-    l0: 207
-  - id: layer_18/width_131k/average_l0_174
-    path: layer_18/width_131k/average_l0_174
-    l0: 174
-  - id: layer_19/width_131k/average_l0_189
-    path: layer_19/width_131k/average_l0_189
-    l0: 189
-  - id: layer_20/width_131k/average_l0_20
-    path: layer_20/width_131k/average_l0_20
-    l0: 20
-  - id: layer_21/width_131k/average_l0_16
-    path: layer_21/width_131k/average_l0_16
+  - id: layer_0/width_16k/average_l0_16
+    path: layer_0/width_16k/average_l0_16/params.npz
     l0: 16
-  - id: layer_22/width_131k/average_l0_17
-    path: layer_22/width_131k/average_l0_17
-    l0: 17
-  - id: layer_22/width_131k/average_l0_172
-    path: layer_22/width_131k/average_l0_172
-    l0: 172
-  - id: layer_23/width_131k/average_l0_146
-    path: layer_23/width_131k/average_l0_146
-    l0: 146
-  - id: layer_24/width_131k/average_l0_147
-    path: layer_24/width_131k/average_l0_147
-    l0: 147
-  - id: layer_25/width_131k/average_l0_139
-    path: layer_25/width_131k/average_l0_139
-    l0: 139
-  - id: layer_26/width_131k/average_l0_110
-    path: layer_26/width_131k/average_l0_110
-    l0: 110
-  - id: layer_27/width_131k/average_l0_14
-    path: layer_27/width_131k/average_l0_14
-    l0: 14
-  - id: layer_28/width_131k/average_l0_15
-    path: layer_28/width_131k/average_l0_15
-    l0: 15
-  - id: layer_29/width_131k/average_l0_15
-    path: layer_29/width_131k/average_l0_15
-    l0: 15
-  - id: layer_30/width_131k/average_l0_14
-    path: layer_30/width_131k/average_l0_14
-    l0: 14
-  - id: layer_31/width_131k/average_l0_12
-    path: layer_31/width_131k/average_l0_12
-    l0: 12
-  - id: layer_32/width_131k/average_l0_12
-    path: layer_32/width_131k/average_l0_12
-    l0: 12
-  - id: layer_33/width_131k/average_l0_12
-    path: layer_33/width_131k/average_l0_12
-    l0: 12
-  - id: layer_34/width_131k/average_l0_10
-    path: layer_34/width_131k/average_l0_10
-    l0: 10
-  - id: layer_35/width_131k/average_l0_10
-    path: layer_35/width_131k/average_l0_10
-    l0: 10
-  - id: layer_36/width_131k/average_l0_11
-    path: layer_36/width_131k/average_l0_11
+  - id: layer_0/width_16k/average_l0_28
+    path: layer_0/width_16k/average_l0_28/params.npz
+    l0: 28
+  - id: layer_0/width_16k/average_l0_50
+    path: layer_0/width_16k/average_l0_50/params.npz
+    l0: 50
+  - id: layer_0/width_131k/average_l0_3
+    path: layer_0/width_131k/average_l0_3/params.npz
+    l0: 3
+  - id: layer_0/width_131k/average_l0_5
+    path: layer_0/width_131k/average_l0_5/params.npz
+    l0: 5
+  - id: layer_0/width_131k/average_l0_7
+    path: layer_0/width_131k/average_l0_7/params.npz
+    l0: 7
+  - id: layer_0/width_131k/average_l0_11
+    path: layer_0/width_131k/average_l0_11/params.npz
     l0: 11
-  - id: layer_37/width_131k/average_l0_12
-    path: layer_37/width_131k/average_l0_12
+  - id: layer_0/width_131k/average_l0_18
+    path: layer_0/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_0/width_131k/average_l0_30
+    path: layer_0/width_131k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_1/width_16k/average_l0_12
+    path: layer_1/width_16k/average_l0_12/params.npz
     l0: 12
-  - id: layer_38/width_131k/average_l0_11
-    path: layer_38/width_131k/average_l0_11
-    l0: 11
-  - id: layer_39/width_131k/average_l0_11
-    path: layer_39/width_131k/average_l0_11
-    l0: 11
-  - id: layer_40/width_131k/average_l0_11
-    path: layer_40/width_131k/average_l0_11
-    l0: 11
-  - id: layer_41/width_131k/average_l0_14
-    path: layer_41/width_131k/average_l0_14
-    l0: 14
-  - id: layer_3/width_16k/average_l0_126
-    path: layer_3/width_16k/average_l0_126
-    l0: 126
-  - id: layer_10/width_16k/average_l0_114
-    path: layer_10/width_16k/average_l0_114
-    l0: 114
-  - id: layer_20/width_16k/average_l0_146
-    path: layer_20/width_16k/average_l0_146
-    l0: 146
-  - id: layer_20/width_16k/average_l0_1522
-    path: layer_20/width_16k/average_l0_1522
-    l0: 1522
-  - id: layer_20/width_16k/average_l0_23
-    path: layer_20/width_16k/average_l0_23
-    l0: 23
-  - id: layer_20/width_16k/average_l0_384
-    path: layer_20/width_16k/average_l0_384
-    l0: 384
-  - id: layer_20/width_16k/average_l0_56
-    path: layer_20/width_16k/average_l0_56
+  - id: layer_1/width_16k/average_l0_26
+    path: layer_1/width_16k/average_l0_26/params.npz
+    l0: 26
+  - id: layer_1/width_16k/average_l0_56
+    path: layer_1/width_16k/average_l0_56/params.npz
     l0: 56
-  - id: layer_20/width_16k/average_l0_868
-    path: layer_20/width_16k/average_l0_868
-    l0: 868
-  - id: layer_26/width_16k/average_l0_14
-    path: layer_26/width_16k/average_l0_14
-    l0: 14
-  - id: layer_26/width_16k/average_l0_142
-    path: layer_26/width_16k/average_l0_142
-    l0: 142
-  - id: layer_31/width_16k/average_l0_12
-    path: layer_31/width_16k/average_l0_12
+  - id: layer_1/width_16k/average_l0_128
+    path: layer_1/width_16k/average_l0_128/params.npz
+    l0: 128
+  - id: layer_1/width_16k/average_l0_278
+    path: layer_1/width_16k/average_l0_278/params.npz
+    l0: 278
+  - id: layer_1/width_131k/average_l0_6
+    path: layer_1/width_131k/average_l0_6/params.npz
+    l0: 6
+  - id: layer_1/width_131k/average_l0_10
+    path: layer_1/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_1/width_131k/average_l0_18
+    path: layer_1/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_1/width_131k/average_l0_32
+    path: layer_1/width_131k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_1/width_131k/average_l0_59
+    path: layer_1/width_131k/average_l0_59/params.npz
+    l0: 59
+  - id: layer_1/width_131k/average_l0_106
+    path: layer_1/width_131k/average_l0_106/params.npz
+    l0: 106
+  - id: layer_10/width_16k/average_l0_13
+    path: layer_10/width_16k/average_l0_13/params.npz
+    l0: 13
+  - id: layer_10/width_16k/average_l0_24
+    path: layer_10/width_16k/average_l0_24/params.npz
+    l0: 24
+  - id: layer_10/width_16k/average_l0_49
+    path: layer_10/width_16k/average_l0_49/params.npz
+    l0: 49
+  - id: layer_10/width_16k/average_l0_114
+    path: layer_10/width_16k/average_l0_114/params.npz
+    l0: 114
+  - id: layer_10/width_16k/average_l0_276
+    path: layer_10/width_16k/average_l0_276/params.npz
+    l0: 276
+  - id: layer_10/width_131k/average_l0_12
+    path: layer_10/width_131k/average_l0_12/params.npz
     l0: 12
+  - id: layer_10/width_131k/average_l0_22
+    path: layer_10/width_131k/average_l0_22/params.npz
+    l0: 22
+  - id: layer_10/width_131k/average_l0_42
+    path: layer_10/width_131k/average_l0_42/params.npz
+    l0: 42
+  - id: layer_10/width_131k/average_l0_83
+    path: layer_10/width_131k/average_l0_83/params.npz
+    l0: 83
+  - id: layer_10/width_131k/average_l0_167
+    path: layer_10/width_131k/average_l0_167/params.npz
+    l0: 167
+  - id: layer_10/width_131k/average_l0_362
+    path: layer_10/width_131k/average_l0_362/params.npz
+    l0: 362
+  - id: layer_11/width_16k/average_l0_17
+    path: layer_11/width_16k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_11/width_16k/average_l0_34
+    path: layer_11/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_11/width_16k/average_l0_76
+    path: layer_11/width_16k/average_l0_76/params.npz
+    l0: 76
+  - id: layer_11/width_16k/average_l0_180
+    path: layer_11/width_16k/average_l0_180/params.npz
+    l0: 180
+  - id: layer_11/width_16k/average_l0_421
+    path: layer_11/width_16k/average_l0_421/params.npz
+    l0: 421
+  - id: layer_11/width_131k/average_l0_17
+    path: layer_11/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_11/width_131k/average_l0_31
+    path: layer_11/width_131k/average_l0_31/params.npz
+    l0: 31
+  - id: layer_11/width_131k/average_l0_60
+    path: layer_11/width_131k/average_l0_60/params.npz
+    l0: 60
+  - id: layer_11/width_131k/average_l0_120
+    path: layer_11/width_131k/average_l0_120/params.npz
+    l0: 120
+  - id: layer_11/width_131k/average_l0_259
+    path: layer_11/width_131k/average_l0_259/params.npz
+    l0: 259
+  - id: layer_11/width_131k/average_l0_569
+    path: layer_11/width_131k/average_l0_569/params.npz
+    l0: 569
+  - id: layer_12/width_16k/average_l0_20
+    path: layer_12/width_16k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_12/width_16k/average_l0_42
+    path: layer_12/width_16k/average_l0_42/params.npz
+    l0: 42
+  - id: layer_12/width_16k/average_l0_96
+    path: layer_12/width_16k/average_l0_96/params.npz
+    l0: 96
+  - id: layer_12/width_16k/average_l0_237
+    path: layer_12/width_16k/average_l0_237/params.npz
+    l0: 237
+  - id: layer_12/width_16k/average_l0_543
+    path: layer_12/width_16k/average_l0_543/params.npz
+    l0: 543
+  - id: layer_12/width_16k/average_l0_1033
+    path: layer_12/width_16k/average_l0_1033/params.npz
+    l0: 1033
+  - id: layer_12/width_131k/average_l0_19
+    path: layer_12/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_12/width_131k/average_l0_38
+    path: layer_12/width_131k/average_l0_38/params.npz
+    l0: 38
+  - id: layer_12/width_131k/average_l0_77
+    path: layer_12/width_131k/average_l0_77/params.npz
+    l0: 77
+  - id: layer_12/width_131k/average_l0_159
+    path: layer_12/width_131k/average_l0_159/params.npz
+    l0: 159
+  - id: layer_12/width_131k/average_l0_338
+    path: layer_12/width_131k/average_l0_338/params.npz
+    l0: 338
+  - id: layer_12/width_131k/average_l0_745
+    path: layer_12/width_131k/average_l0_745/params.npz
+    l0: 745
+  - id: layer_13/width_16k/average_l0_19
+    path: layer_13/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_13/width_16k/average_l0_40
+    path: layer_13/width_16k/average_l0_40/params.npz
+    l0: 40
+  - id: layer_13/width_16k/average_l0_94
+    path: layer_13/width_16k/average_l0_94/params.npz
+    l0: 94
+  - id: layer_13/width_16k/average_l0_225
+    path: layer_13/width_16k/average_l0_225/params.npz
+    l0: 225
+  - id: layer_13/width_16k/average_l0_512
+    path: layer_13/width_16k/average_l0_512/params.npz
+    l0: 512
+  - id: layer_13/width_16k/average_l0_992
+    path: layer_13/width_16k/average_l0_992/params.npz
+    l0: 992
+  - id: layer_13/width_131k/average_l0_20
+    path: layer_13/width_131k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_13/width_131k/average_l0_38
+    path: layer_13/width_131k/average_l0_38/params.npz
+    l0: 38
+  - id: layer_13/width_131k/average_l0_75
+    path: layer_13/width_131k/average_l0_75/params.npz
+    l0: 75
+  - id: layer_13/width_131k/average_l0_160
+    path: layer_13/width_131k/average_l0_160/params.npz
+    l0: 160
+  - id: layer_13/width_131k/average_l0_351
+    path: layer_13/width_131k/average_l0_351/params.npz
+    l0: 351
+  - id: layer_13/width_131k/average_l0_703
+    path: layer_13/width_131k/average_l0_703/params.npz
+    l0: 703
+  - id: layer_14/width_16k/average_l0_19
+    path: layer_14/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_14/width_16k/average_l0_41
+    path: layer_14/width_16k/average_l0_41/params.npz
+    l0: 41
+  - id: layer_14/width_16k/average_l0_97
+    path: layer_14/width_16k/average_l0_97/params.npz
+    l0: 97
+  - id: layer_14/width_16k/average_l0_236
+    path: layer_14/width_16k/average_l0_236/params.npz
+    l0: 236
+  - id: layer_14/width_16k/average_l0_538
+    path: layer_14/width_16k/average_l0_538/params.npz
+    l0: 538
+  - id: layer_14/width_16k/average_l0_1023
+    path: layer_14/width_16k/average_l0_1023/params.npz
+    l0: 1023
+  - id: layer_14/width_131k/average_l0_20
+    path: layer_14/width_131k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_14/width_131k/average_l0_40
+    path: layer_14/width_131k/average_l0_40/params.npz
+    l0: 40
+  - id: layer_14/width_131k/average_l0_80
+    path: layer_14/width_131k/average_l0_80/params.npz
+    l0: 80
+  - id: layer_14/width_131k/average_l0_174
+    path: layer_14/width_131k/average_l0_174/params.npz
+    l0: 174
+  - id: layer_14/width_131k/average_l0_374
+    path: layer_14/width_131k/average_l0_374/params.npz
+    l0: 374
+  - id: layer_14/width_131k/average_l0_743
+    path: layer_14/width_131k/average_l0_743/params.npz
+    l0: 743
+  - id: layer_15/width_16k/average_l0_20
+    path: layer_15/width_16k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_15/width_16k/average_l0_45
+    path: layer_15/width_16k/average_l0_45/params.npz
+    l0: 45
+  - id: layer_15/width_16k/average_l0_107
+    path: layer_15/width_16k/average_l0_107/params.npz
+    l0: 107
+  - id: layer_15/width_16k/average_l0_260
+    path: layer_15/width_16k/average_l0_260/params.npz
+    l0: 260
+  - id: layer_15/width_16k/average_l0_572
+    path: layer_15/width_16k/average_l0_572/params.npz
+    l0: 572
+  - id: layer_15/width_16k/average_l0_1053
+    path: layer_15/width_16k/average_l0_1053/params.npz
+    l0: 1053
+  - id: layer_15/width_131k/average_l0_21
+    path: layer_15/width_131k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_15/width_131k/average_l0_43
+    path: layer_15/width_131k/average_l0_43/params.npz
+    l0: 43
+  - id: layer_15/width_131k/average_l0_89
+    path: layer_15/width_131k/average_l0_89/params.npz
+    l0: 89
+  - id: layer_15/width_131k/average_l0_194
+    path: layer_15/width_131k/average_l0_194/params.npz
+    l0: 194
+  - id: layer_15/width_131k/average_l0_421
+    path: layer_15/width_131k/average_l0_421/params.npz
+    l0: 421
+  - id: layer_15/width_131k/average_l0_828
+    path: layer_15/width_131k/average_l0_828/params.npz
+    l0: 828
+  - id: layer_16/width_16k/average_l0_16
+    path: layer_16/width_16k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_16/width_16k/average_l0_37
+    path: layer_16/width_16k/average_l0_37/params.npz
+    l0: 37
+  - id: layer_16/width_16k/average_l0_91
+    path: layer_16/width_16k/average_l0_91/params.npz
+    l0: 91
+  - id: layer_16/width_16k/average_l0_221
+    path: layer_16/width_16k/average_l0_221/params.npz
+    l0: 221
+  - id: layer_16/width_16k/average_l0_489
+    path: layer_16/width_16k/average_l0_489/params.npz
+    l0: 489
+  - id: layer_16/width_16k/average_l0_916
+    path: layer_16/width_16k/average_l0_916/params.npz
+    l0: 916
+  - id: layer_16/width_131k/average_l0_17
+    path: layer_16/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_16/width_131k/average_l0_38
+    path: layer_16/width_131k/average_l0_38/params.npz
+    l0: 38
+  - id: layer_16/width_131k/average_l0_81
+    path: layer_16/width_131k/average_l0_81/params.npz
+    l0: 81
+  - id: layer_16/width_131k/average_l0_175
+    path: layer_16/width_131k/average_l0_175/params.npz
+    l0: 175
+  - id: layer_16/width_131k/average_l0_384
+    path: layer_16/width_131k/average_l0_384/params.npz
+    l0: 384
+  - id: layer_16/width_131k/average_l0_744
+    path: layer_16/width_131k/average_l0_744/params.npz
+    l0: 744
+  - id: layer_17/width_16k/average_l0_18
+    path: layer_17/width_16k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_17/width_16k/average_l0_41
+    path: layer_17/width_16k/average_l0_41/params.npz
+    l0: 41
+  - id: layer_17/width_16k/average_l0_104
+    path: layer_17/width_16k/average_l0_104/params.npz
+    l0: 104
+  - id: layer_17/width_16k/average_l0_274
+    path: layer_17/width_16k/average_l0_274/params.npz
+    l0: 274
+  - id: layer_17/width_16k/average_l0_624
+    path: layer_17/width_16k/average_l0_624/params.npz
+    l0: 624
+  - id: layer_17/width_16k/average_l0_1137
+    path: layer_17/width_16k/average_l0_1137/params.npz
+    l0: 1137
+  - id: layer_17/width_131k/average_l0_22
+    path: layer_17/width_131k/average_l0_22/params.npz
+    l0: 22
+  - id: layer_17/width_131k/average_l0_43
+    path: layer_17/width_131k/average_l0_43/params.npz
+    l0: 43
+  - id: layer_17/width_131k/average_l0_91
+    path: layer_17/width_131k/average_l0_91/params.npz
+    l0: 91
+  - id: layer_17/width_131k/average_l0_207
+    path: layer_17/width_131k/average_l0_207/params.npz
+    l0: 207
+  - id: layer_17/width_131k/average_l0_483
+    path: layer_17/width_131k/average_l0_483/params.npz
+    l0: 483
+  - id: layer_17/width_131k/average_l0_950
+    path: layer_17/width_131k/average_l0_950/params.npz
+    l0: 950
+  - id: layer_18/width_16k/average_l0_16
+    path: layer_18/width_16k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_18/width_16k/average_l0_36
+    path: layer_18/width_16k/average_l0_36/params.npz
+    l0: 36
+  - id: layer_18/width_16k/average_l0_89
+    path: layer_18/width_16k/average_l0_89/params.npz
+    l0: 89
+  - id: layer_18/width_16k/average_l0_235
+    path: layer_18/width_16k/average_l0_235/params.npz
+    l0: 235
+  - id: layer_18/width_16k/average_l0_564
+    path: layer_18/width_16k/average_l0_564/params.npz
+    l0: 564
+  - id: layer_18/width_16k/average_l0_1052
+    path: layer_18/width_16k/average_l0_1052/params.npz
+    l0: 1052
+  - id: layer_18/width_131k/average_l0_19
+    path: layer_18/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_18/width_131k/average_l0_37
+    path: layer_18/width_131k/average_l0_37/params.npz
+    l0: 37
+  - id: layer_18/width_131k/average_l0_82
+    path: layer_18/width_131k/average_l0_82/params.npz
+    l0: 82
+  - id: layer_18/width_131k/average_l0_174
+    path: layer_18/width_131k/average_l0_174/params.npz
+    l0: 174
+  - id: layer_18/width_131k/average_l0_420
+    path: layer_18/width_131k/average_l0_420/params.npz
+    l0: 420
+  - id: layer_18/width_131k/average_l0_865
+    path: layer_18/width_131k/average_l0_865/params.npz
+    l0: 865
+  - id: layer_19/width_16k/average_l0_16
+    path: layer_19/width_16k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_19/width_16k/average_l0_38
+    path: layer_19/width_16k/average_l0_38/params.npz
+    l0: 38
+  - id: layer_19/width_16k/average_l0_98
+    path: layer_19/width_16k/average_l0_98/params.npz
+    l0: 98
+  - id: layer_19/width_16k/average_l0_255
+    path: layer_19/width_16k/average_l0_255/params.npz
+    l0: 255
+  - id: layer_19/width_16k/average_l0_599
+    path: layer_19/width_16k/average_l0_599/params.npz
+    l0: 599
+  - id: layer_19/width_16k/average_l0_1097
+    path: layer_19/width_16k/average_l0_1097/params.npz
+    l0: 1097
+  - id: layer_19/width_131k/average_l0_19
+    path: layer_19/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_19/width_131k/average_l0_40
+    path: layer_19/width_131k/average_l0_40/params.npz
+    l0: 40
+  - id: layer_19/width_131k/average_l0_85
+    path: layer_19/width_131k/average_l0_85/params.npz
+    l0: 85
+  - id: layer_19/width_131k/average_l0_189
+    path: layer_19/width_131k/average_l0_189/params.npz
+    l0: 189
+  - id: layer_19/width_131k/average_l0_440
+    path: layer_19/width_131k/average_l0_440/params.npz
+    l0: 440
+  - id: layer_19/width_131k/average_l0_899
+    path: layer_19/width_131k/average_l0_899/params.npz
+    l0: 899
+  - id: layer_2/width_16k/average_l0_8
+    path: layer_2/width_16k/average_l0_8/params.npz
+    l0: 8
+  - id: layer_2/width_16k/average_l0_16
+    path: layer_2/width_16k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_2/width_16k/average_l0_33
+    path: layer_2/width_16k/average_l0_33/params.npz
+    l0: 33
+  - id: layer_2/width_16k/average_l0_81
+    path: layer_2/width_16k/average_l0_81/params.npz
+    l0: 81
+  - id: layer_2/width_16k/average_l0_163
+    path: layer_2/width_16k/average_l0_163/params.npz
+    l0: 163
+  - id: layer_2/width_131k/average_l0_4
+    path: layer_2/width_131k/average_l0_4/params.npz
+    l0: 4
+  - id: layer_2/width_131k/average_l0_7
+    path: layer_2/width_131k/average_l0_7/params.npz
+    l0: 7
+  - id: layer_2/width_131k/average_l0_12
+    path: layer_2/width_131k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_2/width_131k/average_l0_20
+    path: layer_2/width_131k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_2/width_131k/average_l0_35
+    path: layer_2/width_131k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_2/width_131k/average_l0_61
+    path: layer_2/width_131k/average_l0_61/params.npz
+    l0: 61
+  - id: layer_20/width_16k/average_l0_17
+    path: layer_20/width_16k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_20/width_16k/average_l0_41
+    path: layer_20/width_16k/average_l0_41/params.npz
+    l0: 41
+  - id: layer_20/width_16k/average_l0_108
+    path: layer_20/width_16k/average_l0_108/params.npz
+    l0: 108
+  - id: layer_20/width_16k/average_l0_284
+    path: layer_20/width_16k/average_l0_284/params.npz
+    l0: 284
+  - id: layer_20/width_16k/average_l0_643
+    path: layer_20/width_16k/average_l0_643/params.npz
+    l0: 643
+  - id: layer_20/width_16k/average_l0_1127
+    path: layer_20/width_16k/average_l0_1127/params.npz
+    l0: 1127
+  - id: layer_20/width_131k/average_l0_20
+    path: layer_20/width_131k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_20/width_131k/average_l0_41
+    path: layer_20/width_131k/average_l0_41/params.npz
+    l0: 41
+  - id: layer_20/width_131k/average_l0_93
+    path: layer_20/width_131k/average_l0_93/params.npz
+    l0: 93
+  - id: layer_20/width_131k/average_l0_212
+    path: layer_20/width_131k/average_l0_212/params.npz
+    l0: 212
+  - id: layer_20/width_131k/average_l0_477
+    path: layer_20/width_131k/average_l0_477/params.npz
+    l0: 477
+  - id: layer_20/width_131k/average_l0_992
+    path: layer_20/width_131k/average_l0_992/params.npz
+    l0: 992
+  - id: layer_21/width_16k/average_l0_15
+    path: layer_21/width_16k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_21/width_16k/average_l0_34
+    path: layer_21/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_21/width_16k/average_l0_88
+    path: layer_21/width_16k/average_l0_88/params.npz
+    l0: 88
+  - id: layer_21/width_16k/average_l0_241
+    path: layer_21/width_16k/average_l0_241/params.npz
+    l0: 241
+  - id: layer_21/width_16k/average_l0_571
+    path: layer_21/width_16k/average_l0_571/params.npz
+    l0: 571
+  - id: layer_21/width_16k/average_l0_1063
+    path: layer_21/width_16k/average_l0_1063/params.npz
+    l0: 1063
+  - id: layer_21/width_131k/average_l0_16
+    path: layer_21/width_131k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_21/width_131k/average_l0_35
+    path: layer_21/width_131k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_21/width_131k/average_l0_79
+    path: layer_21/width_131k/average_l0_79/params.npz
+    l0: 79
+  - id: layer_21/width_131k/average_l0_179
+    path: layer_21/width_131k/average_l0_179/params.npz
+    l0: 179
+  - id: layer_21/width_131k/average_l0_417
+    path: layer_21/width_131k/average_l0_417/params.npz
+    l0: 417
+  - id: layer_21/width_131k/average_l0_884
+    path: layer_21/width_131k/average_l0_884/params.npz
+    l0: 884
+  - id: layer_22/width_16k/average_l0_15
+    path: layer_22/width_16k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_22/width_16k/average_l0_34
+    path: layer_22/width_16k/average_l0_34/params.npz
+    l0: 34
+  - id: layer_22/width_16k/average_l0_85
+    path: layer_22/width_16k/average_l0_85/params.npz
+    l0: 85
+  - id: layer_22/width_16k/average_l0_226
+    path: layer_22/width_16k/average_l0_226/params.npz
+    l0: 226
+  - id: layer_22/width_16k/average_l0_566
+    path: layer_22/width_16k/average_l0_566/params.npz
+    l0: 566
+  - id: layer_22/width_16k/average_l0_1065
+    path: layer_22/width_16k/average_l0_1065/params.npz
+    l0: 1065
+  - id: layer_22/width_131k/average_l0_17
+    path: layer_22/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_22/width_131k/average_l0_35
+    path: layer_22/width_131k/average_l0_35/params.npz
+    l0: 35
+  - id: layer_22/width_131k/average_l0_77
+    path: layer_22/width_131k/average_l0_77/params.npz
+    l0: 77
+  - id: layer_22/width_131k/average_l0_172
+    path: layer_22/width_131k/average_l0_172/params.npz
+    l0: 172
+  - id: layer_22/width_131k/average_l0_404
+    path: layer_22/width_131k/average_l0_404/params.npz
+    l0: 404
+  - id: layer_22/width_131k/average_l0_861
+    path: layer_22/width_131k/average_l0_861/params.npz
+    l0: 861
+  - id: layer_23/width_16k/average_l0_15
+    path: layer_23/width_16k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_23/width_16k/average_l0_31
+    path: layer_23/width_16k/average_l0_31/params.npz
+    l0: 31
+  - id: layer_23/width_16k/average_l0_73
+    path: layer_23/width_16k/average_l0_73/params.npz
+    l0: 73
+  - id: layer_23/width_16k/average_l0_190
+    path: layer_23/width_16k/average_l0_190/params.npz
+    l0: 190
+  - id: layer_23/width_16k/average_l0_492
+    path: layer_23/width_16k/average_l0_492/params.npz
+    l0: 492
+  - id: layer_23/width_16k/average_l0_990
+    path: layer_23/width_16k/average_l0_990/params.npz
+    l0: 990
+  - id: layer_23/width_131k/average_l0_17
+    path: layer_23/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_23/width_131k/average_l0_32
+    path: layer_23/width_131k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_23/width_131k/average_l0_67
+    path: layer_23/width_131k/average_l0_67/params.npz
+    l0: 67
+  - id: layer_23/width_131k/average_l0_146
+    path: layer_23/width_131k/average_l0_146/params.npz
+    l0: 146
+  - id: layer_23/width_131k/average_l0_354
+    path: layer_23/width_131k/average_l0_354/params.npz
+    l0: 354
+  - id: layer_23/width_131k/average_l0_754
+    path: layer_23/width_131k/average_l0_754/params.npz
+    l0: 754
+  - id: layer_24/width_16k/average_l0_15
+    path: layer_24/width_16k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_24/width_16k/average_l0_32
+    path: layer_24/width_16k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_24/width_16k/average_l0_73
+    path: layer_24/width_16k/average_l0_73/params.npz
+    l0: 73
+  - id: layer_24/width_16k/average_l0_192
+    path: layer_24/width_16k/average_l0_192/params.npz
+    l0: 192
+  - id: layer_24/width_16k/average_l0_494
+    path: layer_24/width_16k/average_l0_494/params.npz
+    l0: 494
+  - id: layer_24/width_16k/average_l0_999
+    path: layer_24/width_16k/average_l0_999/params.npz
+    l0: 999
+  - id: layer_24/width_131k/average_l0_17
+    path: layer_24/width_131k/average_l0_17/params.npz
+    l0: 17
+  - id: layer_24/width_131k/average_l0_33
+    path: layer_24/width_131k/average_l0_33/params.npz
+    l0: 33
+  - id: layer_24/width_131k/average_l0_67
+    path: layer_24/width_131k/average_l0_67/params.npz
+    l0: 67
+  - id: layer_24/width_131k/average_l0_147
+    path: layer_24/width_131k/average_l0_147/params.npz
+    l0: 147
+  - id: layer_24/width_131k/average_l0_351
+    path: layer_24/width_131k/average_l0_351/params.npz
+    l0: 351
+  - id: layer_24/width_131k/average_l0_709
+    path: layer_24/width_131k/average_l0_709/params.npz
+    l0: 709
+  - id: layer_25/width_16k/average_l0_15
+    path: layer_25/width_16k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_25/width_16k/average_l0_31
+    path: layer_25/width_16k/average_l0_31/params.npz
+    l0: 31
+  - id: layer_25/width_16k/average_l0_72
+    path: layer_25/width_16k/average_l0_72/params.npz
+    l0: 72
+  - id: layer_25/width_16k/average_l0_184
+    path: layer_25/width_16k/average_l0_184/params.npz
+    l0: 184
+  - id: layer_25/width_16k/average_l0_494
+    path: layer_25/width_16k/average_l0_494/params.npz
+    l0: 494
+  - id: layer_25/width_16k/average_l0_1013
+    path: layer_25/width_16k/average_l0_1013/params.npz
+    l0: 1013
+  - id: layer_25/width_131k/average_l0_16
+    path: layer_25/width_131k/average_l0_16/params.npz
+    l0: 16
+  - id: layer_25/width_131k/average_l0_32
+    path: layer_25/width_131k/average_l0_32/params.npz
+    l0: 32
+  - id: layer_25/width_131k/average_l0_65
+    path: layer_25/width_131k/average_l0_65/params.npz
+    l0: 65
+  - id: layer_25/width_131k/average_l0_139
+    path: layer_25/width_131k/average_l0_139/params.npz
+    l0: 139
+  - id: layer_25/width_131k/average_l0_326
+    path: layer_25/width_131k/average_l0_326/params.npz
+    l0: 326
+  - id: layer_25/width_131k/average_l0_691
+    path: layer_25/width_131k/average_l0_691/params.npz
+    l0: 691
+  - id: layer_26/width_16k/average_l0_14
+    path: layer_26/width_16k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_26/width_16k/average_l0_26
+    path: layer_26/width_16k/average_l0_26/params.npz
+    l0: 26
+  - id: layer_26/width_16k/average_l0_57
+    path: layer_26/width_16k/average_l0_57/params.npz
+    l0: 57
+  - id: layer_26/width_16k/average_l0_142
+    path: layer_26/width_16k/average_l0_142/params.npz
+    l0: 142
+  - id: layer_26/width_16k/average_l0_394
+    path: layer_26/width_16k/average_l0_394/params.npz
+    l0: 394
+  - id: layer_26/width_16k/average_l0_887
+    path: layer_26/width_16k/average_l0_887/params.npz
+    l0: 887
+  - id: layer_26/width_131k/average_l0_14
+    path: layer_26/width_131k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_26/width_131k/average_l0_27
+    path: layer_26/width_131k/average_l0_27/params.npz
+    l0: 27
+  - id: layer_26/width_131k/average_l0_53
+    path: layer_26/width_131k/average_l0_53/params.npz
+    l0: 53
+  - id: layer_26/width_131k/average_l0_110
+    path: layer_26/width_131k/average_l0_110/params.npz
+    l0: 110
+  - id: layer_26/width_131k/average_l0_249
+    path: layer_26/width_131k/average_l0_249/params.npz
+    l0: 249
+  - id: layer_26/width_131k/average_l0_568
+    path: layer_26/width_131k/average_l0_568/params.npz
+    l0: 568
+  - id: layer_27/width_16k/average_l0_14
+    path: layer_27/width_16k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_27/width_16k/average_l0_25
+    path: layer_27/width_16k/average_l0_25/params.npz
+    l0: 25
+  - id: layer_27/width_16k/average_l0_52
+    path: layer_27/width_16k/average_l0_52/params.npz
+    l0: 52
+  - id: layer_27/width_16k/average_l0_126
+    path: layer_27/width_16k/average_l0_126/params.npz
+    l0: 126
+  - id: layer_27/width_16k/average_l0_352
+    path: layer_27/width_16k/average_l0_352/params.npz
+    l0: 352
+  - id: layer_27/width_16k/average_l0_813
+    path: layer_27/width_16k/average_l0_813/params.npz
+    l0: 813
+  - id: layer_27/width_131k/average_l0_14
+    path: layer_27/width_131k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_27/width_131k/average_l0_26
+    path: layer_27/width_131k/average_l0_26/params.npz
+    l0: 26
+  - id: layer_27/width_131k/average_l0_49
+    path: layer_27/width_131k/average_l0_49/params.npz
+    l0: 49
+  - id: layer_27/width_131k/average_l0_99
+    path: layer_27/width_131k/average_l0_99/params.npz
+    l0: 99
+  - id: layer_27/width_131k/average_l0_211
+    path: layer_27/width_131k/average_l0_211/params.npz
+    l0: 211
+  - id: layer_27/width_131k/average_l0_487
+    path: layer_27/width_131k/average_l0_487/params.npz
+    l0: 487
+  - id: layer_28/width_16k/average_l0_14
+    path: layer_28/width_16k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_28/width_16k/average_l0_26
+    path: layer_28/width_16k/average_l0_26/params.npz
+    l0: 26
+  - id: layer_28/width_16k/average_l0_50
+    path: layer_28/width_16k/average_l0_50/params.npz
+    l0: 50
+  - id: layer_28/width_16k/average_l0_115
+    path: layer_28/width_16k/average_l0_115/params.npz
+    l0: 115
+  - id: layer_28/width_16k/average_l0_324
+    path: layer_28/width_16k/average_l0_324/params.npz
+    l0: 324
+  - id: layer_28/width_16k/average_l0_773
+    path: layer_28/width_16k/average_l0_773/params.npz
+    l0: 773
+  - id: layer_28/width_131k/average_l0_15
+    path: layer_28/width_131k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_28/width_131k/average_l0_26
+    path: layer_28/width_131k/average_l0_26/params.npz
+    l0: 26
+  - id: layer_28/width_131k/average_l0_47
+    path: layer_28/width_131k/average_l0_47/params.npz
+    l0: 47
+  - id: layer_28/width_131k/average_l0_91
+    path: layer_28/width_131k/average_l0_91/params.npz
+    l0: 91
+  - id: layer_28/width_131k/average_l0_189
+    path: layer_28/width_131k/average_l0_189/params.npz
+    l0: 189
+  - id: layer_28/width_131k/average_l0_425
+    path: layer_28/width_131k/average_l0_425/params.npz
+    l0: 425
+  - id: layer_29/width_16k/average_l0_15
+    path: layer_29/width_16k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_29/width_16k/average_l0_26
+    path: layer_29/width_16k/average_l0_26/params.npz
+    l0: 26
+  - id: layer_29/width_16k/average_l0_49
+    path: layer_29/width_16k/average_l0_49/params.npz
+    l0: 49
+  - id: layer_29/width_16k/average_l0_111
+    path: layer_29/width_16k/average_l0_111/params.npz
+    l0: 111
+  - id: layer_29/width_16k/average_l0_311
+    path: layer_29/width_16k/average_l0_311/params.npz
+    l0: 311
+  - id: layer_29/width_16k/average_l0_725
+    path: layer_29/width_16k/average_l0_725/params.npz
+    l0: 725
+  - id: layer_29/width_131k/average_l0_15
+    path: layer_29/width_131k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_29/width_131k/average_l0_26
+    path: layer_29/width_131k/average_l0_26/params.npz
+    l0: 26
+  - id: layer_29/width_131k/average_l0_47
+    path: layer_29/width_131k/average_l0_47/params.npz
+    l0: 47
+  - id: layer_29/width_131k/average_l0_87
+    path: layer_29/width_131k/average_l0_87/params.npz
+    l0: 87
+  - id: layer_29/width_131k/average_l0_174
+    path: layer_29/width_131k/average_l0_174/params.npz
+    l0: 174
+  - id: layer_29/width_131k/average_l0_386
+    path: layer_29/width_131k/average_l0_386/params.npz
+    l0: 386
+  - id: layer_3/width_16k/average_l0_13
+    path: layer_3/width_16k/average_l0_13/params.npz
+    l0: 13
+  - id: layer_3/width_16k/average_l0_25
+    path: layer_3/width_16k/average_l0_25/params.npz
+    l0: 25
+  - id: layer_3/width_16k/average_l0_55
+    path: layer_3/width_16k/average_l0_55/params.npz
+    l0: 55
+  - id: layer_3/width_16k/average_l0_126
+    path: layer_3/width_16k/average_l0_126/params.npz
+    l0: 126
+  - id: layer_3/width_16k/average_l0_234
+    path: layer_3/width_16k/average_l0_234/params.npz
+    l0: 234
+  - id: layer_3/width_131k/average_l0_6
+    path: layer_3/width_131k/average_l0_6/params.npz
+    l0: 6
+  - id: layer_3/width_131k/average_l0_11
+    path: layer_3/width_131k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_3/width_131k/average_l0_19
+    path: layer_3/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_3/width_131k/average_l0_33
+    path: layer_3/width_131k/average_l0_33/params.npz
+    l0: 33
+  - id: layer_3/width_131k/average_l0_58
+    path: layer_3/width_131k/average_l0_58/params.npz
+    l0: 58
+  - id: layer_3/width_131k/average_l0_109
+    path: layer_3/width_131k/average_l0_109/params.npz
+    l0: 109
+  - id: layer_30/width_16k/average_l0_14
+    path: layer_30/width_16k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_30/width_16k/average_l0_26
+    path: layer_30/width_16k/average_l0_26/params.npz
+    l0: 26
+  - id: layer_30/width_16k/average_l0_51
+    path: layer_30/width_16k/average_l0_51/params.npz
+    l0: 51
+  - id: layer_30/width_16k/average_l0_116
+    path: layer_30/width_16k/average_l0_116/params.npz
+    l0: 116
+  - id: layer_30/width_16k/average_l0_333
+    path: layer_30/width_16k/average_l0_333/params.npz
+    l0: 333
+  - id: layer_30/width_16k/average_l0_806
+    path: layer_30/width_16k/average_l0_806/params.npz
+    l0: 806
+  - id: layer_30/width_131k/average_l0_14
+    path: layer_30/width_131k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_30/width_131k/average_l0_26
+    path: layer_30/width_131k/average_l0_26/params.npz
+    l0: 26
+  - id: layer_30/width_131k/average_l0_47
+    path: layer_30/width_131k/average_l0_47/params.npz
+    l0: 47
+  - id: layer_30/width_131k/average_l0_89
+    path: layer_30/width_131k/average_l0_89/params.npz
+    l0: 89
+  - id: layer_30/width_131k/average_l0_179
+    path: layer_30/width_131k/average_l0_179/params.npz
+    l0: 179
+  - id: layer_30/width_131k/average_l0_391
+    path: layer_30/width_131k/average_l0_391/params.npz
+    l0: 391
+  - id: layer_31/width_16k/average_l0_12
+    path: layer_31/width_16k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_31/width_16k/average_l0_22
+    path: layer_31/width_16k/average_l0_22/params.npz
+    l0: 22
+  - id: layer_31/width_16k/average_l0_43
+    path: layer_31/width_16k/average_l0_43/params.npz
+    l0: 43
+  - id: layer_31/width_16k/average_l0_94
+    path: layer_31/width_16k/average_l0_94/params.npz
+    l0: 94
+  - id: layer_31/width_16k/average_l0_263
+    path: layer_31/width_16k/average_l0_263/params.npz
+    l0: 263
+  - id: layer_31/width_16k/average_l0_671
+    path: layer_31/width_16k/average_l0_671/params.npz
+    l0: 671
+  - id: layer_31/width_131k/average_l0_12
+    path: layer_31/width_131k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_31/width_131k/average_l0_22
+    path: layer_31/width_131k/average_l0_22/params.npz
+    l0: 22
+  - id: layer_31/width_131k/average_l0_40
+    path: layer_31/width_131k/average_l0_40/params.npz
+    l0: 40
+  - id: layer_31/width_131k/average_l0_77
+    path: layer_31/width_131k/average_l0_77/params.npz
+    l0: 77
+  - id: layer_31/width_131k/average_l0_153
+    path: layer_31/width_131k/average_l0_153/params.npz
+    l0: 153
+  - id: layer_31/width_131k/average_l0_326
+    path: layer_31/width_131k/average_l0_326/params.npz
+    l0: 326
+  - id: layer_32/width_16k/average_l0_11
+    path: layer_32/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_32/width_16k/average_l0_21
+    path: layer_32/width_16k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_32/width_16k/average_l0_44
+    path: layer_32/width_16k/average_l0_44/params.npz
+    l0: 44
+  - id: layer_32/width_16k/average_l0_98
+    path: layer_32/width_16k/average_l0_98/params.npz
+    l0: 98
+  - id: layer_32/width_16k/average_l0_267
+    path: layer_32/width_16k/average_l0_267/params.npz
+    l0: 267
+  - id: layer_32/width_16k/average_l0_623
+    path: layer_32/width_16k/average_l0_623/params.npz
+    l0: 623
+  - id: layer_32/width_131k/average_l0_12
+    path: layer_32/width_131k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_32/width_131k/average_l0_21
+    path: layer_32/width_131k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_32/width_131k/average_l0_40
+    path: layer_32/width_131k/average_l0_40/params.npz
+    l0: 40
+  - id: layer_32/width_131k/average_l0_76
+    path: layer_32/width_131k/average_l0_76/params.npz
+    l0: 76
+  - id: layer_32/width_131k/average_l0_155
+    path: layer_32/width_131k/average_l0_155/params.npz
+    l0: 155
+  - id: layer_32/width_131k/average_l0_336
+    path: layer_32/width_131k/average_l0_336/params.npz
+    l0: 336
+  - id: layer_33/width_16k/average_l0_12
+    path: layer_33/width_16k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_33/width_16k/average_l0_23
+    path: layer_33/width_16k/average_l0_23/params.npz
+    l0: 23
+  - id: layer_33/width_16k/average_l0_48
+    path: layer_33/width_16k/average_l0_48/params.npz
+    l0: 48
+  - id: layer_33/width_16k/average_l0_107
+    path: layer_33/width_16k/average_l0_107/params.npz
+    l0: 107
+  - id: layer_33/width_16k/average_l0_282
+    path: layer_33/width_16k/average_l0_282/params.npz
+    l0: 282
+  - id: layer_33/width_16k/average_l0_628
+    path: layer_33/width_16k/average_l0_628/params.npz
+    l0: 628
+  - id: layer_33/width_131k/average_l0_12
+    path: layer_33/width_131k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_33/width_131k/average_l0_22
+    path: layer_33/width_131k/average_l0_22/params.npz
+    l0: 22
+  - id: layer_33/width_131k/average_l0_42
+    path: layer_33/width_131k/average_l0_42/params.npz
+    l0: 42
+  - id: layer_33/width_131k/average_l0_83
+    path: layer_33/width_131k/average_l0_83/params.npz
+    l0: 83
+  - id: layer_33/width_131k/average_l0_168
+    path: layer_33/width_131k/average_l0_168/params.npz
+    l0: 168
+  - id: layer_33/width_131k/average_l0_394
+    path: layer_33/width_131k/average_l0_394/params.npz
+    l0: 394
+  - id: layer_34/width_16k/average_l0_11
+    path: layer_34/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_34/width_16k/average_l0_22
+    path: layer_34/width_16k/average_l0_22/params.npz
+    l0: 22
+  - id: layer_34/width_16k/average_l0_47
+    path: layer_34/width_16k/average_l0_47/params.npz
+    l0: 47
+  - id: layer_34/width_16k/average_l0_107
+    path: layer_34/width_16k/average_l0_107/params.npz
+    l0: 107
+  - id: layer_34/width_16k/average_l0_268
+    path: layer_34/width_16k/average_l0_268/params.npz
+    l0: 268
+  - id: layer_34/width_16k/average_l0_559
+    path: layer_34/width_16k/average_l0_559/params.npz
+    l0: 559
+  - id: layer_34/width_131k/average_l0_10
+    path: layer_34/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_34/width_131k/average_l0_20
+    path: layer_34/width_131k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_34/width_131k/average_l0_40
+    path: layer_34/width_131k/average_l0_40/params.npz
+    l0: 40
+  - id: layer_34/width_131k/average_l0_82
+    path: layer_34/width_131k/average_l0_82/params.npz
+    l0: 82
+  - id: layer_34/width_131k/average_l0_167
+    path: layer_34/width_131k/average_l0_167/params.npz
+    l0: 167
+  - id: layer_34/width_131k/average_l0_390
+    path: layer_34/width_131k/average_l0_390/params.npz
+    l0: 390
+  - id: layer_35/width_16k/average_l0_10
+    path: layer_35/width_16k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_35/width_16k/average_l0_21
+    path: layer_35/width_16k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_35/width_16k/average_l0_46
+    path: layer_35/width_16k/average_l0_46/params.npz
+    l0: 46
+  - id: layer_35/width_16k/average_l0_108
+    path: layer_35/width_16k/average_l0_108/params.npz
+    l0: 108
+  - id: layer_35/width_16k/average_l0_254
+    path: layer_35/width_16k/average_l0_254/params.npz
+    l0: 254
+  - id: layer_35/width_16k/average_l0_538
+    path: layer_35/width_16k/average_l0_538/params.npz
+    l0: 538
+  - id: layer_35/width_131k/average_l0_10
+    path: layer_35/width_131k/average_l0_10/params.npz
+    l0: 10
+  - id: layer_35/width_131k/average_l0_19
+    path: layer_35/width_131k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_35/width_131k/average_l0_39
+    path: layer_35/width_131k/average_l0_39/params.npz
+    l0: 39
+  - id: layer_35/width_131k/average_l0_80
+    path: layer_35/width_131k/average_l0_80/params.npz
+    l0: 80
+  - id: layer_35/width_131k/average_l0_176
+    path: layer_35/width_131k/average_l0_176/params.npz
+    l0: 176
+  - id: layer_35/width_131k/average_l0_389
+    path: layer_35/width_131k/average_l0_389/params.npz
+    l0: 389
+  - id: layer_36/width_16k/average_l0_11
+    path: layer_36/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_36/width_16k/average_l0_22
+    path: layer_36/width_16k/average_l0_22/params.npz
+    l0: 22
+  - id: layer_36/width_16k/average_l0_47
+    path: layer_36/width_16k/average_l0_47/params.npz
+    l0: 47
+  - id: layer_36/width_16k/average_l0_109
+    path: layer_36/width_16k/average_l0_109/params.npz
+    l0: 109
+  - id: layer_36/width_16k/average_l0_256
+    path: layer_36/width_16k/average_l0_256/params.npz
+    l0: 256
+  - id: layer_36/width_16k/average_l0_523
+    path: layer_36/width_16k/average_l0_523/params.npz
+    l0: 523
+  - id: layer_36/width_131k/average_l0_11
+    path: layer_36/width_131k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_36/width_131k/average_l0_20
+    path: layer_36/width_131k/average_l0_20/params.npz
+    l0: 20
+  - id: layer_36/width_131k/average_l0_40
+    path: layer_36/width_131k/average_l0_40/params.npz
+    l0: 40
+  - id: layer_36/width_131k/average_l0_81
+    path: layer_36/width_131k/average_l0_81/params.npz
+    l0: 81
+  - id: layer_36/width_131k/average_l0_174
+    path: layer_36/width_131k/average_l0_174/params.npz
+    l0: 174
+  - id: layer_36/width_131k/average_l0_389
+    path: layer_36/width_131k/average_l0_389/params.npz
+    l0: 389
+  - id: layer_37/width_16k/average_l0_12
+    path: layer_37/width_16k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_37/width_16k/average_l0_24
+    path: layer_37/width_16k/average_l0_24/params.npz
+    l0: 24
+  - id: layer_37/width_16k/average_l0_53
+    path: layer_37/width_16k/average_l0_53/params.npz
+    l0: 53
+  - id: layer_37/width_16k/average_l0_119
+    path: layer_37/width_16k/average_l0_119/params.npz
+    l0: 119
+  - id: layer_37/width_16k/average_l0_267
+    path: layer_37/width_16k/average_l0_267/params.npz
+    l0: 267
+  - id: layer_37/width_16k/average_l0_549
+    path: layer_37/width_16k/average_l0_549/params.npz
+    l0: 549
+  - id: layer_37/width_131k/average_l0_12
+    path: layer_37/width_131k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_37/width_131k/average_l0_23
+    path: layer_37/width_131k/average_l0_23/params.npz
+    l0: 23
+  - id: layer_37/width_131k/average_l0_44
+    path: layer_37/width_131k/average_l0_44/params.npz
+    l0: 44
+  - id: layer_37/width_131k/average_l0_90
+    path: layer_37/width_131k/average_l0_90/params.npz
+    l0: 90
+  - id: layer_37/width_131k/average_l0_203
+    path: layer_37/width_131k/average_l0_203/params.npz
+    l0: 203
+  - id: layer_37/width_131k/average_l0_403
+    path: layer_37/width_131k/average_l0_403/params.npz
+    l0: 403
+  - id: layer_38/width_16k/average_l0_11
+    path: layer_38/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_38/width_16k/average_l0_22
+    path: layer_38/width_16k/average_l0_22/params.npz
+    l0: 22
+  - id: layer_38/width_16k/average_l0_45
+    path: layer_38/width_16k/average_l0_45/params.npz
+    l0: 45
+  - id: layer_38/width_16k/average_l0_98
+    path: layer_38/width_16k/average_l0_98/params.npz
+    l0: 98
+  - id: layer_38/width_16k/average_l0_225
+    path: layer_38/width_16k/average_l0_225/params.npz
+    l0: 225
+  - id: layer_38/width_16k/average_l0_491
+    path: layer_38/width_16k/average_l0_491/params.npz
+    l0: 491
+  - id: layer_38/width_131k/average_l0_11
+    path: layer_38/width_131k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_38/width_131k/average_l0_21
+    path: layer_38/width_131k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_38/width_131k/average_l0_40
+    path: layer_38/width_131k/average_l0_40/params.npz
+    l0: 40
+  - id: layer_38/width_131k/average_l0_79
+    path: layer_38/width_131k/average_l0_79/params.npz
+    l0: 79
+  - id: layer_38/width_131k/average_l0_161
+    path: layer_38/width_131k/average_l0_161/params.npz
+    l0: 161
+  - id: layer_38/width_131k/average_l0_347
+    path: layer_38/width_131k/average_l0_347/params.npz
+    l0: 347
+  - id: layer_39/width_16k/average_l0_12
+    path: layer_39/width_16k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_39/width_16k/average_l0_22
+    path: layer_39/width_16k/average_l0_22/params.npz
+    l0: 22
+  - id: layer_39/width_16k/average_l0_43
+    path: layer_39/width_16k/average_l0_43/params.npz
+    l0: 43
+  - id: layer_39/width_16k/average_l0_90
+    path: layer_39/width_16k/average_l0_90/params.npz
+    l0: 90
+  - id: layer_39/width_16k/average_l0_207
+    path: layer_39/width_16k/average_l0_207/params.npz
+    l0: 207
+  - id: layer_39/width_16k/average_l0_458
+    path: layer_39/width_16k/average_l0_458/params.npz
+    l0: 458
+  - id: layer_39/width_131k/average_l0_11
+    path: layer_39/width_131k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_39/width_131k/average_l0_21
+    path: layer_39/width_131k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_39/width_131k/average_l0_38
+    path: layer_39/width_131k/average_l0_38/params.npz
+    l0: 38
+  - id: layer_39/width_131k/average_l0_75
+    path: layer_39/width_131k/average_l0_75/params.npz
+    l0: 75
+  - id: layer_39/width_131k/average_l0_150
+    path: layer_39/width_131k/average_l0_150/params.npz
+    l0: 150
+  - id: layer_39/width_131k/average_l0_319
+    path: layer_39/width_131k/average_l0_319/params.npz
+    l0: 319
+  - id: layer_4/width_16k/average_l0_15
+    path: layer_4/width_16k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_4/width_16k/average_l0_30
+    path: layer_4/width_16k/average_l0_30/params.npz
+    l0: 30
+  - id: layer_4/width_16k/average_l0_66
+    path: layer_4/width_16k/average_l0_66/params.npz
+    l0: 66
+  - id: layer_4/width_16k/average_l0_151
+    path: layer_4/width_16k/average_l0_151/params.npz
+    l0: 151
+  - id: layer_4/width_16k/average_l0_343
+    path: layer_4/width_16k/average_l0_343/params.npz
+    l0: 343
+  - id: layer_4/width_131k/average_l0_8
+    path: layer_4/width_131k/average_l0_8/params.npz
+    l0: 8
+  - id: layer_4/width_131k/average_l0_14
+    path: layer_4/width_131k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_4/width_131k/average_l0_24
+    path: layer_4/width_131k/average_l0_24/params.npz
+    l0: 24
+  - id: layer_4/width_131k/average_l0_45
+    path: layer_4/width_131k/average_l0_45/params.npz
+    l0: 45
+  - id: layer_4/width_131k/average_l0_84
+    path: layer_4/width_131k/average_l0_84/params.npz
+    l0: 84
+  - id: layer_4/width_131k/average_l0_157
+    path: layer_4/width_131k/average_l0_157/params.npz
+    l0: 157
+  - id: layer_40/width_16k/average_l0_11
+    path: layer_40/width_16k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_40/width_16k/average_l0_19
+    path: layer_40/width_16k/average_l0_19/params.npz
+    l0: 19
+  - id: layer_40/width_16k/average_l0_37
+    path: layer_40/width_16k/average_l0_37/params.npz
+    l0: 37
+  - id: layer_40/width_16k/average_l0_74
+    path: layer_40/width_16k/average_l0_74/params.npz
+    l0: 74
+  - id: layer_40/width_16k/average_l0_162
+    path: layer_40/width_16k/average_l0_162/params.npz
+    l0: 162
+  - id: layer_40/width_16k/average_l0_371
+    path: layer_40/width_16k/average_l0_371/params.npz
+    l0: 371
+  - id: layer_40/width_131k/average_l0_11
+    path: layer_40/width_131k/average_l0_11/params.npz
+    l0: 11
+  - id: layer_40/width_131k/average_l0_18
+    path: layer_40/width_131k/average_l0_18/params.npz
+    l0: 18
+  - id: layer_40/width_131k/average_l0_33
+    path: layer_40/width_131k/average_l0_33/params.npz
+    l0: 33
+  - id: layer_40/width_131k/average_l0_63
+    path: layer_40/width_131k/average_l0_63/params.npz
+    l0: 63
+  - id: layer_40/width_131k/average_l0_125
+    path: layer_40/width_131k/average_l0_125/params.npz
+    l0: 125
+  - id: layer_40/width_131k/average_l0_267
+    path: layer_40/width_131k/average_l0_267/params.npz
+    l0: 267
+  - id: layer_41/width_16k/average_l0_8
+    path: layer_41/width_16k/average_l0_8/params.npz
+    l0: 8
+  - id: layer_41/width_16k/average_l0_15
+    path: layer_41/width_16k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_41/width_16k/average_l0_28
+    path: layer_41/width_16k/average_l0_28/params.npz
+    l0: 28
+  - id: layer_41/width_16k/average_l0_58
+    path: layer_41/width_16k/average_l0_58/params.npz
+    l0: 58
+  - id: layer_41/width_16k/average_l0_126
+    path: layer_41/width_16k/average_l0_126/params.npz
+    l0: 126
+  - id: layer_41/width_16k/average_l0_288
+    path: layer_41/width_16k/average_l0_288/params.npz
+    l0: 288
+  - id: layer_41/width_131k/average_l0_8
+    path: layer_41/width_131k/average_l0_8/params.npz
+    l0: 8
+  - id: layer_41/width_131k/average_l0_14
+    path: layer_41/width_131k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_41/width_131k/average_l0_25
+    path: layer_41/width_131k/average_l0_25/params.npz
+    l0: 25
+  - id: layer_41/width_131k/average_l0_49
+    path: layer_41/width_131k/average_l0_49/params.npz
+    l0: 49
+  - id: layer_41/width_131k/average_l0_99
+    path: layer_41/width_131k/average_l0_99/params.npz
+    l0: 99
+  - id: layer_41/width_131k/average_l0_208
+    path: layer_41/width_131k/average_l0_208/params.npz
+    l0: 208
+  - id: layer_5/width_16k/average_l0_14
+    path: layer_5/width_16k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_5/width_16k/average_l0_24
+    path: layer_5/width_16k/average_l0_24/params.npz
+    l0: 24
+  - id: layer_5/width_16k/average_l0_46
+    path: layer_5/width_16k/average_l0_46/params.npz
+    l0: 46
+  - id: layer_5/width_16k/average_l0_93
+    path: layer_5/width_16k/average_l0_93/params.npz
+    l0: 93
+  - id: layer_5/width_16k/average_l0_194
+    path: layer_5/width_16k/average_l0_194/params.npz
+    l0: 194
+  - id: layer_5/width_131k/average_l0_7
+    path: layer_5/width_131k/average_l0_7/params.npz
+    l0: 7
+  - id: layer_5/width_131k/average_l0_12
+    path: layer_5/width_131k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_5/width_131k/average_l0_21
+    path: layer_5/width_131k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_5/width_131k/average_l0_37
+    path: layer_5/width_131k/average_l0_37/params.npz
+    l0: 37
+  - id: layer_5/width_131k/average_l0_68
+    path: layer_5/width_131k/average_l0_68/params.npz
+    l0: 68
+  - id: layer_5/width_131k/average_l0_131
+    path: layer_5/width_131k/average_l0_131/params.npz
+    l0: 131
+  - id: layer_6/width_16k/average_l0_12
+    path: layer_6/width_16k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_6/width_16k/average_l0_23
+    path: layer_6/width_16k/average_l0_23/params.npz
+    l0: 23
+  - id: layer_6/width_16k/average_l0_46
+    path: layer_6/width_16k/average_l0_46/params.npz
+    l0: 46
+  - id: layer_6/width_16k/average_l0_96
+    path: layer_6/width_16k/average_l0_96/params.npz
+    l0: 96
+  - id: layer_6/width_16k/average_l0_206
+    path: layer_6/width_16k/average_l0_206/params.npz
+    l0: 206
+  - id: layer_6/width_131k/average_l0_12
+    path: layer_6/width_131k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_6/width_131k/average_l0_22
+    path: layer_6/width_131k/average_l0_22/params.npz
+    l0: 22
+  - id: layer_6/width_131k/average_l0_40
+    path: layer_6/width_131k/average_l0_40/params.npz
+    l0: 40
+  - id: layer_6/width_131k/average_l0_72
+    path: layer_6/width_131k/average_l0_72/params.npz
+    l0: 72
+  - id: layer_6/width_131k/average_l0_135
+    path: layer_6/width_131k/average_l0_135/params.npz
+    l0: 135
+  - id: layer_6/width_131k/average_l0_271
+    path: layer_6/width_131k/average_l0_271/params.npz
+    l0: 271
+  - id: layer_7/width_16k/average_l0_14
+    path: layer_7/width_16k/average_l0_14/params.npz
+    l0: 14
+  - id: layer_7/width_16k/average_l0_25
+    path: layer_7/width_16k/average_l0_25/params.npz
+    l0: 25
+  - id: layer_7/width_16k/average_l0_47
+    path: layer_7/width_16k/average_l0_47/params.npz
+    l0: 47
+  - id: layer_7/width_16k/average_l0_101
+    path: layer_7/width_16k/average_l0_101/params.npz
+    l0: 101
+  - id: layer_7/width_16k/average_l0_231
+    path: layer_7/width_16k/average_l0_231/params.npz
+    l0: 231
+  - id: layer_7/width_131k/average_l0_13
+    path: layer_7/width_131k/average_l0_13/params.npz
+    l0: 13
+  - id: layer_7/width_131k/average_l0_23
+    path: layer_7/width_131k/average_l0_23/params.npz
+    l0: 23
+  - id: layer_7/width_131k/average_l0_41
+    path: layer_7/width_131k/average_l0_41/params.npz
+    l0: 41
+  - id: layer_7/width_131k/average_l0_75
+    path: layer_7/width_131k/average_l0_75/params.npz
+    l0: 75
+  - id: layer_7/width_131k/average_l0_143
+    path: layer_7/width_131k/average_l0_143/params.npz
+    l0: 143
+  - id: layer_7/width_131k/average_l0_309
+    path: layer_7/width_131k/average_l0_309/params.npz
+    l0: 309
+  - id: layer_8/width_16k/average_l0_15
+    path: layer_8/width_16k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_8/width_16k/average_l0_27
+    path: layer_8/width_16k/average_l0_27/params.npz
+    l0: 27
+  - id: layer_8/width_16k/average_l0_55
+    path: layer_8/width_16k/average_l0_55/params.npz
+    l0: 55
+  - id: layer_8/width_16k/average_l0_124
+    path: layer_8/width_16k/average_l0_124/params.npz
+    l0: 124
+  - id: layer_8/width_16k/average_l0_309
+    path: layer_8/width_16k/average_l0_309/params.npz
+    l0: 309
+  - id: layer_8/width_131k/average_l0_15
+    path: layer_8/width_131k/average_l0_15/params.npz
+    l0: 15
+  - id: layer_8/width_131k/average_l0_26
+    path: layer_8/width_131k/average_l0_26/params.npz
+    l0: 26
+  - id: layer_8/width_131k/average_l0_48
+    path: layer_8/width_131k/average_l0_48/params.npz
+    l0: 48
+  - id: layer_8/width_131k/average_l0_89
+    path: layer_8/width_131k/average_l0_89/params.npz
+    l0: 89
+  - id: layer_8/width_131k/average_l0_184
+    path: layer_8/width_131k/average_l0_184/params.npz
+    l0: 184
+  - id: layer_8/width_131k/average_l0_423
+    path: layer_8/width_131k/average_l0_423/params.npz
+    l0: 423
+  - id: layer_9/width_16k/average_l0_12
+    path: layer_9/width_16k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_9/width_16k/average_l0_21
+    path: layer_9/width_16k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_9/width_16k/average_l0_40
+    path: layer_9/width_16k/average_l0_40/params.npz
+    l0: 40
+  - id: layer_9/width_16k/average_l0_83
+    path: layer_9/width_16k/average_l0_83/params.npz
+    l0: 83
+  - id: layer_9/width_16k/average_l0_200
+    path: layer_9/width_16k/average_l0_200/params.npz
+    l0: 200
+  - id: layer_9/width_131k/average_l0_12
+    path: layer_9/width_131k/average_l0_12/params.npz
+    l0: 12
+  - id: layer_9/width_131k/average_l0_21
+    path: layer_9/width_131k/average_l0_21/params.npz
+    l0: 21
+  - id: layer_9/width_131k/average_l0_38
+    path: layer_9/width_131k/average_l0_38/params.npz
+    l0: 38
+  - id: layer_9/width_131k/average_l0_67
+    path: layer_9/width_131k/average_l0_67/params.npz
+    l0: 67
+  - id: layer_9/width_131k/average_l0_129
+    path: layer_9/width_131k/average_l0_129/params.npz
+    l0: 129
+  - id: layer_9/width_131k/average_l0_269
+    path: layer_9/width_131k/average_l0_269/params.npz
+    l0: 269
 gemma-scope-9b-pt-mlp-canonical:
   repo_id: google/gemma-scope-9b-pt-mlp
   model: gemma-2-9b
   conversion_func: gemma_2
   saes:
+  - id: layer_0/width_16k/canonical
+    path: layer_0/width_16k/average_l0_50
+    neuronpedia: gemma-2-9b/0-gemmascope-mlp-16k
+  - id: layer_1/width_16k/canonical
+    path: layer_1/width_16k/average_l0_128
+    neuronpedia: gemma-2-9b/1-gemmascope-mlp-16k
+  - id: layer_2/width_16k/canonical
+    path: layer_2/width_16k/average_l0_81
+    neuronpedia: gemma-2-9b/2-gemmascope-mlp-16k
+  - id: layer_3/width_16k/canonical
+    path: layer_3/width_16k/average_l0_126
+    neuronpedia: gemma-2-9b/3-gemmascope-mlp-16k
+  - id: layer_4/width_16k/canonical
+    path: layer_4/width_16k/average_l0_66
+    neuronpedia: gemma-2-9b/4-gemmascope-mlp-16k
+  - id: layer_5/width_16k/canonical
+    path: layer_5/width_16k/average_l0_93
+    neuronpedia: gemma-2-9b/5-gemmascope-mlp-16k
+  - id: layer_6/width_16k/canonical
+    path: layer_6/width_16k/average_l0_96
+    neuronpedia: gemma-2-9b/6-gemmascope-mlp-16k
+  - id: layer_7/width_16k/canonical
+    path: layer_7/width_16k/average_l0_101
+    neuronpedia: gemma-2-9b/7-gemmascope-mlp-16k
+  - id: layer_8/width_16k/canonical
+    path: layer_8/width_16k/average_l0_124
+    neuronpedia: gemma-2-9b/8-gemmascope-mlp-16k
+  - id: layer_9/width_16k/canonical
+    path: layer_9/width_16k/average_l0_83
+    neuronpedia: gemma-2-9b/9-gemmascope-mlp-16k
+  - id: layer_10/width_16k/canonical
+    path: layer_10/width_16k/average_l0_114
+    neuronpedia: gemma-2-9b/10-gemmascope-mlp-16k
+  - id: layer_11/width_16k/canonical
+    path: layer_11/width_16k/average_l0_76
+    neuronpedia: gemma-2-9b/11-gemmascope-mlp-16k
+  - id: layer_12/width_16k/canonical
+    path: layer_12/width_16k/average_l0_96
+    neuronpedia: gemma-2-9b/12-gemmascope-mlp-16k
+  - id: layer_13/width_16k/canonical
+    path: layer_13/width_16k/average_l0_94
+    neuronpedia: gemma-2-9b/13-gemmascope-mlp-16k
+  - id: layer_14/width_16k/canonical
+    path: layer_14/width_16k/average_l0_97
+    neuronpedia: gemma-2-9b/14-gemmascope-mlp-16k
+  - id: layer_15/width_16k/canonical
+    path: layer_15/width_16k/average_l0_107
+    neuronpedia: gemma-2-9b/15-gemmascope-mlp-16k
+  - id: layer_16/width_16k/canonical
+    path: layer_16/width_16k/average_l0_91
+    neuronpedia: gemma-2-9b/16-gemmascope-mlp-16k
+  - id: layer_17/width_16k/canonical
+    path: layer_17/width_16k/average_l0_104
+    neuronpedia: gemma-2-9b/17-gemmascope-mlp-16k
+  - id: layer_18/width_16k/canonical
+    path: layer_18/width_16k/average_l0_89
+    neuronpedia: gemma-2-9b/18-gemmascope-mlp-16k
+  - id: layer_19/width_16k/canonical
+    path: layer_19/width_16k/average_l0_98
+    neuronpedia: gemma-2-9b/19-gemmascope-mlp-16k
+  - id: layer_20/width_16k/canonical
+    path: layer_20/width_16k/average_l0_108
+    neuronpedia: gemma-2-9b/20-gemmascope-mlp-16k
+  - id: layer_21/width_16k/canonical
+    path: layer_21/width_16k/average_l0_88
+    neuronpedia: gemma-2-9b/21-gemmascope-mlp-16k
+  - id: layer_22/width_16k/canonical
+    path: layer_22/width_16k/average_l0_85
+    neuronpedia: gemma-2-9b/22-gemmascope-mlp-16k
+  - id: layer_23/width_16k/canonical
+    path: layer_23/width_16k/average_l0_73
+    neuronpedia: gemma-2-9b/23-gemmascope-mlp-16k
+  - id: layer_24/width_16k/canonical
+    path: layer_24/width_16k/average_l0_73
+    neuronpedia: gemma-2-9b/24-gemmascope-mlp-16k
+  - id: layer_25/width_16k/canonical
+    path: layer_25/width_16k/average_l0_72
+    neuronpedia: gemma-2-9b/25-gemmascope-mlp-16k
+  - id: layer_26/width_16k/canonical
+    path: layer_26/width_16k/average_l0_142
+    neuronpedia: gemma-2-9b/26-gemmascope-mlp-16k
+  - id: layer_27/width_16k/canonical
+    path: layer_27/width_16k/average_l0_126
+    neuronpedia: gemma-2-9b/27-gemmascope-mlp-16k
+  - id: layer_28/width_16k/canonical
+    path: layer_28/width_16k/average_l0_115
+    neuronpedia: gemma-2-9b/28-gemmascope-mlp-16k
+  - id: layer_29/width_16k/canonical
+    path: layer_29/width_16k/average_l0_111
+    neuronpedia: gemma-2-9b/29-gemmascope-mlp-16k
+  - id: layer_30/width_16k/canonical
+    path: layer_30/width_16k/average_l0_116
+    neuronpedia: gemma-2-9b/30-gemmascope-mlp-16k
+  - id: layer_31/width_16k/canonical
+    path: layer_31/width_16k/average_l0_94
+    neuronpedia: gemma-2-9b/31-gemmascope-mlp-16k
+  - id: layer_32/width_16k/canonical
+    path: layer_32/width_16k/average_l0_98
+    neuronpedia: gemma-2-9b/32-gemmascope-mlp-16k
+  - id: layer_33/width_16k/canonical
+    path: layer_33/width_16k/average_l0_107
+    neuronpedia: gemma-2-9b/33-gemmascope-mlp-16k
+  - id: layer_34/width_16k/canonical
+    path: layer_34/width_16k/average_l0_107
+    neuronpedia: gemma-2-9b/34-gemmascope-mlp-16k
+  - id: layer_35/width_16k/canonical
+    path: layer_35/width_16k/average_l0_108
+    neuronpedia: gemma-2-9b/35-gemmascope-mlp-16k
+  - id: layer_36/width_16k/canonical
+    path: layer_36/width_16k/average_l0_109
+    neuronpedia: gemma-2-9b/36-gemmascope-mlp-16k
+  - id: layer_37/width_16k/canonical
+    path: layer_37/width_16k/average_l0_119
+    neuronpedia: gemma-2-9b/37-gemmascope-mlp-16k
+  - id: layer_38/width_16k/canonical
+    path: layer_38/width_16k/average_l0_98
+    neuronpedia: gemma-2-9b/38-gemmascope-mlp-16k
+  - id: layer_39/width_16k/canonical
+    path: layer_39/width_16k/average_l0_90
+    neuronpedia: gemma-2-9b/39-gemmascope-mlp-16k
+  - id: layer_40/width_16k/canonical
+    path: layer_40/width_16k/average_l0_74
+    neuronpedia: gemma-2-9b/40-gemmascope-mlp-16k
+  - id: layer_41/width_16k/canonical
+    path: layer_41/width_16k/average_l0_126
+    neuronpedia: gemma-2-9b/41-gemmascope-mlp-16k
   - id: layer_0/width_131k/canonical
     path: layer_0/width_131k/average_l0_11
     neuronpedia: gemma-2-9b/0-gemmascope-mlp-131k
@@ -6319,7 +9217,7 @@ gemma-scope-9b-it-res-canonical:
     neuronpedia: gemma-2-9b-it/31-gemmascope-it-res-131k
 gemma-scope-27b-pt-res:
   repo_id: google/gemma-scope-27b-pt-res
-  model: gemma-2-2b
+  model: gemma-2-27b
   conversion_func: gemma_2
   saes:
   - id: layer_10/width_131k/average_l0_106
@@ -6378,18 +9276,18 @@ gemma-scope-27b-pt-res:
     l0: 785
 gemma-scope-27b-pt-res-canonical:
   repo_id: google/gemma-scope-27b-pt-res
-  model: gemma-2-2b
+  model: gemma-2-27b
   conversion_func: gemma_2
   saes:
   - id: layer_10/width_131k/canonical
     path: layer_10/width_131k/average_l0_106
-    neuronpedia: gemma-2-2b/10-gemmascope-res-131k
+    neuronpedia: gemma-2-27b/10-gemmascope-res-131k
   - id: layer_22/width_131k/canonical
     path: layer_22/width_131k/average_l0_82
-    neuronpedia: gemma-2-2b/22-gemmascope-res-131k
+    neuronpedia: gemma-2-27b/22-gemmascope-res-131k
   - id: layer_34/width_131k/canonical
     path: layer_34/width_131k/average_l0_72
-    neuronpedia: gemma-2-2b/34-gemmascope-res-131k
+    neuronpedia: gemma-2-27b/34-gemmascope-res-131k
 pythia-70m-deduped-res-sm:
   repo_id: ctigges/pythia-70m-deduped__res-sm_processed
   model: pythia-70m-deduped

--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -3700,1678 +3700,1678 @@ gemma-scope-9b-pt-res:
   conversion_func: gemma_2
   saes:
   - id: layer_0/width_131k/average_l0_11
-    path: layer_0/width_131k/average_l0_11/params.npz
+    path: layer_0/width_131k/average_l0_11
     l0: 11
   - id: layer_0/width_131k/average_l0_15
-    path: layer_0/width_131k/average_l0_15/params.npz
+    path: layer_0/width_131k/average_l0_15
     l0: 15
   - id: layer_0/width_131k/average_l0_21
-    path: layer_0/width_131k/average_l0_21/params.npz
+    path: layer_0/width_131k/average_l0_21
     l0: 21
   - id: layer_0/width_131k/average_l0_30
-    path: layer_0/width_131k/average_l0_30/params.npz
+    path: layer_0/width_131k/average_l0_30
     l0: 30
   - id: layer_0/width_131k/average_l0_41
-    path: layer_0/width_131k/average_l0_41/params.npz
+    path: layer_0/width_131k/average_l0_41
     l0: 41
   - id: layer_0/width_131k/average_l0_8
-    path: layer_0/width_131k/average_l0_8/params.npz
+    path: layer_0/width_131k/average_l0_8
     l0: 8
   - id: layer_0/width_16k/average_l0_11
-    path: layer_0/width_16k/average_l0_11/params.npz
+    path: layer_0/width_16k/average_l0_11
     l0: 11
   - id: layer_0/width_16k/average_l0_129
-    path: layer_0/width_16k/average_l0_129/params.npz
+    path: layer_0/width_16k/average_l0_129
     l0: 129
   - id: layer_0/width_16k/average_l0_17
-    path: layer_0/width_16k/average_l0_17/params.npz
+    path: layer_0/width_16k/average_l0_17
     l0: 17
   - id: layer_0/width_16k/average_l0_35
-    path: layer_0/width_16k/average_l0_35/params.npz
+    path: layer_0/width_16k/average_l0_35
     l0: 35
   - id: layer_0/width_16k/average_l0_68
-    path: layer_0/width_16k/average_l0_68/params.npz
+    path: layer_0/width_16k/average_l0_68
     l0: 68
   - id: layer_1/width_131k/average_l0_13
-    path: layer_1/width_131k/average_l0_13/params.npz
+    path: layer_1/width_131k/average_l0_13
     l0: 13
   - id: layer_1/width_131k/average_l0_20
-    path: layer_1/width_131k/average_l0_20/params.npz
+    path: layer_1/width_131k/average_l0_20
     l0: 20
   - id: layer_1/width_131k/average_l0_33
-    path: layer_1/width_131k/average_l0_33/params.npz
+    path: layer_1/width_131k/average_l0_33
     l0: 33
   - id: layer_1/width_131k/average_l0_56
-    path: layer_1/width_131k/average_l0_56/params.npz
+    path: layer_1/width_131k/average_l0_56
     l0: 56
   - id: layer_1/width_131k/average_l0_6
-    path: layer_1/width_131k/average_l0_6/params.npz
+    path: layer_1/width_131k/average_l0_6
     l0: 6
   - id: layer_1/width_131k/average_l0_9
-    path: layer_1/width_131k/average_l0_9/params.npz
+    path: layer_1/width_131k/average_l0_9
     l0: 9
   - id: layer_1/width_16k/average_l0_15
-    path: layer_1/width_16k/average_l0_15/params.npz
+    path: layer_1/width_16k/average_l0_15
     l0: 15
   - id: layer_1/width_16k/average_l0_175
-    path: layer_1/width_16k/average_l0_175/params.npz
+    path: layer_1/width_16k/average_l0_175
     l0: 175
   - id: layer_1/width_16k/average_l0_31
-    path: layer_1/width_16k/average_l0_31/params.npz
+    path: layer_1/width_16k/average_l0_31
     l0: 31
   - id: layer_1/width_16k/average_l0_69
-    path: layer_1/width_16k/average_l0_69/params.npz
+    path: layer_1/width_16k/average_l0_69
     l0: 69
   - id: layer_1/width_16k/average_l0_9
-    path: layer_1/width_16k/average_l0_9/params.npz
+    path: layer_1/width_16k/average_l0_9
     l0: 9
   - id: layer_10/width_131k/average_l0_15
-    path: layer_10/width_131k/average_l0_15/params.npz
+    path: layer_10/width_131k/average_l0_15
     l0: 15
   - id: layer_10/width_131k/average_l0_151
-    path: layer_10/width_131k/average_l0_151/params.npz
+    path: layer_10/width_131k/average_l0_151
     l0: 151
   - id: layer_10/width_131k/average_l0_27
-    path: layer_10/width_131k/average_l0_27/params.npz
+    path: layer_10/width_131k/average_l0_27
     l0: 27
   - id: layer_10/width_131k/average_l0_47
-    path: layer_10/width_131k/average_l0_47/params.npz
+    path: layer_10/width_131k/average_l0_47
     l0: 47
   - id: layer_10/width_131k/average_l0_84
-    path: layer_10/width_131k/average_l0_84/params.npz
+    path: layer_10/width_131k/average_l0_84
     l0: 84
   - id: layer_10/width_131k/average_l0_9
-    path: layer_10/width_131k/average_l0_9/params.npz
+    path: layer_10/width_131k/average_l0_9
     l0: 9
   - id: layer_10/width_16k/average_l0_10
-    path: layer_10/width_16k/average_l0_10/params.npz
+    path: layer_10/width_16k/average_l0_10
     l0: 10
   - id: layer_10/width_16k/average_l0_113
-    path: layer_10/width_16k/average_l0_113/params.npz
+    path: layer_10/width_16k/average_l0_113
     l0: 113
   - id: layer_10/width_16k/average_l0_17
-    path: layer_10/width_16k/average_l0_17/params.npz
+    path: layer_10/width_16k/average_l0_17
     l0: 17
   - id: layer_10/width_16k/average_l0_243
-    path: layer_10/width_16k/average_l0_243/params.npz
+    path: layer_10/width_16k/average_l0_243
     l0: 243
   - id: layer_10/width_16k/average_l0_31
-    path: layer_10/width_16k/average_l0_31/params.npz
+    path: layer_10/width_16k/average_l0_31
     l0: 31
   - id: layer_10/width_16k/average_l0_57
-    path: layer_10/width_16k/average_l0_57/params.npz
+    path: layer_10/width_16k/average_l0_57
     l0: 57
   - id: layer_11/width_131k/average_l0_16
-    path: layer_11/width_131k/average_l0_16/params.npz
+    path: layer_11/width_131k/average_l0_16
     l0: 16
   - id: layer_11/width_131k/average_l0_162
-    path: layer_11/width_131k/average_l0_162/params.npz
+    path: layer_11/width_131k/average_l0_162
     l0: 162
   - id: layer_11/width_131k/average_l0_27
-    path: layer_11/width_131k/average_l0_27/params.npz
+    path: layer_11/width_131k/average_l0_27
     l0: 27
   - id: layer_11/width_131k/average_l0_49
-    path: layer_11/width_131k/average_l0_49/params.npz
+    path: layer_11/width_131k/average_l0_49
     l0: 49
   - id: layer_11/width_131k/average_l0_88
-    path: layer_11/width_131k/average_l0_88/params.npz
+    path: layer_11/width_131k/average_l0_88
     l0: 88
   - id: layer_11/width_131k/average_l0_9
-    path: layer_11/width_131k/average_l0_9/params.npz
+    path: layer_11/width_131k/average_l0_9
     l0: 9
   - id: layer_11/width_16k/average_l0_10
-    path: layer_11/width_16k/average_l0_10/params.npz
+    path: layer_11/width_16k/average_l0_10
     l0: 10
   - id: layer_11/width_16k/average_l0_118
-    path: layer_11/width_16k/average_l0_118/params.npz
+    path: layer_11/width_16k/average_l0_118
     l0: 118
   - id: layer_11/width_16k/average_l0_18
-    path: layer_11/width_16k/average_l0_18/params.npz
+    path: layer_11/width_16k/average_l0_18
     l0: 18
   - id: layer_11/width_16k/average_l0_255
-    path: layer_11/width_16k/average_l0_255/params.npz
+    path: layer_11/width_16k/average_l0_255
     l0: 255
   - id: layer_11/width_16k/average_l0_32
-    path: layer_11/width_16k/average_l0_32/params.npz
+    path: layer_11/width_16k/average_l0_32
     l0: 32
   - id: layer_11/width_16k/average_l0_60
-    path: layer_11/width_16k/average_l0_60/params.npz
+    path: layer_11/width_16k/average_l0_60
     l0: 60
   - id: layer_12/width_131k/average_l0_10
-    path: layer_12/width_131k/average_l0_10/params.npz
+    path: layer_12/width_131k/average_l0_10
     l0: 10
   - id: layer_12/width_131k/average_l0_17
-    path: layer_12/width_131k/average_l0_17/params.npz
+    path: layer_12/width_131k/average_l0_17
     l0: 17
   - id: layer_12/width_131k/average_l0_183
-    path: layer_12/width_131k/average_l0_183/params.npz
+    path: layer_12/width_131k/average_l0_183
     l0: 183
   - id: layer_12/width_131k/average_l0_29
-    path: layer_12/width_131k/average_l0_29/params.npz
+    path: layer_12/width_131k/average_l0_29
     l0: 29
   - id: layer_12/width_131k/average_l0_52
-    path: layer_12/width_131k/average_l0_52/params.npz
+    path: layer_12/width_131k/average_l0_52
     l0: 52
   - id: layer_12/width_131k/average_l0_96
-    path: layer_12/width_131k/average_l0_96/params.npz
+    path: layer_12/width_131k/average_l0_96
     l0: 96
   - id: layer_12/width_16k/average_l0_10
-    path: layer_12/width_16k/average_l0_10/params.npz
+    path: layer_12/width_16k/average_l0_10
     l0: 10
   - id: layer_12/width_16k/average_l0_130
-    path: layer_12/width_16k/average_l0_130/params.npz
+    path: layer_12/width_16k/average_l0_130
     l0: 130
   - id: layer_12/width_16k/average_l0_19
-    path: layer_12/width_16k/average_l0_19/params.npz
+    path: layer_12/width_16k/average_l0_19
     l0: 19
   - id: layer_12/width_16k/average_l0_287
-    path: layer_12/width_16k/average_l0_287/params.npz
+    path: layer_12/width_16k/average_l0_287
     l0: 287
   - id: layer_12/width_16k/average_l0_33
-    path: layer_12/width_16k/average_l0_33/params.npz
+    path: layer_12/width_16k/average_l0_33
     l0: 33
   - id: layer_12/width_16k/average_l0_64
-    path: layer_12/width_16k/average_l0_64/params.npz
+    path: layer_12/width_16k/average_l0_64
     l0: 64
   - id: layer_13/width_131k/average_l0_10
-    path: layer_13/width_131k/average_l0_10/params.npz
+    path: layer_13/width_131k/average_l0_10
     l0: 10
   - id: layer_13/width_131k/average_l0_17
-    path: layer_13/width_131k/average_l0_17/params.npz
+    path: layer_13/width_131k/average_l0_17
     l0: 17
   - id: layer_13/width_131k/average_l0_189
-    path: layer_13/width_131k/average_l0_189/params.npz
+    path: layer_13/width_131k/average_l0_189
     l0: 189
   - id: layer_13/width_131k/average_l0_30
-    path: layer_13/width_131k/average_l0_30/params.npz
+    path: layer_13/width_131k/average_l0_30
     l0: 30
   - id: layer_13/width_131k/average_l0_54
-    path: layer_13/width_131k/average_l0_54/params.npz
+    path: layer_13/width_131k/average_l0_54
     l0: 54
   - id: layer_13/width_131k/average_l0_99
-    path: layer_13/width_131k/average_l0_99/params.npz
+    path: layer_13/width_131k/average_l0_99
     l0: 99
   - id: layer_13/width_16k/average_l0_11
-    path: layer_13/width_16k/average_l0_11/params.npz
+    path: layer_13/width_16k/average_l0_11
     l0: 11
   - id: layer_13/width_16k/average_l0_132
-    path: layer_13/width_16k/average_l0_132/params.npz
+    path: layer_13/width_16k/average_l0_132
     l0: 132
   - id: layer_13/width_16k/average_l0_19
-    path: layer_13/width_16k/average_l0_19/params.npz
+    path: layer_13/width_16k/average_l0_19
     l0: 19
   - id: layer_13/width_16k/average_l0_285
-    path: layer_13/width_16k/average_l0_285/params.npz
+    path: layer_13/width_16k/average_l0_285
     l0: 285
   - id: layer_13/width_16k/average_l0_34
-    path: layer_13/width_16k/average_l0_34/params.npz
+    path: layer_13/width_16k/average_l0_34
     l0: 34
   - id: layer_13/width_16k/average_l0_65
-    path: layer_13/width_16k/average_l0_65/params.npz
+    path: layer_13/width_16k/average_l0_65
     l0: 65
   - id: layer_14/width_131k/average_l0_10
-    path: layer_14/width_131k/average_l0_10/params.npz
+    path: layer_14/width_131k/average_l0_10
     l0: 10
   - id: layer_14/width_131k/average_l0_105
-    path: layer_14/width_131k/average_l0_105/params.npz
+    path: layer_14/width_131k/average_l0_105
     l0: 105
   - id: layer_14/width_131k/average_l0_18
-    path: layer_14/width_131k/average_l0_18/params.npz
+    path: layer_14/width_131k/average_l0_18
     l0: 18
   - id: layer_14/width_131k/average_l0_197
-    path: layer_14/width_131k/average_l0_197/params.npz
+    path: layer_14/width_131k/average_l0_197
     l0: 197
   - id: layer_14/width_131k/average_l0_31
-    path: layer_14/width_131k/average_l0_31/params.npz
+    path: layer_14/width_131k/average_l0_31
     l0: 31
   - id: layer_14/width_131k/average_l0_56
-    path: layer_14/width_131k/average_l0_56/params.npz
+    path: layer_14/width_131k/average_l0_56
     l0: 56
   - id: layer_14/width_16k/average_l0_11
-    path: layer_14/width_16k/average_l0_11/params.npz
+    path: layer_14/width_16k/average_l0_11
     l0: 11
   - id: layer_14/width_16k/average_l0_137
-    path: layer_14/width_16k/average_l0_137/params.npz
+    path: layer_14/width_16k/average_l0_137
     l0: 137
   - id: layer_14/width_16k/average_l0_19
-    path: layer_14/width_16k/average_l0_19/params.npz
+    path: layer_14/width_16k/average_l0_19
     l0: 19
   - id: layer_14/width_16k/average_l0_294
-    path: layer_14/width_16k/average_l0_294/params.npz
+    path: layer_14/width_16k/average_l0_294
     l0: 294
   - id: layer_14/width_16k/average_l0_35
-    path: layer_14/width_16k/average_l0_35/params.npz
+    path: layer_14/width_16k/average_l0_35
     l0: 35
   - id: layer_14/width_16k/average_l0_67
-    path: layer_14/width_16k/average_l0_67/params.npz
+    path: layer_14/width_16k/average_l0_67
     l0: 67
   - id: layer_15/width_131k/average_l0_10
-    path: layer_15/width_131k/average_l0_10/params.npz
+    path: layer_15/width_131k/average_l0_10
     l0: 10
   - id: layer_15/width_131k/average_l0_103
-    path: layer_15/width_131k/average_l0_103/params.npz
+    path: layer_15/width_131k/average_l0_103
     l0: 103
   - id: layer_15/width_131k/average_l0_17
-    path: layer_15/width_131k/average_l0_17/params.npz
+    path: layer_15/width_131k/average_l0_17
     l0: 17
   - id: layer_15/width_131k/average_l0_198
-    path: layer_15/width_131k/average_l0_198/params.npz
+    path: layer_15/width_131k/average_l0_198
     l0: 198
   - id: layer_15/width_131k/average_l0_30
-    path: layer_15/width_131k/average_l0_30/params.npz
+    path: layer_15/width_131k/average_l0_30
     l0: 30
   - id: layer_15/width_131k/average_l0_55
-    path: layer_15/width_131k/average_l0_55/params.npz
+    path: layer_15/width_131k/average_l0_55
     l0: 55
   - id: layer_15/width_16k/average_l0_10
-    path: layer_15/width_16k/average_l0_10/params.npz
+    path: layer_15/width_16k/average_l0_10
     l0: 10
   - id: layer_15/width_16k/average_l0_131
-    path: layer_15/width_16k/average_l0_131/params.npz
+    path: layer_15/width_16k/average_l0_131
     l0: 131
   - id: layer_15/width_16k/average_l0_18
-    path: layer_15/width_16k/average_l0_18/params.npz
+    path: layer_15/width_16k/average_l0_18
     l0: 18
   - id: layer_15/width_16k/average_l0_290
-    path: layer_15/width_16k/average_l0_290/params.npz
+    path: layer_15/width_16k/average_l0_290
     l0: 290
   - id: layer_15/width_16k/average_l0_34
-    path: layer_15/width_16k/average_l0_34/params.npz
+    path: layer_15/width_16k/average_l0_34
     l0: 34
   - id: layer_15/width_16k/average_l0_65
-    path: layer_15/width_16k/average_l0_65/params.npz
+    path: layer_15/width_16k/average_l0_65
     l0: 65
   - id: layer_16/width_131k/average_l0_11
-    path: layer_16/width_131k/average_l0_11/params.npz
+    path: layer_16/width_131k/average_l0_11
     l0: 11
   - id: layer_16/width_131k/average_l0_121
-    path: layer_16/width_131k/average_l0_121/params.npz
+    path: layer_16/width_131k/average_l0_121
     l0: 121
   - id: layer_16/width_131k/average_l0_20
-    path: layer_16/width_131k/average_l0_20/params.npz
+    path: layer_16/width_131k/average_l0_20
     l0: 20
   - id: layer_16/width_131k/average_l0_232
-    path: layer_16/width_131k/average_l0_232/params.npz
+    path: layer_16/width_131k/average_l0_232
     l0: 232
   - id: layer_16/width_131k/average_l0_35
-    path: layer_16/width_131k/average_l0_35/params.npz
+    path: layer_16/width_131k/average_l0_35
     l0: 35
   - id: layer_16/width_131k/average_l0_65
-    path: layer_16/width_131k/average_l0_65/params.npz
+    path: layer_16/width_131k/average_l0_65
     l0: 65
   - id: layer_16/width_16k/average_l0_11
-    path: layer_16/width_16k/average_l0_11/params.npz
+    path: layer_16/width_16k/average_l0_11
     l0: 11
   - id: layer_16/width_16k/average_l0_152
-    path: layer_16/width_16k/average_l0_152/params.npz
+    path: layer_16/width_16k/average_l0_152
     l0: 152
   - id: layer_16/width_16k/average_l0_21
-    path: layer_16/width_16k/average_l0_21/params.npz
+    path: layer_16/width_16k/average_l0_21
     l0: 21
   - id: layer_16/width_16k/average_l0_346
-    path: layer_16/width_16k/average_l0_346/params.npz
+    path: layer_16/width_16k/average_l0_346
     l0: 346
   - id: layer_16/width_16k/average_l0_39
-    path: layer_16/width_16k/average_l0_39/params.npz
+    path: layer_16/width_16k/average_l0_39
     l0: 39
   - id: layer_16/width_16k/average_l0_75
-    path: layer_16/width_16k/average_l0_75/params.npz
+    path: layer_16/width_16k/average_l0_75
     l0: 75
   - id: layer_17/width_131k/average_l0_11
-    path: layer_17/width_131k/average_l0_11/params.npz
+    path: layer_17/width_131k/average_l0_11
     l0: 11
   - id: layer_17/width_131k/average_l0_117
-    path: layer_17/width_131k/average_l0_117/params.npz
+    path: layer_17/width_131k/average_l0_117
     l0: 117
   - id: layer_17/width_131k/average_l0_19
-    path: layer_17/width_131k/average_l0_19/params.npz
+    path: layer_17/width_131k/average_l0_19
     l0: 19
   - id: layer_17/width_131k/average_l0_221
-    path: layer_17/width_131k/average_l0_221/params.npz
+    path: layer_17/width_131k/average_l0_221
     l0: 221
   - id: layer_17/width_131k/average_l0_35
-    path: layer_17/width_131k/average_l0_35/params.npz
+    path: layer_17/width_131k/average_l0_35
     l0: 35
   - id: layer_17/width_131k/average_l0_64
-    path: layer_17/width_131k/average_l0_64/params.npz
+    path: layer_17/width_131k/average_l0_64
     l0: 64
   - id: layer_17/width_16k/average_l0_12
-    path: layer_17/width_16k/average_l0_12/params.npz
+    path: layer_17/width_16k/average_l0_12
     l0: 12
   - id: layer_17/width_16k/average_l0_144
-    path: layer_17/width_16k/average_l0_144/params.npz
+    path: layer_17/width_16k/average_l0_144
     l0: 144
   - id: layer_17/width_16k/average_l0_21
-    path: layer_17/width_16k/average_l0_21/params.npz
+    path: layer_17/width_16k/average_l0_21
     l0: 21
   - id: layer_17/width_16k/average_l0_317
-    path: layer_17/width_16k/average_l0_317/params.npz
+    path: layer_17/width_16k/average_l0_317
     l0: 317
   - id: layer_17/width_16k/average_l0_38
-    path: layer_17/width_16k/average_l0_38/params.npz
+    path: layer_17/width_16k/average_l0_38
     l0: 38
   - id: layer_17/width_16k/average_l0_73
-    path: layer_17/width_16k/average_l0_73/params.npz
+    path: layer_17/width_16k/average_l0_73
     l0: 73
   - id: layer_18/width_131k/average_l0_11
-    path: layer_18/width_131k/average_l0_11/params.npz
+    path: layer_18/width_131k/average_l0_11
     l0: 11
   - id: layer_18/width_131k/average_l0_113
-    path: layer_18/width_131k/average_l0_113/params.npz
+    path: layer_18/width_131k/average_l0_113
     l0: 113
   - id: layer_18/width_131k/average_l0_19
-    path: layer_18/width_131k/average_l0_19/params.npz
+    path: layer_18/width_131k/average_l0_19
     l0: 19
   - id: layer_18/width_131k/average_l0_221
-    path: layer_18/width_131k/average_l0_221/params.npz
+    path: layer_18/width_131k/average_l0_221
     l0: 221
   - id: layer_18/width_131k/average_l0_34
-    path: layer_18/width_131k/average_l0_34/params.npz
+    path: layer_18/width_131k/average_l0_34
     l0: 34
   - id: layer_18/width_131k/average_l0_62
-    path: layer_18/width_131k/average_l0_62/params.npz
+    path: layer_18/width_131k/average_l0_62
     l0: 62
   - id: layer_18/width_16k/average_l0_11
-    path: layer_18/width_16k/average_l0_11/params.npz
+    path: layer_18/width_16k/average_l0_11
     l0: 11
   - id: layer_18/width_16k/average_l0_140
-    path: layer_18/width_16k/average_l0_140/params.npz
+    path: layer_18/width_16k/average_l0_140
     l0: 140
   - id: layer_18/width_16k/average_l0_20
-    path: layer_18/width_16k/average_l0_20/params.npz
+    path: layer_18/width_16k/average_l0_20
     l0: 20
   - id: layer_18/width_16k/average_l0_309
-    path: layer_18/width_16k/average_l0_309/params.npz
+    path: layer_18/width_16k/average_l0_309
     l0: 309
   - id: layer_18/width_16k/average_l0_37
-    path: layer_18/width_16k/average_l0_37/params.npz
+    path: layer_18/width_16k/average_l0_37
     l0: 37
   - id: layer_18/width_16k/average_l0_71
-    path: layer_18/width_16k/average_l0_71/params.npz
+    path: layer_18/width_16k/average_l0_71
     l0: 71
   - id: layer_19/width_131k/average_l0_10
-    path: layer_19/width_131k/average_l0_10/params.npz
+    path: layer_19/width_131k/average_l0_10
     l0: 10
   - id: layer_19/width_131k/average_l0_110
-    path: layer_19/width_131k/average_l0_110/params.npz
+    path: layer_19/width_131k/average_l0_110
     l0: 110
   - id: layer_19/width_131k/average_l0_18
-    path: layer_19/width_131k/average_l0_18/params.npz
+    path: layer_19/width_131k/average_l0_18
     l0: 18
   - id: layer_19/width_131k/average_l0_210
-    path: layer_19/width_131k/average_l0_210/params.npz
+    path: layer_19/width_131k/average_l0_210
     l0: 210
   - id: layer_19/width_131k/average_l0_32
-    path: layer_19/width_131k/average_l0_32/params.npz
+    path: layer_19/width_131k/average_l0_32
     l0: 32
   - id: layer_19/width_131k/average_l0_60
-    path: layer_19/width_131k/average_l0_60/params.npz
+    path: layer_19/width_131k/average_l0_60
     l0: 60
   - id: layer_19/width_16k/average_l0_11
-    path: layer_19/width_16k/average_l0_11/params.npz
+    path: layer_19/width_16k/average_l0_11
     l0: 11
   - id: layer_19/width_16k/average_l0_132
-    path: layer_19/width_16k/average_l0_132/params.npz
+    path: layer_19/width_16k/average_l0_132
     l0: 132
   - id: layer_19/width_16k/average_l0_19
-    path: layer_19/width_16k/average_l0_19/params.npz
+    path: layer_19/width_16k/average_l0_19
     l0: 19
   - id: layer_19/width_16k/average_l0_293
-    path: layer_19/width_16k/average_l0_293/params.npz
+    path: layer_19/width_16k/average_l0_293
     l0: 293
   - id: layer_19/width_16k/average_l0_35
-    path: layer_19/width_16k/average_l0_35/params.npz
+    path: layer_19/width_16k/average_l0_35
     l0: 35
   - id: layer_19/width_16k/average_l0_67
-    path: layer_19/width_16k/average_l0_67/params.npz
+    path: layer_19/width_16k/average_l0_67
     l0: 67
   - id: layer_2/width_131k/average_l0_12
-    path: layer_2/width_131k/average_l0_12/params.npz
+    path: layer_2/width_131k/average_l0_12
     l0: 12
   - id: layer_2/width_131k/average_l0_19
-    path: layer_2/width_131k/average_l0_19/params.npz
+    path: layer_2/width_131k/average_l0_19
     l0: 19
   - id: layer_2/width_131k/average_l0_36
-    path: layer_2/width_131k/average_l0_36/params.npz
+    path: layer_2/width_131k/average_l0_36
     l0: 36
   - id: layer_2/width_131k/average_l0_5
-    path: layer_2/width_131k/average_l0_5/params.npz
+    path: layer_2/width_131k/average_l0_5
     l0: 5
   - id: layer_2/width_131k/average_l0_70
-    path: layer_2/width_131k/average_l0_70/params.npz
+    path: layer_2/width_131k/average_l0_70
     l0: 70
   - id: layer_2/width_131k/average_l0_8
-    path: layer_2/width_131k/average_l0_8/params.npz
+    path: layer_2/width_131k/average_l0_8
     l0: 8
   - id: layer_2/width_16k/average_l0_14
-    path: layer_2/width_16k/average_l0_14/params.npz
+    path: layer_2/width_16k/average_l0_14
     l0: 14
   - id: layer_2/width_16k/average_l0_189
-    path: layer_2/width_16k/average_l0_189/params.npz
+    path: layer_2/width_16k/average_l0_189
     l0: 189
   - id: layer_2/width_16k/average_l0_29
-    path: layer_2/width_16k/average_l0_29/params.npz
+    path: layer_2/width_16k/average_l0_29
     l0: 29
   - id: layer_2/width_16k/average_l0_67
-    path: layer_2/width_16k/average_l0_67/params.npz
+    path: layer_2/width_16k/average_l0_67
     l0: 67
   - id: layer_2/width_16k/average_l0_8
-    path: layer_2/width_16k/average_l0_8/params.npz
+    path: layer_2/width_16k/average_l0_8
     l0: 8
   - id: layer_20/width_131k/average_l0_10
-    path: layer_20/width_131k/average_l0_10/params.npz
+    path: layer_20/width_131k/average_l0_10
     l0: 10
   - id: layer_20/width_131k/average_l0_11
-    path: layer_20/width_131k/average_l0_11/params.npz
+    path: layer_20/width_131k/average_l0_11
     l0: 11
   - id: layer_20/width_131k/average_l0_114
-    path: layer_20/width_131k/average_l0_114/params.npz
+    path: layer_20/width_131k/average_l0_114
     l0: 114
   - id: layer_20/width_131k/average_l0_12
-    path: layer_20/width_131k/average_l0_12/params.npz
+    path: layer_20/width_131k/average_l0_12
     l0: 12
   - id: layer_20/width_131k/average_l0_19
-    path: layer_20/width_131k/average_l0_19/params.npz
+    path: layer_20/width_131k/average_l0_19
     l0: 19
   - id: layer_20/width_131k/average_l0_221
-    path: layer_20/width_131k/average_l0_221/params.npz
+    path: layer_20/width_131k/average_l0_221
     l0: 221
   - id: layer_20/width_131k/average_l0_269
-    path: layer_20/width_131k/average_l0_269/params.npz
+    path: layer_20/width_131k/average_l0_269
     l0: 269
   - id: layer_20/width_131k/average_l0_276
-    path: layer_20/width_131k/average_l0_276/params.npz
+    path: layer_20/width_131k/average_l0_276
     l0: 276
   - id: layer_20/width_131k/average_l0_288
-    path: layer_20/width_131k/average_l0_288/params.npz
+    path: layer_20/width_131k/average_l0_288
     l0: 288
   - id: layer_20/width_131k/average_l0_34
-    path: layer_20/width_131k/average_l0_34/params.npz
+    path: layer_20/width_131k/average_l0_34
     l0: 34
   - id: layer_20/width_131k/average_l0_51
-    path: layer_20/width_131k/average_l0_51/params.npz
+    path: layer_20/width_131k/average_l0_51
     l0: 51
   - id: layer_20/width_131k/average_l0_53
-    path: layer_20/width_131k/average_l0_53/params.npz
+    path: layer_20/width_131k/average_l0_53
     l0: 53
   - id: layer_20/width_131k/average_l0_54
-    path: layer_20/width_131k/average_l0_54/params.npz
+    path: layer_20/width_131k/average_l0_54
     l0: 54
   - id: layer_20/width_131k/average_l0_62
-    path: layer_20/width_131k/average_l0_62/params.npz
+    path: layer_20/width_131k/average_l0_62
     l0: 62
   - id: layer_20/width_16k/average_l0_11
-    path: layer_20/width_16k/average_l0_11/params.npz
+    path: layer_20/width_16k/average_l0_11
     l0: 11
   - id: layer_20/width_16k/average_l0_138
-    path: layer_20/width_16k/average_l0_138/params.npz
+    path: layer_20/width_16k/average_l0_138
     l0: 138
   - id: layer_20/width_16k/average_l0_20
-    path: layer_20/width_16k/average_l0_20/params.npz
+    path: layer_20/width_16k/average_l0_20
     l0: 20
   - id: layer_20/width_16k/average_l0_310
-    path: layer_20/width_16k/average_l0_310/params.npz
+    path: layer_20/width_16k/average_l0_310
     l0: 310
   - id: layer_20/width_16k/average_l0_36
-    path: layer_20/width_16k/average_l0_36/params.npz
+    path: layer_20/width_16k/average_l0_36
     l0: 36
   - id: layer_20/width_16k/average_l0_393
-    path: layer_20/width_16k/average_l0_393/params.npz
+    path: layer_20/width_16k/average_l0_393
     l0: 393
   - id: layer_20/width_16k/average_l0_408
-    path: layer_20/width_16k/average_l0_408/params.npz
+    path: layer_20/width_16k/average_l0_408
     l0: 408
   - id: layer_20/width_16k/average_l0_427
-    path: layer_20/width_16k/average_l0_427/params.npz
+    path: layer_20/width_16k/average_l0_427
     l0: 427
   - id: layer_20/width_16k/average_l0_57
-    path: layer_20/width_16k/average_l0_57/params.npz
+    path: layer_20/width_16k/average_l0_57
     l0: 57
   - id: layer_20/width_16k/average_l0_58
-    path: layer_20/width_16k/average_l0_58/params.npz
+    path: layer_20/width_16k/average_l0_58
     l0: 58
   - id: layer_20/width_16k/average_l0_68
-    path: layer_20/width_16k/average_l0_68/params.npz
+    path: layer_20/width_16k/average_l0_68
     l0: 68
   - id: layer_20/width_1m/average_l0_101
-    path: layer_20/width_1m/average_l0_101/params.npz
+    path: layer_20/width_1m/average_l0_101
     l0: 101
   - id: layer_20/width_1m/average_l0_11
-    path: layer_20/width_1m/average_l0_11/params.npz
+    path: layer_20/width_1m/average_l0_11
     l0: 11
   - id: layer_20/width_1m/average_l0_19
-    path: layer_20/width_1m/average_l0_19/params.npz
+    path: layer_20/width_1m/average_l0_19
     l0: 19
   - id: layer_20/width_1m/average_l0_193
-    path: layer_20/width_1m/average_l0_193/params.npz
+    path: layer_20/width_1m/average_l0_193
     l0: 193
   - id: layer_20/width_1m/average_l0_34
-    path: layer_20/width_1m/average_l0_34/params.npz
+    path: layer_20/width_1m/average_l0_34
     l0: 34
   - id: layer_20/width_1m/average_l0_57
-    path: layer_20/width_1m/average_l0_57/params.npz
+    path: layer_20/width_1m/average_l0_57
     l0: 57
   - id: layer_20/width_262k/average_l0_10
-    path: layer_20/width_262k/average_l0_10/params.npz
+    path: layer_20/width_262k/average_l0_10
     l0: 10
   - id: layer_20/width_262k/average_l0_11
-    path: layer_20/width_262k/average_l0_11/params.npz
+    path: layer_20/width_262k/average_l0_11
     l0: 11
   - id: layer_20/width_262k/average_l0_13
-    path: layer_20/width_262k/average_l0_13/params.npz
+    path: layer_20/width_262k/average_l0_13
     l0: 13
   - id: layer_20/width_262k/average_l0_249
-    path: layer_20/width_262k/average_l0_249/params.npz
+    path: layer_20/width_262k/average_l0_249
     l0: 249
   - id: layer_20/width_262k/average_l0_259
-    path: layer_20/width_262k/average_l0_259/params.npz
+    path: layer_20/width_262k/average_l0_259
     l0: 259
   - id: layer_20/width_262k/average_l0_276
-    path: layer_20/width_262k/average_l0_276/params.npz
+    path: layer_20/width_262k/average_l0_276
     l0: 276
   - id: layer_20/width_262k/average_l0_49
-    path: layer_20/width_262k/average_l0_49/params.npz
+    path: layer_20/width_262k/average_l0_49
     l0: 49
   - id: layer_20/width_262k/average_l0_50
-    path: layer_20/width_262k/average_l0_50/params.npz
+    path: layer_20/width_262k/average_l0_50
     l0: 50
   - id: layer_20/width_262k/average_l0_64
-    path: layer_20/width_262k/average_l0_64/params.npz
+    path: layer_20/width_262k/average_l0_64
     l0: 64
   - id: layer_20/width_32k/average_l0_11
-    path: layer_20/width_32k/average_l0_11/params.npz
+    path: layer_20/width_32k/average_l0_11
     l0: 11
   - id: layer_20/width_32k/average_l0_334
-    path: layer_20/width_32k/average_l0_334/params.npz
+    path: layer_20/width_32k/average_l0_334
     l0: 334
   - id: layer_20/width_32k/average_l0_344
-    path: layer_20/width_32k/average_l0_344/params.npz
+    path: layer_20/width_32k/average_l0_344
     l0: 344
   - id: layer_20/width_32k/average_l0_357
-    path: layer_20/width_32k/average_l0_357/params.npz
+    path: layer_20/width_32k/average_l0_357
     l0: 357
   - id: layer_20/width_32k/average_l0_55
-    path: layer_20/width_32k/average_l0_55/params.npz
+    path: layer_20/width_32k/average_l0_55
     l0: 55
   - id: layer_20/width_32k/average_l0_57
-    path: layer_20/width_32k/average_l0_57/params.npz
+    path: layer_20/width_32k/average_l0_57
     l0: 57
   - id: layer_20/width_524k/average_l0_10
-    path: layer_20/width_524k/average_l0_10/params.npz
+    path: layer_20/width_524k/average_l0_10
     l0: 10
   - id: layer_20/width_524k/average_l0_229
-    path: layer_20/width_524k/average_l0_229/params.npz
+    path: layer_20/width_524k/average_l0_229
     l0: 229
   - id: layer_20/width_524k/average_l0_24
-    path: layer_20/width_524k/average_l0_24/params.npz
+    path: layer_20/width_524k/average_l0_24
     l0: 24
   - id: layer_20/width_524k/average_l0_241
-    path: layer_20/width_524k/average_l0_241/params.npz
+    path: layer_20/width_524k/average_l0_241
     l0: 241
   - id: layer_20/width_524k/average_l0_298
-    path: layer_20/width_524k/average_l0_298/params.npz
+    path: layer_20/width_524k/average_l0_298
     l0: 298
   - id: layer_20/width_524k/average_l0_46
-    path: layer_20/width_524k/average_l0_46/params.npz
+    path: layer_20/width_524k/average_l0_46
     l0: 46
   - id: layer_20/width_524k/average_l0_48
-    path: layer_20/width_524k/average_l0_48/params.npz
+    path: layer_20/width_524k/average_l0_48
     l0: 48
   - id: layer_20/width_524k/average_l0_78
-    path: layer_20/width_524k/average_l0_78/params.npz
+    path: layer_20/width_524k/average_l0_78
     l0: 78
   - id: layer_20/width_65k/average_l0_11
-    path: layer_20/width_65k/average_l0_11/params.npz
+    path: layer_20/width_65k/average_l0_11
     l0: 11
   - id: layer_20/width_65k/average_l0_292
-    path: layer_20/width_65k/average_l0_292/params.npz
+    path: layer_20/width_65k/average_l0_292
     l0: 292
   - id: layer_20/width_65k/average_l0_298
-    path: layer_20/width_65k/average_l0_298/params.npz
+    path: layer_20/width_65k/average_l0_298
     l0: 298
   - id: layer_20/width_65k/average_l0_309
-    path: layer_20/width_65k/average_l0_309/params.npz
+    path: layer_20/width_65k/average_l0_309
     l0: 309
   - id: layer_20/width_65k/average_l0_54
-    path: layer_20/width_65k/average_l0_54/params.npz
+    path: layer_20/width_65k/average_l0_54
     l0: 54
   - id: layer_20/width_65k/average_l0_55
-    path: layer_20/width_65k/average_l0_55/params.npz
+    path: layer_20/width_65k/average_l0_55
     l0: 55
   - id: layer_21/width_131k/average_l0_109
-    path: layer_21/width_131k/average_l0_109/params.npz
+    path: layer_21/width_131k/average_l0_109
     l0: 109
   - id: layer_21/width_131k/average_l0_11
-    path: layer_21/width_131k/average_l0_11/params.npz
+    path: layer_21/width_131k/average_l0_11
     l0: 11
   - id: layer_21/width_131k/average_l0_19
-    path: layer_21/width_131k/average_l0_19/params.npz
+    path: layer_21/width_131k/average_l0_19
     l0: 19
   - id: layer_21/width_131k/average_l0_204
-    path: layer_21/width_131k/average_l0_204/params.npz
+    path: layer_21/width_131k/average_l0_204
     l0: 204
   - id: layer_21/width_131k/average_l0_33
-    path: layer_21/width_131k/average_l0_33/params.npz
+    path: layer_21/width_131k/average_l0_33
     l0: 33
   - id: layer_21/width_131k/average_l0_58
-    path: layer_21/width_131k/average_l0_58/params.npz
+    path: layer_21/width_131k/average_l0_58
     l0: 58
   - id: layer_21/width_16k/average_l0_11
-    path: layer_21/width_16k/average_l0_11/params.npz
+    path: layer_21/width_16k/average_l0_11
     l0: 11
   - id: layer_21/width_16k/average_l0_129
-    path: layer_21/width_16k/average_l0_129/params.npz
+    path: layer_21/width_16k/average_l0_129
     l0: 129
   - id: layer_21/width_16k/average_l0_19
-    path: layer_21/width_16k/average_l0_19/params.npz
+    path: layer_21/width_16k/average_l0_19
     l0: 19
   - id: layer_21/width_16k/average_l0_278
-    path: layer_21/width_16k/average_l0_278/params.npz
+    path: layer_21/width_16k/average_l0_278
     l0: 278
   - id: layer_21/width_16k/average_l0_36
-    path: layer_21/width_16k/average_l0_36/params.npz
+    path: layer_21/width_16k/average_l0_36
     l0: 36
   - id: layer_21/width_16k/average_l0_66
-    path: layer_21/width_16k/average_l0_66/params.npz
+    path: layer_21/width_16k/average_l0_66
     l0: 66
   - id: layer_22/width_131k/average_l0_10
-    path: layer_22/width_131k/average_l0_10/params.npz
+    path: layer_22/width_131k/average_l0_10
     l0: 10
   - id: layer_22/width_131k/average_l0_105
-    path: layer_22/width_131k/average_l0_105/params.npz
+    path: layer_22/width_131k/average_l0_105
     l0: 105
   - id: layer_22/width_131k/average_l0_18
-    path: layer_22/width_131k/average_l0_18/params.npz
+    path: layer_22/width_131k/average_l0_18
     l0: 18
   - id: layer_22/width_131k/average_l0_197
-    path: layer_22/width_131k/average_l0_197/params.npz
+    path: layer_22/width_131k/average_l0_197
     l0: 197
   - id: layer_22/width_131k/average_l0_32
-    path: layer_22/width_131k/average_l0_32/params.npz
+    path: layer_22/width_131k/average_l0_32
     l0: 32
   - id: layer_22/width_131k/average_l0_58
-    path: layer_22/width_131k/average_l0_58/params.npz
+    path: layer_22/width_131k/average_l0_58
     l0: 58
   - id: layer_22/width_16k/average_l0_11
-    path: layer_22/width_16k/average_l0_11/params.npz
+    path: layer_22/width_16k/average_l0_11
     l0: 11
   - id: layer_22/width_16k/average_l0_123
-    path: layer_22/width_16k/average_l0_123/params.npz
+    path: layer_22/width_16k/average_l0_123
     l0: 123
   - id: layer_22/width_16k/average_l0_19
-    path: layer_22/width_16k/average_l0_19/params.npz
+    path: layer_22/width_16k/average_l0_19
     l0: 19
   - id: layer_22/width_16k/average_l0_268
-    path: layer_22/width_16k/average_l0_268/params.npz
+    path: layer_22/width_16k/average_l0_268
     l0: 268
   - id: layer_22/width_16k/average_l0_35
-    path: layer_22/width_16k/average_l0_35/params.npz
+    path: layer_22/width_16k/average_l0_35
     l0: 35
   - id: layer_22/width_16k/average_l0_65
-    path: layer_22/width_16k/average_l0_65/params.npz
+    path: layer_22/width_16k/average_l0_65
     l0: 65
   - id: layer_23/width_131k/average_l0_10
-    path: layer_23/width_131k/average_l0_10/params.npz
+    path: layer_23/width_131k/average_l0_10
     l0: 10
   - id: layer_23/width_131k/average_l0_101
-    path: layer_23/width_131k/average_l0_101/params.npz
+    path: layer_23/width_131k/average_l0_101
     l0: 101
   - id: layer_23/width_131k/average_l0_18
-    path: layer_23/width_131k/average_l0_18/params.npz
+    path: layer_23/width_131k/average_l0_18
     l0: 18
   - id: layer_23/width_131k/average_l0_187
-    path: layer_23/width_131k/average_l0_187/params.npz
+    path: layer_23/width_131k/average_l0_187
     l0: 187
   - id: layer_23/width_131k/average_l0_32
-    path: layer_23/width_131k/average_l0_32/params.npz
+    path: layer_23/width_131k/average_l0_32
     l0: 32
   - id: layer_23/width_131k/average_l0_56
-    path: layer_23/width_131k/average_l0_56/params.npz
+    path: layer_23/width_131k/average_l0_56
     l0: 56
   - id: layer_23/width_16k/average_l0_11
-    path: layer_23/width_16k/average_l0_11/params.npz
+    path: layer_23/width_16k/average_l0_11
     l0: 11
   - id: layer_23/width_16k/average_l0_120
-    path: layer_23/width_16k/average_l0_120/params.npz
+    path: layer_23/width_16k/average_l0_120
     l0: 120
   - id: layer_23/width_16k/average_l0_19
-    path: layer_23/width_16k/average_l0_19/params.npz
+    path: layer_23/width_16k/average_l0_19
     l0: 19
   - id: layer_23/width_16k/average_l0_248
-    path: layer_23/width_16k/average_l0_248/params.npz
+    path: layer_23/width_16k/average_l0_248
     l0: 248
   - id: layer_23/width_16k/average_l0_35
-    path: layer_23/width_16k/average_l0_35/params.npz
+    path: layer_23/width_16k/average_l0_35
     l0: 35
   - id: layer_23/width_16k/average_l0_63
-    path: layer_23/width_16k/average_l0_63/params.npz
+    path: layer_23/width_16k/average_l0_63
     l0: 63
   - id: layer_24/width_131k/average_l0_10
-    path: layer_24/width_131k/average_l0_10/params.npz
+    path: layer_24/width_131k/average_l0_10
     l0: 10
   - id: layer_24/width_131k/average_l0_17
-    path: layer_24/width_131k/average_l0_17/params.npz
+    path: layer_24/width_131k/average_l0_17
     l0: 17
   - id: layer_24/width_131k/average_l0_180
-    path: layer_24/width_131k/average_l0_180/params.npz
+    path: layer_24/width_131k/average_l0_180
     l0: 180
   - id: layer_24/width_131k/average_l0_30
-    path: layer_24/width_131k/average_l0_30/params.npz
+    path: layer_24/width_131k/average_l0_30
     l0: 30
   - id: layer_24/width_131k/average_l0_55
-    path: layer_24/width_131k/average_l0_55/params.npz
+    path: layer_24/width_131k/average_l0_55
     l0: 55
   - id: layer_24/width_131k/average_l0_97
-    path: layer_24/width_131k/average_l0_97/params.npz
+    path: layer_24/width_131k/average_l0_97
     l0: 97
   - id: layer_24/width_16k/average_l0_10
-    path: layer_24/width_16k/average_l0_10/params.npz
+    path: layer_24/width_16k/average_l0_10
     l0: 10
   - id: layer_24/width_16k/average_l0_114
-    path: layer_24/width_16k/average_l0_114/params.npz
+    path: layer_24/width_16k/average_l0_114
     l0: 114
   - id: layer_24/width_16k/average_l0_19
-    path: layer_24/width_16k/average_l0_19/params.npz
+    path: layer_24/width_16k/average_l0_19
     l0: 19
   - id: layer_24/width_16k/average_l0_234
-    path: layer_24/width_16k/average_l0_234/params.npz
+    path: layer_24/width_16k/average_l0_234
     l0: 234
   - id: layer_24/width_16k/average_l0_34
-    path: layer_24/width_16k/average_l0_34/params.npz
+    path: layer_24/width_16k/average_l0_34
     l0: 34
   - id: layer_24/width_16k/average_l0_61
-    path: layer_24/width_16k/average_l0_61/params.npz
+    path: layer_24/width_16k/average_l0_61
     l0: 61
   - id: layer_25/width_131k/average_l0_10
-    path: layer_25/width_131k/average_l0_10/params.npz
+    path: layer_25/width_131k/average_l0_10
     l0: 10
   - id: layer_25/width_131k/average_l0_177
-    path: layer_25/width_131k/average_l0_177/params.npz
+    path: layer_25/width_131k/average_l0_177
     l0: 177
   - id: layer_25/width_131k/average_l0_18
-    path: layer_25/width_131k/average_l0_18/params.npz
+    path: layer_25/width_131k/average_l0_18
     l0: 18
   - id: layer_25/width_131k/average_l0_31
-    path: layer_25/width_131k/average_l0_31/params.npz
+    path: layer_25/width_131k/average_l0_31
     l0: 31
   - id: layer_25/width_131k/average_l0_54
-    path: layer_25/width_131k/average_l0_54/params.npz
+    path: layer_25/width_131k/average_l0_54
     l0: 54
   - id: layer_25/width_131k/average_l0_96
-    path: layer_25/width_131k/average_l0_96/params.npz
+    path: layer_25/width_131k/average_l0_96
     l0: 96
   - id: layer_25/width_16k/average_l0_11
-    path: layer_25/width_16k/average_l0_11/params.npz
+    path: layer_25/width_16k/average_l0_11
     l0: 11
   - id: layer_25/width_16k/average_l0_114
-    path: layer_25/width_16k/average_l0_114/params.npz
+    path: layer_25/width_16k/average_l0_114
     l0: 114
   - id: layer_25/width_16k/average_l0_19
-    path: layer_25/width_16k/average_l0_19/params.npz
+    path: layer_25/width_16k/average_l0_19
     l0: 19
   - id: layer_25/width_16k/average_l0_231
-    path: layer_25/width_16k/average_l0_231/params.npz
+    path: layer_25/width_16k/average_l0_231
     l0: 231
   - id: layer_25/width_16k/average_l0_34
-    path: layer_25/width_16k/average_l0_34/params.npz
+    path: layer_25/width_16k/average_l0_34
     l0: 34
   - id: layer_25/width_16k/average_l0_61
-    path: layer_25/width_16k/average_l0_61/params.npz
+    path: layer_25/width_16k/average_l0_61
     l0: 61
   - id: layer_26/width_131k/average_l0_10
-    path: layer_26/width_131k/average_l0_10/params.npz
+    path: layer_26/width_131k/average_l0_10
     l0: 10
   - id: layer_26/width_131k/average_l0_176
-    path: layer_26/width_131k/average_l0_176/params.npz
+    path: layer_26/width_131k/average_l0_176
     l0: 176
   - id: layer_26/width_131k/average_l0_18
-    path: layer_26/width_131k/average_l0_18/params.npz
+    path: layer_26/width_131k/average_l0_18
     l0: 18
   - id: layer_26/width_131k/average_l0_32
-    path: layer_26/width_131k/average_l0_32/params.npz
+    path: layer_26/width_131k/average_l0_32
     l0: 32
   - id: layer_26/width_131k/average_l0_55
-    path: layer_26/width_131k/average_l0_55/params.npz
+    path: layer_26/width_131k/average_l0_55
     l0: 55
   - id: layer_26/width_131k/average_l0_97
-    path: layer_26/width_131k/average_l0_97/params.npz
+    path: layer_26/width_131k/average_l0_97
     l0: 97
   - id: layer_26/width_16k/average_l0_11
-    path: layer_26/width_16k/average_l0_11/params.npz
+    path: layer_26/width_16k/average_l0_11
     l0: 11
   - id: layer_26/width_16k/average_l0_116
-    path: layer_26/width_16k/average_l0_116/params.npz
+    path: layer_26/width_16k/average_l0_116
     l0: 116
   - id: layer_26/width_16k/average_l0_20
-    path: layer_26/width_16k/average_l0_20/params.npz
+    path: layer_26/width_16k/average_l0_20
     l0: 20
   - id: layer_26/width_16k/average_l0_233
-    path: layer_26/width_16k/average_l0_233/params.npz
+    path: layer_26/width_16k/average_l0_233
     l0: 233
   - id: layer_26/width_16k/average_l0_35
-    path: layer_26/width_16k/average_l0_35/params.npz
+    path: layer_26/width_16k/average_l0_35
     l0: 35
   - id: layer_26/width_16k/average_l0_63
-    path: layer_26/width_16k/average_l0_63/params.npz
+    path: layer_26/width_16k/average_l0_63
     l0: 63
   - id: layer_27/width_131k/average_l0_11
-    path: layer_27/width_131k/average_l0_11/params.npz
+    path: layer_27/width_131k/average_l0_11
     l0: 11
   - id: layer_27/width_131k/average_l0_171
-    path: layer_27/width_131k/average_l0_171/params.npz
+    path: layer_27/width_131k/average_l0_171
     l0: 171
   - id: layer_27/width_131k/average_l0_19
-    path: layer_27/width_131k/average_l0_19/params.npz
+    path: layer_27/width_131k/average_l0_19
     l0: 19
   - id: layer_27/width_131k/average_l0_33
-    path: layer_27/width_131k/average_l0_33/params.npz
+    path: layer_27/width_131k/average_l0_33
     l0: 33
   - id: layer_27/width_131k/average_l0_56
-    path: layer_27/width_131k/average_l0_56/params.npz
+    path: layer_27/width_131k/average_l0_56
     l0: 56
   - id: layer_27/width_131k/average_l0_96
-    path: layer_27/width_131k/average_l0_96/params.npz
+    path: layer_27/width_131k/average_l0_96
     l0: 96
   - id: layer_27/width_16k/average_l0_118
-    path: layer_27/width_16k/average_l0_118/params.npz
+    path: layer_27/width_16k/average_l0_118
     l0: 118
   - id: layer_27/width_16k/average_l0_12
-    path: layer_27/width_16k/average_l0_12/params.npz
+    path: layer_27/width_16k/average_l0_12
     l0: 12
   - id: layer_27/width_16k/average_l0_21
-    path: layer_27/width_16k/average_l0_21/params.npz
+    path: layer_27/width_16k/average_l0_21
     l0: 21
   - id: layer_27/width_16k/average_l0_230
-    path: layer_27/width_16k/average_l0_230/params.npz
+    path: layer_27/width_16k/average_l0_230
     l0: 230
   - id: layer_27/width_16k/average_l0_36
-    path: layer_27/width_16k/average_l0_36/params.npz
+    path: layer_27/width_16k/average_l0_36
     l0: 36
   - id: layer_27/width_16k/average_l0_65
-    path: layer_27/width_16k/average_l0_65/params.npz
+    path: layer_27/width_16k/average_l0_65
     l0: 65
   - id: layer_28/width_131k/average_l0_11
-    path: layer_28/width_131k/average_l0_11/params.npz
+    path: layer_28/width_131k/average_l0_11
     l0: 11
   - id: layer_28/width_131k/average_l0_171
-    path: layer_28/width_131k/average_l0_171/params.npz
+    path: layer_28/width_131k/average_l0_171
     l0: 171
   - id: layer_28/width_131k/average_l0_19
-    path: layer_28/width_131k/average_l0_19/params.npz
+    path: layer_28/width_131k/average_l0_19
     l0: 19
   - id: layer_28/width_131k/average_l0_32
-    path: layer_28/width_131k/average_l0_32/params.npz
+    path: layer_28/width_131k/average_l0_32
     l0: 32
   - id: layer_28/width_131k/average_l0_57
-    path: layer_28/width_131k/average_l0_57/params.npz
+    path: layer_28/width_131k/average_l0_57
     l0: 57
   - id: layer_28/width_131k/average_l0_98
-    path: layer_28/width_131k/average_l0_98/params.npz
+    path: layer_28/width_131k/average_l0_98
     l0: 98
   - id: layer_28/width_16k/average_l0_119
-    path: layer_28/width_16k/average_l0_119/params.npz
+    path: layer_28/width_16k/average_l0_119
     l0: 119
   - id: layer_28/width_16k/average_l0_12
-    path: layer_28/width_16k/average_l0_12/params.npz
+    path: layer_28/width_16k/average_l0_12
     l0: 12
   - id: layer_28/width_16k/average_l0_21
-    path: layer_28/width_16k/average_l0_21/params.npz
+    path: layer_28/width_16k/average_l0_21
     l0: 21
   - id: layer_28/width_16k/average_l0_229
-    path: layer_28/width_16k/average_l0_229/params.npz
+    path: layer_28/width_16k/average_l0_229
     l0: 229
   - id: layer_28/width_16k/average_l0_37
-    path: layer_28/width_16k/average_l0_37/params.npz
+    path: layer_28/width_16k/average_l0_37
     l0: 37
   - id: layer_28/width_16k/average_l0_65
-    path: layer_28/width_16k/average_l0_65/params.npz
+    path: layer_28/width_16k/average_l0_65
     l0: 65
   - id: layer_29/width_131k/average_l0_11
-    path: layer_29/width_131k/average_l0_11/params.npz
+    path: layer_29/width_131k/average_l0_11
     l0: 11
   - id: layer_29/width_131k/average_l0_171
-    path: layer_29/width_131k/average_l0_171/params.npz
+    path: layer_29/width_131k/average_l0_171
     l0: 171
   - id: layer_29/width_131k/average_l0_19
-    path: layer_29/width_131k/average_l0_19/params.npz
+    path: layer_29/width_131k/average_l0_19
     l0: 19
   - id: layer_29/width_131k/average_l0_33
-    path: layer_29/width_131k/average_l0_33/params.npz
+    path: layer_29/width_131k/average_l0_33
     l0: 33
   - id: layer_29/width_131k/average_l0_56
-    path: layer_29/width_131k/average_l0_56/params.npz
+    path: layer_29/width_131k/average_l0_56
     l0: 56
   - id: layer_29/width_131k/average_l0_97
-    path: layer_29/width_131k/average_l0_97/params.npz
+    path: layer_29/width_131k/average_l0_97
     l0: 97
   - id: layer_29/width_16k/average_l0_119
-    path: layer_29/width_16k/average_l0_119/params.npz
+    path: layer_29/width_16k/average_l0_119
     l0: 119
   - id: layer_29/width_16k/average_l0_12
-    path: layer_29/width_16k/average_l0_12/params.npz
+    path: layer_29/width_16k/average_l0_12
     l0: 12
   - id: layer_29/width_16k/average_l0_21
-    path: layer_29/width_16k/average_l0_21/params.npz
+    path: layer_29/width_16k/average_l0_21
     l0: 21
   - id: layer_29/width_16k/average_l0_224
-    path: layer_29/width_16k/average_l0_224/params.npz
+    path: layer_29/width_16k/average_l0_224
     l0: 224
   - id: layer_29/width_16k/average_l0_38
-    path: layer_29/width_16k/average_l0_38/params.npz
+    path: layer_29/width_16k/average_l0_38
     l0: 38
   - id: layer_29/width_16k/average_l0_66
-    path: layer_29/width_16k/average_l0_66/params.npz
+    path: layer_29/width_16k/average_l0_66
     l0: 66
   - id: layer_3/width_131k/average_l0_103
-    path: layer_3/width_131k/average_l0_103/params.npz
+    path: layer_3/width_131k/average_l0_103
     l0: 103
   - id: layer_3/width_131k/average_l0_14
-    path: layer_3/width_131k/average_l0_14/params.npz
+    path: layer_3/width_131k/average_l0_14
     l0: 14
   - id: layer_3/width_131k/average_l0_25
-    path: layer_3/width_131k/average_l0_25/params.npz
+    path: layer_3/width_131k/average_l0_25
     l0: 25
   - id: layer_3/width_131k/average_l0_46
-    path: layer_3/width_131k/average_l0_46/params.npz
+    path: layer_3/width_131k/average_l0_46
     l0: 46
   - id: layer_3/width_131k/average_l0_6
-    path: layer_3/width_131k/average_l0_6/params.npz
+    path: layer_3/width_131k/average_l0_6
     l0: 6
   - id: layer_3/width_131k/average_l0_9
-    path: layer_3/width_131k/average_l0_9/params.npz
+    path: layer_3/width_131k/average_l0_9
     l0: 9
   - id: layer_3/width_16k/average_l0_10
-    path: layer_3/width_16k/average_l0_10/params.npz
+    path: layer_3/width_16k/average_l0_10
     l0: 10
   - id: layer_3/width_16k/average_l0_17
-    path: layer_3/width_16k/average_l0_17/params.npz
+    path: layer_3/width_16k/average_l0_17
     l0: 17
   - id: layer_3/width_16k/average_l0_229
-    path: layer_3/width_16k/average_l0_229/params.npz
+    path: layer_3/width_16k/average_l0_229
     l0: 229
   - id: layer_3/width_16k/average_l0_37
-    path: layer_3/width_16k/average_l0_37/params.npz
+    path: layer_3/width_16k/average_l0_37
     l0: 37
   - id: layer_3/width_16k/average_l0_90
-    path: layer_3/width_16k/average_l0_90/params.npz
+    path: layer_3/width_16k/average_l0_90
     l0: 90
   - id: layer_30/width_131k/average_l0_11
-    path: layer_30/width_131k/average_l0_11/params.npz
+    path: layer_30/width_131k/average_l0_11
     l0: 11
   - id: layer_30/width_131k/average_l0_170
-    path: layer_30/width_131k/average_l0_170/params.npz
+    path: layer_30/width_131k/average_l0_170
     l0: 170
   - id: layer_30/width_131k/average_l0_18
-    path: layer_30/width_131k/average_l0_18/params.npz
+    path: layer_30/width_131k/average_l0_18
     l0: 18
   - id: layer_30/width_131k/average_l0_32
-    path: layer_30/width_131k/average_l0_32/params.npz
+    path: layer_30/width_131k/average_l0_32
     l0: 32
   - id: layer_30/width_131k/average_l0_56
-    path: layer_30/width_131k/average_l0_56/params.npz
+    path: layer_30/width_131k/average_l0_56
     l0: 56
   - id: layer_30/width_131k/average_l0_95
-    path: layer_30/width_131k/average_l0_95/params.npz
+    path: layer_30/width_131k/average_l0_95
     l0: 95
   - id: layer_30/width_16k/average_l0_12
-    path: layer_30/width_16k/average_l0_12/params.npz
+    path: layer_30/width_16k/average_l0_12
     l0: 12
   - id: layer_30/width_16k/average_l0_120
-    path: layer_30/width_16k/average_l0_120/params.npz
+    path: layer_30/width_16k/average_l0_120
     l0: 120
   - id: layer_30/width_16k/average_l0_21
-    path: layer_30/width_16k/average_l0_21/params.npz
+    path: layer_30/width_16k/average_l0_21
     l0: 21
   - id: layer_30/width_16k/average_l0_226
-    path: layer_30/width_16k/average_l0_226/params.npz
+    path: layer_30/width_16k/average_l0_226
     l0: 226
   - id: layer_30/width_16k/average_l0_37
-    path: layer_30/width_16k/average_l0_37/params.npz
+    path: layer_30/width_16k/average_l0_37
     l0: 37
   - id: layer_30/width_16k/average_l0_66
-    path: layer_30/width_16k/average_l0_66/params.npz
+    path: layer_30/width_16k/average_l0_66
     l0: 66
   - id: layer_31/width_131k/average_l0_10
-    path: layer_31/width_131k/average_l0_10/params.npz
+    path: layer_31/width_131k/average_l0_10
     l0: 10
   - id: layer_31/width_131k/average_l0_160
-    path: layer_31/width_131k/average_l0_160/params.npz
+    path: layer_31/width_131k/average_l0_160
     l0: 160
   - id: layer_31/width_131k/average_l0_18
-    path: layer_31/width_131k/average_l0_18/params.npz
+    path: layer_31/width_131k/average_l0_18
     l0: 18
   - id: layer_31/width_131k/average_l0_31
-    path: layer_31/width_131k/average_l0_31/params.npz
+    path: layer_31/width_131k/average_l0_31
     l0: 31
   - id: layer_31/width_131k/average_l0_52
-    path: layer_31/width_131k/average_l0_52/params.npz
+    path: layer_31/width_131k/average_l0_52
     l0: 52
   - id: layer_31/width_131k/average_l0_92
-    path: layer_31/width_131k/average_l0_92/params.npz
+    path: layer_31/width_131k/average_l0_92
     l0: 92
   - id: layer_31/width_16k/average_l0_11
-    path: layer_31/width_16k/average_l0_11/params.npz
+    path: layer_31/width_16k/average_l0_11
     l0: 11
   - id: layer_31/width_16k/average_l0_114
-    path: layer_31/width_16k/average_l0_114/params.npz
+    path: layer_31/width_16k/average_l0_114
     l0: 114
   - id: layer_31/width_16k/average_l0_20
-    path: layer_31/width_16k/average_l0_20/params.npz
+    path: layer_31/width_16k/average_l0_20
     l0: 20
   - id: layer_31/width_16k/average_l0_218
-    path: layer_31/width_16k/average_l0_218/params.npz
+    path: layer_31/width_16k/average_l0_218
     l0: 218
   - id: layer_31/width_16k/average_l0_35
-    path: layer_31/width_16k/average_l0_35/params.npz
+    path: layer_31/width_16k/average_l0_35
     l0: 35
   - id: layer_31/width_16k/average_l0_63
-    path: layer_31/width_16k/average_l0_63/params.npz
+    path: layer_31/width_16k/average_l0_63
     l0: 63
   - id: layer_31/width_1m/average_l0_11
-    path: layer_31/width_1m/average_l0_11/params.npz
+    path: layer_31/width_1m/average_l0_11
     l0: 11
   - id: layer_31/width_1m/average_l0_132
-    path: layer_31/width_1m/average_l0_132/params.npz
+    path: layer_31/width_1m/average_l0_132
     l0: 132
   - id: layer_31/width_1m/average_l0_25
-    path: layer_31/width_1m/average_l0_25/params.npz
+    path: layer_31/width_1m/average_l0_25
     l0: 25
   - id: layer_31/width_1m/average_l0_27
-    path: layer_31/width_1m/average_l0_27/params.npz
+    path: layer_31/width_1m/average_l0_27
     l0: 27
   - id: layer_31/width_1m/average_l0_45
-    path: layer_31/width_1m/average_l0_45/params.npz
+    path: layer_31/width_1m/average_l0_45
     l0: 45
   - id: layer_31/width_1m/average_l0_77
-    path: layer_31/width_1m/average_l0_77/params.npz
+    path: layer_31/width_1m/average_l0_77
     l0: 77
   - id: layer_32/width_131k/average_l0_10
-    path: layer_32/width_131k/average_l0_10/params.npz
+    path: layer_32/width_131k/average_l0_10
     l0: 10
   - id: layer_32/width_131k/average_l0_158
-    path: layer_32/width_131k/average_l0_158/params.npz
+    path: layer_32/width_131k/average_l0_158
     l0: 158
   - id: layer_32/width_131k/average_l0_18
-    path: layer_32/width_131k/average_l0_18/params.npz
+    path: layer_32/width_131k/average_l0_18
     l0: 18
   - id: layer_32/width_131k/average_l0_30
-    path: layer_32/width_131k/average_l0_30/params.npz
+    path: layer_32/width_131k/average_l0_30
     l0: 30
   - id: layer_32/width_131k/average_l0_51
-    path: layer_32/width_131k/average_l0_51/params.npz
+    path: layer_32/width_131k/average_l0_51
     l0: 51
   - id: layer_32/width_131k/average_l0_88
-    path: layer_32/width_131k/average_l0_88/params.npz
+    path: layer_32/width_131k/average_l0_88
     l0: 88
   - id: layer_32/width_16k/average_l0_11
-    path: layer_32/width_16k/average_l0_11/params.npz
+    path: layer_32/width_16k/average_l0_11
     l0: 11
   - id: layer_32/width_16k/average_l0_111
-    path: layer_32/width_16k/average_l0_111/params.npz
+    path: layer_32/width_16k/average_l0_111
     l0: 111
   - id: layer_32/width_16k/average_l0_20
-    path: layer_32/width_16k/average_l0_20/params.npz
+    path: layer_32/width_16k/average_l0_20
     l0: 20
   - id: layer_32/width_16k/average_l0_219
-    path: layer_32/width_16k/average_l0_219/params.npz
+    path: layer_32/width_16k/average_l0_219
     l0: 219
   - id: layer_32/width_16k/average_l0_34
-    path: layer_32/width_16k/average_l0_34/params.npz
+    path: layer_32/width_16k/average_l0_34
     l0: 34
   - id: layer_32/width_16k/average_l0_61
-    path: layer_32/width_16k/average_l0_61/params.npz
+    path: layer_32/width_16k/average_l0_61
     l0: 61
   - id: layer_33/width_131k/average_l0_10
-    path: layer_33/width_131k/average_l0_10/params.npz
+    path: layer_33/width_131k/average_l0_10
     l0: 10
   - id: layer_33/width_131k/average_l0_165
-    path: layer_33/width_131k/average_l0_165/params.npz
+    path: layer_33/width_131k/average_l0_165
     l0: 165
   - id: layer_33/width_131k/average_l0_18
-    path: layer_33/width_131k/average_l0_18/params.npz
+    path: layer_33/width_131k/average_l0_18
     l0: 18
   - id: layer_33/width_131k/average_l0_30
-    path: layer_33/width_131k/average_l0_30/params.npz
+    path: layer_33/width_131k/average_l0_30
     l0: 30
   - id: layer_33/width_131k/average_l0_51
-    path: layer_33/width_131k/average_l0_51/params.npz
+    path: layer_33/width_131k/average_l0_51
     l0: 51
   - id: layer_33/width_131k/average_l0_91
-    path: layer_33/width_131k/average_l0_91/params.npz
+    path: layer_33/width_131k/average_l0_91
     l0: 91
   - id: layer_33/width_16k/average_l0_11
-    path: layer_33/width_16k/average_l0_11/params.npz
+    path: layer_33/width_16k/average_l0_11
     l0: 11
   - id: layer_33/width_16k/average_l0_114
-    path: layer_33/width_16k/average_l0_114/params.npz
+    path: layer_33/width_16k/average_l0_114
     l0: 114
   - id: layer_33/width_16k/average_l0_20
-    path: layer_33/width_16k/average_l0_20/params.npz
+    path: layer_33/width_16k/average_l0_20
     l0: 20
   - id: layer_33/width_16k/average_l0_228
-    path: layer_33/width_16k/average_l0_228/params.npz
+    path: layer_33/width_16k/average_l0_228
     l0: 228
   - id: layer_33/width_16k/average_l0_34
-    path: layer_33/width_16k/average_l0_34/params.npz
+    path: layer_33/width_16k/average_l0_34
     l0: 34
   - id: layer_33/width_16k/average_l0_63
-    path: layer_33/width_16k/average_l0_63/params.npz
+    path: layer_33/width_16k/average_l0_63
     l0: 63
   - id: layer_34/width_131k/average_l0_10
-    path: layer_34/width_131k/average_l0_10/params.npz
+    path: layer_34/width_131k/average_l0_10
     l0: 10
   - id: layer_34/width_131k/average_l0_163
-    path: layer_34/width_131k/average_l0_163/params.npz
+    path: layer_34/width_131k/average_l0_163
     l0: 163
   - id: layer_34/width_131k/average_l0_17
-    path: layer_34/width_131k/average_l0_17/params.npz
+    path: layer_34/width_131k/average_l0_17
     l0: 17
   - id: layer_34/width_131k/average_l0_30
-    path: layer_34/width_131k/average_l0_30/params.npz
+    path: layer_34/width_131k/average_l0_30
     l0: 30
   - id: layer_34/width_131k/average_l0_51
-    path: layer_34/width_131k/average_l0_51/params.npz
+    path: layer_34/width_131k/average_l0_51
     l0: 51
   - id: layer_34/width_131k/average_l0_89
-    path: layer_34/width_131k/average_l0_89/params.npz
+    path: layer_34/width_131k/average_l0_89
     l0: 89
   - id: layer_34/width_16k/average_l0_11
-    path: layer_34/width_16k/average_l0_11/params.npz
+    path: layer_34/width_16k/average_l0_11
     l0: 11
   - id: layer_34/width_16k/average_l0_114
-    path: layer_34/width_16k/average_l0_114/params.npz
+    path: layer_34/width_16k/average_l0_114
     l0: 114
   - id: layer_34/width_16k/average_l0_19
-    path: layer_34/width_16k/average_l0_19/params.npz
+    path: layer_34/width_16k/average_l0_19
     l0: 19
   - id: layer_34/width_16k/average_l0_229
-    path: layer_34/width_16k/average_l0_229/params.npz
+    path: layer_34/width_16k/average_l0_229
     l0: 229
   - id: layer_34/width_16k/average_l0_34
-    path: layer_34/width_16k/average_l0_34/params.npz
+    path: layer_34/width_16k/average_l0_34
     l0: 34
   - id: layer_34/width_16k/average_l0_60
-    path: layer_34/width_16k/average_l0_60/params.npz
+    path: layer_34/width_16k/average_l0_60
     l0: 60
   - id: layer_35/width_131k/average_l0_10
-    path: layer_35/width_131k/average_l0_10/params.npz
+    path: layer_35/width_131k/average_l0_10
     l0: 10
   - id: layer_35/width_131k/average_l0_17
-    path: layer_35/width_131k/average_l0_17/params.npz
+    path: layer_35/width_131k/average_l0_17
     l0: 17
   - id: layer_35/width_131k/average_l0_171
-    path: layer_35/width_131k/average_l0_171/params.npz
+    path: layer_35/width_131k/average_l0_171
     l0: 171
   - id: layer_35/width_131k/average_l0_30
-    path: layer_35/width_131k/average_l0_30/params.npz
+    path: layer_35/width_131k/average_l0_30
     l0: 30
   - id: layer_35/width_131k/average_l0_51
-    path: layer_35/width_131k/average_l0_51/params.npz
+    path: layer_35/width_131k/average_l0_51
     l0: 51
   - id: layer_35/width_131k/average_l0_94
-    path: layer_35/width_131k/average_l0_94/params.npz
+    path: layer_35/width_131k/average_l0_94
     l0: 94
   - id: layer_35/width_16k/average_l0_11
-    path: layer_35/width_16k/average_l0_11/params.npz
+    path: layer_35/width_16k/average_l0_11
     l0: 11
   - id: layer_35/width_16k/average_l0_120
-    path: layer_35/width_16k/average_l0_120/params.npz
+    path: layer_35/width_16k/average_l0_120
     l0: 120
   - id: layer_35/width_16k/average_l0_19
-    path: layer_35/width_16k/average_l0_19/params.npz
+    path: layer_35/width_16k/average_l0_19
     l0: 19
   - id: layer_35/width_16k/average_l0_246
-    path: layer_35/width_16k/average_l0_246/params.npz
+    path: layer_35/width_16k/average_l0_246
     l0: 246
   - id: layer_35/width_16k/average_l0_34
-    path: layer_35/width_16k/average_l0_34/params.npz
+    path: layer_35/width_16k/average_l0_34
     l0: 34
   - id: layer_35/width_16k/average_l0_61
-    path: layer_35/width_16k/average_l0_61/params.npz
+    path: layer_35/width_16k/average_l0_61
     l0: 61
   - id: layer_36/width_131k/average_l0_10
-    path: layer_36/width_131k/average_l0_10/params.npz
+    path: layer_36/width_131k/average_l0_10
     l0: 10
   - id: layer_36/width_131k/average_l0_17
-    path: layer_36/width_131k/average_l0_17/params.npz
+    path: layer_36/width_131k/average_l0_17
     l0: 17
   - id: layer_36/width_131k/average_l0_180
-    path: layer_36/width_131k/average_l0_180/params.npz
+    path: layer_36/width_131k/average_l0_180
     l0: 180
   - id: layer_36/width_131k/average_l0_30
-    path: layer_36/width_131k/average_l0_30/params.npz
+    path: layer_36/width_131k/average_l0_30
     l0: 30
   - id: layer_36/width_131k/average_l0_51
-    path: layer_36/width_131k/average_l0_51/params.npz
+    path: layer_36/width_131k/average_l0_51
     l0: 51
   - id: layer_36/width_131k/average_l0_93
-    path: layer_36/width_131k/average_l0_93/params.npz
+    path: layer_36/width_131k/average_l0_93
     l0: 93
   - id: layer_36/width_16k/average_l0_11
-    path: layer_36/width_16k/average_l0_11/params.npz
+    path: layer_36/width_16k/average_l0_11
     l0: 11
   - id: layer_36/width_16k/average_l0_120
-    path: layer_36/width_16k/average_l0_120/params.npz
+    path: layer_36/width_16k/average_l0_120
     l0: 120
   - id: layer_36/width_16k/average_l0_19
-    path: layer_36/width_16k/average_l0_19/params.npz
+    path: layer_36/width_16k/average_l0_19
     l0: 19
   - id: layer_36/width_16k/average_l0_252
-    path: layer_36/width_16k/average_l0_252/params.npz
+    path: layer_36/width_16k/average_l0_252
     l0: 252
   - id: layer_36/width_16k/average_l0_34
-    path: layer_36/width_16k/average_l0_34/params.npz
+    path: layer_36/width_16k/average_l0_34
     l0: 34
   - id: layer_36/width_16k/average_l0_61
-    path: layer_36/width_16k/average_l0_61/params.npz
+    path: layer_36/width_16k/average_l0_61
     l0: 61
   - id: layer_37/width_131k/average_l0_10
-    path: layer_37/width_131k/average_l0_10/params.npz
+    path: layer_37/width_131k/average_l0_10
     l0: 10
   - id: layer_37/width_131k/average_l0_18
-    path: layer_37/width_131k/average_l0_18/params.npz
+    path: layer_37/width_131k/average_l0_18
     l0: 18
   - id: layer_37/width_131k/average_l0_184
-    path: layer_37/width_131k/average_l0_184/params.npz
+    path: layer_37/width_131k/average_l0_184
     l0: 184
   - id: layer_37/width_131k/average_l0_30
-    path: layer_37/width_131k/average_l0_30/params.npz
+    path: layer_37/width_131k/average_l0_30
     l0: 30
   - id: layer_37/width_131k/average_l0_53
-    path: layer_37/width_131k/average_l0_53/params.npz
+    path: layer_37/width_131k/average_l0_53
     l0: 53
   - id: layer_37/width_131k/average_l0_96
-    path: layer_37/width_131k/average_l0_96/params.npz
+    path: layer_37/width_131k/average_l0_96
     l0: 96
   - id: layer_37/width_16k/average_l0_11
-    path: layer_37/width_16k/average_l0_11/params.npz
+    path: layer_37/width_16k/average_l0_11
     l0: 11
   - id: layer_37/width_16k/average_l0_124
-    path: layer_37/width_16k/average_l0_124/params.npz
+    path: layer_37/width_16k/average_l0_124
     l0: 124
   - id: layer_37/width_16k/average_l0_20
-    path: layer_37/width_16k/average_l0_20/params.npz
+    path: layer_37/width_16k/average_l0_20
     l0: 20
   - id: layer_37/width_16k/average_l0_266
-    path: layer_37/width_16k/average_l0_266/params.npz
+    path: layer_37/width_16k/average_l0_266
     l0: 266
   - id: layer_37/width_16k/average_l0_34
-    path: layer_37/width_16k/average_l0_34/params.npz
+    path: layer_37/width_16k/average_l0_34
     l0: 34
   - id: layer_37/width_16k/average_l0_63
-    path: layer_37/width_16k/average_l0_63/params.npz
+    path: layer_37/width_16k/average_l0_63
     l0: 63
   - id: layer_38/width_131k/average_l0_10
-    path: layer_38/width_131k/average_l0_10/params.npz
+    path: layer_38/width_131k/average_l0_10
     l0: 10
   - id: layer_38/width_131k/average_l0_101
-    path: layer_38/width_131k/average_l0_101/params.npz
+    path: layer_38/width_131k/average_l0_101
     l0: 101
   - id: layer_38/width_131k/average_l0_18
-    path: layer_38/width_131k/average_l0_18/params.npz
+    path: layer_38/width_131k/average_l0_18
     l0: 18
   - id: layer_38/width_131k/average_l0_194
-    path: layer_38/width_131k/average_l0_194/params.npz
+    path: layer_38/width_131k/average_l0_194
     l0: 194
   - id: layer_38/width_131k/average_l0_30
-    path: layer_38/width_131k/average_l0_30/params.npz
+    path: layer_38/width_131k/average_l0_30
     l0: 30
   - id: layer_38/width_131k/average_l0_53
-    path: layer_38/width_131k/average_l0_53/params.npz
+    path: layer_38/width_131k/average_l0_53
     l0: 53
   - id: layer_38/width_16k/average_l0_11
-    path: layer_38/width_16k/average_l0_11/params.npz
+    path: layer_38/width_16k/average_l0_11
     l0: 11
   - id: layer_38/width_16k/average_l0_128
-    path: layer_38/width_16k/average_l0_128/params.npz
+    path: layer_38/width_16k/average_l0_128
     l0: 128
   - id: layer_38/width_16k/average_l0_20
-    path: layer_38/width_16k/average_l0_20/params.npz
+    path: layer_38/width_16k/average_l0_20
     l0: 20
   - id: layer_38/width_16k/average_l0_286
-    path: layer_38/width_16k/average_l0_286/params.npz
+    path: layer_38/width_16k/average_l0_286
     l0: 286
   - id: layer_38/width_16k/average_l0_34
-    path: layer_38/width_16k/average_l0_34/params.npz
+    path: layer_38/width_16k/average_l0_34
     l0: 34
   - id: layer_38/width_16k/average_l0_64
-    path: layer_38/width_16k/average_l0_64/params.npz
+    path: layer_38/width_16k/average_l0_64
     l0: 64
   - id: layer_39/width_131k/average_l0_10
-    path: layer_39/width_131k/average_l0_10/params.npz
+    path: layer_39/width_131k/average_l0_10
     l0: 10
   - id: layer_39/width_131k/average_l0_18
-    path: layer_39/width_131k/average_l0_18/params.npz
+    path: layer_39/width_131k/average_l0_18
     l0: 18
   - id: layer_39/width_131k/average_l0_199
-    path: layer_39/width_131k/average_l0_199/params.npz
+    path: layer_39/width_131k/average_l0_199
     l0: 199
   - id: layer_39/width_131k/average_l0_30
-    path: layer_39/width_131k/average_l0_30/params.npz
+    path: layer_39/width_131k/average_l0_30
     l0: 30
   - id: layer_39/width_131k/average_l0_54
-    path: layer_39/width_131k/average_l0_54/params.npz
+    path: layer_39/width_131k/average_l0_54
     l0: 54
   - id: layer_39/width_131k/average_l0_99
-    path: layer_39/width_131k/average_l0_99/params.npz
+    path: layer_39/width_131k/average_l0_99
     l0: 99
   - id: layer_39/width_16k/average_l0_11
-    path: layer_39/width_16k/average_l0_11/params.npz
+    path: layer_39/width_16k/average_l0_11
     l0: 11
   - id: layer_39/width_16k/average_l0_131
-    path: layer_39/width_16k/average_l0_131/params.npz
+    path: layer_39/width_16k/average_l0_131
     l0: 131
   - id: layer_39/width_16k/average_l0_19
-    path: layer_39/width_16k/average_l0_19/params.npz
+    path: layer_39/width_16k/average_l0_19
     l0: 19
   - id: layer_39/width_16k/average_l0_298
-    path: layer_39/width_16k/average_l0_298/params.npz
+    path: layer_39/width_16k/average_l0_298
     l0: 298
   - id: layer_39/width_16k/average_l0_34
-    path: layer_39/width_16k/average_l0_34/params.npz
+    path: layer_39/width_16k/average_l0_34
     l0: 34
   - id: layer_39/width_16k/average_l0_64
-    path: layer_39/width_16k/average_l0_64/params.npz
+    path: layer_39/width_16k/average_l0_64
     l0: 64
   - id: layer_4/width_131k/average_l0_101
-    path: layer_4/width_131k/average_l0_101/params.npz
+    path: layer_4/width_131k/average_l0_101
     l0: 101
   - id: layer_4/width_131k/average_l0_16
-    path: layer_4/width_131k/average_l0_16/params.npz
+    path: layer_4/width_131k/average_l0_16
     l0: 16
   - id: layer_4/width_131k/average_l0_28
-    path: layer_4/width_131k/average_l0_28/params.npz
+    path: layer_4/width_131k/average_l0_28
     l0: 28
   - id: layer_4/width_131k/average_l0_51
-    path: layer_4/width_131k/average_l0_51/params.npz
+    path: layer_4/width_131k/average_l0_51
     l0: 51
   - id: layer_4/width_131k/average_l0_6
-    path: layer_4/width_131k/average_l0_6/params.npz
+    path: layer_4/width_131k/average_l0_6
     l0: 6
   - id: layer_4/width_131k/average_l0_9
-    path: layer_4/width_131k/average_l0_9/params.npz
+    path: layer_4/width_131k/average_l0_9
     l0: 9
   - id: layer_4/width_16k/average_l0_10
-    path: layer_4/width_16k/average_l0_10/params.npz
+    path: layer_4/width_16k/average_l0_10
     l0: 10
   - id: layer_4/width_16k/average_l0_18
-    path: layer_4/width_16k/average_l0_18/params.npz
+    path: layer_4/width_16k/average_l0_18
     l0: 18
   - id: layer_4/width_16k/average_l0_234
-    path: layer_4/width_16k/average_l0_234/params.npz
+    path: layer_4/width_16k/average_l0_234
     l0: 234
   - id: layer_4/width_16k/average_l0_37
-    path: layer_4/width_16k/average_l0_37/params.npz
+    path: layer_4/width_16k/average_l0_37
     l0: 37
   - id: layer_4/width_16k/average_l0_91
-    path: layer_4/width_16k/average_l0_91/params.npz
+    path: layer_4/width_16k/average_l0_91
     l0: 91
   - id: layer_40/width_131k/average_l0_10
-    path: layer_40/width_131k/average_l0_10/params.npz
+    path: layer_40/width_131k/average_l0_10
     l0: 10
   - id: layer_40/width_131k/average_l0_17
-    path: layer_40/width_131k/average_l0_17/params.npz
+    path: layer_40/width_131k/average_l0_17
     l0: 17
   - id: layer_40/width_131k/average_l0_193
-    path: layer_40/width_131k/average_l0_193/params.npz
+    path: layer_40/width_131k/average_l0_193
     l0: 193
   - id: layer_40/width_131k/average_l0_29
-    path: layer_40/width_131k/average_l0_29/params.npz
+    path: layer_40/width_131k/average_l0_29
     l0: 29
   - id: layer_40/width_131k/average_l0_49
-    path: layer_40/width_131k/average_l0_49/params.npz
+    path: layer_40/width_131k/average_l0_49
     l0: 49
   - id: layer_40/width_131k/average_l0_94
-    path: layer_40/width_131k/average_l0_94/params.npz
+    path: layer_40/width_131k/average_l0_94
     l0: 94
   - id: layer_40/width_16k/average_l0_10
-    path: layer_40/width_16k/average_l0_10/params.npz
+    path: layer_40/width_16k/average_l0_10
     l0: 10
   - id: layer_40/width_16k/average_l0_125
-    path: layer_40/width_16k/average_l0_125/params.npz
+    path: layer_40/width_16k/average_l0_125
     l0: 125
   - id: layer_40/width_16k/average_l0_18
-    path: layer_40/width_16k/average_l0_18/params.npz
+    path: layer_40/width_16k/average_l0_18
     l0: 18
   - id: layer_40/width_16k/average_l0_292
-    path: layer_40/width_16k/average_l0_292/params.npz
+    path: layer_40/width_16k/average_l0_292
     l0: 292
   - id: layer_40/width_16k/average_l0_32
-    path: layer_40/width_16k/average_l0_32/params.npz
+    path: layer_40/width_16k/average_l0_32
     l0: 32
   - id: layer_40/width_16k/average_l0_61
-    path: layer_40/width_16k/average_l0_61/params.npz
+    path: layer_40/width_16k/average_l0_61
     l0: 61
   - id: layer_41/width_131k/average_l0_10
-    path: layer_41/width_131k/average_l0_10/params.npz
+    path: layer_41/width_131k/average_l0_10
     l0: 10
   - id: layer_41/width_131k/average_l0_15
-    path: layer_41/width_131k/average_l0_15/params.npz
+    path: layer_41/width_131k/average_l0_15
     l0: 15
   - id: layer_41/width_131k/average_l0_175
-    path: layer_41/width_131k/average_l0_175/params.npz
+    path: layer_41/width_131k/average_l0_175
     l0: 175
   - id: layer_41/width_131k/average_l0_26
-    path: layer_41/width_131k/average_l0_26/params.npz
+    path: layer_41/width_131k/average_l0_26
     l0: 26
   - id: layer_41/width_131k/average_l0_45
-    path: layer_41/width_131k/average_l0_45/params.npz
+    path: layer_41/width_131k/average_l0_45
     l0: 45
   - id: layer_41/width_131k/average_l0_84
-    path: layer_41/width_131k/average_l0_84/params.npz
+    path: layer_41/width_131k/average_l0_84
     l0: 84
   - id: layer_41/width_16k/average_l0_10
-    path: layer_41/width_16k/average_l0_10/params.npz
+    path: layer_41/width_16k/average_l0_10
     l0: 10
   - id: layer_41/width_16k/average_l0_113
-    path: layer_41/width_16k/average_l0_113/params.npz
+    path: layer_41/width_16k/average_l0_113
     l0: 113
   - id: layer_41/width_16k/average_l0_16
-    path: layer_41/width_16k/average_l0_16/params.npz
+    path: layer_41/width_16k/average_l0_16
     l0: 16
   - id: layer_41/width_16k/average_l0_270
-    path: layer_41/width_16k/average_l0_270/params.npz
+    path: layer_41/width_16k/average_l0_270
     l0: 270
   - id: layer_41/width_16k/average_l0_28
-    path: layer_41/width_16k/average_l0_28/params.npz
+    path: layer_41/width_16k/average_l0_28
     l0: 28
   - id: layer_41/width_16k/average_l0_52
-    path: layer_41/width_16k/average_l0_52/params.npz
+    path: layer_41/width_16k/average_l0_52
     l0: 52
   - id: layer_5/width_131k/average_l0_10
-    path: layer_5/width_131k/average_l0_10/params.npz
+    path: layer_5/width_131k/average_l0_10
     l0: 10
   - id: layer_5/width_131k/average_l0_16
-    path: layer_5/width_131k/average_l0_16/params.npz
+    path: layer_5/width_131k/average_l0_16
     l0: 16
   - id: layer_5/width_131k/average_l0_29
-    path: layer_5/width_131k/average_l0_29/params.npz
+    path: layer_5/width_131k/average_l0_29
     l0: 29
   - id: layer_5/width_131k/average_l0_51
-    path: layer_5/width_131k/average_l0_51/params.npz
+    path: layer_5/width_131k/average_l0_51
     l0: 51
   - id: layer_5/width_131k/average_l0_6
-    path: layer_5/width_131k/average_l0_6/params.npz
+    path: layer_5/width_131k/average_l0_6
     l0: 6
   - id: layer_5/width_131k/average_l0_94
-    path: layer_5/width_131k/average_l0_94/params.npz
+    path: layer_5/width_131k/average_l0_94
     l0: 94
   - id: layer_5/width_16k/average_l0_11
-    path: layer_5/width_16k/average_l0_11/params.npz
+    path: layer_5/width_16k/average_l0_11
     l0: 11
   - id: layer_5/width_16k/average_l0_193
-    path: layer_5/width_16k/average_l0_193/params.npz
+    path: layer_5/width_16k/average_l0_193
     l0: 193
   - id: layer_5/width_16k/average_l0_20
-    path: layer_5/width_16k/average_l0_20/params.npz
+    path: layer_5/width_16k/average_l0_20
     l0: 20
   - id: layer_5/width_16k/average_l0_37
-    path: layer_5/width_16k/average_l0_37/params.npz
+    path: layer_5/width_16k/average_l0_37
     l0: 37
   - id: layer_5/width_16k/average_l0_77
-    path: layer_5/width_16k/average_l0_77/params.npz
+    path: layer_5/width_16k/average_l0_77
     l0: 77
   - id: layer_6/width_131k/average_l0_12
-    path: layer_6/width_131k/average_l0_12/params.npz
+    path: layer_6/width_131k/average_l0_12
     l0: 12
   - id: layer_6/width_131k/average_l0_120
-    path: layer_6/width_131k/average_l0_120/params.npz
+    path: layer_6/width_131k/average_l0_120
     l0: 120
   - id: layer_6/width_131k/average_l0_21
-    path: layer_6/width_131k/average_l0_21/params.npz
+    path: layer_6/width_131k/average_l0_21
     l0: 21
   - id: layer_6/width_131k/average_l0_36
-    path: layer_6/width_131k/average_l0_36/params.npz
+    path: layer_6/width_131k/average_l0_36
     l0: 36
   - id: layer_6/width_131k/average_l0_66
-    path: layer_6/width_131k/average_l0_66/params.npz
+    path: layer_6/width_131k/average_l0_66
     l0: 66
   - id: layer_6/width_131k/average_l0_7
-    path: layer_6/width_131k/average_l0_7/params.npz
+    path: layer_6/width_131k/average_l0_7
     l0: 7
   - id: layer_6/width_16k/average_l0_14
-    path: layer_6/width_16k/average_l0_14/params.npz
+    path: layer_6/width_16k/average_l0_14
     l0: 14
   - id: layer_6/width_16k/average_l0_224
-    path: layer_6/width_16k/average_l0_224/params.npz
+    path: layer_6/width_16k/average_l0_224
     l0: 224
   - id: layer_6/width_16k/average_l0_25
-    path: layer_6/width_16k/average_l0_25/params.npz
+    path: layer_6/width_16k/average_l0_25
     l0: 25
   - id: layer_6/width_16k/average_l0_47
-    path: layer_6/width_16k/average_l0_47/params.npz
+    path: layer_6/width_16k/average_l0_47
     l0: 47
   - id: layer_6/width_16k/average_l0_8
-    path: layer_6/width_16k/average_l0_8/params.npz
+    path: layer_6/width_16k/average_l0_8
     l0: 8
   - id: layer_6/width_16k/average_l0_93
-    path: layer_6/width_16k/average_l0_93/params.npz
+    path: layer_6/width_16k/average_l0_93
     l0: 93
   - id: layer_7/width_131k/average_l0_119
-    path: layer_7/width_131k/average_l0_119/params.npz
+    path: layer_7/width_131k/average_l0_119
     l0: 119
   - id: layer_7/width_131k/average_l0_13
-    path: layer_7/width_131k/average_l0_13/params.npz
+    path: layer_7/width_131k/average_l0_13
     l0: 13
   - id: layer_7/width_131k/average_l0_21
-    path: layer_7/width_131k/average_l0_21/params.npz
+    path: layer_7/width_131k/average_l0_21
     l0: 21
   - id: layer_7/width_131k/average_l0_38
-    path: layer_7/width_131k/average_l0_38/params.npz
+    path: layer_7/width_131k/average_l0_38
     l0: 38
   - id: layer_7/width_131k/average_l0_65
-    path: layer_7/width_131k/average_l0_65/params.npz
+    path: layer_7/width_131k/average_l0_65
     l0: 65
   - id: layer_7/width_131k/average_l0_8
-    path: layer_7/width_131k/average_l0_8/params.npz
+    path: layer_7/width_131k/average_l0_8
     l0: 8
   - id: layer_7/width_16k/average_l0_14
-    path: layer_7/width_16k/average_l0_14/params.npz
+    path: layer_7/width_16k/average_l0_14
     l0: 14
   - id: layer_7/width_16k/average_l0_198
-    path: layer_7/width_16k/average_l0_198/params.npz
+    path: layer_7/width_16k/average_l0_198
     l0: 198
   - id: layer_7/width_16k/average_l0_25
-    path: layer_7/width_16k/average_l0_25/params.npz
+    path: layer_7/width_16k/average_l0_25
     l0: 25
   - id: layer_7/width_16k/average_l0_46
-    path: layer_7/width_16k/average_l0_46/params.npz
+    path: layer_7/width_16k/average_l0_46
     l0: 46
   - id: layer_7/width_16k/average_l0_8
-    path: layer_7/width_16k/average_l0_8/params.npz
+    path: layer_7/width_16k/average_l0_8
     l0: 8
   - id: layer_7/width_16k/average_l0_92
-    path: layer_7/width_16k/average_l0_92/params.npz
+    path: layer_7/width_16k/average_l0_92
     l0: 92
   - id: layer_8/width_131k/average_l0_129
-    path: layer_8/width_131k/average_l0_129/params.npz
+    path: layer_8/width_131k/average_l0_129
     l0: 129
   - id: layer_8/width_131k/average_l0_14
-    path: layer_8/width_131k/average_l0_14/params.npz
+    path: layer_8/width_131k/average_l0_14
     l0: 14
   - id: layer_8/width_131k/average_l0_24
-    path: layer_8/width_131k/average_l0_24/params.npz
+    path: layer_8/width_131k/average_l0_24
     l0: 24
   - id: layer_8/width_131k/average_l0_41
-    path: layer_8/width_131k/average_l0_41/params.npz
+    path: layer_8/width_131k/average_l0_41
     l0: 41
   - id: layer_8/width_131k/average_l0_72
-    path: layer_8/width_131k/average_l0_72/params.npz
+    path: layer_8/width_131k/average_l0_72
     l0: 72
   - id: layer_8/width_131k/average_l0_8
-    path: layer_8/width_131k/average_l0_8/params.npz
+    path: layer_8/width_131k/average_l0_8
     l0: 8
   - id: layer_8/width_16k/average_l0_16
-    path: layer_8/width_16k/average_l0_16/params.npz
+    path: layer_8/width_16k/average_l0_16
     l0: 16
   - id: layer_8/width_16k/average_l0_207
-    path: layer_8/width_16k/average_l0_207/params.npz
+    path: layer_8/width_16k/average_l0_207
     l0: 207
   - id: layer_8/width_16k/average_l0_28
-    path: layer_8/width_16k/average_l0_28/params.npz
+    path: layer_8/width_16k/average_l0_28
     l0: 28
   - id: layer_8/width_16k/average_l0_51
-    path: layer_8/width_16k/average_l0_51/params.npz
+    path: layer_8/width_16k/average_l0_51
     l0: 51
   - id: layer_8/width_16k/average_l0_9
-    path: layer_8/width_16k/average_l0_9/params.npz
+    path: layer_8/width_16k/average_l0_9
     l0: 9
   - id: layer_8/width_16k/average_l0_99
-    path: layer_8/width_16k/average_l0_99/params.npz
+    path: layer_8/width_16k/average_l0_99
     l0: 99
   - id: layer_9/width_131k/average_l0_134
-    path: layer_9/width_131k/average_l0_134/params.npz
+    path: layer_9/width_131k/average_l0_134
     l0: 134
   - id: layer_9/width_131k/average_l0_14
-    path: layer_9/width_131k/average_l0_14/params.npz
+    path: layer_9/width_131k/average_l0_14
     l0: 14
   - id: layer_9/width_131k/average_l0_25
-    path: layer_9/width_131k/average_l0_25/params.npz
+    path: layer_9/width_131k/average_l0_25
     l0: 25
   - id: layer_9/width_131k/average_l0_42
-    path: layer_9/width_131k/average_l0_42/params.npz
+    path: layer_9/width_131k/average_l0_42
     l0: 42
   - id: layer_9/width_131k/average_l0_75
-    path: layer_9/width_131k/average_l0_75/params.npz
+    path: layer_9/width_131k/average_l0_75
     l0: 75
   - id: layer_9/width_131k/average_l0_8
-    path: layer_9/width_131k/average_l0_8/params.npz
+    path: layer_9/width_131k/average_l0_8
     l0: 8
   - id: layer_9/width_16k/average_l0_100
-    path: layer_9/width_16k/average_l0_100/params.npz
+    path: layer_9/width_16k/average_l0_100
     l0: 100
   - id: layer_9/width_16k/average_l0_16
-    path: layer_9/width_16k/average_l0_16/params.npz
+    path: layer_9/width_16k/average_l0_16
     l0: 16
   - id: layer_9/width_16k/average_l0_209
-    path: layer_9/width_16k/average_l0_209/params.npz
+    path: layer_9/width_16k/average_l0_209
     l0: 209
   - id: layer_9/width_16k/average_l0_28
-    path: layer_9/width_16k/average_l0_28/params.npz
+    path: layer_9/width_16k/average_l0_28
     l0: 28
   - id: layer_9/width_16k/average_l0_51
-    path: layer_9/width_16k/average_l0_51/params.npz
+    path: layer_9/width_16k/average_l0_51
     l0: 51
   - id: layer_9/width_16k/average_l0_9
-    path: layer_9/width_16k/average_l0_9/params.npz
+    path: layer_9/width_16k/average_l0_9
     l0: 9
   - id: layer_9/width_1m/average_l0_122
-    path: layer_9/width_1m/average_l0_122/params.npz
+    path: layer_9/width_1m/average_l0_122
     l0: 122
   - id: layer_9/width_1m/average_l0_14
-    path: layer_9/width_1m/average_l0_14/params.npz
+    path: layer_9/width_1m/average_l0_14
     l0: 14
   - id: layer_9/width_1m/average_l0_24
-    path: layer_9/width_1m/average_l0_24/params.npz
+    path: layer_9/width_1m/average_l0_24
     l0: 24
   - id: layer_9/width_1m/average_l0_41
-    path: layer_9/width_1m/average_l0_41/params.npz
+    path: layer_9/width_1m/average_l0_41
     l0: 41
   - id: layer_9/width_1m/average_l0_70
-    path: layer_9/width_1m/average_l0_70/params.npz
+    path: layer_9/width_1m/average_l0_70
     l0: 70
   - id: layer_9/width_1m/average_l0_9
-    path: layer_9/width_1m/average_l0_9/params.npz
+    path: layer_9/width_1m/average_l0_9
     l0: 9
 gemma-scope-9b-pt-res-canonical:
   repo_id: google/gemma-scope-9b-pt-res
@@ -5636,1480 +5636,1480 @@ gemma-scope-9b-pt-att:
   conversion_func: gemma_2
   saes:
   - id: layer_0/width_16k/average_l0_12
-    path: layer_0/width_16k/average_l0_12/params.npz
+    path: layer_0/width_16k/average_l0_12
     l0: 12
   - id: layer_0/width_16k/average_l0_16
-    path: layer_0/width_16k/average_l0_16/params.npz
+    path: layer_0/width_16k/average_l0_16
     l0: 16
   - id: layer_0/width_16k/average_l0_25
-    path: layer_0/width_16k/average_l0_25/params.npz
+    path: layer_0/width_16k/average_l0_25
     l0: 25
   - id: layer_0/width_16k/average_l0_38
-    path: layer_0/width_16k/average_l0_38/params.npz
+    path: layer_0/width_16k/average_l0_38
     l0: 38
   - id: layer_0/width_16k/average_l0_61
-    path: layer_0/width_16k/average_l0_61/params.npz
+    path: layer_0/width_16k/average_l0_61
     l0: 61
   - id: layer_0/width_131k/average_l0_8
-    path: layer_0/width_131k/average_l0_8/params.npz
+    path: layer_0/width_131k/average_l0_8
     l0: 8
   - id: layer_0/width_131k/average_l0_11
-    path: layer_0/width_131k/average_l0_11/params.npz
+    path: layer_0/width_131k/average_l0_11
     l0: 11
   - id: layer_0/width_131k/average_l0_15
-    path: layer_0/width_131k/average_l0_15/params.npz
+    path: layer_0/width_131k/average_l0_15
     l0: 15
   - id: layer_0/width_131k/average_l0_22
-    path: layer_0/width_131k/average_l0_22/params.npz
+    path: layer_0/width_131k/average_l0_22
     l0: 22
   - id: layer_0/width_131k/average_l0_33
-    path: layer_0/width_131k/average_l0_33/params.npz
+    path: layer_0/width_131k/average_l0_33
     l0: 33
   - id: layer_0/width_131k/average_l0_55
-    path: layer_0/width_131k/average_l0_55/params.npz
+    path: layer_0/width_131k/average_l0_55
     l0: 55
   - id: layer_1/width_16k/average_l0_17
-    path: layer_1/width_16k/average_l0_17/params.npz
+    path: layer_1/width_16k/average_l0_17
     l0: 17
   - id: layer_1/width_16k/average_l0_34
-    path: layer_1/width_16k/average_l0_34/params.npz
+    path: layer_1/width_16k/average_l0_34
     l0: 34
   - id: layer_1/width_16k/average_l0_77
-    path: layer_1/width_16k/average_l0_77/params.npz
+    path: layer_1/width_16k/average_l0_77
     l0: 77
   - id: layer_1/width_16k/average_l0_147
-    path: layer_1/width_16k/average_l0_147/params.npz
+    path: layer_1/width_16k/average_l0_147
     l0: 147
   - id: layer_1/width_16k/average_l0_266
-    path: layer_1/width_16k/average_l0_266/params.npz
+    path: layer_1/width_16k/average_l0_266
     l0: 266
   - id: layer_1/width_131k/average_l0_8
-    path: layer_1/width_131k/average_l0_8/params.npz
+    path: layer_1/width_131k/average_l0_8
     l0: 8
   - id: layer_1/width_131k/average_l0_12
-    path: layer_1/width_131k/average_l0_12/params.npz
+    path: layer_1/width_131k/average_l0_12
     l0: 12
   - id: layer_1/width_131k/average_l0_18
-    path: layer_1/width_131k/average_l0_18/params.npz
+    path: layer_1/width_131k/average_l0_18
     l0: 18
   - id: layer_1/width_131k/average_l0_29
-    path: layer_1/width_131k/average_l0_29/params.npz
+    path: layer_1/width_131k/average_l0_29
     l0: 29
   - id: layer_1/width_131k/average_l0_63
-    path: layer_1/width_131k/average_l0_63/params.npz
+    path: layer_1/width_131k/average_l0_63
     l0: 63
   - id: layer_1/width_131k/average_l0_116
-    path: layer_1/width_131k/average_l0_116/params.npz
+    path: layer_1/width_131k/average_l0_116
     l0: 116
   - id: layer_10/width_16k/average_l0_18
-    path: layer_10/width_16k/average_l0_18/params.npz
+    path: layer_10/width_16k/average_l0_18
     l0: 18
   - id: layer_10/width_16k/average_l0_33
-    path: layer_10/width_16k/average_l0_33/params.npz
+    path: layer_10/width_16k/average_l0_33
     l0: 33
   - id: layer_10/width_16k/average_l0_63
-    path: layer_10/width_16k/average_l0_63/params.npz
+    path: layer_10/width_16k/average_l0_63
     l0: 63
   - id: layer_10/width_16k/average_l0_132
-    path: layer_10/width_16k/average_l0_132/params.npz
+    path: layer_10/width_16k/average_l0_132
     l0: 132
   - id: layer_10/width_16k/average_l0_301
-    path: layer_10/width_16k/average_l0_301/params.npz
+    path: layer_10/width_16k/average_l0_301
     l0: 301
   - id: layer_10/width_131k/average_l0_16
-    path: layer_10/width_131k/average_l0_16/params.npz
+    path: layer_10/width_131k/average_l0_16
     l0: 16
   - id: layer_10/width_131k/average_l0_28
-    path: layer_10/width_131k/average_l0_28/params.npz
+    path: layer_10/width_131k/average_l0_28
     l0: 28
   - id: layer_10/width_131k/average_l0_51
-    path: layer_10/width_131k/average_l0_51/params.npz
+    path: layer_10/width_131k/average_l0_51
     l0: 51
   - id: layer_10/width_131k/average_l0_97
-    path: layer_10/width_131k/average_l0_97/params.npz
+    path: layer_10/width_131k/average_l0_97
     l0: 97
   - id: layer_10/width_131k/average_l0_199
-    path: layer_10/width_131k/average_l0_199/params.npz
+    path: layer_10/width_131k/average_l0_199
     l0: 199
   - id: layer_10/width_131k/average_l0_440
-    path: layer_10/width_131k/average_l0_440/params.npz
+    path: layer_10/width_131k/average_l0_440
     l0: 440
   - id: layer_11/width_16k/average_l0_18
-    path: layer_11/width_16k/average_l0_18/params.npz
+    path: layer_11/width_16k/average_l0_18
     l0: 18
   - id: layer_11/width_16k/average_l0_34
-    path: layer_11/width_16k/average_l0_34/params.npz
+    path: layer_11/width_16k/average_l0_34
     l0: 34
   - id: layer_11/width_16k/average_l0_67
-    path: layer_11/width_16k/average_l0_67/params.npz
+    path: layer_11/width_16k/average_l0_67
     l0: 67
   - id: layer_11/width_16k/average_l0_153
-    path: layer_11/width_16k/average_l0_153/params.npz
+    path: layer_11/width_16k/average_l0_153
     l0: 153
   - id: layer_11/width_16k/average_l0_366
-    path: layer_11/width_16k/average_l0_366/params.npz
+    path: layer_11/width_16k/average_l0_366
     l0: 366
   - id: layer_11/width_131k/average_l0_17
-    path: layer_11/width_131k/average_l0_17/params.npz
+    path: layer_11/width_131k/average_l0_17
     l0: 17
   - id: layer_11/width_131k/average_l0_29
-    path: layer_11/width_131k/average_l0_29/params.npz
+    path: layer_11/width_131k/average_l0_29
     l0: 29
   - id: layer_11/width_131k/average_l0_54
-    path: layer_11/width_131k/average_l0_54/params.npz
+    path: layer_11/width_131k/average_l0_54
     l0: 54
   - id: layer_11/width_131k/average_l0_104
-    path: layer_11/width_131k/average_l0_104/params.npz
+    path: layer_11/width_131k/average_l0_104
     l0: 104
   - id: layer_11/width_131k/average_l0_241
-    path: layer_11/width_131k/average_l0_241/params.npz
+    path: layer_11/width_131k/average_l0_241
     l0: 241
   - id: layer_11/width_131k/average_l0_552
-    path: layer_11/width_131k/average_l0_552/params.npz
+    path: layer_11/width_131k/average_l0_552
     l0: 552
   - id: layer_12/width_16k/average_l0_19
-    path: layer_12/width_16k/average_l0_19/params.npz
+    path: layer_12/width_16k/average_l0_19
     l0: 19
   - id: layer_12/width_16k/average_l0_35
-    path: layer_12/width_16k/average_l0_35/params.npz
+    path: layer_12/width_16k/average_l0_35
     l0: 35
   - id: layer_12/width_16k/average_l0_68
-    path: layer_12/width_16k/average_l0_68/params.npz
+    path: layer_12/width_16k/average_l0_68
     l0: 68
   - id: layer_12/width_16k/average_l0_149
-    path: layer_12/width_16k/average_l0_149/params.npz
+    path: layer_12/width_16k/average_l0_149
     l0: 149
   - id: layer_12/width_16k/average_l0_337
-    path: layer_12/width_16k/average_l0_337/params.npz
+    path: layer_12/width_16k/average_l0_337
     l0: 337
   - id: layer_12/width_16k/average_l0_654
-    path: layer_12/width_16k/average_l0_654/params.npz
+    path: layer_12/width_16k/average_l0_654
     l0: 654
   - id: layer_12/width_131k/average_l0_17
-    path: layer_12/width_131k/average_l0_17/params.npz
+    path: layer_12/width_131k/average_l0_17
     l0: 17
   - id: layer_12/width_131k/average_l0_29
-    path: layer_12/width_131k/average_l0_29/params.npz
+    path: layer_12/width_131k/average_l0_29
     l0: 29
   - id: layer_12/width_131k/average_l0_55
-    path: layer_12/width_131k/average_l0_55/params.npz
+    path: layer_12/width_131k/average_l0_55
     l0: 55
   - id: layer_12/width_131k/average_l0_110
-    path: layer_12/width_131k/average_l0_110/params.npz
+    path: layer_12/width_131k/average_l0_110
     l0: 110
   - id: layer_12/width_131k/average_l0_237
-    path: layer_12/width_131k/average_l0_237/params.npz
+    path: layer_12/width_131k/average_l0_237
     l0: 237
   - id: layer_12/width_131k/average_l0_525
-    path: layer_12/width_131k/average_l0_525/params.npz
+    path: layer_12/width_131k/average_l0_525
     l0: 525
   - id: layer_13/width_16k/average_l0_20
-    path: layer_13/width_16k/average_l0_20/params.npz
+    path: layer_13/width_16k/average_l0_20
     l0: 20
   - id: layer_13/width_16k/average_l0_38
-    path: layer_13/width_16k/average_l0_38/params.npz
+    path: layer_13/width_16k/average_l0_38
     l0: 38
   - id: layer_13/width_16k/average_l0_77
-    path: layer_13/width_16k/average_l0_77/params.npz
+    path: layer_13/width_16k/average_l0_77
     l0: 77
   - id: layer_13/width_16k/average_l0_170
-    path: layer_13/width_16k/average_l0_170/params.npz
+    path: layer_13/width_16k/average_l0_170
     l0: 170
   - id: layer_13/width_16k/average_l0_380
-    path: layer_13/width_16k/average_l0_380/params.npz
+    path: layer_13/width_16k/average_l0_380
     l0: 380
   - id: layer_13/width_16k/average_l0_675
-    path: layer_13/width_16k/average_l0_675/params.npz
+    path: layer_13/width_16k/average_l0_675
     l0: 675
   - id: layer_13/width_131k/average_l0_18
-    path: layer_13/width_131k/average_l0_18/params.npz
+    path: layer_13/width_131k/average_l0_18
     l0: 18
   - id: layer_13/width_131k/average_l0_33
-    path: layer_13/width_131k/average_l0_33/params.npz
+    path: layer_13/width_131k/average_l0_33
     l0: 33
   - id: layer_13/width_131k/average_l0_64
-    path: layer_13/width_131k/average_l0_64/params.npz
+    path: layer_13/width_131k/average_l0_64
     l0: 64
   - id: layer_13/width_131k/average_l0_126
-    path: layer_13/width_131k/average_l0_126/params.npz
+    path: layer_13/width_131k/average_l0_126
     l0: 126
   - id: layer_13/width_131k/average_l0_283
-    path: layer_13/width_131k/average_l0_283/params.npz
+    path: layer_13/width_131k/average_l0_283
     l0: 283
   - id: layer_13/width_131k/average_l0_611
-    path: layer_13/width_131k/average_l0_611/params.npz
+    path: layer_13/width_131k/average_l0_611
     l0: 611
   - id: layer_14/width_16k/average_l0_21
-    path: layer_14/width_16k/average_l0_21/params.npz
+    path: layer_14/width_16k/average_l0_21
     l0: 21
   - id: layer_14/width_16k/average_l0_40
-    path: layer_14/width_16k/average_l0_40/params.npz
+    path: layer_14/width_16k/average_l0_40
     l0: 40
   - id: layer_14/width_16k/average_l0_81
-    path: layer_14/width_16k/average_l0_81/params.npz
+    path: layer_14/width_16k/average_l0_81
     l0: 81
   - id: layer_14/width_16k/average_l0_179
-    path: layer_14/width_16k/average_l0_179/params.npz
+    path: layer_14/width_16k/average_l0_179
     l0: 179
   - id: layer_14/width_16k/average_l0_411
-    path: layer_14/width_16k/average_l0_411/params.npz
+    path: layer_14/width_16k/average_l0_411
     l0: 411
   - id: layer_14/width_16k/average_l0_767
-    path: layer_14/width_16k/average_l0_767/params.npz
+    path: layer_14/width_16k/average_l0_767
     l0: 767
   - id: layer_14/width_131k/average_l0_18
-    path: layer_14/width_131k/average_l0_18/params.npz
+    path: layer_14/width_131k/average_l0_18
     l0: 18
   - id: layer_14/width_131k/average_l0_35
-    path: layer_14/width_131k/average_l0_35/params.npz
+    path: layer_14/width_131k/average_l0_35
     l0: 35
   - id: layer_14/width_131k/average_l0_67
-    path: layer_14/width_131k/average_l0_67/params.npz
+    path: layer_14/width_131k/average_l0_67
     l0: 67
   - id: layer_14/width_131k/average_l0_131
-    path: layer_14/width_131k/average_l0_131/params.npz
+    path: layer_14/width_131k/average_l0_131
     l0: 131
   - id: layer_14/width_131k/average_l0_306
-    path: layer_14/width_131k/average_l0_306/params.npz
+    path: layer_14/width_131k/average_l0_306
     l0: 306
   - id: layer_14/width_131k/average_l0_650
-    path: layer_14/width_131k/average_l0_650/params.npz
+    path: layer_14/width_131k/average_l0_650
     l0: 650
   - id: layer_15/width_16k/average_l0_21
-    path: layer_15/width_16k/average_l0_21/params.npz
+    path: layer_15/width_16k/average_l0_21
     l0: 21
   - id: layer_15/width_16k/average_l0_40
-    path: layer_15/width_16k/average_l0_40/params.npz
+    path: layer_15/width_16k/average_l0_40
     l0: 40
   - id: layer_15/width_16k/average_l0_79
-    path: layer_15/width_16k/average_l0_79/params.npz
+    path: layer_15/width_16k/average_l0_79
     l0: 79
   - id: layer_15/width_16k/average_l0_168
-    path: layer_15/width_16k/average_l0_168/params.npz
+    path: layer_15/width_16k/average_l0_168
     l0: 168
   - id: layer_15/width_16k/average_l0_344
-    path: layer_15/width_16k/average_l0_344/params.npz
+    path: layer_15/width_16k/average_l0_344
     l0: 344
   - id: layer_15/width_16k/average_l0_638
-    path: layer_15/width_16k/average_l0_638/params.npz
+    path: layer_15/width_16k/average_l0_638
     l0: 638
   - id: layer_15/width_131k/average_l0_19
-    path: layer_15/width_131k/average_l0_19/params.npz
+    path: layer_15/width_131k/average_l0_19
     l0: 19
   - id: layer_15/width_131k/average_l0_35
-    path: layer_15/width_131k/average_l0_35/params.npz
+    path: layer_15/width_131k/average_l0_35
     l0: 35
   - id: layer_15/width_131k/average_l0_67
-    path: layer_15/width_131k/average_l0_67/params.npz
+    path: layer_15/width_131k/average_l0_67
     l0: 67
   - id: layer_15/width_131k/average_l0_130
-    path: layer_15/width_131k/average_l0_130/params.npz
+    path: layer_15/width_131k/average_l0_130
     l0: 130
   - id: layer_15/width_131k/average_l0_283
-    path: layer_15/width_131k/average_l0_283/params.npz
+    path: layer_15/width_131k/average_l0_283
     l0: 283
   - id: layer_15/width_131k/average_l0_540
-    path: layer_15/width_131k/average_l0_540/params.npz
+    path: layer_15/width_131k/average_l0_540
     l0: 540
   - id: layer_16/width_16k/average_l0_21
-    path: layer_16/width_16k/average_l0_21/params.npz
+    path: layer_16/width_16k/average_l0_21
     l0: 21
   - id: layer_16/width_16k/average_l0_40
-    path: layer_16/width_16k/average_l0_40/params.npz
+    path: layer_16/width_16k/average_l0_40
     l0: 40
   - id: layer_16/width_16k/average_l0_81
-    path: layer_16/width_16k/average_l0_81/params.npz
+    path: layer_16/width_16k/average_l0_81
     l0: 81
   - id: layer_16/width_16k/average_l0_172
-    path: layer_16/width_16k/average_l0_172/params.npz
+    path: layer_16/width_16k/average_l0_172
     l0: 172
   - id: layer_16/width_16k/average_l0_376
-    path: layer_16/width_16k/average_l0_376/params.npz
+    path: layer_16/width_16k/average_l0_376
     l0: 376
   - id: layer_16/width_16k/average_l0_705
-    path: layer_16/width_16k/average_l0_705/params.npz
+    path: layer_16/width_16k/average_l0_705
     l0: 705
   - id: layer_16/width_131k/average_l0_19
-    path: layer_16/width_131k/average_l0_19/params.npz
+    path: layer_16/width_131k/average_l0_19
     l0: 19
   - id: layer_16/width_131k/average_l0_36
-    path: layer_16/width_131k/average_l0_36/params.npz
+    path: layer_16/width_131k/average_l0_36
     l0: 36
   - id: layer_16/width_131k/average_l0_71
-    path: layer_16/width_131k/average_l0_71/params.npz
+    path: layer_16/width_131k/average_l0_71
     l0: 71
   - id: layer_16/width_131k/average_l0_140
-    path: layer_16/width_131k/average_l0_140/params.npz
+    path: layer_16/width_131k/average_l0_140
     l0: 140
   - id: layer_16/width_131k/average_l0_298
-    path: layer_16/width_131k/average_l0_298/params.npz
+    path: layer_16/width_131k/average_l0_298
     l0: 298
   - id: layer_16/width_131k/average_l0_621
-    path: layer_16/width_131k/average_l0_621/params.npz
+    path: layer_16/width_131k/average_l0_621
     l0: 621
   - id: layer_17/width_16k/average_l0_24
-    path: layer_17/width_16k/average_l0_24/params.npz
+    path: layer_17/width_16k/average_l0_24
     l0: 24
   - id: layer_17/width_16k/average_l0_50
-    path: layer_17/width_16k/average_l0_50/params.npz
+    path: layer_17/width_16k/average_l0_50
     l0: 50
   - id: layer_17/width_16k/average_l0_110
-    path: layer_17/width_16k/average_l0_110/params.npz
+    path: layer_17/width_16k/average_l0_110
     l0: 110
   - id: layer_17/width_16k/average_l0_227
-    path: layer_17/width_16k/average_l0_227/params.npz
+    path: layer_17/width_16k/average_l0_227
     l0: 227
   - id: layer_17/width_16k/average_l0_435
-    path: layer_17/width_16k/average_l0_435/params.npz
+    path: layer_17/width_16k/average_l0_435
     l0: 435
   - id: layer_17/width_16k/average_l0_719
-    path: layer_17/width_16k/average_l0_719/params.npz
+    path: layer_17/width_16k/average_l0_719
     l0: 719
   - id: layer_17/width_131k/average_l0_22
-    path: layer_17/width_131k/average_l0_22/params.npz
+    path: layer_17/width_131k/average_l0_22
     l0: 22
   - id: layer_17/width_131k/average_l0_44
-    path: layer_17/width_131k/average_l0_44/params.npz
+    path: layer_17/width_131k/average_l0_44
     l0: 44
   - id: layer_17/width_131k/average_l0_90
-    path: layer_17/width_131k/average_l0_90/params.npz
+    path: layer_17/width_131k/average_l0_90
     l0: 90
   - id: layer_17/width_131k/average_l0_191
-    path: layer_17/width_131k/average_l0_191/params.npz
+    path: layer_17/width_131k/average_l0_191
     l0: 191
   - id: layer_17/width_131k/average_l0_380
-    path: layer_17/width_131k/average_l0_380/params.npz
+    path: layer_17/width_131k/average_l0_380
     l0: 380
   - id: layer_17/width_131k/average_l0_672
-    path: layer_17/width_131k/average_l0_672/params.npz
+    path: layer_17/width_131k/average_l0_672
     l0: 672
   - id: layer_18/width_16k/average_l0_21
-    path: layer_18/width_16k/average_l0_21/params.npz
+    path: layer_18/width_16k/average_l0_21
     l0: 21
   - id: layer_18/width_16k/average_l0_40
-    path: layer_18/width_16k/average_l0_40/params.npz
+    path: layer_18/width_16k/average_l0_40
     l0: 40
   - id: layer_18/width_16k/average_l0_80
-    path: layer_18/width_16k/average_l0_80/params.npz
+    path: layer_18/width_16k/average_l0_80
     l0: 80
   - id: layer_18/width_16k/average_l0_171
-    path: layer_18/width_16k/average_l0_171/params.npz
+    path: layer_18/width_16k/average_l0_171
     l0: 171
   - id: layer_18/width_16k/average_l0_352
-    path: layer_18/width_16k/average_l0_352/params.npz
+    path: layer_18/width_16k/average_l0_352
     l0: 352
   - id: layer_18/width_16k/average_l0_646
-    path: layer_18/width_16k/average_l0_646/params.npz
+    path: layer_18/width_16k/average_l0_646
     l0: 646
   - id: layer_18/width_131k/average_l0_19
-    path: layer_18/width_131k/average_l0_19/params.npz
+    path: layer_18/width_131k/average_l0_19
     l0: 19
   - id: layer_18/width_131k/average_l0_35
-    path: layer_18/width_131k/average_l0_35/params.npz
+    path: layer_18/width_131k/average_l0_35
     l0: 35
   - id: layer_18/width_131k/average_l0_69
-    path: layer_18/width_131k/average_l0_69/params.npz
+    path: layer_18/width_131k/average_l0_69
     l0: 69
   - id: layer_18/width_131k/average_l0_133
-    path: layer_18/width_131k/average_l0_133/params.npz
+    path: layer_18/width_131k/average_l0_133
     l0: 133
   - id: layer_18/width_131k/average_l0_294
-    path: layer_18/width_131k/average_l0_294/params.npz
+    path: layer_18/width_131k/average_l0_294
     l0: 294
   - id: layer_18/width_131k/average_l0_557
-    path: layer_18/width_131k/average_l0_557/params.npz
+    path: layer_18/width_131k/average_l0_557
     l0: 557
   - id: layer_19/width_16k/average_l0_21
-    path: layer_19/width_16k/average_l0_21/params.npz
+    path: layer_19/width_16k/average_l0_21
     l0: 21
   - id: layer_19/width_16k/average_l0_41
-    path: layer_19/width_16k/average_l0_41/params.npz
+    path: layer_19/width_16k/average_l0_41
     l0: 41
   - id: layer_19/width_16k/average_l0_86
-    path: layer_19/width_16k/average_l0_86/params.npz
+    path: layer_19/width_16k/average_l0_86
     l0: 86
   - id: layer_19/width_16k/average_l0_186
-    path: layer_19/width_16k/average_l0_186/params.npz
+    path: layer_19/width_16k/average_l0_186
     l0: 186
   - id: layer_19/width_16k/average_l0_360
-    path: layer_19/width_16k/average_l0_360/params.npz
+    path: layer_19/width_16k/average_l0_360
     l0: 360
   - id: layer_19/width_16k/average_l0_661
-    path: layer_19/width_16k/average_l0_661/params.npz
+    path: layer_19/width_16k/average_l0_661
     l0: 661
   - id: layer_19/width_131k/average_l0_19
-    path: layer_19/width_131k/average_l0_19/params.npz
+    path: layer_19/width_131k/average_l0_19
     l0: 19
   - id: layer_19/width_131k/average_l0_38
-    path: layer_19/width_131k/average_l0_38/params.npz
+    path: layer_19/width_131k/average_l0_38
     l0: 38
   - id: layer_19/width_131k/average_l0_71
-    path: layer_19/width_131k/average_l0_71/params.npz
+    path: layer_19/width_131k/average_l0_71
     l0: 71
   - id: layer_19/width_131k/average_l0_152
-    path: layer_19/width_131k/average_l0_152/params.npz
+    path: layer_19/width_131k/average_l0_152
     l0: 152
   - id: layer_19/width_131k/average_l0_307
-    path: layer_19/width_131k/average_l0_307/params.npz
+    path: layer_19/width_131k/average_l0_307
     l0: 307
   - id: layer_19/width_131k/average_l0_571
-    path: layer_19/width_131k/average_l0_571/params.npz
+    path: layer_19/width_131k/average_l0_571
     l0: 571
   - id: layer_2/width_16k/average_l0_15
-    path: layer_2/width_16k/average_l0_15/params.npz
+    path: layer_2/width_16k/average_l0_15
     l0: 15
   - id: layer_2/width_16k/average_l0_30
-    path: layer_2/width_16k/average_l0_30/params.npz
+    path: layer_2/width_16k/average_l0_30
     l0: 30
   - id: layer_2/width_16k/average_l0_69
-    path: layer_2/width_16k/average_l0_69/params.npz
+    path: layer_2/width_16k/average_l0_69
     l0: 69
   - id: layer_2/width_16k/average_l0_180
-    path: layer_2/width_16k/average_l0_180/params.npz
+    path: layer_2/width_16k/average_l0_180
     l0: 180
   - id: layer_2/width_16k/average_l0_384
-    path: layer_2/width_16k/average_l0_384/params.npz
+    path: layer_2/width_16k/average_l0_384
     l0: 384
   - id: layer_2/width_131k/average_l0_7
-    path: layer_2/width_131k/average_l0_7/params.npz
+    path: layer_2/width_131k/average_l0_7
     l0: 7
   - id: layer_2/width_131k/average_l0_11
-    path: layer_2/width_131k/average_l0_11/params.npz
+    path: layer_2/width_131k/average_l0_11
     l0: 11
   - id: layer_2/width_131k/average_l0_18
-    path: layer_2/width_131k/average_l0_18/params.npz
+    path: layer_2/width_131k/average_l0_18
     l0: 18
   - id: layer_2/width_131k/average_l0_32
-    path: layer_2/width_131k/average_l0_32/params.npz
+    path: layer_2/width_131k/average_l0_32
     l0: 32
   - id: layer_2/width_131k/average_l0_62
-    path: layer_2/width_131k/average_l0_62/params.npz
+    path: layer_2/width_131k/average_l0_62
     l0: 62
   - id: layer_2/width_131k/average_l0_135
-    path: layer_2/width_131k/average_l0_135/params.npz
+    path: layer_2/width_131k/average_l0_135
     l0: 135
   - id: layer_20/width_16k/average_l0_20
-    path: layer_20/width_16k/average_l0_20/params.npz
+    path: layer_20/width_16k/average_l0_20
     l0: 20
   - id: layer_20/width_16k/average_l0_39
-    path: layer_20/width_16k/average_l0_39/params.npz
+    path: layer_20/width_16k/average_l0_39
     l0: 39
   - id: layer_20/width_16k/average_l0_76
-    path: layer_20/width_16k/average_l0_76/params.npz
+    path: layer_20/width_16k/average_l0_76
     l0: 76
   - id: layer_20/width_16k/average_l0_158
-    path: layer_20/width_16k/average_l0_158/params.npz
+    path: layer_20/width_16k/average_l0_158
     l0: 158
   - id: layer_20/width_16k/average_l0_342
-    path: layer_20/width_16k/average_l0_342/params.npz
+    path: layer_20/width_16k/average_l0_342
     l0: 342
   - id: layer_20/width_16k/average_l0_674
-    path: layer_20/width_16k/average_l0_674/params.npz
+    path: layer_20/width_16k/average_l0_674
     l0: 674
   - id: layer_20/width_131k/average_l0_18
-    path: layer_20/width_131k/average_l0_18/params.npz
+    path: layer_20/width_131k/average_l0_18
     l0: 18
   - id: layer_20/width_131k/average_l0_34
-    path: layer_20/width_131k/average_l0_34/params.npz
+    path: layer_20/width_131k/average_l0_34
     l0: 34
   - id: layer_20/width_131k/average_l0_65
-    path: layer_20/width_131k/average_l0_65/params.npz
+    path: layer_20/width_131k/average_l0_65
     l0: 65
   - id: layer_20/width_131k/average_l0_125
-    path: layer_20/width_131k/average_l0_125/params.npz
+    path: layer_20/width_131k/average_l0_125
     l0: 125
   - id: layer_20/width_131k/average_l0_270
-    path: layer_20/width_131k/average_l0_270/params.npz
+    path: layer_20/width_131k/average_l0_270
     l0: 270
   - id: layer_20/width_131k/average_l0_558
-    path: layer_20/width_131k/average_l0_558/params.npz
+    path: layer_20/width_131k/average_l0_558
     l0: 558
   - id: layer_21/width_16k/average_l0_21
-    path: layer_21/width_16k/average_l0_21/params.npz
+    path: layer_21/width_16k/average_l0_21
     l0: 21
   - id: layer_21/width_16k/average_l0_41
-    path: layer_21/width_16k/average_l0_41/params.npz
+    path: layer_21/width_16k/average_l0_41
     l0: 41
   - id: layer_21/width_16k/average_l0_86
-    path: layer_21/width_16k/average_l0_86/params.npz
+    path: layer_21/width_16k/average_l0_86
     l0: 86
   - id: layer_21/width_16k/average_l0_195
-    path: layer_21/width_16k/average_l0_195/params.npz
+    path: layer_21/width_16k/average_l0_195
     l0: 195
   - id: layer_21/width_16k/average_l0_420
-    path: layer_21/width_16k/average_l0_420/params.npz
+    path: layer_21/width_16k/average_l0_420
     l0: 420
   - id: layer_21/width_16k/average_l0_792
-    path: layer_21/width_16k/average_l0_792/params.npz
+    path: layer_21/width_16k/average_l0_792
     l0: 792
   - id: layer_21/width_131k/average_l0_18
-    path: layer_21/width_131k/average_l0_18/params.npz
+    path: layer_21/width_131k/average_l0_18
     l0: 18
   - id: layer_21/width_131k/average_l0_35
-    path: layer_21/width_131k/average_l0_35/params.npz
+    path: layer_21/width_131k/average_l0_35
     l0: 35
   - id: layer_21/width_131k/average_l0_71
-    path: layer_21/width_131k/average_l0_71/params.npz
+    path: layer_21/width_131k/average_l0_71
     l0: 71
   - id: layer_21/width_131k/average_l0_150
-    path: layer_21/width_131k/average_l0_150/params.npz
+    path: layer_21/width_131k/average_l0_150
     l0: 150
   - id: layer_21/width_131k/average_l0_333
-    path: layer_21/width_131k/average_l0_333/params.npz
+    path: layer_21/width_131k/average_l0_333
     l0: 333
   - id: layer_21/width_131k/average_l0_665
-    path: layer_21/width_131k/average_l0_665/params.npz
+    path: layer_21/width_131k/average_l0_665
     l0: 665
   - id: layer_22/width_16k/average_l0_20
-    path: layer_22/width_16k/average_l0_20/params.npz
+    path: layer_22/width_16k/average_l0_20
     l0: 20
   - id: layer_22/width_16k/average_l0_36
-    path: layer_22/width_16k/average_l0_36/params.npz
+    path: layer_22/width_16k/average_l0_36
     l0: 36
   - id: layer_22/width_16k/average_l0_70
-    path: layer_22/width_16k/average_l0_70/params.npz
+    path: layer_22/width_16k/average_l0_70
     l0: 70
   - id: layer_22/width_16k/average_l0_141
-    path: layer_22/width_16k/average_l0_141/params.npz
+    path: layer_22/width_16k/average_l0_141
     l0: 141
   - id: layer_22/width_16k/average_l0_289
-    path: layer_22/width_16k/average_l0_289/params.npz
+    path: layer_22/width_16k/average_l0_289
     l0: 289
   - id: layer_22/width_16k/average_l0_569
-    path: layer_22/width_16k/average_l0_569/params.npz
+    path: layer_22/width_16k/average_l0_569
     l0: 569
   - id: layer_22/width_131k/average_l0_17
-    path: layer_22/width_131k/average_l0_17/params.npz
+    path: layer_22/width_131k/average_l0_17
     l0: 17
   - id: layer_22/width_131k/average_l0_32
-    path: layer_22/width_131k/average_l0_32/params.npz
+    path: layer_22/width_131k/average_l0_32
     l0: 32
   - id: layer_22/width_131k/average_l0_59
-    path: layer_22/width_131k/average_l0_59/params.npz
+    path: layer_22/width_131k/average_l0_59
     l0: 59
   - id: layer_22/width_131k/average_l0_115
-    path: layer_22/width_131k/average_l0_115/params.npz
+    path: layer_22/width_131k/average_l0_115
     l0: 115
   - id: layer_22/width_131k/average_l0_231
-    path: layer_22/width_131k/average_l0_231/params.npz
+    path: layer_22/width_131k/average_l0_231
     l0: 231
   - id: layer_22/width_131k/average_l0_446
-    path: layer_22/width_131k/average_l0_446/params.npz
+    path: layer_22/width_131k/average_l0_446
     l0: 446
   - id: layer_23/width_16k/average_l0_21
-    path: layer_23/width_16k/average_l0_21/params.npz
+    path: layer_23/width_16k/average_l0_21
     l0: 21
   - id: layer_23/width_16k/average_l0_41
-    path: layer_23/width_16k/average_l0_41/params.npz
+    path: layer_23/width_16k/average_l0_41
     l0: 41
   - id: layer_23/width_16k/average_l0_80
-    path: layer_23/width_16k/average_l0_80/params.npz
+    path: layer_23/width_16k/average_l0_80
     l0: 80
   - id: layer_23/width_16k/average_l0_173
-    path: layer_23/width_16k/average_l0_173/params.npz
+    path: layer_23/width_16k/average_l0_173
     l0: 173
   - id: layer_23/width_16k/average_l0_356
-    path: layer_23/width_16k/average_l0_356/params.npz
+    path: layer_23/width_16k/average_l0_356
     l0: 356
   - id: layer_23/width_16k/average_l0_649
-    path: layer_23/width_16k/average_l0_649/params.npz
+    path: layer_23/width_16k/average_l0_649
     l0: 649
   - id: layer_23/width_131k/average_l0_19
-    path: layer_23/width_131k/average_l0_19/params.npz
+    path: layer_23/width_131k/average_l0_19
     l0: 19
   - id: layer_23/width_131k/average_l0_36
-    path: layer_23/width_131k/average_l0_36/params.npz
+    path: layer_23/width_131k/average_l0_36
     l0: 36
   - id: layer_23/width_131k/average_l0_66
-    path: layer_23/width_131k/average_l0_66/params.npz
+    path: layer_23/width_131k/average_l0_66
     l0: 66
   - id: layer_23/width_131k/average_l0_134
-    path: layer_23/width_131k/average_l0_134/params.npz
+    path: layer_23/width_131k/average_l0_134
     l0: 134
   - id: layer_23/width_131k/average_l0_288
-    path: layer_23/width_131k/average_l0_288/params.npz
+    path: layer_23/width_131k/average_l0_288
     l0: 288
   - id: layer_23/width_131k/average_l0_568
-    path: layer_23/width_131k/average_l0_568/params.npz
+    path: layer_23/width_131k/average_l0_568
     l0: 568
   - id: layer_24/width_16k/average_l0_21
-    path: layer_24/width_16k/average_l0_21/params.npz
+    path: layer_24/width_16k/average_l0_21
     l0: 21
   - id: layer_24/width_16k/average_l0_40
-    path: layer_24/width_16k/average_l0_40/params.npz
+    path: layer_24/width_16k/average_l0_40
     l0: 40
   - id: layer_24/width_16k/average_l0_79
-    path: layer_24/width_16k/average_l0_79/params.npz
+    path: layer_24/width_16k/average_l0_79
     l0: 79
   - id: layer_24/width_16k/average_l0_167
-    path: layer_24/width_16k/average_l0_167/params.npz
+    path: layer_24/width_16k/average_l0_167
     l0: 167
   - id: layer_24/width_16k/average_l0_348
-    path: layer_24/width_16k/average_l0_348/params.npz
+    path: layer_24/width_16k/average_l0_348
     l0: 348
   - id: layer_24/width_16k/average_l0_615
-    path: layer_24/width_16k/average_l0_615/params.npz
+    path: layer_24/width_16k/average_l0_615
     l0: 615
   - id: layer_24/width_131k/average_l0_19
-    path: layer_24/width_131k/average_l0_19/params.npz
+    path: layer_24/width_131k/average_l0_19
     l0: 19
   - id: layer_24/width_131k/average_l0_35
-    path: layer_24/width_131k/average_l0_35/params.npz
+    path: layer_24/width_131k/average_l0_35
     l0: 35
   - id: layer_24/width_131k/average_l0_66
-    path: layer_24/width_131k/average_l0_66/params.npz
+    path: layer_24/width_131k/average_l0_66
     l0: 66
   - id: layer_24/width_131k/average_l0_130
-    path: layer_24/width_131k/average_l0_130/params.npz
+    path: layer_24/width_131k/average_l0_130
     l0: 130
   - id: layer_24/width_131k/average_l0_273
-    path: layer_24/width_131k/average_l0_273/params.npz
+    path: layer_24/width_131k/average_l0_273
     l0: 273
   - id: layer_24/width_131k/average_l0_542
-    path: layer_24/width_131k/average_l0_542/params.npz
+    path: layer_24/width_131k/average_l0_542
     l0: 542
   - id: layer_25/width_16k/average_l0_19
-    path: layer_25/width_16k/average_l0_19/params.npz
+    path: layer_25/width_16k/average_l0_19
     l0: 19
   - id: layer_25/width_16k/average_l0_36
-    path: layer_25/width_16k/average_l0_36/params.npz
+    path: layer_25/width_16k/average_l0_36
     l0: 36
   - id: layer_25/width_16k/average_l0_73
-    path: layer_25/width_16k/average_l0_73/params.npz
+    path: layer_25/width_16k/average_l0_73
     l0: 73
   - id: layer_25/width_16k/average_l0_156
-    path: layer_25/width_16k/average_l0_156/params.npz
+    path: layer_25/width_16k/average_l0_156
     l0: 156
   - id: layer_25/width_16k/average_l0_371
-    path: layer_25/width_16k/average_l0_371/params.npz
+    path: layer_25/width_16k/average_l0_371
     l0: 371
   - id: layer_25/width_16k/average_l0_686
-    path: layer_25/width_16k/average_l0_686/params.npz
+    path: layer_25/width_16k/average_l0_686
     l0: 686
   - id: layer_25/width_131k/average_l0_17
-    path: layer_25/width_131k/average_l0_17/params.npz
+    path: layer_25/width_131k/average_l0_17
     l0: 17
   - id: layer_25/width_131k/average_l0_31
-    path: layer_25/width_131k/average_l0_31/params.npz
+    path: layer_25/width_131k/average_l0_31
     l0: 31
   - id: layer_25/width_131k/average_l0_59
-    path: layer_25/width_131k/average_l0_59/params.npz
+    path: layer_25/width_131k/average_l0_59
     l0: 59
   - id: layer_25/width_131k/average_l0_115
-    path: layer_25/width_131k/average_l0_115/params.npz
+    path: layer_25/width_131k/average_l0_115
     l0: 115
   - id: layer_25/width_131k/average_l0_261
-    path: layer_25/width_131k/average_l0_261/params.npz
+    path: layer_25/width_131k/average_l0_261
     l0: 261
   - id: layer_25/width_131k/average_l0_605
-    path: layer_25/width_131k/average_l0_605/params.npz
+    path: layer_25/width_131k/average_l0_605
     l0: 605
   - id: layer_26/width_16k/average_l0_20
-    path: layer_26/width_16k/average_l0_20/params.npz
+    path: layer_26/width_16k/average_l0_20
     l0: 20
   - id: layer_26/width_16k/average_l0_38
-    path: layer_26/width_16k/average_l0_38/params.npz
+    path: layer_26/width_16k/average_l0_38
     l0: 38
   - id: layer_26/width_16k/average_l0_75
-    path: layer_26/width_16k/average_l0_75/params.npz
+    path: layer_26/width_16k/average_l0_75
     l0: 75
   - id: layer_26/width_16k/average_l0_159
-    path: layer_26/width_16k/average_l0_159/params.npz
+    path: layer_26/width_16k/average_l0_159
     l0: 159
   - id: layer_26/width_16k/average_l0_336
-    path: layer_26/width_16k/average_l0_336/params.npz
+    path: layer_26/width_16k/average_l0_336
     l0: 336
   - id: layer_26/width_16k/average_l0_634
-    path: layer_26/width_16k/average_l0_634/params.npz
+    path: layer_26/width_16k/average_l0_634
     l0: 634
   - id: layer_26/width_131k/average_l0_18
-    path: layer_26/width_131k/average_l0_18/params.npz
+    path: layer_26/width_131k/average_l0_18
     l0: 18
   - id: layer_26/width_131k/average_l0_32
-    path: layer_26/width_131k/average_l0_32/params.npz
+    path: layer_26/width_131k/average_l0_32
     l0: 32
   - id: layer_26/width_131k/average_l0_62
-    path: layer_26/width_131k/average_l0_62/params.npz
+    path: layer_26/width_131k/average_l0_62
     l0: 62
   - id: layer_26/width_131k/average_l0_120
-    path: layer_26/width_131k/average_l0_120/params.npz
+    path: layer_26/width_131k/average_l0_120
     l0: 120
   - id: layer_26/width_131k/average_l0_267
-    path: layer_26/width_131k/average_l0_267/params.npz
+    path: layer_26/width_131k/average_l0_267
     l0: 267
   - id: layer_26/width_131k/average_l0_525
-    path: layer_26/width_131k/average_l0_525/params.npz
+    path: layer_26/width_131k/average_l0_525
     l0: 525
   - id: layer_27/width_16k/average_l0_18
-    path: layer_27/width_16k/average_l0_18/params.npz
+    path: layer_27/width_16k/average_l0_18
     l0: 18
   - id: layer_27/width_16k/average_l0_33
-    path: layer_27/width_16k/average_l0_33/params.npz
+    path: layer_27/width_16k/average_l0_33
     l0: 33
   - id: layer_27/width_16k/average_l0_64
-    path: layer_27/width_16k/average_l0_64/params.npz
+    path: layer_27/width_16k/average_l0_64
     l0: 64
   - id: layer_27/width_16k/average_l0_136
-    path: layer_27/width_16k/average_l0_136/params.npz
+    path: layer_27/width_16k/average_l0_136
     l0: 136
   - id: layer_27/width_16k/average_l0_306
-    path: layer_27/width_16k/average_l0_306/params.npz
+    path: layer_27/width_16k/average_l0_306
     l0: 306
   - id: layer_27/width_16k/average_l0_613
-    path: layer_27/width_16k/average_l0_613/params.npz
+    path: layer_27/width_16k/average_l0_613
     l0: 613
   - id: layer_27/width_131k/average_l0_16
-    path: layer_27/width_131k/average_l0_16/params.npz
+    path: layer_27/width_131k/average_l0_16
     l0: 16
   - id: layer_27/width_131k/average_l0_28
-    path: layer_27/width_131k/average_l0_28/params.npz
+    path: layer_27/width_131k/average_l0_28
     l0: 28
   - id: layer_27/width_131k/average_l0_53
-    path: layer_27/width_131k/average_l0_53/params.npz
+    path: layer_27/width_131k/average_l0_53
     l0: 53
   - id: layer_27/width_131k/average_l0_102
-    path: layer_27/width_131k/average_l0_102/params.npz
+    path: layer_27/width_131k/average_l0_102
     l0: 102
   - id: layer_27/width_131k/average_l0_211
-    path: layer_27/width_131k/average_l0_211/params.npz
+    path: layer_27/width_131k/average_l0_211
     l0: 211
   - id: layer_27/width_131k/average_l0_458
-    path: layer_27/width_131k/average_l0_458/params.npz
+    path: layer_27/width_131k/average_l0_458
     l0: 458
   - id: layer_28/width_16k/average_l0_20
-    path: layer_28/width_16k/average_l0_20/params.npz
+    path: layer_28/width_16k/average_l0_20
     l0: 20
   - id: layer_28/width_16k/average_l0_37
-    path: layer_28/width_16k/average_l0_37/params.npz
+    path: layer_28/width_16k/average_l0_37
     l0: 37
   - id: layer_28/width_16k/average_l0_71
-    path: layer_28/width_16k/average_l0_71/params.npz
+    path: layer_28/width_16k/average_l0_71
     l0: 71
   - id: layer_28/width_16k/average_l0_143
-    path: layer_28/width_16k/average_l0_143/params.npz
+    path: layer_28/width_16k/average_l0_143
     l0: 143
   - id: layer_28/width_16k/average_l0_279
-    path: layer_28/width_16k/average_l0_279/params.npz
+    path: layer_28/width_16k/average_l0_279
     l0: 279
   - id: layer_28/width_16k/average_l0_498
-    path: layer_28/width_16k/average_l0_498/params.npz
+    path: layer_28/width_16k/average_l0_498
     l0: 498
   - id: layer_28/width_131k/average_l0_19
-    path: layer_28/width_131k/average_l0_19/params.npz
+    path: layer_28/width_131k/average_l0_19
     l0: 19
   - id: layer_28/width_131k/average_l0_32
-    path: layer_28/width_131k/average_l0_32/params.npz
+    path: layer_28/width_131k/average_l0_32
     l0: 32
   - id: layer_28/width_131k/average_l0_59
-    path: layer_28/width_131k/average_l0_59/params.npz
+    path: layer_28/width_131k/average_l0_59
     l0: 59
   - id: layer_28/width_131k/average_l0_115
-    path: layer_28/width_131k/average_l0_115/params.npz
+    path: layer_28/width_131k/average_l0_115
     l0: 115
   - id: layer_28/width_131k/average_l0_230
-    path: layer_28/width_131k/average_l0_230/params.npz
+    path: layer_28/width_131k/average_l0_230
     l0: 230
   - id: layer_28/width_131k/average_l0_452
-    path: layer_28/width_131k/average_l0_452/params.npz
+    path: layer_28/width_131k/average_l0_452
     l0: 452
   - id: layer_29/width_16k/average_l0_18
-    path: layer_29/width_16k/average_l0_18/params.npz
+    path: layer_29/width_16k/average_l0_18
     l0: 18
   - id: layer_29/width_16k/average_l0_35
-    path: layer_29/width_16k/average_l0_35/params.npz
+    path: layer_29/width_16k/average_l0_35
     l0: 35
   - id: layer_29/width_16k/average_l0_76
-    path: layer_29/width_16k/average_l0_76/params.npz
+    path: layer_29/width_16k/average_l0_76
     l0: 76
   - id: layer_29/width_16k/average_l0_171
-    path: layer_29/width_16k/average_l0_171/params.npz
+    path: layer_29/width_16k/average_l0_171
     l0: 171
   - id: layer_29/width_16k/average_l0_308
-    path: layer_29/width_16k/average_l0_308/params.npz
+    path: layer_29/width_16k/average_l0_308
     l0: 308
   - id: layer_29/width_16k/average_l0_559
-    path: layer_29/width_16k/average_l0_559/params.npz
+    path: layer_29/width_16k/average_l0_559
     l0: 559
   - id: layer_29/width_131k/average_l0_17
-    path: layer_29/width_131k/average_l0_17/params.npz
+    path: layer_29/width_131k/average_l0_17
     l0: 17
   - id: layer_29/width_131k/average_l0_30
-    path: layer_29/width_131k/average_l0_30/params.npz
+    path: layer_29/width_131k/average_l0_30
     l0: 30
   - id: layer_29/width_131k/average_l0_57
-    path: layer_29/width_131k/average_l0_57/params.npz
+    path: layer_29/width_131k/average_l0_57
     l0: 57
   - id: layer_29/width_131k/average_l0_128
-    path: layer_29/width_131k/average_l0_128/params.npz
+    path: layer_29/width_131k/average_l0_128
     l0: 128
   - id: layer_29/width_131k/average_l0_265
-    path: layer_29/width_131k/average_l0_265/params.npz
+    path: layer_29/width_131k/average_l0_265
     l0: 265
   - id: layer_29/width_131k/average_l0_446
-    path: layer_29/width_131k/average_l0_446/params.npz
+    path: layer_29/width_131k/average_l0_446
     l0: 446
   - id: layer_3/width_16k/average_l0_23
-    path: layer_3/width_16k/average_l0_23/params.npz
+    path: layer_3/width_16k/average_l0_23
     l0: 23
   - id: layer_3/width_16k/average_l0_44
-    path: layer_3/width_16k/average_l0_44/params.npz
+    path: layer_3/width_16k/average_l0_44
     l0: 44
   - id: layer_3/width_16k/average_l0_102
-    path: layer_3/width_16k/average_l0_102/params.npz
+    path: layer_3/width_16k/average_l0_102
     l0: 102
   - id: layer_3/width_16k/average_l0_221
-    path: layer_3/width_16k/average_l0_221/params.npz
+    path: layer_3/width_16k/average_l0_221
     l0: 221
   - id: layer_3/width_16k/average_l0_435
-    path: layer_3/width_16k/average_l0_435/params.npz
+    path: layer_3/width_16k/average_l0_435
     l0: 435
   - id: layer_3/width_131k/average_l0_10
-    path: layer_3/width_131k/average_l0_10/params.npz
+    path: layer_3/width_131k/average_l0_10
     l0: 10
   - id: layer_3/width_131k/average_l0_17
-    path: layer_3/width_131k/average_l0_17/params.npz
+    path: layer_3/width_131k/average_l0_17
     l0: 17
   - id: layer_3/width_131k/average_l0_31
-    path: layer_3/width_131k/average_l0_31/params.npz
+    path: layer_3/width_131k/average_l0_31
     l0: 31
   - id: layer_3/width_131k/average_l0_58
-    path: layer_3/width_131k/average_l0_58/params.npz
+    path: layer_3/width_131k/average_l0_58
     l0: 58
   - id: layer_3/width_131k/average_l0_119
-    path: layer_3/width_131k/average_l0_119/params.npz
+    path: layer_3/width_131k/average_l0_119
     l0: 119
   - id: layer_3/width_131k/average_l0_252
-    path: layer_3/width_131k/average_l0_252/params.npz
+    path: layer_3/width_131k/average_l0_252
     l0: 252
   - id: layer_30/width_16k/average_l0_19
-    path: layer_30/width_16k/average_l0_19/params.npz
+    path: layer_30/width_16k/average_l0_19
     l0: 19
   - id: layer_30/width_16k/average_l0_36
-    path: layer_30/width_16k/average_l0_36/params.npz
+    path: layer_30/width_16k/average_l0_36
     l0: 36
   - id: layer_30/width_16k/average_l0_73
-    path: layer_30/width_16k/average_l0_73/params.npz
+    path: layer_30/width_16k/average_l0_73
     l0: 73
   - id: layer_30/width_16k/average_l0_157
-    path: layer_30/width_16k/average_l0_157/params.npz
+    path: layer_30/width_16k/average_l0_157
     l0: 157
   - id: layer_30/width_16k/average_l0_313
-    path: layer_30/width_16k/average_l0_313/params.npz
+    path: layer_30/width_16k/average_l0_313
     l0: 313
   - id: layer_30/width_16k/average_l0_558
-    path: layer_30/width_16k/average_l0_558/params.npz
+    path: layer_30/width_16k/average_l0_558
     l0: 558
   - id: layer_30/width_131k/average_l0_17
-    path: layer_30/width_131k/average_l0_17/params.npz
+    path: layer_30/width_131k/average_l0_17
     l0: 17
   - id: layer_30/width_131k/average_l0_29
-    path: layer_30/width_131k/average_l0_29/params.npz
+    path: layer_30/width_131k/average_l0_29
     l0: 29
   - id: layer_30/width_131k/average_l0_55
-    path: layer_30/width_131k/average_l0_55/params.npz
+    path: layer_30/width_131k/average_l0_55
     l0: 55
   - id: layer_30/width_131k/average_l0_109
-    path: layer_30/width_131k/average_l0_109/params.npz
+    path: layer_30/width_131k/average_l0_109
     l0: 109
   - id: layer_30/width_131k/average_l0_236
-    path: layer_30/width_131k/average_l0_236/params.npz
+    path: layer_30/width_131k/average_l0_236
     l0: 236
   - id: layer_30/width_131k/average_l0_491
-    path: layer_30/width_131k/average_l0_491/params.npz
+    path: layer_30/width_131k/average_l0_491
     l0: 491
   - id: layer_31/width_16k/average_l0_18
-    path: layer_31/width_16k/average_l0_18/params.npz
+    path: layer_31/width_16k/average_l0_18
     l0: 18
   - id: layer_31/width_16k/average_l0_36
-    path: layer_31/width_16k/average_l0_36/params.npz
+    path: layer_31/width_16k/average_l0_36
     l0: 36
   - id: layer_31/width_16k/average_l0_73
-    path: layer_31/width_16k/average_l0_73/params.npz
+    path: layer_31/width_16k/average_l0_73
     l0: 73
   - id: layer_31/width_16k/average_l0_168
-    path: layer_31/width_16k/average_l0_168/params.npz
+    path: layer_31/width_16k/average_l0_168
     l0: 168
   - id: layer_31/width_16k/average_l0_356
-    path: layer_31/width_16k/average_l0_356/params.npz
+    path: layer_31/width_16k/average_l0_356
     l0: 356
   - id: layer_31/width_16k/average_l0_630
-    path: layer_31/width_16k/average_l0_630/params.npz
+    path: layer_31/width_16k/average_l0_630
     l0: 630
   - id: layer_31/width_131k/average_l0_16
-    path: layer_31/width_131k/average_l0_16/params.npz
+    path: layer_31/width_131k/average_l0_16
     l0: 16
   - id: layer_31/width_131k/average_l0_29
-    path: layer_31/width_131k/average_l0_29/params.npz
+    path: layer_31/width_131k/average_l0_29
     l0: 29
   - id: layer_31/width_131k/average_l0_56
-    path: layer_31/width_131k/average_l0_56/params.npz
+    path: layer_31/width_131k/average_l0_56
     l0: 56
   - id: layer_31/width_131k/average_l0_117
-    path: layer_31/width_131k/average_l0_117/params.npz
+    path: layer_31/width_131k/average_l0_117
     l0: 117
   - id: layer_31/width_131k/average_l0_265
-    path: layer_31/width_131k/average_l0_265/params.npz
+    path: layer_31/width_131k/average_l0_265
     l0: 265
   - id: layer_31/width_131k/average_l0_543
-    path: layer_31/width_131k/average_l0_543/params.npz
+    path: layer_31/width_131k/average_l0_543
     l0: 543
   - id: layer_32/width_16k/average_l0_18
-    path: layer_32/width_16k/average_l0_18/params.npz
+    path: layer_32/width_16k/average_l0_18
     l0: 18
   - id: layer_32/width_16k/average_l0_35
-    path: layer_32/width_16k/average_l0_35/params.npz
+    path: layer_32/width_16k/average_l0_35
     l0: 35
   - id: layer_32/width_16k/average_l0_74
-    path: layer_32/width_16k/average_l0_74/params.npz
+    path: layer_32/width_16k/average_l0_74
     l0: 74
   - id: layer_32/width_16k/average_l0_158
-    path: layer_32/width_16k/average_l0_158/params.npz
+    path: layer_32/width_16k/average_l0_158
     l0: 158
   - id: layer_32/width_16k/average_l0_306
-    path: layer_32/width_16k/average_l0_306/params.npz
+    path: layer_32/width_16k/average_l0_306
     l0: 306
   - id: layer_32/width_16k/average_l0_534
-    path: layer_32/width_16k/average_l0_534/params.npz
+    path: layer_32/width_16k/average_l0_534
     l0: 534
   - id: layer_32/width_131k/average_l0_16
-    path: layer_32/width_131k/average_l0_16/params.npz
+    path: layer_32/width_131k/average_l0_16
     l0: 16
   - id: layer_32/width_131k/average_l0_31
-    path: layer_32/width_131k/average_l0_31/params.npz
+    path: layer_32/width_131k/average_l0_31
     l0: 31
   - id: layer_32/width_131k/average_l0_56
-    path: layer_32/width_131k/average_l0_56/params.npz
+    path: layer_32/width_131k/average_l0_56
     l0: 56
   - id: layer_32/width_131k/average_l0_117
-    path: layer_32/width_131k/average_l0_117/params.npz
+    path: layer_32/width_131k/average_l0_117
     l0: 117
   - id: layer_32/width_131k/average_l0_248
-    path: layer_32/width_131k/average_l0_248/params.npz
+    path: layer_32/width_131k/average_l0_248
     l0: 248
   - id: layer_32/width_131k/average_l0_464
-    path: layer_32/width_131k/average_l0_464/params.npz
+    path: layer_32/width_131k/average_l0_464
     l0: 464
   - id: layer_33/width_16k/average_l0_17
-    path: layer_33/width_16k/average_l0_17/params.npz
+    path: layer_33/width_16k/average_l0_17
     l0: 17
   - id: layer_33/width_16k/average_l0_37
-    path: layer_33/width_16k/average_l0_37/params.npz
+    path: layer_33/width_16k/average_l0_37
     l0: 37
   - id: layer_33/width_16k/average_l0_78
-    path: layer_33/width_16k/average_l0_78/params.npz
+    path: layer_33/width_16k/average_l0_78
     l0: 78
   - id: layer_33/width_16k/average_l0_158
-    path: layer_33/width_16k/average_l0_158/params.npz
+    path: layer_33/width_16k/average_l0_158
     l0: 158
   - id: layer_33/width_16k/average_l0_318
-    path: layer_33/width_16k/average_l0_318/params.npz
+    path: layer_33/width_16k/average_l0_318
     l0: 318
   - id: layer_33/width_16k/average_l0_531
-    path: layer_33/width_16k/average_l0_531/params.npz
+    path: layer_33/width_16k/average_l0_531
     l0: 531
   - id: layer_33/width_131k/average_l0_16
-    path: layer_33/width_131k/average_l0_16/params.npz
+    path: layer_33/width_131k/average_l0_16
     l0: 16
   - id: layer_33/width_131k/average_l0_28
-    path: layer_33/width_131k/average_l0_28/params.npz
+    path: layer_33/width_131k/average_l0_28
     l0: 28
   - id: layer_33/width_131k/average_l0_58
-    path: layer_33/width_131k/average_l0_58/params.npz
+    path: layer_33/width_131k/average_l0_58
     l0: 58
   - id: layer_33/width_131k/average_l0_128
-    path: layer_33/width_131k/average_l0_128/params.npz
+    path: layer_33/width_131k/average_l0_128
     l0: 128
   - id: layer_33/width_131k/average_l0_248
-    path: layer_33/width_131k/average_l0_248/params.npz
+    path: layer_33/width_131k/average_l0_248
     l0: 248
   - id: layer_33/width_131k/average_l0_471
-    path: layer_33/width_131k/average_l0_471/params.npz
+    path: layer_33/width_131k/average_l0_471
     l0: 471
   - id: layer_34/width_16k/average_l0_17
-    path: layer_34/width_16k/average_l0_17/params.npz
+    path: layer_34/width_16k/average_l0_17
     l0: 17
   - id: layer_34/width_16k/average_l0_38
-    path: layer_34/width_16k/average_l0_38/params.npz
+    path: layer_34/width_16k/average_l0_38
     l0: 38
   - id: layer_34/width_16k/average_l0_91
-    path: layer_34/width_16k/average_l0_91/params.npz
+    path: layer_34/width_16k/average_l0_91
     l0: 91
   - id: layer_34/width_16k/average_l0_192
-    path: layer_34/width_16k/average_l0_192/params.npz
+    path: layer_34/width_16k/average_l0_192
     l0: 192
   - id: layer_34/width_16k/average_l0_339
-    path: layer_34/width_16k/average_l0_339/params.npz
+    path: layer_34/width_16k/average_l0_339
     l0: 339
   - id: layer_34/width_16k/average_l0_527
-    path: layer_34/width_16k/average_l0_527/params.npz
+    path: layer_34/width_16k/average_l0_527
     l0: 527
   - id: layer_34/width_131k/average_l0_15
-    path: layer_34/width_131k/average_l0_15/params.npz
+    path: layer_34/width_131k/average_l0_15
     l0: 15
   - id: layer_34/width_131k/average_l0_29
-    path: layer_34/width_131k/average_l0_29/params.npz
+    path: layer_34/width_131k/average_l0_29
     l0: 29
   - id: layer_34/width_131k/average_l0_63
-    path: layer_34/width_131k/average_l0_63/params.npz
+    path: layer_34/width_131k/average_l0_63
     l0: 63
   - id: layer_34/width_131k/average_l0_199
-    path: layer_34/width_131k/average_l0_199/params.npz
+    path: layer_34/width_131k/average_l0_199
     l0: 199
   - id: layer_34/width_131k/average_l0_291
-    path: layer_34/width_131k/average_l0_291/params.npz
+    path: layer_34/width_131k/average_l0_291
     l0: 291
   - id: layer_34/width_131k/average_l0_483
-    path: layer_34/width_131k/average_l0_483/params.npz
+    path: layer_34/width_131k/average_l0_483
     l0: 483
   - id: layer_35/width_16k/average_l0_14
-    path: layer_35/width_16k/average_l0_14/params.npz
+    path: layer_35/width_16k/average_l0_14
     l0: 14
   - id: layer_35/width_16k/average_l0_33
-    path: layer_35/width_16k/average_l0_33/params.npz
+    path: layer_35/width_16k/average_l0_33
     l0: 33
   - id: layer_35/width_16k/average_l0_77
-    path: layer_35/width_16k/average_l0_77/params.npz
+    path: layer_35/width_16k/average_l0_77
     l0: 77
   - id: layer_35/width_16k/average_l0_168
-    path: layer_35/width_16k/average_l0_168/params.npz
+    path: layer_35/width_16k/average_l0_168
     l0: 168
   - id: layer_35/width_16k/average_l0_303
-    path: layer_35/width_16k/average_l0_303/params.npz
+    path: layer_35/width_16k/average_l0_303
     l0: 303
   - id: layer_35/width_16k/average_l0_488
-    path: layer_35/width_16k/average_l0_488/params.npz
+    path: layer_35/width_16k/average_l0_488
     l0: 488
   - id: layer_35/width_131k/average_l0_13
-    path: layer_35/width_131k/average_l0_13/params.npz
+    path: layer_35/width_131k/average_l0_13
     l0: 13
   - id: layer_35/width_131k/average_l0_26
-    path: layer_35/width_131k/average_l0_26/params.npz
+    path: layer_35/width_131k/average_l0_26
     l0: 26
   - id: layer_35/width_131k/average_l0_54
-    path: layer_35/width_131k/average_l0_54/params.npz
+    path: layer_35/width_131k/average_l0_54
     l0: 54
   - id: layer_35/width_131k/average_l0_124
-    path: layer_35/width_131k/average_l0_124/params.npz
+    path: layer_35/width_131k/average_l0_124
     l0: 124
   - id: layer_35/width_131k/average_l0_258
-    path: layer_35/width_131k/average_l0_258/params.npz
+    path: layer_35/width_131k/average_l0_258
     l0: 258
   - id: layer_35/width_131k/average_l0_427
-    path: layer_35/width_131k/average_l0_427/params.npz
+    path: layer_35/width_131k/average_l0_427
     l0: 427
   - id: layer_36/width_16k/average_l0_15
-    path: layer_36/width_16k/average_l0_15/params.npz
+    path: layer_36/width_16k/average_l0_15
     l0: 15
   - id: layer_36/width_16k/average_l0_32
-    path: layer_36/width_16k/average_l0_32/params.npz
+    path: layer_36/width_16k/average_l0_32
     l0: 32
   - id: layer_36/width_16k/average_l0_69
-    path: layer_36/width_16k/average_l0_69/params.npz
+    path: layer_36/width_16k/average_l0_69
     l0: 69
   - id: layer_36/width_16k/average_l0_144
-    path: layer_36/width_16k/average_l0_144/params.npz
+    path: layer_36/width_16k/average_l0_144
     l0: 144
   - id: layer_36/width_16k/average_l0_293
-    path: layer_36/width_16k/average_l0_293/params.npz
+    path: layer_36/width_16k/average_l0_293
     l0: 293
   - id: layer_36/width_16k/average_l0_544
-    path: layer_36/width_16k/average_l0_544/params.npz
+    path: layer_36/width_16k/average_l0_544
     l0: 544
   - id: layer_36/width_131k/average_l0_16
-    path: layer_36/width_131k/average_l0_16/params.npz
+    path: layer_36/width_131k/average_l0_16
     l0: 16
   - id: layer_36/width_131k/average_l0_26
-    path: layer_36/width_131k/average_l0_26/params.npz
+    path: layer_36/width_131k/average_l0_26
     l0: 26
   - id: layer_36/width_131k/average_l0_51
-    path: layer_36/width_131k/average_l0_51/params.npz
+    path: layer_36/width_131k/average_l0_51
     l0: 51
   - id: layer_36/width_131k/average_l0_105
-    path: layer_36/width_131k/average_l0_105/params.npz
+    path: layer_36/width_131k/average_l0_105
     l0: 105
   - id: layer_36/width_131k/average_l0_229
-    path: layer_36/width_131k/average_l0_229/params.npz
+    path: layer_36/width_131k/average_l0_229
     l0: 229
   - id: layer_36/width_131k/average_l0_455
-    path: layer_36/width_131k/average_l0_455/params.npz
+    path: layer_36/width_131k/average_l0_455
     l0: 455
   - id: layer_37/width_16k/average_l0_17
-    path: layer_37/width_16k/average_l0_17/params.npz
+    path: layer_37/width_16k/average_l0_17
     l0: 17
   - id: layer_37/width_16k/average_l0_34
-    path: layer_37/width_16k/average_l0_34/params.npz
+    path: layer_37/width_16k/average_l0_34
     l0: 34
   - id: layer_37/width_16k/average_l0_82
-    path: layer_37/width_16k/average_l0_82/params.npz
+    path: layer_37/width_16k/average_l0_82
     l0: 82
   - id: layer_37/width_16k/average_l0_172
-    path: layer_37/width_16k/average_l0_172/params.npz
+    path: layer_37/width_16k/average_l0_172
     l0: 172
   - id: layer_37/width_16k/average_l0_309
-    path: layer_37/width_16k/average_l0_309/params.npz
+    path: layer_37/width_16k/average_l0_309
     l0: 309
   - id: layer_37/width_16k/average_l0_519
-    path: layer_37/width_16k/average_l0_519/params.npz
+    path: layer_37/width_16k/average_l0_519
     l0: 519
   - id: layer_37/width_131k/average_l0_15
-    path: layer_37/width_131k/average_l0_15/params.npz
+    path: layer_37/width_131k/average_l0_15
     l0: 15
   - id: layer_37/width_131k/average_l0_28
-    path: layer_37/width_131k/average_l0_28/params.npz
+    path: layer_37/width_131k/average_l0_28
     l0: 28
   - id: layer_37/width_131k/average_l0_55
-    path: layer_37/width_131k/average_l0_55/params.npz
+    path: layer_37/width_131k/average_l0_55
     l0: 55
   - id: layer_37/width_131k/average_l0_124
-    path: layer_37/width_131k/average_l0_124/params.npz
+    path: layer_37/width_131k/average_l0_124
     l0: 124
   - id: layer_37/width_131k/average_l0_248
-    path: layer_37/width_131k/average_l0_248/params.npz
+    path: layer_37/width_131k/average_l0_248
     l0: 248
   - id: layer_37/width_131k/average_l0_450
-    path: layer_37/width_131k/average_l0_450/params.npz
+    path: layer_37/width_131k/average_l0_450
     l0: 450
   - id: layer_38/width_16k/average_l0_18
-    path: layer_38/width_16k/average_l0_18/params.npz
+    path: layer_38/width_16k/average_l0_18
     l0: 18
   - id: layer_38/width_16k/average_l0_36
-    path: layer_38/width_16k/average_l0_36/params.npz
+    path: layer_38/width_16k/average_l0_36
     l0: 36
   - id: layer_38/width_16k/average_l0_81
-    path: layer_38/width_16k/average_l0_81/params.npz
+    path: layer_38/width_16k/average_l0_81
     l0: 81
   - id: layer_38/width_16k/average_l0_175
-    path: layer_38/width_16k/average_l0_175/params.npz
+    path: layer_38/width_16k/average_l0_175
     l0: 175
   - id: layer_38/width_16k/average_l0_334
-    path: layer_38/width_16k/average_l0_334/params.npz
+    path: layer_38/width_16k/average_l0_334
     l0: 334
   - id: layer_38/width_16k/average_l0_547
-    path: layer_38/width_16k/average_l0_547/params.npz
+    path: layer_38/width_16k/average_l0_547
     l0: 547
   - id: layer_38/width_131k/average_l0_17
-    path: layer_38/width_131k/average_l0_17/params.npz
+    path: layer_38/width_131k/average_l0_17
     l0: 17
   - id: layer_38/width_131k/average_l0_30
-    path: layer_38/width_131k/average_l0_30/params.npz
+    path: layer_38/width_131k/average_l0_30
     l0: 30
   - id: layer_38/width_131k/average_l0_60
-    path: layer_38/width_131k/average_l0_60/params.npz
+    path: layer_38/width_131k/average_l0_60
     l0: 60
   - id: layer_38/width_131k/average_l0_135
-    path: layer_38/width_131k/average_l0_135/params.npz
+    path: layer_38/width_131k/average_l0_135
     l0: 135
   - id: layer_38/width_131k/average_l0_284
-    path: layer_38/width_131k/average_l0_284/params.npz
+    path: layer_38/width_131k/average_l0_284
     l0: 284
   - id: layer_38/width_131k/average_l0_489
-    path: layer_38/width_131k/average_l0_489/params.npz
+    path: layer_38/width_131k/average_l0_489
     l0: 489
   - id: layer_39/width_16k/average_l0_15
-    path: layer_39/width_16k/average_l0_15/params.npz
+    path: layer_39/width_16k/average_l0_15
     l0: 15
   - id: layer_39/width_16k/average_l0_33
-    path: layer_39/width_16k/average_l0_33/params.npz
+    path: layer_39/width_16k/average_l0_33
     l0: 33
   - id: layer_39/width_16k/average_l0_77
-    path: layer_39/width_16k/average_l0_77/params.npz
+    path: layer_39/width_16k/average_l0_77
     l0: 77
   - id: layer_39/width_16k/average_l0_176
-    path: layer_39/width_16k/average_l0_176/params.npz
+    path: layer_39/width_16k/average_l0_176
     l0: 176
   - id: layer_39/width_16k/average_l0_391
-    path: layer_39/width_16k/average_l0_391/params.npz
+    path: layer_39/width_16k/average_l0_391
     l0: 391
   - id: layer_39/width_16k/average_l0_694
-    path: layer_39/width_16k/average_l0_694/params.npz
+    path: layer_39/width_16k/average_l0_694
     l0: 694
   - id: layer_39/width_131k/average_l0_17
-    path: layer_39/width_131k/average_l0_17/params.npz
+    path: layer_39/width_131k/average_l0_17
     l0: 17
   - id: layer_39/width_131k/average_l0_27
-    path: layer_39/width_131k/average_l0_27/params.npz
+    path: layer_39/width_131k/average_l0_27
     l0: 27
   - id: layer_39/width_131k/average_l0_54
-    path: layer_39/width_131k/average_l0_54/params.npz
+    path: layer_39/width_131k/average_l0_54
     l0: 54
   - id: layer_39/width_131k/average_l0_120
-    path: layer_39/width_131k/average_l0_120/params.npz
+    path: layer_39/width_131k/average_l0_120
     l0: 120
   - id: layer_39/width_131k/average_l0_273
-    path: layer_39/width_131k/average_l0_273/params.npz
+    path: layer_39/width_131k/average_l0_273
     l0: 273
   - id: layer_39/width_131k/average_l0_604
-    path: layer_39/width_131k/average_l0_604/params.npz
+    path: layer_39/width_131k/average_l0_604
     l0: 604
   - id: layer_4/width_16k/average_l0_26
-    path: layer_4/width_16k/average_l0_26/params.npz
+    path: layer_4/width_16k/average_l0_26
     l0: 26
   - id: layer_4/width_16k/average_l0_54
-    path: layer_4/width_16k/average_l0_54/params.npz
+    path: layer_4/width_16k/average_l0_54
     l0: 54
   - id: layer_4/width_16k/average_l0_126
-    path: layer_4/width_16k/average_l0_126/params.npz
+    path: layer_4/width_16k/average_l0_126
     l0: 126
   - id: layer_4/width_16k/average_l0_274
-    path: layer_4/width_16k/average_l0_274/params.npz
+    path: layer_4/width_16k/average_l0_274
     l0: 274
   - id: layer_4/width_16k/average_l0_524
-    path: layer_4/width_16k/average_l0_524/params.npz
+    path: layer_4/width_16k/average_l0_524
     l0: 524
   - id: layer_4/width_131k/average_l0_12
-    path: layer_4/width_131k/average_l0_12/params.npz
+    path: layer_4/width_131k/average_l0_12
     l0: 12
   - id: layer_4/width_131k/average_l0_21
-    path: layer_4/width_131k/average_l0_21/params.npz
+    path: layer_4/width_131k/average_l0_21
     l0: 21
   - id: layer_4/width_131k/average_l0_38
-    path: layer_4/width_131k/average_l0_38/params.npz
+    path: layer_4/width_131k/average_l0_38
     l0: 38
   - id: layer_4/width_131k/average_l0_75
-    path: layer_4/width_131k/average_l0_75/params.npz
+    path: layer_4/width_131k/average_l0_75
     l0: 75
   - id: layer_4/width_131k/average_l0_163
-    path: layer_4/width_131k/average_l0_163/params.npz
+    path: layer_4/width_131k/average_l0_163
     l0: 163
   - id: layer_4/width_131k/average_l0_330
-    path: layer_4/width_131k/average_l0_330/params.npz
+    path: layer_4/width_131k/average_l0_330
     l0: 330
   - id: layer_40/width_16k/average_l0_18
-    path: layer_40/width_16k/average_l0_18/params.npz
+    path: layer_40/width_16k/average_l0_18
     l0: 18
   - id: layer_40/width_16k/average_l0_38
-    path: layer_40/width_16k/average_l0_38/params.npz
+    path: layer_40/width_16k/average_l0_38
     l0: 38
   - id: layer_40/width_16k/average_l0_91
-    path: layer_40/width_16k/average_l0_91/params.npz
+    path: layer_40/width_16k/average_l0_91
     l0: 91
   - id: layer_40/width_16k/average_l0_189
-    path: layer_40/width_16k/average_l0_189/params.npz
+    path: layer_40/width_16k/average_l0_189
     l0: 189
   - id: layer_40/width_16k/average_l0_341
-    path: layer_40/width_16k/average_l0_341/params.npz
+    path: layer_40/width_16k/average_l0_341
     l0: 341
   - id: layer_40/width_16k/average_l0_603
-    path: layer_40/width_16k/average_l0_603/params.npz
+    path: layer_40/width_16k/average_l0_603
     l0: 603
   - id: layer_40/width_131k/average_l0_16
-    path: layer_40/width_131k/average_l0_16/params.npz
+    path: layer_40/width_131k/average_l0_16
     l0: 16
   - id: layer_40/width_131k/average_l0_30
-    path: layer_40/width_131k/average_l0_30/params.npz
+    path: layer_40/width_131k/average_l0_30
     l0: 30
   - id: layer_40/width_131k/average_l0_64
-    path: layer_40/width_131k/average_l0_64/params.npz
+    path: layer_40/width_131k/average_l0_64
     l0: 64
   - id: layer_40/width_131k/average_l0_144
-    path: layer_40/width_131k/average_l0_144/params.npz
+    path: layer_40/width_131k/average_l0_144
     l0: 144
   - id: layer_40/width_131k/average_l0_269
-    path: layer_40/width_131k/average_l0_269/params.npz
+    path: layer_40/width_131k/average_l0_269
     l0: 269
   - id: layer_40/width_131k/average_l0_493
-    path: layer_40/width_131k/average_l0_493/params.npz
+    path: layer_40/width_131k/average_l0_493
     l0: 493
   - id: layer_41/width_16k/average_l0_13
-    path: layer_41/width_16k/average_l0_13/params.npz
+    path: layer_41/width_16k/average_l0_13
     l0: 13
   - id: layer_41/width_16k/average_l0_25
-    path: layer_41/width_16k/average_l0_25/params.npz
+    path: layer_41/width_16k/average_l0_25
     l0: 25
   - id: layer_41/width_16k/average_l0_56
-    path: layer_41/width_16k/average_l0_56/params.npz
+    path: layer_41/width_16k/average_l0_56
     l0: 56
   - id: layer_41/width_16k/average_l0_129
-    path: layer_41/width_16k/average_l0_129/params.npz
+    path: layer_41/width_16k/average_l0_129
     l0: 129
   - id: layer_41/width_16k/average_l0_254
-    path: layer_41/width_16k/average_l0_254/params.npz
+    path: layer_41/width_16k/average_l0_254
     l0: 254
   - id: layer_41/width_16k/average_l0_450
-    path: layer_41/width_16k/average_l0_450/params.npz
+    path: layer_41/width_16k/average_l0_450
     l0: 450
   - id: layer_41/width_131k/average_l0_13
-    path: layer_41/width_131k/average_l0_13/params.npz
+    path: layer_41/width_131k/average_l0_13
     l0: 13
   - id: layer_41/width_131k/average_l0_22
-    path: layer_41/width_131k/average_l0_22/params.npz
+    path: layer_41/width_131k/average_l0_22
     l0: 22
   - id: layer_41/width_131k/average_l0_43
-    path: layer_41/width_131k/average_l0_43/params.npz
+    path: layer_41/width_131k/average_l0_43
     l0: 43
   - id: layer_41/width_131k/average_l0_92
-    path: layer_41/width_131k/average_l0_92/params.npz
+    path: layer_41/width_131k/average_l0_92
     l0: 92
   - id: layer_41/width_131k/average_l0_202
-    path: layer_41/width_131k/average_l0_202/params.npz
+    path: layer_41/width_131k/average_l0_202
     l0: 202
   - id: layer_41/width_131k/average_l0_370
-    path: layer_41/width_131k/average_l0_370/params.npz
+    path: layer_41/width_131k/average_l0_370
     l0: 370
   - id: layer_5/width_16k/average_l0_25
-    path: layer_5/width_16k/average_l0_25/params.npz
+    path: layer_5/width_16k/average_l0_25
     l0: 25
   - id: layer_5/width_16k/average_l0_53
-    path: layer_5/width_16k/average_l0_53/params.npz
+    path: layer_5/width_16k/average_l0_53
     l0: 53
   - id: layer_5/width_16k/average_l0_125
-    path: layer_5/width_16k/average_l0_125/params.npz
+    path: layer_5/width_16k/average_l0_125
     l0: 125
   - id: layer_5/width_16k/average_l0_270
-    path: layer_5/width_16k/average_l0_270/params.npz
+    path: layer_5/width_16k/average_l0_270
     l0: 270
   - id: layer_5/width_16k/average_l0_529
-    path: layer_5/width_16k/average_l0_529/params.npz
+    path: layer_5/width_16k/average_l0_529
     l0: 529
   - id: layer_5/width_131k/average_l0_12
-    path: layer_5/width_131k/average_l0_12/params.npz
+    path: layer_5/width_131k/average_l0_12
     l0: 12
   - id: layer_5/width_131k/average_l0_21
-    path: layer_5/width_131k/average_l0_21/params.npz
+    path: layer_5/width_131k/average_l0_21
     l0: 21
   - id: layer_5/width_131k/average_l0_39
-    path: layer_5/width_131k/average_l0_39/params.npz
+    path: layer_5/width_131k/average_l0_39
     l0: 39
   - id: layer_5/width_131k/average_l0_78
-    path: layer_5/width_131k/average_l0_78/params.npz
+    path: layer_5/width_131k/average_l0_78
     l0: 78
   - id: layer_5/width_131k/average_l0_160
-    path: layer_5/width_131k/average_l0_160/params.npz
+    path: layer_5/width_131k/average_l0_160
     l0: 160
   - id: layer_5/width_131k/average_l0_351
-    path: layer_5/width_131k/average_l0_351/params.npz
+    path: layer_5/width_131k/average_l0_351
     l0: 351
   - id: layer_6/width_16k/average_l0_16
-    path: layer_6/width_16k/average_l0_16/params.npz
+    path: layer_6/width_16k/average_l0_16
     l0: 16
   - id: layer_6/width_16k/average_l0_28
-    path: layer_6/width_16k/average_l0_28/params.npz
+    path: layer_6/width_16k/average_l0_28
     l0: 28
   - id: layer_6/width_16k/average_l0_51
-    path: layer_6/width_16k/average_l0_51/params.npz
+    path: layer_6/width_16k/average_l0_51
     l0: 51
   - id: layer_6/width_16k/average_l0_108
-    path: layer_6/width_16k/average_l0_108/params.npz
+    path: layer_6/width_16k/average_l0_108
     l0: 108
   - id: layer_6/width_16k/average_l0_258
-    path: layer_6/width_16k/average_l0_258/params.npz
+    path: layer_6/width_16k/average_l0_258
     l0: 258
   - id: layer_6/width_131k/average_l0_14
-    path: layer_6/width_131k/average_l0_14/params.npz
+    path: layer_6/width_131k/average_l0_14
     l0: 14
   - id: layer_6/width_131k/average_l0_24
-    path: layer_6/width_131k/average_l0_24/params.npz
+    path: layer_6/width_131k/average_l0_24
     l0: 24
   - id: layer_6/width_131k/average_l0_41
-    path: layer_6/width_131k/average_l0_41/params.npz
+    path: layer_6/width_131k/average_l0_41
     l0: 41
   - id: layer_6/width_131k/average_l0_73
-    path: layer_6/width_131k/average_l0_73/params.npz
+    path: layer_6/width_131k/average_l0_73
     l0: 73
   - id: layer_6/width_131k/average_l0_148
-    path: layer_6/width_131k/average_l0_148/params.npz
+    path: layer_6/width_131k/average_l0_148
     l0: 148
   - id: layer_6/width_131k/average_l0_353
-    path: layer_6/width_131k/average_l0_353/params.npz
+    path: layer_6/width_131k/average_l0_353
     l0: 353
   - id: layer_7/width_16k/average_l0_18
-    path: layer_7/width_16k/average_l0_18/params.npz
+    path: layer_7/width_16k/average_l0_18
     l0: 18
   - id: layer_7/width_16k/average_l0_33
-    path: layer_7/width_16k/average_l0_33/params.npz
+    path: layer_7/width_16k/average_l0_33
     l0: 33
   - id: layer_7/width_16k/average_l0_70
-    path: layer_7/width_16k/average_l0_70/params.npz
+    path: layer_7/width_16k/average_l0_70
     l0: 70
   - id: layer_7/width_16k/average_l0_160
-    path: layer_7/width_16k/average_l0_160/params.npz
+    path: layer_7/width_16k/average_l0_160
     l0: 160
   - id: layer_7/width_16k/average_l0_335
-    path: layer_7/width_16k/average_l0_335/params.npz
+    path: layer_7/width_16k/average_l0_335
     l0: 335
   - id: layer_7/width_131k/average_l0_16
-    path: layer_7/width_131k/average_l0_16/params.npz
+    path: layer_7/width_131k/average_l0_16
     l0: 16
   - id: layer_7/width_131k/average_l0_28
-    path: layer_7/width_131k/average_l0_28/params.npz
+    path: layer_7/width_131k/average_l0_28
     l0: 28
   - id: layer_7/width_131k/average_l0_52
-    path: layer_7/width_131k/average_l0_52/params.npz
+    path: layer_7/width_131k/average_l0_52
     l0: 52
   - id: layer_7/width_131k/average_l0_106
-    path: layer_7/width_131k/average_l0_106/params.npz
+    path: layer_7/width_131k/average_l0_106
     l0: 106
   - id: layer_7/width_131k/average_l0_229
-    path: layer_7/width_131k/average_l0_229/params.npz
+    path: layer_7/width_131k/average_l0_229
     l0: 229
   - id: layer_7/width_131k/average_l0_473
-    path: layer_7/width_131k/average_l0_473/params.npz
+    path: layer_7/width_131k/average_l0_473
     l0: 473
   - id: layer_8/width_16k/average_l0_17
-    path: layer_8/width_16k/average_l0_17/params.npz
+    path: layer_8/width_16k/average_l0_17
     l0: 17
   - id: layer_8/width_16k/average_l0_32
-    path: layer_8/width_16k/average_l0_32/params.npz
+    path: layer_8/width_16k/average_l0_32
     l0: 32
   - id: layer_8/width_16k/average_l0_65
-    path: layer_8/width_16k/average_l0_65/params.npz
+    path: layer_8/width_16k/average_l0_65
     l0: 65
   - id: layer_8/width_16k/average_l0_150
-    path: layer_8/width_16k/average_l0_150/params.npz
+    path: layer_8/width_16k/average_l0_150
     l0: 150
   - id: layer_8/width_16k/average_l0_362
-    path: layer_8/width_16k/average_l0_362/params.npz
+    path: layer_8/width_16k/average_l0_362
     l0: 362
   - id: layer_8/width_131k/average_l0_16
-    path: layer_8/width_131k/average_l0_16/params.npz
+    path: layer_8/width_131k/average_l0_16
     l0: 16
   - id: layer_8/width_131k/average_l0_27
-    path: layer_8/width_131k/average_l0_27/params.npz
+    path: layer_8/width_131k/average_l0_27
     l0: 27
   - id: layer_8/width_131k/average_l0_51
-    path: layer_8/width_131k/average_l0_51/params.npz
+    path: layer_8/width_131k/average_l0_51
     l0: 51
   - id: layer_8/width_131k/average_l0_98
-    path: layer_8/width_131k/average_l0_98/params.npz
+    path: layer_8/width_131k/average_l0_98
     l0: 98
   - id: layer_8/width_131k/average_l0_222
-    path: layer_8/width_131k/average_l0_222/params.npz
+    path: layer_8/width_131k/average_l0_222
     l0: 222
   - id: layer_8/width_131k/average_l0_531
-    path: layer_8/width_131k/average_l0_531/params.npz
+    path: layer_8/width_131k/average_l0_531
     l0: 531
   - id: layer_9/width_16k/average_l0_18
-    path: layer_9/width_16k/average_l0_18/params.npz
+    path: layer_9/width_16k/average_l0_18
     l0: 18
   - id: layer_9/width_16k/average_l0_34
-    path: layer_9/width_16k/average_l0_34/params.npz
+    path: layer_9/width_16k/average_l0_34
     l0: 34
   - id: layer_9/width_16k/average_l0_71
-    path: layer_9/width_16k/average_l0_71/params.npz
+    path: layer_9/width_16k/average_l0_71
     l0: 71
   - id: layer_9/width_16k/average_l0_172
-    path: layer_9/width_16k/average_l0_172/params.npz
+    path: layer_9/width_16k/average_l0_172
     l0: 172
   - id: layer_9/width_16k/average_l0_349
-    path: layer_9/width_16k/average_l0_349/params.npz
+    path: layer_9/width_16k/average_l0_349
     l0: 349
   - id: layer_9/width_131k/average_l0_16
-    path: layer_9/width_131k/average_l0_16/params.npz
+    path: layer_9/width_131k/average_l0_16
     l0: 16
   - id: layer_9/width_131k/average_l0_30
-    path: layer_9/width_131k/average_l0_30/params.npz
+    path: layer_9/width_131k/average_l0_30
     l0: 30
   - id: layer_9/width_131k/average_l0_54
-    path: layer_9/width_131k/average_l0_54/params.npz
+    path: layer_9/width_131k/average_l0_54
     l0: 54
   - id: layer_9/width_131k/average_l0_111
-    path: layer_9/width_131k/average_l0_111/params.npz
+    path: layer_9/width_131k/average_l0_111
     l0: 111
   - id: layer_9/width_131k/average_l0_263
-    path: layer_9/width_131k/average_l0_263/params.npz
+    path: layer_9/width_131k/average_l0_263
     l0: 263
   - id: layer_9/width_131k/average_l0_511
-    path: layer_9/width_131k/average_l0_511/params.npz
+    path: layer_9/width_131k/average_l0_511
     l0: 511
 gemma-scope-9b-pt-att-canonical:
   repo_id: google/gemma-scope-9b-pt-att
@@ -7374,1480 +7374,1480 @@ gemma-scope-9b-pt-mlp:
   conversion_func: gemma_2
   saes:
   - id: layer_0/width_16k/average_l0_6
-    path: layer_0/width_16k/average_l0_6/params.npz
+    path: layer_0/width_16k/average_l0_6
     l0: 6
   - id: layer_0/width_16k/average_l0_10
-    path: layer_0/width_16k/average_l0_10/params.npz
+    path: layer_0/width_16k/average_l0_10
     l0: 10
   - id: layer_0/width_16k/average_l0_16
-    path: layer_0/width_16k/average_l0_16/params.npz
+    path: layer_0/width_16k/average_l0_16
     l0: 16
   - id: layer_0/width_16k/average_l0_28
-    path: layer_0/width_16k/average_l0_28/params.npz
+    path: layer_0/width_16k/average_l0_28
     l0: 28
   - id: layer_0/width_16k/average_l0_50
-    path: layer_0/width_16k/average_l0_50/params.npz
+    path: layer_0/width_16k/average_l0_50
     l0: 50
   - id: layer_0/width_131k/average_l0_3
-    path: layer_0/width_131k/average_l0_3/params.npz
+    path: layer_0/width_131k/average_l0_3
     l0: 3
   - id: layer_0/width_131k/average_l0_5
-    path: layer_0/width_131k/average_l0_5/params.npz
+    path: layer_0/width_131k/average_l0_5
     l0: 5
   - id: layer_0/width_131k/average_l0_7
-    path: layer_0/width_131k/average_l0_7/params.npz
+    path: layer_0/width_131k/average_l0_7
     l0: 7
   - id: layer_0/width_131k/average_l0_11
-    path: layer_0/width_131k/average_l0_11/params.npz
+    path: layer_0/width_131k/average_l0_11
     l0: 11
   - id: layer_0/width_131k/average_l0_18
-    path: layer_0/width_131k/average_l0_18/params.npz
+    path: layer_0/width_131k/average_l0_18
     l0: 18
   - id: layer_0/width_131k/average_l0_30
-    path: layer_0/width_131k/average_l0_30/params.npz
+    path: layer_0/width_131k/average_l0_30
     l0: 30
   - id: layer_1/width_16k/average_l0_12
-    path: layer_1/width_16k/average_l0_12/params.npz
+    path: layer_1/width_16k/average_l0_12
     l0: 12
   - id: layer_1/width_16k/average_l0_26
-    path: layer_1/width_16k/average_l0_26/params.npz
+    path: layer_1/width_16k/average_l0_26
     l0: 26
   - id: layer_1/width_16k/average_l0_56
-    path: layer_1/width_16k/average_l0_56/params.npz
+    path: layer_1/width_16k/average_l0_56
     l0: 56
   - id: layer_1/width_16k/average_l0_128
-    path: layer_1/width_16k/average_l0_128/params.npz
+    path: layer_1/width_16k/average_l0_128
     l0: 128
   - id: layer_1/width_16k/average_l0_278
-    path: layer_1/width_16k/average_l0_278/params.npz
+    path: layer_1/width_16k/average_l0_278
     l0: 278
   - id: layer_1/width_131k/average_l0_6
-    path: layer_1/width_131k/average_l0_6/params.npz
+    path: layer_1/width_131k/average_l0_6
     l0: 6
   - id: layer_1/width_131k/average_l0_10
-    path: layer_1/width_131k/average_l0_10/params.npz
+    path: layer_1/width_131k/average_l0_10
     l0: 10
   - id: layer_1/width_131k/average_l0_18
-    path: layer_1/width_131k/average_l0_18/params.npz
+    path: layer_1/width_131k/average_l0_18
     l0: 18
   - id: layer_1/width_131k/average_l0_32
-    path: layer_1/width_131k/average_l0_32/params.npz
+    path: layer_1/width_131k/average_l0_32
     l0: 32
   - id: layer_1/width_131k/average_l0_59
-    path: layer_1/width_131k/average_l0_59/params.npz
+    path: layer_1/width_131k/average_l0_59
     l0: 59
   - id: layer_1/width_131k/average_l0_106
-    path: layer_1/width_131k/average_l0_106/params.npz
+    path: layer_1/width_131k/average_l0_106
     l0: 106
   - id: layer_10/width_16k/average_l0_13
-    path: layer_10/width_16k/average_l0_13/params.npz
+    path: layer_10/width_16k/average_l0_13
     l0: 13
   - id: layer_10/width_16k/average_l0_24
-    path: layer_10/width_16k/average_l0_24/params.npz
+    path: layer_10/width_16k/average_l0_24
     l0: 24
   - id: layer_10/width_16k/average_l0_49
-    path: layer_10/width_16k/average_l0_49/params.npz
+    path: layer_10/width_16k/average_l0_49
     l0: 49
   - id: layer_10/width_16k/average_l0_114
-    path: layer_10/width_16k/average_l0_114/params.npz
+    path: layer_10/width_16k/average_l0_114
     l0: 114
   - id: layer_10/width_16k/average_l0_276
-    path: layer_10/width_16k/average_l0_276/params.npz
+    path: layer_10/width_16k/average_l0_276
     l0: 276
   - id: layer_10/width_131k/average_l0_12
-    path: layer_10/width_131k/average_l0_12/params.npz
+    path: layer_10/width_131k/average_l0_12
     l0: 12
   - id: layer_10/width_131k/average_l0_22
-    path: layer_10/width_131k/average_l0_22/params.npz
+    path: layer_10/width_131k/average_l0_22
     l0: 22
   - id: layer_10/width_131k/average_l0_42
-    path: layer_10/width_131k/average_l0_42/params.npz
+    path: layer_10/width_131k/average_l0_42
     l0: 42
   - id: layer_10/width_131k/average_l0_83
-    path: layer_10/width_131k/average_l0_83/params.npz
+    path: layer_10/width_131k/average_l0_83
     l0: 83
   - id: layer_10/width_131k/average_l0_167
-    path: layer_10/width_131k/average_l0_167/params.npz
+    path: layer_10/width_131k/average_l0_167
     l0: 167
   - id: layer_10/width_131k/average_l0_362
-    path: layer_10/width_131k/average_l0_362/params.npz
+    path: layer_10/width_131k/average_l0_362
     l0: 362
   - id: layer_11/width_16k/average_l0_17
-    path: layer_11/width_16k/average_l0_17/params.npz
+    path: layer_11/width_16k/average_l0_17
     l0: 17
   - id: layer_11/width_16k/average_l0_34
-    path: layer_11/width_16k/average_l0_34/params.npz
+    path: layer_11/width_16k/average_l0_34
     l0: 34
   - id: layer_11/width_16k/average_l0_76
-    path: layer_11/width_16k/average_l0_76/params.npz
+    path: layer_11/width_16k/average_l0_76
     l0: 76
   - id: layer_11/width_16k/average_l0_180
-    path: layer_11/width_16k/average_l0_180/params.npz
+    path: layer_11/width_16k/average_l0_180
     l0: 180
   - id: layer_11/width_16k/average_l0_421
-    path: layer_11/width_16k/average_l0_421/params.npz
+    path: layer_11/width_16k/average_l0_421
     l0: 421
   - id: layer_11/width_131k/average_l0_17
-    path: layer_11/width_131k/average_l0_17/params.npz
+    path: layer_11/width_131k/average_l0_17
     l0: 17
   - id: layer_11/width_131k/average_l0_31
-    path: layer_11/width_131k/average_l0_31/params.npz
+    path: layer_11/width_131k/average_l0_31
     l0: 31
   - id: layer_11/width_131k/average_l0_60
-    path: layer_11/width_131k/average_l0_60/params.npz
+    path: layer_11/width_131k/average_l0_60
     l0: 60
   - id: layer_11/width_131k/average_l0_120
-    path: layer_11/width_131k/average_l0_120/params.npz
+    path: layer_11/width_131k/average_l0_120
     l0: 120
   - id: layer_11/width_131k/average_l0_259
-    path: layer_11/width_131k/average_l0_259/params.npz
+    path: layer_11/width_131k/average_l0_259
     l0: 259
   - id: layer_11/width_131k/average_l0_569
-    path: layer_11/width_131k/average_l0_569/params.npz
+    path: layer_11/width_131k/average_l0_569
     l0: 569
   - id: layer_12/width_16k/average_l0_20
-    path: layer_12/width_16k/average_l0_20/params.npz
+    path: layer_12/width_16k/average_l0_20
     l0: 20
   - id: layer_12/width_16k/average_l0_42
-    path: layer_12/width_16k/average_l0_42/params.npz
+    path: layer_12/width_16k/average_l0_42
     l0: 42
   - id: layer_12/width_16k/average_l0_96
-    path: layer_12/width_16k/average_l0_96/params.npz
+    path: layer_12/width_16k/average_l0_96
     l0: 96
   - id: layer_12/width_16k/average_l0_237
-    path: layer_12/width_16k/average_l0_237/params.npz
+    path: layer_12/width_16k/average_l0_237
     l0: 237
   - id: layer_12/width_16k/average_l0_543
-    path: layer_12/width_16k/average_l0_543/params.npz
+    path: layer_12/width_16k/average_l0_543
     l0: 543
   - id: layer_12/width_16k/average_l0_1033
-    path: layer_12/width_16k/average_l0_1033/params.npz
+    path: layer_12/width_16k/average_l0_1033
     l0: 1033
   - id: layer_12/width_131k/average_l0_19
-    path: layer_12/width_131k/average_l0_19/params.npz
+    path: layer_12/width_131k/average_l0_19
     l0: 19
   - id: layer_12/width_131k/average_l0_38
-    path: layer_12/width_131k/average_l0_38/params.npz
+    path: layer_12/width_131k/average_l0_38
     l0: 38
   - id: layer_12/width_131k/average_l0_77
-    path: layer_12/width_131k/average_l0_77/params.npz
+    path: layer_12/width_131k/average_l0_77
     l0: 77
   - id: layer_12/width_131k/average_l0_159
-    path: layer_12/width_131k/average_l0_159/params.npz
+    path: layer_12/width_131k/average_l0_159
     l0: 159
   - id: layer_12/width_131k/average_l0_338
-    path: layer_12/width_131k/average_l0_338/params.npz
+    path: layer_12/width_131k/average_l0_338
     l0: 338
   - id: layer_12/width_131k/average_l0_745
-    path: layer_12/width_131k/average_l0_745/params.npz
+    path: layer_12/width_131k/average_l0_745
     l0: 745
   - id: layer_13/width_16k/average_l0_19
-    path: layer_13/width_16k/average_l0_19/params.npz
+    path: layer_13/width_16k/average_l0_19
     l0: 19
   - id: layer_13/width_16k/average_l0_40
-    path: layer_13/width_16k/average_l0_40/params.npz
+    path: layer_13/width_16k/average_l0_40
     l0: 40
   - id: layer_13/width_16k/average_l0_94
-    path: layer_13/width_16k/average_l0_94/params.npz
+    path: layer_13/width_16k/average_l0_94
     l0: 94
   - id: layer_13/width_16k/average_l0_225
-    path: layer_13/width_16k/average_l0_225/params.npz
+    path: layer_13/width_16k/average_l0_225
     l0: 225
   - id: layer_13/width_16k/average_l0_512
-    path: layer_13/width_16k/average_l0_512/params.npz
+    path: layer_13/width_16k/average_l0_512
     l0: 512
   - id: layer_13/width_16k/average_l0_992
-    path: layer_13/width_16k/average_l0_992/params.npz
+    path: layer_13/width_16k/average_l0_992
     l0: 992
   - id: layer_13/width_131k/average_l0_20
-    path: layer_13/width_131k/average_l0_20/params.npz
+    path: layer_13/width_131k/average_l0_20
     l0: 20
   - id: layer_13/width_131k/average_l0_38
-    path: layer_13/width_131k/average_l0_38/params.npz
+    path: layer_13/width_131k/average_l0_38
     l0: 38
   - id: layer_13/width_131k/average_l0_75
-    path: layer_13/width_131k/average_l0_75/params.npz
+    path: layer_13/width_131k/average_l0_75
     l0: 75
   - id: layer_13/width_131k/average_l0_160
-    path: layer_13/width_131k/average_l0_160/params.npz
+    path: layer_13/width_131k/average_l0_160
     l0: 160
   - id: layer_13/width_131k/average_l0_351
-    path: layer_13/width_131k/average_l0_351/params.npz
+    path: layer_13/width_131k/average_l0_351
     l0: 351
   - id: layer_13/width_131k/average_l0_703
-    path: layer_13/width_131k/average_l0_703/params.npz
+    path: layer_13/width_131k/average_l0_703
     l0: 703
   - id: layer_14/width_16k/average_l0_19
-    path: layer_14/width_16k/average_l0_19/params.npz
+    path: layer_14/width_16k/average_l0_19
     l0: 19
   - id: layer_14/width_16k/average_l0_41
-    path: layer_14/width_16k/average_l0_41/params.npz
+    path: layer_14/width_16k/average_l0_41
     l0: 41
   - id: layer_14/width_16k/average_l0_97
-    path: layer_14/width_16k/average_l0_97/params.npz
+    path: layer_14/width_16k/average_l0_97
     l0: 97
   - id: layer_14/width_16k/average_l0_236
-    path: layer_14/width_16k/average_l0_236/params.npz
+    path: layer_14/width_16k/average_l0_236
     l0: 236
   - id: layer_14/width_16k/average_l0_538
-    path: layer_14/width_16k/average_l0_538/params.npz
+    path: layer_14/width_16k/average_l0_538
     l0: 538
   - id: layer_14/width_16k/average_l0_1023
-    path: layer_14/width_16k/average_l0_1023/params.npz
+    path: layer_14/width_16k/average_l0_1023
     l0: 1023
   - id: layer_14/width_131k/average_l0_20
-    path: layer_14/width_131k/average_l0_20/params.npz
+    path: layer_14/width_131k/average_l0_20
     l0: 20
   - id: layer_14/width_131k/average_l0_40
-    path: layer_14/width_131k/average_l0_40/params.npz
+    path: layer_14/width_131k/average_l0_40
     l0: 40
   - id: layer_14/width_131k/average_l0_80
-    path: layer_14/width_131k/average_l0_80/params.npz
+    path: layer_14/width_131k/average_l0_80
     l0: 80
   - id: layer_14/width_131k/average_l0_174
-    path: layer_14/width_131k/average_l0_174/params.npz
+    path: layer_14/width_131k/average_l0_174
     l0: 174
   - id: layer_14/width_131k/average_l0_374
-    path: layer_14/width_131k/average_l0_374/params.npz
+    path: layer_14/width_131k/average_l0_374
     l0: 374
   - id: layer_14/width_131k/average_l0_743
-    path: layer_14/width_131k/average_l0_743/params.npz
+    path: layer_14/width_131k/average_l0_743
     l0: 743
   - id: layer_15/width_16k/average_l0_20
-    path: layer_15/width_16k/average_l0_20/params.npz
+    path: layer_15/width_16k/average_l0_20
     l0: 20
   - id: layer_15/width_16k/average_l0_45
-    path: layer_15/width_16k/average_l0_45/params.npz
+    path: layer_15/width_16k/average_l0_45
     l0: 45
   - id: layer_15/width_16k/average_l0_107
-    path: layer_15/width_16k/average_l0_107/params.npz
+    path: layer_15/width_16k/average_l0_107
     l0: 107
   - id: layer_15/width_16k/average_l0_260
-    path: layer_15/width_16k/average_l0_260/params.npz
+    path: layer_15/width_16k/average_l0_260
     l0: 260
   - id: layer_15/width_16k/average_l0_572
-    path: layer_15/width_16k/average_l0_572/params.npz
+    path: layer_15/width_16k/average_l0_572
     l0: 572
   - id: layer_15/width_16k/average_l0_1053
-    path: layer_15/width_16k/average_l0_1053/params.npz
+    path: layer_15/width_16k/average_l0_1053
     l0: 1053
   - id: layer_15/width_131k/average_l0_21
-    path: layer_15/width_131k/average_l0_21/params.npz
+    path: layer_15/width_131k/average_l0_21
     l0: 21
   - id: layer_15/width_131k/average_l0_43
-    path: layer_15/width_131k/average_l0_43/params.npz
+    path: layer_15/width_131k/average_l0_43
     l0: 43
   - id: layer_15/width_131k/average_l0_89
-    path: layer_15/width_131k/average_l0_89/params.npz
+    path: layer_15/width_131k/average_l0_89
     l0: 89
   - id: layer_15/width_131k/average_l0_194
-    path: layer_15/width_131k/average_l0_194/params.npz
+    path: layer_15/width_131k/average_l0_194
     l0: 194
   - id: layer_15/width_131k/average_l0_421
-    path: layer_15/width_131k/average_l0_421/params.npz
+    path: layer_15/width_131k/average_l0_421
     l0: 421
   - id: layer_15/width_131k/average_l0_828
-    path: layer_15/width_131k/average_l0_828/params.npz
+    path: layer_15/width_131k/average_l0_828
     l0: 828
   - id: layer_16/width_16k/average_l0_16
-    path: layer_16/width_16k/average_l0_16/params.npz
+    path: layer_16/width_16k/average_l0_16
     l0: 16
   - id: layer_16/width_16k/average_l0_37
-    path: layer_16/width_16k/average_l0_37/params.npz
+    path: layer_16/width_16k/average_l0_37
     l0: 37
   - id: layer_16/width_16k/average_l0_91
-    path: layer_16/width_16k/average_l0_91/params.npz
+    path: layer_16/width_16k/average_l0_91
     l0: 91
   - id: layer_16/width_16k/average_l0_221
-    path: layer_16/width_16k/average_l0_221/params.npz
+    path: layer_16/width_16k/average_l0_221
     l0: 221
   - id: layer_16/width_16k/average_l0_489
-    path: layer_16/width_16k/average_l0_489/params.npz
+    path: layer_16/width_16k/average_l0_489
     l0: 489
   - id: layer_16/width_16k/average_l0_916
-    path: layer_16/width_16k/average_l0_916/params.npz
+    path: layer_16/width_16k/average_l0_916
     l0: 916
   - id: layer_16/width_131k/average_l0_17
-    path: layer_16/width_131k/average_l0_17/params.npz
+    path: layer_16/width_131k/average_l0_17
     l0: 17
   - id: layer_16/width_131k/average_l0_38
-    path: layer_16/width_131k/average_l0_38/params.npz
+    path: layer_16/width_131k/average_l0_38
     l0: 38
   - id: layer_16/width_131k/average_l0_81
-    path: layer_16/width_131k/average_l0_81/params.npz
+    path: layer_16/width_131k/average_l0_81
     l0: 81
   - id: layer_16/width_131k/average_l0_175
-    path: layer_16/width_131k/average_l0_175/params.npz
+    path: layer_16/width_131k/average_l0_175
     l0: 175
   - id: layer_16/width_131k/average_l0_384
-    path: layer_16/width_131k/average_l0_384/params.npz
+    path: layer_16/width_131k/average_l0_384
     l0: 384
   - id: layer_16/width_131k/average_l0_744
-    path: layer_16/width_131k/average_l0_744/params.npz
+    path: layer_16/width_131k/average_l0_744
     l0: 744
   - id: layer_17/width_16k/average_l0_18
-    path: layer_17/width_16k/average_l0_18/params.npz
+    path: layer_17/width_16k/average_l0_18
     l0: 18
   - id: layer_17/width_16k/average_l0_41
-    path: layer_17/width_16k/average_l0_41/params.npz
+    path: layer_17/width_16k/average_l0_41
     l0: 41
   - id: layer_17/width_16k/average_l0_104
-    path: layer_17/width_16k/average_l0_104/params.npz
+    path: layer_17/width_16k/average_l0_104
     l0: 104
   - id: layer_17/width_16k/average_l0_274
-    path: layer_17/width_16k/average_l0_274/params.npz
+    path: layer_17/width_16k/average_l0_274
     l0: 274
   - id: layer_17/width_16k/average_l0_624
-    path: layer_17/width_16k/average_l0_624/params.npz
+    path: layer_17/width_16k/average_l0_624
     l0: 624
   - id: layer_17/width_16k/average_l0_1137
-    path: layer_17/width_16k/average_l0_1137/params.npz
+    path: layer_17/width_16k/average_l0_1137
     l0: 1137
   - id: layer_17/width_131k/average_l0_22
-    path: layer_17/width_131k/average_l0_22/params.npz
+    path: layer_17/width_131k/average_l0_22
     l0: 22
   - id: layer_17/width_131k/average_l0_43
-    path: layer_17/width_131k/average_l0_43/params.npz
+    path: layer_17/width_131k/average_l0_43
     l0: 43
   - id: layer_17/width_131k/average_l0_91
-    path: layer_17/width_131k/average_l0_91/params.npz
+    path: layer_17/width_131k/average_l0_91
     l0: 91
   - id: layer_17/width_131k/average_l0_207
-    path: layer_17/width_131k/average_l0_207/params.npz
+    path: layer_17/width_131k/average_l0_207
     l0: 207
   - id: layer_17/width_131k/average_l0_483
-    path: layer_17/width_131k/average_l0_483/params.npz
+    path: layer_17/width_131k/average_l0_483
     l0: 483
   - id: layer_17/width_131k/average_l0_950
-    path: layer_17/width_131k/average_l0_950/params.npz
+    path: layer_17/width_131k/average_l0_950
     l0: 950
   - id: layer_18/width_16k/average_l0_16
-    path: layer_18/width_16k/average_l0_16/params.npz
+    path: layer_18/width_16k/average_l0_16
     l0: 16
   - id: layer_18/width_16k/average_l0_36
-    path: layer_18/width_16k/average_l0_36/params.npz
+    path: layer_18/width_16k/average_l0_36
     l0: 36
   - id: layer_18/width_16k/average_l0_89
-    path: layer_18/width_16k/average_l0_89/params.npz
+    path: layer_18/width_16k/average_l0_89
     l0: 89
   - id: layer_18/width_16k/average_l0_235
-    path: layer_18/width_16k/average_l0_235/params.npz
+    path: layer_18/width_16k/average_l0_235
     l0: 235
   - id: layer_18/width_16k/average_l0_564
-    path: layer_18/width_16k/average_l0_564/params.npz
+    path: layer_18/width_16k/average_l0_564
     l0: 564
   - id: layer_18/width_16k/average_l0_1052
-    path: layer_18/width_16k/average_l0_1052/params.npz
+    path: layer_18/width_16k/average_l0_1052
     l0: 1052
   - id: layer_18/width_131k/average_l0_19
-    path: layer_18/width_131k/average_l0_19/params.npz
+    path: layer_18/width_131k/average_l0_19
     l0: 19
   - id: layer_18/width_131k/average_l0_37
-    path: layer_18/width_131k/average_l0_37/params.npz
+    path: layer_18/width_131k/average_l0_37
     l0: 37
   - id: layer_18/width_131k/average_l0_82
-    path: layer_18/width_131k/average_l0_82/params.npz
+    path: layer_18/width_131k/average_l0_82
     l0: 82
   - id: layer_18/width_131k/average_l0_174
-    path: layer_18/width_131k/average_l0_174/params.npz
+    path: layer_18/width_131k/average_l0_174
     l0: 174
   - id: layer_18/width_131k/average_l0_420
-    path: layer_18/width_131k/average_l0_420/params.npz
+    path: layer_18/width_131k/average_l0_420
     l0: 420
   - id: layer_18/width_131k/average_l0_865
-    path: layer_18/width_131k/average_l0_865/params.npz
+    path: layer_18/width_131k/average_l0_865
     l0: 865
   - id: layer_19/width_16k/average_l0_16
-    path: layer_19/width_16k/average_l0_16/params.npz
+    path: layer_19/width_16k/average_l0_16
     l0: 16
   - id: layer_19/width_16k/average_l0_38
-    path: layer_19/width_16k/average_l0_38/params.npz
+    path: layer_19/width_16k/average_l0_38
     l0: 38
   - id: layer_19/width_16k/average_l0_98
-    path: layer_19/width_16k/average_l0_98/params.npz
+    path: layer_19/width_16k/average_l0_98
     l0: 98
   - id: layer_19/width_16k/average_l0_255
-    path: layer_19/width_16k/average_l0_255/params.npz
+    path: layer_19/width_16k/average_l0_255
     l0: 255
   - id: layer_19/width_16k/average_l0_599
-    path: layer_19/width_16k/average_l0_599/params.npz
+    path: layer_19/width_16k/average_l0_599
     l0: 599
   - id: layer_19/width_16k/average_l0_1097
-    path: layer_19/width_16k/average_l0_1097/params.npz
+    path: layer_19/width_16k/average_l0_1097
     l0: 1097
   - id: layer_19/width_131k/average_l0_19
-    path: layer_19/width_131k/average_l0_19/params.npz
+    path: layer_19/width_131k/average_l0_19
     l0: 19
   - id: layer_19/width_131k/average_l0_40
-    path: layer_19/width_131k/average_l0_40/params.npz
+    path: layer_19/width_131k/average_l0_40
     l0: 40
   - id: layer_19/width_131k/average_l0_85
-    path: layer_19/width_131k/average_l0_85/params.npz
+    path: layer_19/width_131k/average_l0_85
     l0: 85
   - id: layer_19/width_131k/average_l0_189
-    path: layer_19/width_131k/average_l0_189/params.npz
+    path: layer_19/width_131k/average_l0_189
     l0: 189
   - id: layer_19/width_131k/average_l0_440
-    path: layer_19/width_131k/average_l0_440/params.npz
+    path: layer_19/width_131k/average_l0_440
     l0: 440
   - id: layer_19/width_131k/average_l0_899
-    path: layer_19/width_131k/average_l0_899/params.npz
+    path: layer_19/width_131k/average_l0_899
     l0: 899
   - id: layer_2/width_16k/average_l0_8
-    path: layer_2/width_16k/average_l0_8/params.npz
+    path: layer_2/width_16k/average_l0_8
     l0: 8
   - id: layer_2/width_16k/average_l0_16
-    path: layer_2/width_16k/average_l0_16/params.npz
+    path: layer_2/width_16k/average_l0_16
     l0: 16
   - id: layer_2/width_16k/average_l0_33
-    path: layer_2/width_16k/average_l0_33/params.npz
+    path: layer_2/width_16k/average_l0_33
     l0: 33
   - id: layer_2/width_16k/average_l0_81
-    path: layer_2/width_16k/average_l0_81/params.npz
+    path: layer_2/width_16k/average_l0_81
     l0: 81
   - id: layer_2/width_16k/average_l0_163
-    path: layer_2/width_16k/average_l0_163/params.npz
+    path: layer_2/width_16k/average_l0_163
     l0: 163
   - id: layer_2/width_131k/average_l0_4
-    path: layer_2/width_131k/average_l0_4/params.npz
+    path: layer_2/width_131k/average_l0_4
     l0: 4
   - id: layer_2/width_131k/average_l0_7
-    path: layer_2/width_131k/average_l0_7/params.npz
+    path: layer_2/width_131k/average_l0_7
     l0: 7
   - id: layer_2/width_131k/average_l0_12
-    path: layer_2/width_131k/average_l0_12/params.npz
+    path: layer_2/width_131k/average_l0_12
     l0: 12
   - id: layer_2/width_131k/average_l0_20
-    path: layer_2/width_131k/average_l0_20/params.npz
+    path: layer_2/width_131k/average_l0_20
     l0: 20
   - id: layer_2/width_131k/average_l0_35
-    path: layer_2/width_131k/average_l0_35/params.npz
+    path: layer_2/width_131k/average_l0_35
     l0: 35
   - id: layer_2/width_131k/average_l0_61
-    path: layer_2/width_131k/average_l0_61/params.npz
+    path: layer_2/width_131k/average_l0_61
     l0: 61
   - id: layer_20/width_16k/average_l0_17
-    path: layer_20/width_16k/average_l0_17/params.npz
+    path: layer_20/width_16k/average_l0_17
     l0: 17
   - id: layer_20/width_16k/average_l0_41
-    path: layer_20/width_16k/average_l0_41/params.npz
+    path: layer_20/width_16k/average_l0_41
     l0: 41
   - id: layer_20/width_16k/average_l0_108
-    path: layer_20/width_16k/average_l0_108/params.npz
+    path: layer_20/width_16k/average_l0_108
     l0: 108
   - id: layer_20/width_16k/average_l0_284
-    path: layer_20/width_16k/average_l0_284/params.npz
+    path: layer_20/width_16k/average_l0_284
     l0: 284
   - id: layer_20/width_16k/average_l0_643
-    path: layer_20/width_16k/average_l0_643/params.npz
+    path: layer_20/width_16k/average_l0_643
     l0: 643
   - id: layer_20/width_16k/average_l0_1127
-    path: layer_20/width_16k/average_l0_1127/params.npz
+    path: layer_20/width_16k/average_l0_1127
     l0: 1127
   - id: layer_20/width_131k/average_l0_20
-    path: layer_20/width_131k/average_l0_20/params.npz
+    path: layer_20/width_131k/average_l0_20
     l0: 20
   - id: layer_20/width_131k/average_l0_41
-    path: layer_20/width_131k/average_l0_41/params.npz
+    path: layer_20/width_131k/average_l0_41
     l0: 41
   - id: layer_20/width_131k/average_l0_93
-    path: layer_20/width_131k/average_l0_93/params.npz
+    path: layer_20/width_131k/average_l0_93
     l0: 93
   - id: layer_20/width_131k/average_l0_212
-    path: layer_20/width_131k/average_l0_212/params.npz
+    path: layer_20/width_131k/average_l0_212
     l0: 212
   - id: layer_20/width_131k/average_l0_477
-    path: layer_20/width_131k/average_l0_477/params.npz
+    path: layer_20/width_131k/average_l0_477
     l0: 477
   - id: layer_20/width_131k/average_l0_992
-    path: layer_20/width_131k/average_l0_992/params.npz
+    path: layer_20/width_131k/average_l0_992
     l0: 992
   - id: layer_21/width_16k/average_l0_15
-    path: layer_21/width_16k/average_l0_15/params.npz
+    path: layer_21/width_16k/average_l0_15
     l0: 15
   - id: layer_21/width_16k/average_l0_34
-    path: layer_21/width_16k/average_l0_34/params.npz
+    path: layer_21/width_16k/average_l0_34
     l0: 34
   - id: layer_21/width_16k/average_l0_88
-    path: layer_21/width_16k/average_l0_88/params.npz
+    path: layer_21/width_16k/average_l0_88
     l0: 88
   - id: layer_21/width_16k/average_l0_241
-    path: layer_21/width_16k/average_l0_241/params.npz
+    path: layer_21/width_16k/average_l0_241
     l0: 241
   - id: layer_21/width_16k/average_l0_571
-    path: layer_21/width_16k/average_l0_571/params.npz
+    path: layer_21/width_16k/average_l0_571
     l0: 571
   - id: layer_21/width_16k/average_l0_1063
-    path: layer_21/width_16k/average_l0_1063/params.npz
+    path: layer_21/width_16k/average_l0_1063
     l0: 1063
   - id: layer_21/width_131k/average_l0_16
-    path: layer_21/width_131k/average_l0_16/params.npz
+    path: layer_21/width_131k/average_l0_16
     l0: 16
   - id: layer_21/width_131k/average_l0_35
-    path: layer_21/width_131k/average_l0_35/params.npz
+    path: layer_21/width_131k/average_l0_35
     l0: 35
   - id: layer_21/width_131k/average_l0_79
-    path: layer_21/width_131k/average_l0_79/params.npz
+    path: layer_21/width_131k/average_l0_79
     l0: 79
   - id: layer_21/width_131k/average_l0_179
-    path: layer_21/width_131k/average_l0_179/params.npz
+    path: layer_21/width_131k/average_l0_179
     l0: 179
   - id: layer_21/width_131k/average_l0_417
-    path: layer_21/width_131k/average_l0_417/params.npz
+    path: layer_21/width_131k/average_l0_417
     l0: 417
   - id: layer_21/width_131k/average_l0_884
-    path: layer_21/width_131k/average_l0_884/params.npz
+    path: layer_21/width_131k/average_l0_884
     l0: 884
   - id: layer_22/width_16k/average_l0_15
-    path: layer_22/width_16k/average_l0_15/params.npz
+    path: layer_22/width_16k/average_l0_15
     l0: 15
   - id: layer_22/width_16k/average_l0_34
-    path: layer_22/width_16k/average_l0_34/params.npz
+    path: layer_22/width_16k/average_l0_34
     l0: 34
   - id: layer_22/width_16k/average_l0_85
-    path: layer_22/width_16k/average_l0_85/params.npz
+    path: layer_22/width_16k/average_l0_85
     l0: 85
   - id: layer_22/width_16k/average_l0_226
-    path: layer_22/width_16k/average_l0_226/params.npz
+    path: layer_22/width_16k/average_l0_226
     l0: 226
   - id: layer_22/width_16k/average_l0_566
-    path: layer_22/width_16k/average_l0_566/params.npz
+    path: layer_22/width_16k/average_l0_566
     l0: 566
   - id: layer_22/width_16k/average_l0_1065
-    path: layer_22/width_16k/average_l0_1065/params.npz
+    path: layer_22/width_16k/average_l0_1065
     l0: 1065
   - id: layer_22/width_131k/average_l0_17
-    path: layer_22/width_131k/average_l0_17/params.npz
+    path: layer_22/width_131k/average_l0_17
     l0: 17
   - id: layer_22/width_131k/average_l0_35
-    path: layer_22/width_131k/average_l0_35/params.npz
+    path: layer_22/width_131k/average_l0_35
     l0: 35
   - id: layer_22/width_131k/average_l0_77
-    path: layer_22/width_131k/average_l0_77/params.npz
+    path: layer_22/width_131k/average_l0_77
     l0: 77
   - id: layer_22/width_131k/average_l0_172
-    path: layer_22/width_131k/average_l0_172/params.npz
+    path: layer_22/width_131k/average_l0_172
     l0: 172
   - id: layer_22/width_131k/average_l0_404
-    path: layer_22/width_131k/average_l0_404/params.npz
+    path: layer_22/width_131k/average_l0_404
     l0: 404
   - id: layer_22/width_131k/average_l0_861
-    path: layer_22/width_131k/average_l0_861/params.npz
+    path: layer_22/width_131k/average_l0_861
     l0: 861
   - id: layer_23/width_16k/average_l0_15
-    path: layer_23/width_16k/average_l0_15/params.npz
+    path: layer_23/width_16k/average_l0_15
     l0: 15
   - id: layer_23/width_16k/average_l0_31
-    path: layer_23/width_16k/average_l0_31/params.npz
+    path: layer_23/width_16k/average_l0_31
     l0: 31
   - id: layer_23/width_16k/average_l0_73
-    path: layer_23/width_16k/average_l0_73/params.npz
+    path: layer_23/width_16k/average_l0_73
     l0: 73
   - id: layer_23/width_16k/average_l0_190
-    path: layer_23/width_16k/average_l0_190/params.npz
+    path: layer_23/width_16k/average_l0_190
     l0: 190
   - id: layer_23/width_16k/average_l0_492
-    path: layer_23/width_16k/average_l0_492/params.npz
+    path: layer_23/width_16k/average_l0_492
     l0: 492
   - id: layer_23/width_16k/average_l0_990
-    path: layer_23/width_16k/average_l0_990/params.npz
+    path: layer_23/width_16k/average_l0_990
     l0: 990
   - id: layer_23/width_131k/average_l0_17
-    path: layer_23/width_131k/average_l0_17/params.npz
+    path: layer_23/width_131k/average_l0_17
     l0: 17
   - id: layer_23/width_131k/average_l0_32
-    path: layer_23/width_131k/average_l0_32/params.npz
+    path: layer_23/width_131k/average_l0_32
     l0: 32
   - id: layer_23/width_131k/average_l0_67
-    path: layer_23/width_131k/average_l0_67/params.npz
+    path: layer_23/width_131k/average_l0_67
     l0: 67
   - id: layer_23/width_131k/average_l0_146
-    path: layer_23/width_131k/average_l0_146/params.npz
+    path: layer_23/width_131k/average_l0_146
     l0: 146
   - id: layer_23/width_131k/average_l0_354
-    path: layer_23/width_131k/average_l0_354/params.npz
+    path: layer_23/width_131k/average_l0_354
     l0: 354
   - id: layer_23/width_131k/average_l0_754
-    path: layer_23/width_131k/average_l0_754/params.npz
+    path: layer_23/width_131k/average_l0_754
     l0: 754
   - id: layer_24/width_16k/average_l0_15
-    path: layer_24/width_16k/average_l0_15/params.npz
+    path: layer_24/width_16k/average_l0_15
     l0: 15
   - id: layer_24/width_16k/average_l0_32
-    path: layer_24/width_16k/average_l0_32/params.npz
+    path: layer_24/width_16k/average_l0_32
     l0: 32
   - id: layer_24/width_16k/average_l0_73
-    path: layer_24/width_16k/average_l0_73/params.npz
+    path: layer_24/width_16k/average_l0_73
     l0: 73
   - id: layer_24/width_16k/average_l0_192
-    path: layer_24/width_16k/average_l0_192/params.npz
+    path: layer_24/width_16k/average_l0_192
     l0: 192
   - id: layer_24/width_16k/average_l0_494
-    path: layer_24/width_16k/average_l0_494/params.npz
+    path: layer_24/width_16k/average_l0_494
     l0: 494
   - id: layer_24/width_16k/average_l0_999
-    path: layer_24/width_16k/average_l0_999/params.npz
+    path: layer_24/width_16k/average_l0_999
     l0: 999
   - id: layer_24/width_131k/average_l0_17
-    path: layer_24/width_131k/average_l0_17/params.npz
+    path: layer_24/width_131k/average_l0_17
     l0: 17
   - id: layer_24/width_131k/average_l0_33
-    path: layer_24/width_131k/average_l0_33/params.npz
+    path: layer_24/width_131k/average_l0_33
     l0: 33
   - id: layer_24/width_131k/average_l0_67
-    path: layer_24/width_131k/average_l0_67/params.npz
+    path: layer_24/width_131k/average_l0_67
     l0: 67
   - id: layer_24/width_131k/average_l0_147
-    path: layer_24/width_131k/average_l0_147/params.npz
+    path: layer_24/width_131k/average_l0_147
     l0: 147
   - id: layer_24/width_131k/average_l0_351
-    path: layer_24/width_131k/average_l0_351/params.npz
+    path: layer_24/width_131k/average_l0_351
     l0: 351
   - id: layer_24/width_131k/average_l0_709
-    path: layer_24/width_131k/average_l0_709/params.npz
+    path: layer_24/width_131k/average_l0_709
     l0: 709
   - id: layer_25/width_16k/average_l0_15
-    path: layer_25/width_16k/average_l0_15/params.npz
+    path: layer_25/width_16k/average_l0_15
     l0: 15
   - id: layer_25/width_16k/average_l0_31
-    path: layer_25/width_16k/average_l0_31/params.npz
+    path: layer_25/width_16k/average_l0_31
     l0: 31
   - id: layer_25/width_16k/average_l0_72
-    path: layer_25/width_16k/average_l0_72/params.npz
+    path: layer_25/width_16k/average_l0_72
     l0: 72
   - id: layer_25/width_16k/average_l0_184
-    path: layer_25/width_16k/average_l0_184/params.npz
+    path: layer_25/width_16k/average_l0_184
     l0: 184
   - id: layer_25/width_16k/average_l0_494
-    path: layer_25/width_16k/average_l0_494/params.npz
+    path: layer_25/width_16k/average_l0_494
     l0: 494
   - id: layer_25/width_16k/average_l0_1013
-    path: layer_25/width_16k/average_l0_1013/params.npz
+    path: layer_25/width_16k/average_l0_1013
     l0: 1013
   - id: layer_25/width_131k/average_l0_16
-    path: layer_25/width_131k/average_l0_16/params.npz
+    path: layer_25/width_131k/average_l0_16
     l0: 16
   - id: layer_25/width_131k/average_l0_32
-    path: layer_25/width_131k/average_l0_32/params.npz
+    path: layer_25/width_131k/average_l0_32
     l0: 32
   - id: layer_25/width_131k/average_l0_65
-    path: layer_25/width_131k/average_l0_65/params.npz
+    path: layer_25/width_131k/average_l0_65
     l0: 65
   - id: layer_25/width_131k/average_l0_139
-    path: layer_25/width_131k/average_l0_139/params.npz
+    path: layer_25/width_131k/average_l0_139
     l0: 139
   - id: layer_25/width_131k/average_l0_326
-    path: layer_25/width_131k/average_l0_326/params.npz
+    path: layer_25/width_131k/average_l0_326
     l0: 326
   - id: layer_25/width_131k/average_l0_691
-    path: layer_25/width_131k/average_l0_691/params.npz
+    path: layer_25/width_131k/average_l0_691
     l0: 691
   - id: layer_26/width_16k/average_l0_14
-    path: layer_26/width_16k/average_l0_14/params.npz
+    path: layer_26/width_16k/average_l0_14
     l0: 14
   - id: layer_26/width_16k/average_l0_26
-    path: layer_26/width_16k/average_l0_26/params.npz
+    path: layer_26/width_16k/average_l0_26
     l0: 26
   - id: layer_26/width_16k/average_l0_57
-    path: layer_26/width_16k/average_l0_57/params.npz
+    path: layer_26/width_16k/average_l0_57
     l0: 57
   - id: layer_26/width_16k/average_l0_142
-    path: layer_26/width_16k/average_l0_142/params.npz
+    path: layer_26/width_16k/average_l0_142
     l0: 142
   - id: layer_26/width_16k/average_l0_394
-    path: layer_26/width_16k/average_l0_394/params.npz
+    path: layer_26/width_16k/average_l0_394
     l0: 394
   - id: layer_26/width_16k/average_l0_887
-    path: layer_26/width_16k/average_l0_887/params.npz
+    path: layer_26/width_16k/average_l0_887
     l0: 887
   - id: layer_26/width_131k/average_l0_14
-    path: layer_26/width_131k/average_l0_14/params.npz
+    path: layer_26/width_131k/average_l0_14
     l0: 14
   - id: layer_26/width_131k/average_l0_27
-    path: layer_26/width_131k/average_l0_27/params.npz
+    path: layer_26/width_131k/average_l0_27
     l0: 27
   - id: layer_26/width_131k/average_l0_53
-    path: layer_26/width_131k/average_l0_53/params.npz
+    path: layer_26/width_131k/average_l0_53
     l0: 53
   - id: layer_26/width_131k/average_l0_110
-    path: layer_26/width_131k/average_l0_110/params.npz
+    path: layer_26/width_131k/average_l0_110
     l0: 110
   - id: layer_26/width_131k/average_l0_249
-    path: layer_26/width_131k/average_l0_249/params.npz
+    path: layer_26/width_131k/average_l0_249
     l0: 249
   - id: layer_26/width_131k/average_l0_568
-    path: layer_26/width_131k/average_l0_568/params.npz
+    path: layer_26/width_131k/average_l0_568
     l0: 568
   - id: layer_27/width_16k/average_l0_14
-    path: layer_27/width_16k/average_l0_14/params.npz
+    path: layer_27/width_16k/average_l0_14
     l0: 14
   - id: layer_27/width_16k/average_l0_25
-    path: layer_27/width_16k/average_l0_25/params.npz
+    path: layer_27/width_16k/average_l0_25
     l0: 25
   - id: layer_27/width_16k/average_l0_52
-    path: layer_27/width_16k/average_l0_52/params.npz
+    path: layer_27/width_16k/average_l0_52
     l0: 52
   - id: layer_27/width_16k/average_l0_126
-    path: layer_27/width_16k/average_l0_126/params.npz
+    path: layer_27/width_16k/average_l0_126
     l0: 126
   - id: layer_27/width_16k/average_l0_352
-    path: layer_27/width_16k/average_l0_352/params.npz
+    path: layer_27/width_16k/average_l0_352
     l0: 352
   - id: layer_27/width_16k/average_l0_813
-    path: layer_27/width_16k/average_l0_813/params.npz
+    path: layer_27/width_16k/average_l0_813
     l0: 813
   - id: layer_27/width_131k/average_l0_14
-    path: layer_27/width_131k/average_l0_14/params.npz
+    path: layer_27/width_131k/average_l0_14
     l0: 14
   - id: layer_27/width_131k/average_l0_26
-    path: layer_27/width_131k/average_l0_26/params.npz
+    path: layer_27/width_131k/average_l0_26
     l0: 26
   - id: layer_27/width_131k/average_l0_49
-    path: layer_27/width_131k/average_l0_49/params.npz
+    path: layer_27/width_131k/average_l0_49
     l0: 49
   - id: layer_27/width_131k/average_l0_99
-    path: layer_27/width_131k/average_l0_99/params.npz
+    path: layer_27/width_131k/average_l0_99
     l0: 99
   - id: layer_27/width_131k/average_l0_211
-    path: layer_27/width_131k/average_l0_211/params.npz
+    path: layer_27/width_131k/average_l0_211
     l0: 211
   - id: layer_27/width_131k/average_l0_487
-    path: layer_27/width_131k/average_l0_487/params.npz
+    path: layer_27/width_131k/average_l0_487
     l0: 487
   - id: layer_28/width_16k/average_l0_14
-    path: layer_28/width_16k/average_l0_14/params.npz
+    path: layer_28/width_16k/average_l0_14
     l0: 14
   - id: layer_28/width_16k/average_l0_26
-    path: layer_28/width_16k/average_l0_26/params.npz
+    path: layer_28/width_16k/average_l0_26
     l0: 26
   - id: layer_28/width_16k/average_l0_50
-    path: layer_28/width_16k/average_l0_50/params.npz
+    path: layer_28/width_16k/average_l0_50
     l0: 50
   - id: layer_28/width_16k/average_l0_115
-    path: layer_28/width_16k/average_l0_115/params.npz
+    path: layer_28/width_16k/average_l0_115
     l0: 115
   - id: layer_28/width_16k/average_l0_324
-    path: layer_28/width_16k/average_l0_324/params.npz
+    path: layer_28/width_16k/average_l0_324
     l0: 324
   - id: layer_28/width_16k/average_l0_773
-    path: layer_28/width_16k/average_l0_773/params.npz
+    path: layer_28/width_16k/average_l0_773
     l0: 773
   - id: layer_28/width_131k/average_l0_15
-    path: layer_28/width_131k/average_l0_15/params.npz
+    path: layer_28/width_131k/average_l0_15
     l0: 15
   - id: layer_28/width_131k/average_l0_26
-    path: layer_28/width_131k/average_l0_26/params.npz
+    path: layer_28/width_131k/average_l0_26
     l0: 26
   - id: layer_28/width_131k/average_l0_47
-    path: layer_28/width_131k/average_l0_47/params.npz
+    path: layer_28/width_131k/average_l0_47
     l0: 47
   - id: layer_28/width_131k/average_l0_91
-    path: layer_28/width_131k/average_l0_91/params.npz
+    path: layer_28/width_131k/average_l0_91
     l0: 91
   - id: layer_28/width_131k/average_l0_189
-    path: layer_28/width_131k/average_l0_189/params.npz
+    path: layer_28/width_131k/average_l0_189
     l0: 189
   - id: layer_28/width_131k/average_l0_425
-    path: layer_28/width_131k/average_l0_425/params.npz
+    path: layer_28/width_131k/average_l0_425
     l0: 425
   - id: layer_29/width_16k/average_l0_15
-    path: layer_29/width_16k/average_l0_15/params.npz
+    path: layer_29/width_16k/average_l0_15
     l0: 15
   - id: layer_29/width_16k/average_l0_26
-    path: layer_29/width_16k/average_l0_26/params.npz
+    path: layer_29/width_16k/average_l0_26
     l0: 26
   - id: layer_29/width_16k/average_l0_49
-    path: layer_29/width_16k/average_l0_49/params.npz
+    path: layer_29/width_16k/average_l0_49
     l0: 49
   - id: layer_29/width_16k/average_l0_111
-    path: layer_29/width_16k/average_l0_111/params.npz
+    path: layer_29/width_16k/average_l0_111
     l0: 111
   - id: layer_29/width_16k/average_l0_311
-    path: layer_29/width_16k/average_l0_311/params.npz
+    path: layer_29/width_16k/average_l0_311
     l0: 311
   - id: layer_29/width_16k/average_l0_725
-    path: layer_29/width_16k/average_l0_725/params.npz
+    path: layer_29/width_16k/average_l0_725
     l0: 725
   - id: layer_29/width_131k/average_l0_15
-    path: layer_29/width_131k/average_l0_15/params.npz
+    path: layer_29/width_131k/average_l0_15
     l0: 15
   - id: layer_29/width_131k/average_l0_26
-    path: layer_29/width_131k/average_l0_26/params.npz
+    path: layer_29/width_131k/average_l0_26
     l0: 26
   - id: layer_29/width_131k/average_l0_47
-    path: layer_29/width_131k/average_l0_47/params.npz
+    path: layer_29/width_131k/average_l0_47
     l0: 47
   - id: layer_29/width_131k/average_l0_87
-    path: layer_29/width_131k/average_l0_87/params.npz
+    path: layer_29/width_131k/average_l0_87
     l0: 87
   - id: layer_29/width_131k/average_l0_174
-    path: layer_29/width_131k/average_l0_174/params.npz
+    path: layer_29/width_131k/average_l0_174
     l0: 174
   - id: layer_29/width_131k/average_l0_386
-    path: layer_29/width_131k/average_l0_386/params.npz
+    path: layer_29/width_131k/average_l0_386
     l0: 386
   - id: layer_3/width_16k/average_l0_13
-    path: layer_3/width_16k/average_l0_13/params.npz
+    path: layer_3/width_16k/average_l0_13
     l0: 13
   - id: layer_3/width_16k/average_l0_25
-    path: layer_3/width_16k/average_l0_25/params.npz
+    path: layer_3/width_16k/average_l0_25
     l0: 25
   - id: layer_3/width_16k/average_l0_55
-    path: layer_3/width_16k/average_l0_55/params.npz
+    path: layer_3/width_16k/average_l0_55
     l0: 55
   - id: layer_3/width_16k/average_l0_126
-    path: layer_3/width_16k/average_l0_126/params.npz
+    path: layer_3/width_16k/average_l0_126
     l0: 126
   - id: layer_3/width_16k/average_l0_234
-    path: layer_3/width_16k/average_l0_234/params.npz
+    path: layer_3/width_16k/average_l0_234
     l0: 234
   - id: layer_3/width_131k/average_l0_6
-    path: layer_3/width_131k/average_l0_6/params.npz
+    path: layer_3/width_131k/average_l0_6
     l0: 6
   - id: layer_3/width_131k/average_l0_11
-    path: layer_3/width_131k/average_l0_11/params.npz
+    path: layer_3/width_131k/average_l0_11
     l0: 11
   - id: layer_3/width_131k/average_l0_19
-    path: layer_3/width_131k/average_l0_19/params.npz
+    path: layer_3/width_131k/average_l0_19
     l0: 19
   - id: layer_3/width_131k/average_l0_33
-    path: layer_3/width_131k/average_l0_33/params.npz
+    path: layer_3/width_131k/average_l0_33
     l0: 33
   - id: layer_3/width_131k/average_l0_58
-    path: layer_3/width_131k/average_l0_58/params.npz
+    path: layer_3/width_131k/average_l0_58
     l0: 58
   - id: layer_3/width_131k/average_l0_109
-    path: layer_3/width_131k/average_l0_109/params.npz
+    path: layer_3/width_131k/average_l0_109
     l0: 109
   - id: layer_30/width_16k/average_l0_14
-    path: layer_30/width_16k/average_l0_14/params.npz
+    path: layer_30/width_16k/average_l0_14
     l0: 14
   - id: layer_30/width_16k/average_l0_26
-    path: layer_30/width_16k/average_l0_26/params.npz
+    path: layer_30/width_16k/average_l0_26
     l0: 26
   - id: layer_30/width_16k/average_l0_51
-    path: layer_30/width_16k/average_l0_51/params.npz
+    path: layer_30/width_16k/average_l0_51
     l0: 51
   - id: layer_30/width_16k/average_l0_116
-    path: layer_30/width_16k/average_l0_116/params.npz
+    path: layer_30/width_16k/average_l0_116
     l0: 116
   - id: layer_30/width_16k/average_l0_333
-    path: layer_30/width_16k/average_l0_333/params.npz
+    path: layer_30/width_16k/average_l0_333
     l0: 333
   - id: layer_30/width_16k/average_l0_806
-    path: layer_30/width_16k/average_l0_806/params.npz
+    path: layer_30/width_16k/average_l0_806
     l0: 806
   - id: layer_30/width_131k/average_l0_14
-    path: layer_30/width_131k/average_l0_14/params.npz
+    path: layer_30/width_131k/average_l0_14
     l0: 14
   - id: layer_30/width_131k/average_l0_26
-    path: layer_30/width_131k/average_l0_26/params.npz
+    path: layer_30/width_131k/average_l0_26
     l0: 26
   - id: layer_30/width_131k/average_l0_47
-    path: layer_30/width_131k/average_l0_47/params.npz
+    path: layer_30/width_131k/average_l0_47
     l0: 47
   - id: layer_30/width_131k/average_l0_89
-    path: layer_30/width_131k/average_l0_89/params.npz
+    path: layer_30/width_131k/average_l0_89
     l0: 89
   - id: layer_30/width_131k/average_l0_179
-    path: layer_30/width_131k/average_l0_179/params.npz
+    path: layer_30/width_131k/average_l0_179
     l0: 179
   - id: layer_30/width_131k/average_l0_391
-    path: layer_30/width_131k/average_l0_391/params.npz
+    path: layer_30/width_131k/average_l0_391
     l0: 391
   - id: layer_31/width_16k/average_l0_12
-    path: layer_31/width_16k/average_l0_12/params.npz
+    path: layer_31/width_16k/average_l0_12
     l0: 12
   - id: layer_31/width_16k/average_l0_22
-    path: layer_31/width_16k/average_l0_22/params.npz
+    path: layer_31/width_16k/average_l0_22
     l0: 22
   - id: layer_31/width_16k/average_l0_43
-    path: layer_31/width_16k/average_l0_43/params.npz
+    path: layer_31/width_16k/average_l0_43
     l0: 43
   - id: layer_31/width_16k/average_l0_94
-    path: layer_31/width_16k/average_l0_94/params.npz
+    path: layer_31/width_16k/average_l0_94
     l0: 94
   - id: layer_31/width_16k/average_l0_263
-    path: layer_31/width_16k/average_l0_263/params.npz
+    path: layer_31/width_16k/average_l0_263
     l0: 263
   - id: layer_31/width_16k/average_l0_671
-    path: layer_31/width_16k/average_l0_671/params.npz
+    path: layer_31/width_16k/average_l0_671
     l0: 671
   - id: layer_31/width_131k/average_l0_12
-    path: layer_31/width_131k/average_l0_12/params.npz
+    path: layer_31/width_131k/average_l0_12
     l0: 12
   - id: layer_31/width_131k/average_l0_22
-    path: layer_31/width_131k/average_l0_22/params.npz
+    path: layer_31/width_131k/average_l0_22
     l0: 22
   - id: layer_31/width_131k/average_l0_40
-    path: layer_31/width_131k/average_l0_40/params.npz
+    path: layer_31/width_131k/average_l0_40
     l0: 40
   - id: layer_31/width_131k/average_l0_77
-    path: layer_31/width_131k/average_l0_77/params.npz
+    path: layer_31/width_131k/average_l0_77
     l0: 77
   - id: layer_31/width_131k/average_l0_153
-    path: layer_31/width_131k/average_l0_153/params.npz
+    path: layer_31/width_131k/average_l0_153
     l0: 153
   - id: layer_31/width_131k/average_l0_326
-    path: layer_31/width_131k/average_l0_326/params.npz
+    path: layer_31/width_131k/average_l0_326
     l0: 326
   - id: layer_32/width_16k/average_l0_11
-    path: layer_32/width_16k/average_l0_11/params.npz
+    path: layer_32/width_16k/average_l0_11
     l0: 11
   - id: layer_32/width_16k/average_l0_21
-    path: layer_32/width_16k/average_l0_21/params.npz
+    path: layer_32/width_16k/average_l0_21
     l0: 21
   - id: layer_32/width_16k/average_l0_44
-    path: layer_32/width_16k/average_l0_44/params.npz
+    path: layer_32/width_16k/average_l0_44
     l0: 44
   - id: layer_32/width_16k/average_l0_98
-    path: layer_32/width_16k/average_l0_98/params.npz
+    path: layer_32/width_16k/average_l0_98
     l0: 98
   - id: layer_32/width_16k/average_l0_267
-    path: layer_32/width_16k/average_l0_267/params.npz
+    path: layer_32/width_16k/average_l0_267
     l0: 267
   - id: layer_32/width_16k/average_l0_623
-    path: layer_32/width_16k/average_l0_623/params.npz
+    path: layer_32/width_16k/average_l0_623
     l0: 623
   - id: layer_32/width_131k/average_l0_12
-    path: layer_32/width_131k/average_l0_12/params.npz
+    path: layer_32/width_131k/average_l0_12
     l0: 12
   - id: layer_32/width_131k/average_l0_21
-    path: layer_32/width_131k/average_l0_21/params.npz
+    path: layer_32/width_131k/average_l0_21
     l0: 21
   - id: layer_32/width_131k/average_l0_40
-    path: layer_32/width_131k/average_l0_40/params.npz
+    path: layer_32/width_131k/average_l0_40
     l0: 40
   - id: layer_32/width_131k/average_l0_76
-    path: layer_32/width_131k/average_l0_76/params.npz
+    path: layer_32/width_131k/average_l0_76
     l0: 76
   - id: layer_32/width_131k/average_l0_155
-    path: layer_32/width_131k/average_l0_155/params.npz
+    path: layer_32/width_131k/average_l0_155
     l0: 155
   - id: layer_32/width_131k/average_l0_336
-    path: layer_32/width_131k/average_l0_336/params.npz
+    path: layer_32/width_131k/average_l0_336
     l0: 336
   - id: layer_33/width_16k/average_l0_12
-    path: layer_33/width_16k/average_l0_12/params.npz
+    path: layer_33/width_16k/average_l0_12
     l0: 12
   - id: layer_33/width_16k/average_l0_23
-    path: layer_33/width_16k/average_l0_23/params.npz
+    path: layer_33/width_16k/average_l0_23
     l0: 23
   - id: layer_33/width_16k/average_l0_48
-    path: layer_33/width_16k/average_l0_48/params.npz
+    path: layer_33/width_16k/average_l0_48
     l0: 48
   - id: layer_33/width_16k/average_l0_107
-    path: layer_33/width_16k/average_l0_107/params.npz
+    path: layer_33/width_16k/average_l0_107
     l0: 107
   - id: layer_33/width_16k/average_l0_282
-    path: layer_33/width_16k/average_l0_282/params.npz
+    path: layer_33/width_16k/average_l0_282
     l0: 282
   - id: layer_33/width_16k/average_l0_628
-    path: layer_33/width_16k/average_l0_628/params.npz
+    path: layer_33/width_16k/average_l0_628
     l0: 628
   - id: layer_33/width_131k/average_l0_12
-    path: layer_33/width_131k/average_l0_12/params.npz
+    path: layer_33/width_131k/average_l0_12
     l0: 12
   - id: layer_33/width_131k/average_l0_22
-    path: layer_33/width_131k/average_l0_22/params.npz
+    path: layer_33/width_131k/average_l0_22
     l0: 22
   - id: layer_33/width_131k/average_l0_42
-    path: layer_33/width_131k/average_l0_42/params.npz
+    path: layer_33/width_131k/average_l0_42
     l0: 42
   - id: layer_33/width_131k/average_l0_83
-    path: layer_33/width_131k/average_l0_83/params.npz
+    path: layer_33/width_131k/average_l0_83
     l0: 83
   - id: layer_33/width_131k/average_l0_168
-    path: layer_33/width_131k/average_l0_168/params.npz
+    path: layer_33/width_131k/average_l0_168
     l0: 168
   - id: layer_33/width_131k/average_l0_394
-    path: layer_33/width_131k/average_l0_394/params.npz
+    path: layer_33/width_131k/average_l0_394
     l0: 394
   - id: layer_34/width_16k/average_l0_11
-    path: layer_34/width_16k/average_l0_11/params.npz
+    path: layer_34/width_16k/average_l0_11
     l0: 11
   - id: layer_34/width_16k/average_l0_22
-    path: layer_34/width_16k/average_l0_22/params.npz
+    path: layer_34/width_16k/average_l0_22
     l0: 22
   - id: layer_34/width_16k/average_l0_47
-    path: layer_34/width_16k/average_l0_47/params.npz
+    path: layer_34/width_16k/average_l0_47
     l0: 47
   - id: layer_34/width_16k/average_l0_107
-    path: layer_34/width_16k/average_l0_107/params.npz
+    path: layer_34/width_16k/average_l0_107
     l0: 107
   - id: layer_34/width_16k/average_l0_268
-    path: layer_34/width_16k/average_l0_268/params.npz
+    path: layer_34/width_16k/average_l0_268
     l0: 268
   - id: layer_34/width_16k/average_l0_559
-    path: layer_34/width_16k/average_l0_559/params.npz
+    path: layer_34/width_16k/average_l0_559
     l0: 559
   - id: layer_34/width_131k/average_l0_10
-    path: layer_34/width_131k/average_l0_10/params.npz
+    path: layer_34/width_131k/average_l0_10
     l0: 10
   - id: layer_34/width_131k/average_l0_20
-    path: layer_34/width_131k/average_l0_20/params.npz
+    path: layer_34/width_131k/average_l0_20
     l0: 20
   - id: layer_34/width_131k/average_l0_40
-    path: layer_34/width_131k/average_l0_40/params.npz
+    path: layer_34/width_131k/average_l0_40
     l0: 40
   - id: layer_34/width_131k/average_l0_82
-    path: layer_34/width_131k/average_l0_82/params.npz
+    path: layer_34/width_131k/average_l0_82
     l0: 82
   - id: layer_34/width_131k/average_l0_167
-    path: layer_34/width_131k/average_l0_167/params.npz
+    path: layer_34/width_131k/average_l0_167
     l0: 167
   - id: layer_34/width_131k/average_l0_390
-    path: layer_34/width_131k/average_l0_390/params.npz
+    path: layer_34/width_131k/average_l0_390
     l0: 390
   - id: layer_35/width_16k/average_l0_10
-    path: layer_35/width_16k/average_l0_10/params.npz
+    path: layer_35/width_16k/average_l0_10
     l0: 10
   - id: layer_35/width_16k/average_l0_21
-    path: layer_35/width_16k/average_l0_21/params.npz
+    path: layer_35/width_16k/average_l0_21
     l0: 21
   - id: layer_35/width_16k/average_l0_46
-    path: layer_35/width_16k/average_l0_46/params.npz
+    path: layer_35/width_16k/average_l0_46
     l0: 46
   - id: layer_35/width_16k/average_l0_108
-    path: layer_35/width_16k/average_l0_108/params.npz
+    path: layer_35/width_16k/average_l0_108
     l0: 108
   - id: layer_35/width_16k/average_l0_254
-    path: layer_35/width_16k/average_l0_254/params.npz
+    path: layer_35/width_16k/average_l0_254
     l0: 254
   - id: layer_35/width_16k/average_l0_538
-    path: layer_35/width_16k/average_l0_538/params.npz
+    path: layer_35/width_16k/average_l0_538
     l0: 538
   - id: layer_35/width_131k/average_l0_10
-    path: layer_35/width_131k/average_l0_10/params.npz
+    path: layer_35/width_131k/average_l0_10
     l0: 10
   - id: layer_35/width_131k/average_l0_19
-    path: layer_35/width_131k/average_l0_19/params.npz
+    path: layer_35/width_131k/average_l0_19
     l0: 19
   - id: layer_35/width_131k/average_l0_39
-    path: layer_35/width_131k/average_l0_39/params.npz
+    path: layer_35/width_131k/average_l0_39
     l0: 39
   - id: layer_35/width_131k/average_l0_80
-    path: layer_35/width_131k/average_l0_80/params.npz
+    path: layer_35/width_131k/average_l0_80
     l0: 80
   - id: layer_35/width_131k/average_l0_176
-    path: layer_35/width_131k/average_l0_176/params.npz
+    path: layer_35/width_131k/average_l0_176
     l0: 176
   - id: layer_35/width_131k/average_l0_389
-    path: layer_35/width_131k/average_l0_389/params.npz
+    path: layer_35/width_131k/average_l0_389
     l0: 389
   - id: layer_36/width_16k/average_l0_11
-    path: layer_36/width_16k/average_l0_11/params.npz
+    path: layer_36/width_16k/average_l0_11
     l0: 11
   - id: layer_36/width_16k/average_l0_22
-    path: layer_36/width_16k/average_l0_22/params.npz
+    path: layer_36/width_16k/average_l0_22
     l0: 22
   - id: layer_36/width_16k/average_l0_47
-    path: layer_36/width_16k/average_l0_47/params.npz
+    path: layer_36/width_16k/average_l0_47
     l0: 47
   - id: layer_36/width_16k/average_l0_109
-    path: layer_36/width_16k/average_l0_109/params.npz
+    path: layer_36/width_16k/average_l0_109
     l0: 109
   - id: layer_36/width_16k/average_l0_256
-    path: layer_36/width_16k/average_l0_256/params.npz
+    path: layer_36/width_16k/average_l0_256
     l0: 256
   - id: layer_36/width_16k/average_l0_523
-    path: layer_36/width_16k/average_l0_523/params.npz
+    path: layer_36/width_16k/average_l0_523
     l0: 523
   - id: layer_36/width_131k/average_l0_11
-    path: layer_36/width_131k/average_l0_11/params.npz
+    path: layer_36/width_131k/average_l0_11
     l0: 11
   - id: layer_36/width_131k/average_l0_20
-    path: layer_36/width_131k/average_l0_20/params.npz
+    path: layer_36/width_131k/average_l0_20
     l0: 20
   - id: layer_36/width_131k/average_l0_40
-    path: layer_36/width_131k/average_l0_40/params.npz
+    path: layer_36/width_131k/average_l0_40
     l0: 40
   - id: layer_36/width_131k/average_l0_81
-    path: layer_36/width_131k/average_l0_81/params.npz
+    path: layer_36/width_131k/average_l0_81
     l0: 81
   - id: layer_36/width_131k/average_l0_174
-    path: layer_36/width_131k/average_l0_174/params.npz
+    path: layer_36/width_131k/average_l0_174
     l0: 174
   - id: layer_36/width_131k/average_l0_389
-    path: layer_36/width_131k/average_l0_389/params.npz
+    path: layer_36/width_131k/average_l0_389
     l0: 389
   - id: layer_37/width_16k/average_l0_12
-    path: layer_37/width_16k/average_l0_12/params.npz
+    path: layer_37/width_16k/average_l0_12
     l0: 12
   - id: layer_37/width_16k/average_l0_24
-    path: layer_37/width_16k/average_l0_24/params.npz
+    path: layer_37/width_16k/average_l0_24
     l0: 24
   - id: layer_37/width_16k/average_l0_53
-    path: layer_37/width_16k/average_l0_53/params.npz
+    path: layer_37/width_16k/average_l0_53
     l0: 53
   - id: layer_37/width_16k/average_l0_119
-    path: layer_37/width_16k/average_l0_119/params.npz
+    path: layer_37/width_16k/average_l0_119
     l0: 119
   - id: layer_37/width_16k/average_l0_267
-    path: layer_37/width_16k/average_l0_267/params.npz
+    path: layer_37/width_16k/average_l0_267
     l0: 267
   - id: layer_37/width_16k/average_l0_549
-    path: layer_37/width_16k/average_l0_549/params.npz
+    path: layer_37/width_16k/average_l0_549
     l0: 549
   - id: layer_37/width_131k/average_l0_12
-    path: layer_37/width_131k/average_l0_12/params.npz
+    path: layer_37/width_131k/average_l0_12
     l0: 12
   - id: layer_37/width_131k/average_l0_23
-    path: layer_37/width_131k/average_l0_23/params.npz
+    path: layer_37/width_131k/average_l0_23
     l0: 23
   - id: layer_37/width_131k/average_l0_44
-    path: layer_37/width_131k/average_l0_44/params.npz
+    path: layer_37/width_131k/average_l0_44
     l0: 44
   - id: layer_37/width_131k/average_l0_90
-    path: layer_37/width_131k/average_l0_90/params.npz
+    path: layer_37/width_131k/average_l0_90
     l0: 90
   - id: layer_37/width_131k/average_l0_203
-    path: layer_37/width_131k/average_l0_203/params.npz
+    path: layer_37/width_131k/average_l0_203
     l0: 203
   - id: layer_37/width_131k/average_l0_403
-    path: layer_37/width_131k/average_l0_403/params.npz
+    path: layer_37/width_131k/average_l0_403
     l0: 403
   - id: layer_38/width_16k/average_l0_11
-    path: layer_38/width_16k/average_l0_11/params.npz
+    path: layer_38/width_16k/average_l0_11
     l0: 11
   - id: layer_38/width_16k/average_l0_22
-    path: layer_38/width_16k/average_l0_22/params.npz
+    path: layer_38/width_16k/average_l0_22
     l0: 22
   - id: layer_38/width_16k/average_l0_45
-    path: layer_38/width_16k/average_l0_45/params.npz
+    path: layer_38/width_16k/average_l0_45
     l0: 45
   - id: layer_38/width_16k/average_l0_98
-    path: layer_38/width_16k/average_l0_98/params.npz
+    path: layer_38/width_16k/average_l0_98
     l0: 98
   - id: layer_38/width_16k/average_l0_225
-    path: layer_38/width_16k/average_l0_225/params.npz
+    path: layer_38/width_16k/average_l0_225
     l0: 225
   - id: layer_38/width_16k/average_l0_491
-    path: layer_38/width_16k/average_l0_491/params.npz
+    path: layer_38/width_16k/average_l0_491
     l0: 491
   - id: layer_38/width_131k/average_l0_11
-    path: layer_38/width_131k/average_l0_11/params.npz
+    path: layer_38/width_131k/average_l0_11
     l0: 11
   - id: layer_38/width_131k/average_l0_21
-    path: layer_38/width_131k/average_l0_21/params.npz
+    path: layer_38/width_131k/average_l0_21
     l0: 21
   - id: layer_38/width_131k/average_l0_40
-    path: layer_38/width_131k/average_l0_40/params.npz
+    path: layer_38/width_131k/average_l0_40
     l0: 40
   - id: layer_38/width_131k/average_l0_79
-    path: layer_38/width_131k/average_l0_79/params.npz
+    path: layer_38/width_131k/average_l0_79
     l0: 79
   - id: layer_38/width_131k/average_l0_161
-    path: layer_38/width_131k/average_l0_161/params.npz
+    path: layer_38/width_131k/average_l0_161
     l0: 161
   - id: layer_38/width_131k/average_l0_347
-    path: layer_38/width_131k/average_l0_347/params.npz
+    path: layer_38/width_131k/average_l0_347
     l0: 347
   - id: layer_39/width_16k/average_l0_12
-    path: layer_39/width_16k/average_l0_12/params.npz
+    path: layer_39/width_16k/average_l0_12
     l0: 12
   - id: layer_39/width_16k/average_l0_22
-    path: layer_39/width_16k/average_l0_22/params.npz
+    path: layer_39/width_16k/average_l0_22
     l0: 22
   - id: layer_39/width_16k/average_l0_43
-    path: layer_39/width_16k/average_l0_43/params.npz
+    path: layer_39/width_16k/average_l0_43
     l0: 43
   - id: layer_39/width_16k/average_l0_90
-    path: layer_39/width_16k/average_l0_90/params.npz
+    path: layer_39/width_16k/average_l0_90
     l0: 90
   - id: layer_39/width_16k/average_l0_207
-    path: layer_39/width_16k/average_l0_207/params.npz
+    path: layer_39/width_16k/average_l0_207
     l0: 207
   - id: layer_39/width_16k/average_l0_458
-    path: layer_39/width_16k/average_l0_458/params.npz
+    path: layer_39/width_16k/average_l0_458
     l0: 458
   - id: layer_39/width_131k/average_l0_11
-    path: layer_39/width_131k/average_l0_11/params.npz
+    path: layer_39/width_131k/average_l0_11
     l0: 11
   - id: layer_39/width_131k/average_l0_21
-    path: layer_39/width_131k/average_l0_21/params.npz
+    path: layer_39/width_131k/average_l0_21
     l0: 21
   - id: layer_39/width_131k/average_l0_38
-    path: layer_39/width_131k/average_l0_38/params.npz
+    path: layer_39/width_131k/average_l0_38
     l0: 38
   - id: layer_39/width_131k/average_l0_75
-    path: layer_39/width_131k/average_l0_75/params.npz
+    path: layer_39/width_131k/average_l0_75
     l0: 75
   - id: layer_39/width_131k/average_l0_150
-    path: layer_39/width_131k/average_l0_150/params.npz
+    path: layer_39/width_131k/average_l0_150
     l0: 150
   - id: layer_39/width_131k/average_l0_319
-    path: layer_39/width_131k/average_l0_319/params.npz
+    path: layer_39/width_131k/average_l0_319
     l0: 319
   - id: layer_4/width_16k/average_l0_15
-    path: layer_4/width_16k/average_l0_15/params.npz
+    path: layer_4/width_16k/average_l0_15
     l0: 15
   - id: layer_4/width_16k/average_l0_30
-    path: layer_4/width_16k/average_l0_30/params.npz
+    path: layer_4/width_16k/average_l0_30
     l0: 30
   - id: layer_4/width_16k/average_l0_66
-    path: layer_4/width_16k/average_l0_66/params.npz
+    path: layer_4/width_16k/average_l0_66
     l0: 66
   - id: layer_4/width_16k/average_l0_151
-    path: layer_4/width_16k/average_l0_151/params.npz
+    path: layer_4/width_16k/average_l0_151
     l0: 151
   - id: layer_4/width_16k/average_l0_343
-    path: layer_4/width_16k/average_l0_343/params.npz
+    path: layer_4/width_16k/average_l0_343
     l0: 343
   - id: layer_4/width_131k/average_l0_8
-    path: layer_4/width_131k/average_l0_8/params.npz
+    path: layer_4/width_131k/average_l0_8
     l0: 8
   - id: layer_4/width_131k/average_l0_14
-    path: layer_4/width_131k/average_l0_14/params.npz
+    path: layer_4/width_131k/average_l0_14
     l0: 14
   - id: layer_4/width_131k/average_l0_24
-    path: layer_4/width_131k/average_l0_24/params.npz
+    path: layer_4/width_131k/average_l0_24
     l0: 24
   - id: layer_4/width_131k/average_l0_45
-    path: layer_4/width_131k/average_l0_45/params.npz
+    path: layer_4/width_131k/average_l0_45
     l0: 45
   - id: layer_4/width_131k/average_l0_84
-    path: layer_4/width_131k/average_l0_84/params.npz
+    path: layer_4/width_131k/average_l0_84
     l0: 84
   - id: layer_4/width_131k/average_l0_157
-    path: layer_4/width_131k/average_l0_157/params.npz
+    path: layer_4/width_131k/average_l0_157
     l0: 157
   - id: layer_40/width_16k/average_l0_11
-    path: layer_40/width_16k/average_l0_11/params.npz
+    path: layer_40/width_16k/average_l0_11
     l0: 11
   - id: layer_40/width_16k/average_l0_19
-    path: layer_40/width_16k/average_l0_19/params.npz
+    path: layer_40/width_16k/average_l0_19
     l0: 19
   - id: layer_40/width_16k/average_l0_37
-    path: layer_40/width_16k/average_l0_37/params.npz
+    path: layer_40/width_16k/average_l0_37
     l0: 37
   - id: layer_40/width_16k/average_l0_74
-    path: layer_40/width_16k/average_l0_74/params.npz
+    path: layer_40/width_16k/average_l0_74
     l0: 74
   - id: layer_40/width_16k/average_l0_162
-    path: layer_40/width_16k/average_l0_162/params.npz
+    path: layer_40/width_16k/average_l0_162
     l0: 162
   - id: layer_40/width_16k/average_l0_371
-    path: layer_40/width_16k/average_l0_371/params.npz
+    path: layer_40/width_16k/average_l0_371
     l0: 371
   - id: layer_40/width_131k/average_l0_11
-    path: layer_40/width_131k/average_l0_11/params.npz
+    path: layer_40/width_131k/average_l0_11
     l0: 11
   - id: layer_40/width_131k/average_l0_18
-    path: layer_40/width_131k/average_l0_18/params.npz
+    path: layer_40/width_131k/average_l0_18
     l0: 18
   - id: layer_40/width_131k/average_l0_33
-    path: layer_40/width_131k/average_l0_33/params.npz
+    path: layer_40/width_131k/average_l0_33
     l0: 33
   - id: layer_40/width_131k/average_l0_63
-    path: layer_40/width_131k/average_l0_63/params.npz
+    path: layer_40/width_131k/average_l0_63
     l0: 63
   - id: layer_40/width_131k/average_l0_125
-    path: layer_40/width_131k/average_l0_125/params.npz
+    path: layer_40/width_131k/average_l0_125
     l0: 125
   - id: layer_40/width_131k/average_l0_267
-    path: layer_40/width_131k/average_l0_267/params.npz
+    path: layer_40/width_131k/average_l0_267
     l0: 267
   - id: layer_41/width_16k/average_l0_8
-    path: layer_41/width_16k/average_l0_8/params.npz
+    path: layer_41/width_16k/average_l0_8
     l0: 8
   - id: layer_41/width_16k/average_l0_15
-    path: layer_41/width_16k/average_l0_15/params.npz
+    path: layer_41/width_16k/average_l0_15
     l0: 15
   - id: layer_41/width_16k/average_l0_28
-    path: layer_41/width_16k/average_l0_28/params.npz
+    path: layer_41/width_16k/average_l0_28
     l0: 28
   - id: layer_41/width_16k/average_l0_58
-    path: layer_41/width_16k/average_l0_58/params.npz
+    path: layer_41/width_16k/average_l0_58
     l0: 58
   - id: layer_41/width_16k/average_l0_126
-    path: layer_41/width_16k/average_l0_126/params.npz
+    path: layer_41/width_16k/average_l0_126
     l0: 126
   - id: layer_41/width_16k/average_l0_288
-    path: layer_41/width_16k/average_l0_288/params.npz
+    path: layer_41/width_16k/average_l0_288
     l0: 288
   - id: layer_41/width_131k/average_l0_8
-    path: layer_41/width_131k/average_l0_8/params.npz
+    path: layer_41/width_131k/average_l0_8
     l0: 8
   - id: layer_41/width_131k/average_l0_14
-    path: layer_41/width_131k/average_l0_14/params.npz
+    path: layer_41/width_131k/average_l0_14
     l0: 14
   - id: layer_41/width_131k/average_l0_25
-    path: layer_41/width_131k/average_l0_25/params.npz
+    path: layer_41/width_131k/average_l0_25
     l0: 25
   - id: layer_41/width_131k/average_l0_49
-    path: layer_41/width_131k/average_l0_49/params.npz
+    path: layer_41/width_131k/average_l0_49
     l0: 49
   - id: layer_41/width_131k/average_l0_99
-    path: layer_41/width_131k/average_l0_99/params.npz
+    path: layer_41/width_131k/average_l0_99
     l0: 99
   - id: layer_41/width_131k/average_l0_208
-    path: layer_41/width_131k/average_l0_208/params.npz
+    path: layer_41/width_131k/average_l0_208
     l0: 208
   - id: layer_5/width_16k/average_l0_14
-    path: layer_5/width_16k/average_l0_14/params.npz
+    path: layer_5/width_16k/average_l0_14
     l0: 14
   - id: layer_5/width_16k/average_l0_24
-    path: layer_5/width_16k/average_l0_24/params.npz
+    path: layer_5/width_16k/average_l0_24
     l0: 24
   - id: layer_5/width_16k/average_l0_46
-    path: layer_5/width_16k/average_l0_46/params.npz
+    path: layer_5/width_16k/average_l0_46
     l0: 46
   - id: layer_5/width_16k/average_l0_93
-    path: layer_5/width_16k/average_l0_93/params.npz
+    path: layer_5/width_16k/average_l0_93
     l0: 93
   - id: layer_5/width_16k/average_l0_194
-    path: layer_5/width_16k/average_l0_194/params.npz
+    path: layer_5/width_16k/average_l0_194
     l0: 194
   - id: layer_5/width_131k/average_l0_7
-    path: layer_5/width_131k/average_l0_7/params.npz
+    path: layer_5/width_131k/average_l0_7
     l0: 7
   - id: layer_5/width_131k/average_l0_12
-    path: layer_5/width_131k/average_l0_12/params.npz
+    path: layer_5/width_131k/average_l0_12
     l0: 12
   - id: layer_5/width_131k/average_l0_21
-    path: layer_5/width_131k/average_l0_21/params.npz
+    path: layer_5/width_131k/average_l0_21
     l0: 21
   - id: layer_5/width_131k/average_l0_37
-    path: layer_5/width_131k/average_l0_37/params.npz
+    path: layer_5/width_131k/average_l0_37
     l0: 37
   - id: layer_5/width_131k/average_l0_68
-    path: layer_5/width_131k/average_l0_68/params.npz
+    path: layer_5/width_131k/average_l0_68
     l0: 68
   - id: layer_5/width_131k/average_l0_131
-    path: layer_5/width_131k/average_l0_131/params.npz
+    path: layer_5/width_131k/average_l0_131
     l0: 131
   - id: layer_6/width_16k/average_l0_12
-    path: layer_6/width_16k/average_l0_12/params.npz
+    path: layer_6/width_16k/average_l0_12
     l0: 12
   - id: layer_6/width_16k/average_l0_23
-    path: layer_6/width_16k/average_l0_23/params.npz
+    path: layer_6/width_16k/average_l0_23
     l0: 23
   - id: layer_6/width_16k/average_l0_46
-    path: layer_6/width_16k/average_l0_46/params.npz
+    path: layer_6/width_16k/average_l0_46
     l0: 46
   - id: layer_6/width_16k/average_l0_96
-    path: layer_6/width_16k/average_l0_96/params.npz
+    path: layer_6/width_16k/average_l0_96
     l0: 96
   - id: layer_6/width_16k/average_l0_206
-    path: layer_6/width_16k/average_l0_206/params.npz
+    path: layer_6/width_16k/average_l0_206
     l0: 206
   - id: layer_6/width_131k/average_l0_12
-    path: layer_6/width_131k/average_l0_12/params.npz
+    path: layer_6/width_131k/average_l0_12
     l0: 12
   - id: layer_6/width_131k/average_l0_22
-    path: layer_6/width_131k/average_l0_22/params.npz
+    path: layer_6/width_131k/average_l0_22
     l0: 22
   - id: layer_6/width_131k/average_l0_40
-    path: layer_6/width_131k/average_l0_40/params.npz
+    path: layer_6/width_131k/average_l0_40
     l0: 40
   - id: layer_6/width_131k/average_l0_72
-    path: layer_6/width_131k/average_l0_72/params.npz
+    path: layer_6/width_131k/average_l0_72
     l0: 72
   - id: layer_6/width_131k/average_l0_135
-    path: layer_6/width_131k/average_l0_135/params.npz
+    path: layer_6/width_131k/average_l0_135
     l0: 135
   - id: layer_6/width_131k/average_l0_271
-    path: layer_6/width_131k/average_l0_271/params.npz
+    path: layer_6/width_131k/average_l0_271
     l0: 271
   - id: layer_7/width_16k/average_l0_14
-    path: layer_7/width_16k/average_l0_14/params.npz
+    path: layer_7/width_16k/average_l0_14
     l0: 14
   - id: layer_7/width_16k/average_l0_25
-    path: layer_7/width_16k/average_l0_25/params.npz
+    path: layer_7/width_16k/average_l0_25
     l0: 25
   - id: layer_7/width_16k/average_l0_47
-    path: layer_7/width_16k/average_l0_47/params.npz
+    path: layer_7/width_16k/average_l0_47
     l0: 47
   - id: layer_7/width_16k/average_l0_101
-    path: layer_7/width_16k/average_l0_101/params.npz
+    path: layer_7/width_16k/average_l0_101
     l0: 101
   - id: layer_7/width_16k/average_l0_231
-    path: layer_7/width_16k/average_l0_231/params.npz
+    path: layer_7/width_16k/average_l0_231
     l0: 231
   - id: layer_7/width_131k/average_l0_13
-    path: layer_7/width_131k/average_l0_13/params.npz
+    path: layer_7/width_131k/average_l0_13
     l0: 13
   - id: layer_7/width_131k/average_l0_23
-    path: layer_7/width_131k/average_l0_23/params.npz
+    path: layer_7/width_131k/average_l0_23
     l0: 23
   - id: layer_7/width_131k/average_l0_41
-    path: layer_7/width_131k/average_l0_41/params.npz
+    path: layer_7/width_131k/average_l0_41
     l0: 41
   - id: layer_7/width_131k/average_l0_75
-    path: layer_7/width_131k/average_l0_75/params.npz
+    path: layer_7/width_131k/average_l0_75
     l0: 75
   - id: layer_7/width_131k/average_l0_143
-    path: layer_7/width_131k/average_l0_143/params.npz
+    path: layer_7/width_131k/average_l0_143
     l0: 143
   - id: layer_7/width_131k/average_l0_309
-    path: layer_7/width_131k/average_l0_309/params.npz
+    path: layer_7/width_131k/average_l0_309
     l0: 309
   - id: layer_8/width_16k/average_l0_15
-    path: layer_8/width_16k/average_l0_15/params.npz
+    path: layer_8/width_16k/average_l0_15
     l0: 15
   - id: layer_8/width_16k/average_l0_27
-    path: layer_8/width_16k/average_l0_27/params.npz
+    path: layer_8/width_16k/average_l0_27
     l0: 27
   - id: layer_8/width_16k/average_l0_55
-    path: layer_8/width_16k/average_l0_55/params.npz
+    path: layer_8/width_16k/average_l0_55
     l0: 55
   - id: layer_8/width_16k/average_l0_124
-    path: layer_8/width_16k/average_l0_124/params.npz
+    path: layer_8/width_16k/average_l0_124
     l0: 124
   - id: layer_8/width_16k/average_l0_309
-    path: layer_8/width_16k/average_l0_309/params.npz
+    path: layer_8/width_16k/average_l0_309
     l0: 309
   - id: layer_8/width_131k/average_l0_15
-    path: layer_8/width_131k/average_l0_15/params.npz
+    path: layer_8/width_131k/average_l0_15
     l0: 15
   - id: layer_8/width_131k/average_l0_26
-    path: layer_8/width_131k/average_l0_26/params.npz
+    path: layer_8/width_131k/average_l0_26
     l0: 26
   - id: layer_8/width_131k/average_l0_48
-    path: layer_8/width_131k/average_l0_48/params.npz
+    path: layer_8/width_131k/average_l0_48
     l0: 48
   - id: layer_8/width_131k/average_l0_89
-    path: layer_8/width_131k/average_l0_89/params.npz
+    path: layer_8/width_131k/average_l0_89
     l0: 89
   - id: layer_8/width_131k/average_l0_184
-    path: layer_8/width_131k/average_l0_184/params.npz
+    path: layer_8/width_131k/average_l0_184
     l0: 184
   - id: layer_8/width_131k/average_l0_423
-    path: layer_8/width_131k/average_l0_423/params.npz
+    path: layer_8/width_131k/average_l0_423
     l0: 423
   - id: layer_9/width_16k/average_l0_12
-    path: layer_9/width_16k/average_l0_12/params.npz
+    path: layer_9/width_16k/average_l0_12
     l0: 12
   - id: layer_9/width_16k/average_l0_21
-    path: layer_9/width_16k/average_l0_21/params.npz
+    path: layer_9/width_16k/average_l0_21
     l0: 21
   - id: layer_9/width_16k/average_l0_40
-    path: layer_9/width_16k/average_l0_40/params.npz
+    path: layer_9/width_16k/average_l0_40
     l0: 40
   - id: layer_9/width_16k/average_l0_83
-    path: layer_9/width_16k/average_l0_83/params.npz
+    path: layer_9/width_16k/average_l0_83
     l0: 83
   - id: layer_9/width_16k/average_l0_200
-    path: layer_9/width_16k/average_l0_200/params.npz
+    path: layer_9/width_16k/average_l0_200
     l0: 200
   - id: layer_9/width_131k/average_l0_12
-    path: layer_9/width_131k/average_l0_12/params.npz
+    path: layer_9/width_131k/average_l0_12
     l0: 12
   - id: layer_9/width_131k/average_l0_21
-    path: layer_9/width_131k/average_l0_21/params.npz
+    path: layer_9/width_131k/average_l0_21
     l0: 21
   - id: layer_9/width_131k/average_l0_38
-    path: layer_9/width_131k/average_l0_38/params.npz
+    path: layer_9/width_131k/average_l0_38
     l0: 38
   - id: layer_9/width_131k/average_l0_67
-    path: layer_9/width_131k/average_l0_67/params.npz
+    path: layer_9/width_131k/average_l0_67
     l0: 67
   - id: layer_9/width_131k/average_l0_129
-    path: layer_9/width_131k/average_l0_129/params.npz
+    path: layer_9/width_131k/average_l0_129
     l0: 129
   - id: layer_9/width_131k/average_l0_269
-    path: layer_9/width_131k/average_l0_269/params.npz
+    path: layer_9/width_131k/average_l0_269
     l0: 269
 gemma-scope-9b-pt-mlp-canonical:
   repo_id: google/gemma-scope-9b-pt-mlp
@@ -9112,94 +9112,94 @@ gemma-scope-9b-it-res:
   conversion_func: gemma_2
   saes:
   - id: layer_20/width_131k/average_l0_13
-    path: layer_20/width_131k/average_l0_13/params.npz
+    path: layer_20/width_131k/average_l0_13
     l0: 13
   - id: layer_20/width_131k/average_l0_153
-    path: layer_20/width_131k/average_l0_153/params.npz
+    path: layer_20/width_131k/average_l0_153
     l0: 153
   - id: layer_20/width_131k/average_l0_24
-    path: layer_20/width_131k/average_l0_24/params.npz
+    path: layer_20/width_131k/average_l0_24
     l0: 24
   - id: layer_20/width_131k/average_l0_43
-    path: layer_20/width_131k/average_l0_43/params.npz
+    path: layer_20/width_131k/average_l0_43
     l0: 43
   - id: layer_20/width_131k/average_l0_81
-    path: layer_20/width_131k/average_l0_81/params.npz
+    path: layer_20/width_131k/average_l0_81
     l0: 81
   - id: layer_20/width_16k/average_l0_14
-    path: layer_20/width_16k/average_l0_14/params.npz
+    path: layer_20/width_16k/average_l0_14
     l0: 14
   - id: layer_20/width_16k/average_l0_189
-    path: layer_20/width_16k/average_l0_189/params.npz
+    path: layer_20/width_16k/average_l0_189
     l0: 189
   - id: layer_20/width_16k/average_l0_25
-    path: layer_20/width_16k/average_l0_25/params.npz
+    path: layer_20/width_16k/average_l0_25
     l0: 25
   - id: layer_20/width_16k/average_l0_47
-    path: layer_20/width_16k/average_l0_47/params.npz
+    path: layer_20/width_16k/average_l0_47
     l0: 47
   - id: layer_20/width_16k/average_l0_91
-    path: layer_20/width_16k/average_l0_91/params.npz
+    path: layer_20/width_16k/average_l0_91
     l0: 91
   - id: layer_31/width_131k/average_l0_109
-    path: layer_31/width_131k/average_l0_109/params.npz
+    path: layer_31/width_131k/average_l0_109
     l0: 109
   - id: layer_31/width_131k/average_l0_13
-    path: layer_31/width_131k/average_l0_13/params.npz
+    path: layer_31/width_131k/average_l0_13
     l0: 13
   - id: layer_31/width_131k/average_l0_22
-    path: layer_31/width_131k/average_l0_22/params.npz
+    path: layer_31/width_131k/average_l0_22
     l0: 22
   - id: layer_31/width_131k/average_l0_37
-    path: layer_31/width_131k/average_l0_37/params.npz
+    path: layer_31/width_131k/average_l0_37
     l0: 37
   - id: layer_31/width_131k/average_l0_63
-    path: layer_31/width_131k/average_l0_63/params.npz
+    path: layer_31/width_131k/average_l0_63
     l0: 63
   - id: layer_31/width_16k/average_l0_14
-    path: layer_31/width_16k/average_l0_14/params.npz
+    path: layer_31/width_16k/average_l0_14
     l0: 14
   - id: layer_31/width_16k/average_l0_142
-    path: layer_31/width_16k/average_l0_142/params.npz
+    path: layer_31/width_16k/average_l0_142
     l0: 142
   - id: layer_31/width_16k/average_l0_24
-    path: layer_31/width_16k/average_l0_24/params.npz
+    path: layer_31/width_16k/average_l0_24
     l0: 24
   - id: layer_31/width_16k/average_l0_43
-    path: layer_31/width_16k/average_l0_43/params.npz
+    path: layer_31/width_16k/average_l0_43
     l0: 43
   - id: layer_31/width_16k/average_l0_76
-    path: layer_31/width_16k/average_l0_76/params.npz
+    path: layer_31/width_16k/average_l0_76
     l0: 76
   - id: layer_9/width_131k/average_l0_121
-    path: layer_9/width_131k/average_l0_121/params.npz
+    path: layer_9/width_131k/average_l0_121
     l0: 121
   - id: layer_9/width_131k/average_l0_13
-    path: layer_9/width_131k/average_l0_13/params.npz
+    path: layer_9/width_131k/average_l0_13
     l0: 13
   - id: layer_9/width_131k/average_l0_22
-    path: layer_9/width_131k/average_l0_22/params.npz
+    path: layer_9/width_131k/average_l0_22
     l0: 22
   - id: layer_9/width_131k/average_l0_39
-    path: layer_9/width_131k/average_l0_39/params.npz
+    path: layer_9/width_131k/average_l0_39
     l0: 39
   - id: layer_9/width_131k/average_l0_67
-    path: layer_9/width_131k/average_l0_67/params.npz
+    path: layer_9/width_131k/average_l0_67
     l0: 67
   - id: layer_9/width_16k/average_l0_14
-    path: layer_9/width_16k/average_l0_14/params.npz
+    path: layer_9/width_16k/average_l0_14
     l0: 14
   - id: layer_9/width_16k/average_l0_186
-    path: layer_9/width_16k/average_l0_186/params.npz
+    path: layer_9/width_16k/average_l0_186
     l0: 186
   - id: layer_9/width_16k/average_l0_26
-    path: layer_9/width_16k/average_l0_26/params.npz
+    path: layer_9/width_16k/average_l0_26
     l0: 26
   - id: layer_9/width_16k/average_l0_47
-    path: layer_9/width_16k/average_l0_47/params.npz
+    path: layer_9/width_16k/average_l0_47
     l0: 47
   - id: layer_9/width_16k/average_l0_88
-    path: layer_9/width_16k/average_l0_88/params.npz
+    path: layer_9/width_16k/average_l0_88
     l0: 88
 gemma-scope-9b-it-res-canonical:
   repo_id: google/gemma-scope-9b-it-res
@@ -9207,13 +9207,13 @@ gemma-scope-9b-it-res-canonical:
   conversion_func: gemma_2
   saes:
   - id: layer_9/width_131k/canonical
-    path: layer_9/width_131k/average_l0_121/params.npz
+    path: layer_9/width_131k/average_l0_121
     neuronpedia: gemma-2-9b-it/9-gemmascope-it-res-131k
   - id: layer_20/width_131k/canonical
-    path: layer_20/width_131k/average_l0_81/params.npz
+    path: layer_20/width_131k/average_l0_81
     neuronpedia: gemma-2-9b-it/20-gemmascope-it-res-131k
   - id: layer_31/width_131k/canonical
-    path: layer_31/width_131k/average_l0_109/params.npz
+    path: layer_31/width_131k/average_l0_109
     neuronpedia: gemma-2-9b-it/31-gemmascope-it-res-131k
 gemma-scope-27b-pt-res:
   repo_id: google/gemma-scope-27b-pt-res


### PR DESCRIPTION
# Description

Yaml fix. So many SAEs. 