### PR TITLE
fix: add ignore tokens in evals

### DIFF
--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -637,14 +637,5 @@ if __name__ == "__main__":
         ctx_lens=args.ctx_lens,
     )
 
-    eval_results = multiple_evals(
-        sae_regex_pattern="gpt2-small-res-jb",
-        sae_block_pattern="blocks.*",
-        num_eval_batches=10,
-        eval_batch_size_prompts=8,
-        datasets=["Skylion007/openwebtext", "lighteval/MATH"],
-        ctx_lens=[128],
-    )
-
     eval_results.to_csv(args.save_path, index=False)
     eval_results.to_json(args.save_path.replace(".csv", ".json"), orient="records")


### PR DESCRIPTION
# Description

We want to ignore bos / similar tokens when calculating evals. This PR defaults to masking bos, pad and eos tokens when doing evals. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility