### PR TITLE
saelens: only log ghost grad if you've enabled it

### DIFF
--- a/tests/unit/training/test_sae_trainer.py
+++ b/tests/unit/training/test_sae_trainer.py
@@ -184,7 +184,6 @@ def test_build_train_step_log_dict(trainer: SAETrainer) -> None:
         "losses/mse_loss": 0.25,
         # l1 loss is scaled by l1_coefficient
         "losses/l1_loss": train_output.l1_loss / trainer.cfg.l1_coefficient,
-        "losses/ghost_grad_loss": pytest.approx(0.15),
         "losses/auxiliary_reconstruction_loss": 0.0,
         "losses/overall_loss": 0.5,
         "metrics/explained_variance": 0.75,


### PR DESCRIPTION
# Description

Don't log the ghost grads if you're not using them.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

There should be no performance impact to these changes.