### PR TITLE
Cleanup basic tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,6 @@ scripts/ansible/ansible.log
 
 
 *.pt
+
+# Don't add outputs from tutorials, as they ballon the repo size for no reason
+tutorials/*.html

--- a/tutorials/training_a_sparse_autoencoder.ipynb
+++ b/tutorials/training_a_sparse_autoencoder.ipynb
@@ -6,9 +6,11 @@
         "id": "5O8tQblzOVHu"
       },
       "source": [
-        "# A very basic SAE Training Tutorial\n",
+        "# Training a basic SAE with SAELens\n",
         "\n",
-        "Please note that it is very easy for tutorial code to go stale so please have a low bar for raising an issue in the"
+        "This tutorial demonstrates training a simple, relatively small Sparse Autoencoder, specifically on the tiny-stories-1L-21M model. \n",
+        "\n",
+        "As the SAELens library is under active development, please open an issue if this tutorial is stale [here](https://github.com/jbloomAus/SAELens)."
       ]
     },
     {


### PR DESCRIPTION
# Description

1. Removes an html output file (and adds them to .gitignore) to remove some of the repo size (25MB file of unnecessary outputs). 
2. Updates the basic training tutorial comment up top to link to the correct repo. 

## Type of change

Just a tutorial update.