### PR TITLE
Fix imports from huggingface_hub.utils.errors package

### DIFF
--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Protocol, Tuple
 import numpy as np
 import torch
 from huggingface_hub import hf_hub_download
-from huggingface_hub.utils._errors import EntryNotFoundError
+from huggingface_hub.utils.errors import EntryNotFoundError
 from safetensors import safe_open
 
 

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Protocol, Tuple
 import numpy as np
 import torch
 from huggingface_hub import hf_hub_download
-from huggingface_hub.utils.errors import EntryNotFoundError
+from huggingface_hub.utils import EntryNotFoundError
 from safetensors import safe_open
 
 

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -9,7 +9,7 @@ import numpy as np
 import torch
 from datasets import Dataset, DatasetDict, IterableDataset, load_dataset
 from huggingface_hub import hf_hub_download
-from huggingface_hub.utils.errors import HfHubHTTPError
+from huggingface_hub.utils import HfHubHTTPError
 from requests import HTTPError
 from safetensors import safe_open
 from safetensors.torch import save_file

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -9,7 +9,7 @@ import numpy as np
 import torch
 from datasets import Dataset, DatasetDict, IterableDataset, load_dataset
 from huggingface_hub import hf_hub_download
-from huggingface_hub.utils._errors import HfHubHTTPError
+from huggingface_hub.utils.errors import HfHubHTTPError
 from requests import HTTPError
 from safetensors import safe_open
 from safetensors.torch import save_file

--- a/sae_lens/training/upload_saes_to_huggingface.py
+++ b/sae_lens/training/upload_saes_to_huggingface.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 from typing import Iterable
 
 from huggingface_hub import HfApi, create_repo, get_hf_file_metadata, hf_hub_url
-from huggingface_hub.utils._errors import EntryNotFoundError, RepositoryNotFoundError
+from huggingface_hub.utils.errors import EntryNotFoundError, RepositoryNotFoundError
 from tqdm.autonotebook import tqdm
 
 from sae_lens.sae import SAE, SAE_CFG_PATH, SAE_WEIGHTS_PATH, SPARSITY_PATH

--- a/sae_lens/training/upload_saes_to_huggingface.py
+++ b/sae_lens/training/upload_saes_to_huggingface.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 from typing import Iterable
 
 from huggingface_hub import HfApi, create_repo, get_hf_file_metadata, hf_hub_url
-from huggingface_hub.utils.errors import EntryNotFoundError, RepositoryNotFoundError
+from huggingface_hub.utils import EntryNotFoundError, RepositoryNotFoundError
 from tqdm.autonotebook import tqdm
 
 from sae_lens.sae import SAE, SAE_CFG_PATH, SAE_WEIGHTS_PATH, SPARSITY_PATH


### PR DESCRIPTION
# Description

Fixes `ModuleNotFoundError: No module named 'huggingface_hub.utils._errors'`. This package was [refactored in HF](https://github.com/huggingface/huggingface_hub/commit/4aa2053707b2fa3391be2c126d98b47ad0fbf5d9) and no longer exists. Its new name is [`errors`](https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/errors.py).

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)