### PR TITLE
Improve error message for Gemma Scope non-canonical ID not found

### DIFF
--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -666,12 +666,27 @@ class SAE(HookedRootModule):
                     f"Release {release} not found in pretrained SAEs directory, and is not a valid huggingface repo."
                 )
         elif sae_id not in sae_directory[release].saes_map:
+            # If using Gemma Scope and not the canonical release, give a hint to use it
             if "gemma-scope" in release and "canonical" not in release and f"{release}-canonical" in sae_directory:
-                value_suffix = f"If you don't want to specify an L0 value, consider using release {release}-canonical which has valid IDs {sae_directory[release+'-canonical'].saes_map.keys()}"
+                canonical_ids = list(sae_directory[release+'-canonical'].saes_map.keys())
+                # Shorten the lengthy string of valid IDs
+                if len(canonical_valid_ids) > 5:
+                    str_canonical_ids = str(canonical_ids[:5])[:-1]+", ...]"
+                else:
+                    str_canonical_ids = str(canonical_ids)
+                value_suffix = f" If you don't want to specify an L0 value, consider using release {release}-canonical which has valid IDs {str_canonical_ids}"
             else:
                 value_suffix = ""
+
+            valid_ids = list(sae_directory[release].saes_map.keys())
+            # Shorten the lengthy string of valid IDs
+            if len(valid_ids) > 5:
+                str_valid_ids = str(valid_ids[:5])[:-1]+", ...]"
+            else:
+                str_valid_ids = str(valid_ids)
+            
             raise ValueError(
-                f"ID {sae_id} not found in release {release}. Valid IDs are {sae_directory[release].saes_map.keys()}. " + value_suffix
+                f"ID {sae_id} not found in release {release}. Valid IDs are {str_valid_ids}." + value_suffix
             )
         sae_info = sae_directory.get(release, None)
         hf_repo_id = sae_info.repo_id if sae_info is not None else release

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -667,11 +667,17 @@ class SAE(HookedRootModule):
                 )
         elif sae_id not in sae_directory[release].saes_map:
             # If using Gemma Scope and not the canonical release, give a hint to use it
-            if "gemma-scope" in release and "canonical" not in release and f"{release}-canonical" in sae_directory:
-                canonical_ids = list(sae_directory[release+'-canonical'].saes_map.keys())
+            if (
+                "gemma-scope" in release
+                and "canonical" not in release
+                and f"{release}-canonical" in sae_directory
+            ):
+                canonical_ids = list(
+                    sae_directory[release + "-canonical"].saes_map.keys()
+                )
                 # Shorten the lengthy string of valid IDs
                 if len(canonical_ids) > 5:
-                    str_canonical_ids = str(canonical_ids[:5])[:-1]+", ...]"
+                    str_canonical_ids = str(canonical_ids[:5])[:-1] + ", ...]"
                 else:
                     str_canonical_ids = str(canonical_ids)
                 value_suffix = f" If you don't want to specify an L0 value, consider using release {release}-canonical which has valid IDs {str_canonical_ids}"
@@ -681,12 +687,13 @@ class SAE(HookedRootModule):
             valid_ids = list(sae_directory[release].saes_map.keys())
             # Shorten the lengthy string of valid IDs
             if len(valid_ids) > 5:
-                str_valid_ids = str(valid_ids[:5])[:-1]+", ...]"
+                str_valid_ids = str(valid_ids[:5])[:-1] + ", ...]"
             else:
                 str_valid_ids = str(valid_ids)
-            
+
             raise ValueError(
-                f"ID {sae_id} not found in release {release}. Valid IDs are {str_valid_ids}." + value_suffix
+                f"ID {sae_id} not found in release {release}. Valid IDs are {str_valid_ids}."
+                + value_suffix
             )
         sae_info = sae_directory.get(release, None)
         hf_repo_id = sae_info.repo_id if sae_info is not None else release

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -670,7 +670,7 @@ class SAE(HookedRootModule):
             if "gemma-scope" in release and "canonical" not in release and f"{release}-canonical" in sae_directory:
                 canonical_ids = list(sae_directory[release+'-canonical'].saes_map.keys())
                 # Shorten the lengthy string of valid IDs
-                if len(canonical_valid_ids) > 5:
+                if len(canonical_ids) > 5:
                     str_canonical_ids = str(canonical_ids[:5])[:-1]+", ...]"
                 else:
                     str_canonical_ids = str(canonical_ids)

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -666,8 +666,12 @@ class SAE(HookedRootModule):
                     f"Release {release} not found in pretrained SAEs directory, and is not a valid huggingface repo."
                 )
         elif sae_id not in sae_directory[release].saes_map:
+            if "gemma-scope" in release and "canonical" not in release and f"{release}-canonical" in sae_directory:
+                value_suffix = f"If you don't want to specify an L0 value, consider using release {release}-canonical which has valid IDs {sae_directory[release+'-canonical'].saes_map.keys()}"
+            else:
+                value_suffix = ""
             raise ValueError(
-                f"ID {sae_id} not found in release {release}. Valid IDs are {sae_directory[release].saes_map.keys()}"
+                f"ID {sae_id} not found in release {release}. Valid IDs are {sae_directory[release].saes_map.keys()}. " + value_suffix
             )
         sae_info = sae_directory.get(release, None)
         hf_repo_id = sae_info.repo_id if sae_info is not None else release


### PR DESCRIPTION
# Description

There are two issues with the current error message for SAE ID for not found:

1. The list of valid IDs can be absurdly long so doesn't even make the whole error fit:

![Screenshot 2024-09-12 at 16 52 27](https://github.com/user-attachments/assets/2e1f928f-330a-402e-bc95-48bfae19eab7)

2. If users try to use e.g. `gemma-scope-2b-pt-res` we should give a hint that they might want to use `gemma-scope-2b-pt-res-canonical` instead so they don't need to specify `average_l0`. Here's a screenshot of the new behavior:

![Screenshot 2024-09-12 at 17 05 56](https://github.com/user-attachments/assets/c919522c-1c98-4992-844f-bb17bbd0e828)

~Fixes # (issue)~

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [ ] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:

I have not implemented a training change.