### PR TITLE
updating howpublished url in docs

### DIFF
--- a/docs/citation.md
+++ b/docs/citation.md
@@ -5,6 +5,6 @@
    title = {SAELens Training
    author = {Joseph Bloom},
    year = {2024},
-   howpublished = {\url{}},
+   howpublished = {\url{https://github.com/jbloomAus/SAELens}},
 }}
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,6 @@ WandB Dashboards provide lots of useful insights while training SAE's. Here's a 
    title = {SAELens Training
    author = {Joseph Bloom, David Chanin},
    year = {2024},
-   howpublished = {\url{}},
+   howpublished = {\url{https://github.com/jbloomAus/SAELens}},
 }}
 ```


### PR DESCRIPTION
# Description

This PR updates the `howpublished` url in citations to the Github repo, matching what's in the `README.md`. Previously, this was blank.