### PR TITLE
fix: add OAI mid SAEs for neuronpedia

### DIFF
--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -476,28 +476,40 @@ gpt2-small-resid-mid-v5-32k:
   saes:
   - id: blocks.0.hook_resid_mid
     path: v5_32k_layer_0
+    neuronpedia: gpt2-small/0-res_mid_32k-oai
   - id: blocks.1.hook_resid_mid
     path: v5_32k_layer_1
+    neuronpedia: gpt2-small/1-res_mid_32k-oai
   - id: blocks.2.hook_resid_mid
     path: v5_32k_layer_2
+    neuronpedia: gpt2-small/2-res_mid_32k-oai
   - id: blocks.3.hook_resid_mid
     path: v5_32k_layer_3
+    neuronpedia: gpt2-small/3-res_mid_32k-oai
   - id: blocks.4.hook_resid_mid
     path: v5_32k_layer_4
+    neuronpedia: gpt2-small/4-res_mid_32k-oai
   - id: blocks.5.hook_resid_mid
     path: v5_32k_layer_5
+    neuronpedia: gpt2-small/5-res_mid_32k-oai
   - id: blocks.6.hook_resid_mid
     path: v5_32k_layer_6
+    neuronpedia: gpt2-small/6-res_mid_32k-oai
   - id: blocks.7.hook_resid_mid
     path: v5_32k_layer_7
+    neuronpedia: gpt2-small/7-res_mid_32k-oai
   - id: blocks.8.hook_resid_mid
     path: v5_32k_layer_8
+    neuronpedia: gpt2-small/8-res_mid_32k-oai
   - id: blocks.9.hook_resid_mid
     path: v5_32k_layer_9
+    neuronpedia: gpt2-small/9-res_mid_32k-oai
   - id: blocks.10.hook_resid_mid
     path: v5_32k_layer_10
+    neuronpedia: gpt2-small/10-res_mid_32k-oai
   - id: blocks.11.hook_resid_mid
     path: v5_32k_layer_11
+    neuronpedia: gpt2-small/11-res_mid_32k-oai
 gpt2-small-resid-mid-v5-128k:
   repo_id: jbloom/GPT2-Small-OAI-v5-128k-resid-mid-SAEs
   model: gpt2-small
@@ -507,28 +519,40 @@ gpt2-small-resid-mid-v5-128k:
   saes:
   - id: blocks.0.hook_resid_mid
     path: v5_128k_layer_0
+    neuronpedia: gpt2-small/0-res_mid_128k-oai
   - id: blocks.1.hook_resid_mid
     path: v5_128k_layer_1
+    neuronpedia: gpt2-small/1-res_mid_128k-oai
   - id: blocks.2.hook_resid_mid
     path: v5_128k_layer_2
+    neuronpedia: gpt2-small/2-res_mid_128k-oai
   - id: blocks.3.hook_resid_mid
     path: v5_128k_layer_3
+    neuronpedia: gpt2-small/3-res_mid_128k-oai
   - id: blocks.4.hook_resid_mid
     path: v5_128k_layer_4
+    neuronpedia: gpt2-small/4-res_mid_128k-oai
   - id: blocks.5.hook_resid_mid
     path: v5_128k_layer_5
+    neuronpedia: gpt2-small/5-res_mid_128k-oai
   - id: blocks.6.hook_resid_mid
     path: v5_128k_layer_6
+    neuronpedia: gpt2-small/6-res_mid_128k-oai
   - id: blocks.7.hook_resid_mid
     path: v5_128k_layer_7
+    neuronpedia: gpt2-small/7-res_mid_128k-oai
   - id: blocks.8.hook_resid_mid
     path: v5_128k_layer_8
+    neuronpedia: gpt2-small/8-res_mid_128k-oai
   - id: blocks.9.hook_resid_mid
     path: v5_128k_layer_9
+    neuronpedia: gpt2-small/9-res_mid_128k-oai
   - id: blocks.10.hook_resid_mid
     path: v5_128k_layer_10
+    neuronpedia: gpt2-small/10-res_mid_128k-oai
   - id: blocks.11.hook_resid_mid
     path: v5_128k_layer_11
+    neuronpedia: gpt2-small/11-res_mid_128k-oai
 gpt2-small-mlp-out-v5-32k:
   repo_id: jbloom/GPT2-Small-OAI-v5-32k-mlp-out-SAEs
   model: gpt2-small


### PR DESCRIPTION
# Description

The OAI mid SAEs (32k and 128k) were missing neuronpedia entries. This adds them.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update