### PR TITLE
fix: Gemma Scope 9b IT ids for Neuronpedia

### DIFF
--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -9246,22 +9246,22 @@ gemma-scope-9b-it-res-canonical:
   saes:
   - id: layer_9/width_16k/canonical
     path: layer_9/width_16k/average_l0_88
-    neuronpedia: gemma-2-9b-it/9-gemmascope-it-res-16k
+    neuronpedia: gemma-2-9b-it/9-gemmascope-res-16k
   - id: layer_20/width_16k/canonical
     path: layer_20/width_16k/average_l0_91
-    neuronpedia: gemma-2-9b-it/20-gemmascope-it-res-16k
+    neuronpedia: gemma-2-9b-it/20-gemmascope-res-16k
   - id: layer_31/width_16k/canonical
     path: layer_31/width_16k/average_l0_76
-    neuronpedia: gemma-2-9b-it/31-gemmascope-it-res-16k
+    neuronpedia: gemma-2-9b-it/31-gemmascope-res-16k
   - id: layer_9/width_131k/canonical
     path: layer_9/width_131k/average_l0_121
-    neuronpedia: gemma-2-9b-it/9-gemmascope-it-res-131k
+    neuronpedia: gemma-2-9b-it/9-gemmascope-res-131k
   - id: layer_20/width_131k/canonical
     path: layer_20/width_131k/average_l0_81
-    neuronpedia: gemma-2-9b-it/20-gemmascope-it-res-131k
+    neuronpedia: gemma-2-9b-it/20-gemmascope-res-131k
   - id: layer_31/width_131k/canonical
     path: layer_31/width_131k/average_l0_109
-    neuronpedia: gemma-2-9b-it/31-gemmascope-it-res-131k
+    neuronpedia: gemma-2-9b-it/31-gemmascope-res-131k
 gemma-scope-27b-pt-res:
   repo_id: google/gemma-scope-27b-pt-res
   model: gemma-2-27b


### PR DESCRIPTION
# Description

The Neuronpedia IDs do not contain `-it` in the SAE IDs.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

