### PR TITLE
chore: updating mkdocs deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,12 +53,12 @@ ansible-lint = { version = "^24.2.3", markers = "platform_system != 'Windows'" }
 botocore = "^1.34.101"
 boto3 = "^1.34.101"
 docstr-coverage = "^2.3.2"
-mkdocs = "^1.5.3"
-mkdocs-material = "^9.5.15"
-mkdocs-autorefs = "^1.0.1"
-mkdocs-section-index = "^0.3.8"
-mkdocstrings = "^0.24.1"
-mkdocstrings-python = "^1.9.0"
+mkdocs = "^1.6.1"
+mkdocs-material = "^9.5.34"
+mkdocs-autorefs = "^1.1.0"
+mkdocs-section-index = "^0.3.9"
+mkdocstrings = "^0.25.2"
+mkdocstrings-python = "^1.10.9"
 tabulate = "^0.9.0"
 
 [tool.poetry.extras]

--- a/sae_lens/sae_training_runner.py
+++ b/sae_lens/sae_training_runner.py
@@ -106,7 +106,8 @@ class SAETrainingRunner:
         sae = self.run_trainer_with_interruption_handling(trainer)
 
         if self.cfg.log_to_wandb:
-            wandb.finish()
+            # remove this type ignore comment after https://github.com/wandb/wandb/issues/8248 is resolved
+            wandb.finish()  # type: ignore
 
         return sae
 
@@ -220,7 +221,8 @@ class SAETrainingRunner:
             model_artifact.add_file(f"{path}/{SAE_WEIGHTS_PATH}")
             model_artifact.add_file(f"{path}/{SAE_CFG_PATH}")
 
-            wandb.log_artifact(model_artifact, aliases=wandb_aliases)
+            # remove this type ignore comment after https://github.com/wandb/wandb/issues/8248 is resolved
+            wandb.log_artifact(model_artifact, aliases=wandb_aliases)  # type: ignore
 
             sparsity_artifact = wandb.Artifact(
                 f"{sae_name}_log_feature_sparsity",
@@ -228,6 +230,7 @@ class SAETrainingRunner:
                 metadata=dict(trainer.cfg.__dict__),
             )
             sparsity_artifact.add_file(log_feature_sparsity_path)
-            wandb.log_artifact(sparsity_artifact)
+            # remove this type ignore comment after https://github.com/wandb/wandb/issues/8248 is resolved
+            wandb.log_artifact(sparsity_artifact)  # type: ignore
 
         return checkpoint_path

--- a/sae_lens/toy_model_runner.py
+++ b/sae_lens/toy_model_runner.py
@@ -59,6 +59,7 @@ def toy_model_sae_runner(cfg: ToyModelSAERunnerConfig):
     )
 
     if cfg.log_to_wandb:
-        wandb.finish()
+        # remove this type ignore comment after https://github.com/wandb/wandb/issues/8248 is resolved
+        wandb.finish()  # type: ignore
 
     return sae


### PR DESCRIPTION
# Description

Attempting to fix docs failures, e.g. https://github.com/jbloomAus/SAELens/actions/runs/10547867695/job/29517908592. I'm struggling to reproduce this locally and don't see others reporting this same issue. A first attempt is to just update all the mkdocs dependencies and see if that resolves the issue.

This PR also adds `type: ignore` comments to `wandb.finish()` and `wandb.log_artifact()`, as it looks like 0.17.8 broke these types in wandb, and now our CI is failing as a result. More info here: https://github.com/wandb/wandb/issues/8248

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update