### PR TITLE
fix: centre writing weights defaults

### DIFF
--- a/docs/training_saes.md
+++ b/docs/training_saes.md
@@ -22,6 +22,7 @@ However, we are attempting to maintain this [tutorial](https://github.com/jbloom
  - `l1_coefficient`: This controls how much sparsity the SAE will have after training.
  - `training_tokens`: The total tokens used for training.
  - `train_batch_size_tokens`: The batch size used for training. Adjust this to keep the GPU saturated.
+ -  `model_from_pretrained_kwargs`: A dictionary of keyword arguments to pass to HookedTransformer.from_pretrained when loading the model. It's best to set "center_writing_weights" to False (this will be the default in the future).
 
 A sample training run from the [tutorial](https://github.com/jbloomAus/SAELens/blob/main/tutorials/training_a_sparse_autoencoder.ipynb) is shown below:
 

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -224,7 +224,9 @@ class LanguageModelSAERunnerConfig:
     checkpoint_path: str = "checkpoints"
     verbose: bool = True
     model_kwargs: dict[str, Any] = field(default_factory=dict)
-    model_from_pretrained_kwargs: dict[str, Any] = field(default_factory=dict)
+    model_from_pretrained_kwargs: dict[str, Any] = field(
+        default_factory=lambda: {"center_writing_weights": False}
+    )
     sae_lens_version: str = field(default_factory=lambda: __version__)
     sae_lens_training_version: str = field(default_factory=lambda: __version__)
 

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -377,6 +377,7 @@ class LanguageModelSAERunnerConfig:
             "sae_lens_training_version": self.sae_lens_training_version,
             "normalize_activations": self.normalize_activations,
             "activation_fn_kwargs": self.activation_fn_kwargs,
+            "model_from_pretrained_kwargs": self.model_from_pretrained_kwargs,
         }
 
     def get_training_sae_cfg_dict(self) -> dict[str, Any]:

--- a/sae_lens/load_model.py
+++ b/sae_lens/load_model.py
@@ -23,7 +23,7 @@ def load_model(
             print("-------------")
 
     if model_class_name == "HookedTransformer":
-        return HookedTransformer.from_pretrained(
+        return HookedTransformer.from_pretrained_no_processing(
             model_name=model_name, device=device, **model_from_pretrained_kwargs
         )
     elif model_class_name == "HookedMamba":

--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -6,6 +6,9 @@ gpt2-small-res-jb:
     model: https://huggingface.co/gpt2
     dashboards: https://www.neuronpedia.org/gpt2sm-res-jb
     publication: https://www.lesswrong.com/posts/f9EgfLSurAiqRJySD/open-source-sparse-autoencoders-for-all-residual-stream
+  config_overrides:
+    model_from_pretrained_kwargs:
+      center_writing_weights: true
   saes:
   - id: blocks.0.hook_resid_pre
     path: blocks.0.hook_resid_pre
@@ -149,6 +152,8 @@ gpt2-small-mlp-tm:
   conversion_func: null
   config_overrides:
     dataset_path: Skylion007/openwebtext
+    model_from_pretrained_kwargs:
+      center_writing_weights: true
   saes:
   - id: blocks.0.hook_mlp_out
     path: sae_group_gpt2_blocks.0.hook_mlp_out_24576:v1
@@ -217,6 +222,9 @@ gpt2-small-res-jb-feature-splitting:
     model: https://huggingface.co/gpt2
     dashboards: https://www.neuronpedia.org/gpt2sm-rfs-jb
   conversion_func: null
+  config_overrides:
+    model_from_pretrained_kwargs:
+      center_writing_weights: true
   saes:
   - id: blocks.8.hook_resid_pre_768
     path: blocks.8.hook_resid_pre_768

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -61,6 +61,7 @@ class SAEConfig:
     sae_lens_training_version: Optional[str]
     activation_fn_kwargs: dict[str, Any] = field(default_factory=dict)
     neuronpedia_id: Optional[str] = None
+    model_from_pretrained_kwargs: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, config_dict: dict[str, Any]) -> "SAEConfig":
@@ -106,6 +107,7 @@ class SAEConfig:
             "context_size": self.context_size,
             "normalize_activations": self.normalize_activations,
             "neuronpedia_id": self.neuronpedia_id,
+            "model_from_pretrained_kwargs": self.model_from_pretrained_kwargs,
         }
 
 

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -131,6 +131,16 @@ class SAE(HookedRootModule):
         super().__init__()
 
         self.cfg = cfg
+
+        if cfg.model_from_pretrained_kwargs:
+            warnings.warn(
+                "\nThis SAE has non-empty model_from_pretrained_kwargs. "
+                "\nFor optimal performance, load the model like so:\n"
+                "model = HookedSAETransformer.from_pretrained_no_processing(..., **cfg.model_from_pretrained_kwargs)",
+                category=UserWarning,
+                stacklevel=1,
+            )
+
         self.activation_fn = get_activation_fn(
             cfg.activation_fn_str, **cfg.activation_fn_kwargs or {}
         )

--- a/sae_lens/toolkit/pretrained_saes_directory.py
+++ b/sae_lens/toolkit/pretrained_saes_directory.py
@@ -16,7 +16,7 @@ class PretrainedSAELookup:
     expected_var_explained: dict[str, float]
     expected_l0: dict[str, float]
     neuronpedia_id: dict[str, str]
-    config_overrides: dict[str, str] | None
+    config_overrides: dict[str, str] | dict[str, dict[str, str | bool | int]] | None
 
 
 @cache

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -88,6 +88,7 @@ class TrainingSAEConfig(SAEConfig):
             scale_sparsity_penalty_by_decoder_norm=cfg.scale_sparsity_penalty_by_decoder_norm,
             normalize_activations=cfg.normalize_activations,
             dataset_trust_remote_code=cfg.dataset_trust_remote_code,
+            model_from_pretrained_kwargs=cfg.model_from_pretrained_kwargs,
         )
 
     @classmethod

--- a/tests/unit/analysis/test_hooked_sae.py
+++ b/tests/unit/analysis/test_hooked_sae.py
@@ -21,7 +21,7 @@ class Counter:
 
 @pytest.fixture(scope="module")
 def model():
-    model = HookedSAETransformer.from_pretrained(MODEL, device="cpu")
+    model = HookedSAETransformer.from_pretrained_no_processing(MODEL, device="cpu")
     yield model
     model.reset_saes()
 
@@ -60,6 +60,7 @@ def get_hooked_sae(model: HookedTransformer, act_name: str) -> SAE:
         finetuning_scaling_factor=False,
         sae_lens_training_version=None,
         normalize_activations="none",
+        model_from_pretrained_kwargs={},
     )
 
     return SAE(sae_cfg)

--- a/tests/unit/toolkit/test_pretrained_saes_directory.py
+++ b/tests/unit/toolkit/test_pretrained_saes_directory.py
@@ -59,7 +59,11 @@ def test_get_pretrained_saes_directory():
             "blocks.11.hook_resid_pre": 56.0,
             "blocks.11.hook_resid_post": 70.0,
         },
-        config_overrides=None,
+        config_overrides={
+            "model_from_pretrained_kwargs": {
+                "center_writing_weights": True,
+            }
+        },
         neuronpedia_id={
             "blocks.0.hook_resid_pre": "gpt2-small/0-res-jb",
             "blocks.1.hook_resid_pre": "gpt2-small/1-res-jb",

--- a/tests/unit/training/test_config.py
+++ b/tests/unit/training/test_config.py
@@ -64,6 +64,9 @@ def test_sae_training_runner_config_get_sae_base_parameters():
         "dataset_trust_remote_code": True,
         "sae_lens_training_version": str(__version__),
         "normalize_activations": "none",
+        "model_from_pretrained_kwargs": {
+            "center_writing_weights": False,
+        },
     }
     assert expected_config == cfg.get_base_sae_cfg_dict()
 


### PR DESCRIPTION
# Description

Modifications that TransformerLens makes to model weights can affect SAE performance and transferability with other code bases (though this effect is generally small, it can be pronounced for some SAEs). In particular, GPT2 Small res-jb and res-jb-feature-splitting SAEs (especially later layers) show worse performance if `center_writing_weights` is set to False when loading a `HookedTransformer`. It seems like other SAEs tend not to be affected by `center_writing_weights` which is somewhat interesting. 

To avoid further issues, we've made the following changes:
1. `model_from_pretrained_kwargs` is now part of the `SAEConfig` class. 
2. We've set an override for affected SAEs, and a warning to encourage users to load the model appropriately

```
SAELens/sae_lens/sae.py:136): UserWarning: 
This SAE has non-empty model_from_pretrained_kwargs. 
For optimal performance, load the model like so:
model = HookedTransformer.from_pretrained_no_processing(..., **cfg.model_from_pretrained_kwargs)
```
3. From now on, during SAE training we will load the model with `from_pretrained_no_processing` (but respect `model_from_pretrained_kwargs` if passed to the training config.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)