### PR TITLE
fix: removing missing Gemma Scope layer 11, 16k, l0=79 sae

### DIFF
--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -913,9 +913,6 @@ gemma-scope-2b-pt-res:
   - id: layer_11/width_16k/average_l0_41
     path: layer_11/width_16k/average_l0_41
     l0: 41
-  - id: layer_11/width_16k/average_l0_79
-    path: layer_11/width_16k/average_l0_79
-    l0: 79
   - id: layer_11/width_16k/average_l0_80
     path: layer_11/width_16k/average_l0_80
     l0: 80


### PR DESCRIPTION
# Description

In `pretrained_saes.yaml`, there is a reference to a Gemma Scope layer 11, 16k l0=79 SAE. However, this SAE does not exist in https://huggingface.co/google/gemma-scope-2b-pt-res/tree/main/layer_11/width_16k. Likely this SAE is a duplicate of the l0=80 SAE and was probably removed for that reason.

This PR removes this non-existent SAE from the `pretrained_saes.yaml` file.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update