### PR TITLE
minor dev improvement: return the original model as well inside of TrainingSAE

### DIFF
--- a/docs/training_saes.md
+++ b/docs/training_saes.md
@@ -211,3 +211,16 @@ upload_saes_to_huggingface(
     hf_repo_id="your-username/your-sae-repo",
 )
 ```
+
+## Accessing the model your SAE was trained on
+
+If you train a new SAE, and which to access the original model that your SAE was trained on directly, you can use the `original_model` property from the returned `sparse_autoencoder`:
+
+```python
+cfg = LanguageModelSAERunnerConfig(
+    ...
+)
+sparse_autoencoder = SAETrainingRunner(cfg).run()
+sparse_autoencoder.original_model
+```
+

--- a/sae_lens/sae_training_runner.py
+++ b/sae_lens/sae_training_runner.py
@@ -77,7 +77,9 @@ class SAETrainingRunner:
             self.sae = TrainingSAE(
                 TrainingSAEConfig.from_dict(
                     self.cfg.get_training_sae_cfg_dict(),
-                )
+                ),
+                original_model=self.model
+
             )
             self._init_sae_group_b_decs()
 

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -11,6 +11,7 @@ import einops
 import torch
 from jaxtyping import Float
 from torch import nn
+from transformer_lens.hook_points import HookedRootModule
 
 from sae_lens.config import DTYPE_MAP, LanguageModelSAERunnerConfig
 from sae_lens.sae import SAE, SAEConfig
@@ -153,11 +154,18 @@ class TrainingSAE(SAE):
     dtype: torch.dtype
     device: torch.device
 
-    def __init__(self, cfg: TrainingSAEConfig, use_error_term: bool = False):
+    # The model that this SAE was trained on. As SAETrainingRunner(cfg).run() may be 
+    # called directly without previously defining the model, and TrainingSAE is the 
+    # return type, it can be useful to allow the user to access this original model 
+    # directly from the returned SAE output
+    original_model: HookedRootModule 
+
+    def __init__(self, cfg: TrainingSAEConfig, original_model: HookedRootModule, use_error_term: bool = False):
 
         base_sae_cfg = SAEConfig.from_dict(cfg.get_base_sae_cfg_dict())
         super().__init__(base_sae_cfg)
         self.cfg = cfg  # type: ignore
+        self.original_model = original_model
 
         self.encode_with_hidden_pre_fn = (
             self.encode_with_hidden_pre


### PR DESCRIPTION
# Description

Adds a new parameter to TrainingSAE - the model that this SAE was trained on. As SAETrainingRunner(cfg).run() may be called directly without previously defining the model, and TrainingSAE is return type, it can be useful to allow the user to access this original model directly from the returned SAE output.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)\

I do not think this is a breaking change, as TrainingSAE is only instantiated directly in one location in the codebase, and I do not think it is exposed internally to be created directly. But let me know if I'm missing something here. 

- [x] This change requires a documentation update

I added docs in the one place where they seemed relevant. Happy to move, though - let me know.


# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

(Again, check me on backwards compatibility please. Not totally sure about what the public interface is here. We could really easily fix backwards compatibility by making this parameter option, but we get less-strong types, so all things equal this solution seems better.). 

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [ ] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

No changes here.