### PR TITLE
deletes print() in unit tests

### DIFF
--- a/tests/unit/test_evals.py
+++ b/tests/unit/test_evals.py
@@ -155,7 +155,6 @@ def test_run_evals_training_sae(
         eval_config=get_eval_everything_config(),
     )
 
-    print(eval_metrics)
     for key in all_expected_keys:
         assert key in eval_metrics
 
@@ -178,7 +177,6 @@ def test_run_evals_training_sae_ignore_bos(
         },  # type: ignore
     )
 
-    print(eval_metrics)
     for key in all_expected_keys:
         assert key in eval_metrics
 

--- a/tests/unit/training/test_cache_activations_runner.py
+++ b/tests/unit/training/test_cache_activations_runner.py
@@ -25,17 +25,12 @@ def test_cache_activations_runner(tmp_path: Path):
 
     # total_training_steps = 20_000
     context_size = 1024
-    print(f"n tokens per context: {context_size}")
     n_batches_in_buffer = 32
-    print(f"n batches in buffer: {n_batches_in_buffer}")
     store_batch_size = 1
-    print(f"store_batch_size: {store_batch_size}")
     n_buffers = 3
-    print(f"n_buffers: {n_buffers}")
 
     tokens_in_buffer = n_batches_in_buffer * store_batch_size * context_size
     total_training_tokens = n_buffers * tokens_in_buffer
-    print(f"Total Training Tokens: {total_training_tokens}")
 
     # better if we can look at the files (change tmp_path to a real path to look at the files)
     # tmp_path = os.path.join(os.path.dirname(__file__), "tmp")
@@ -103,13 +98,9 @@ def test_load_cached_activations():
 
     # total_training_steps = 20_000
     context_size = 256
-    print(f"n tokens per context: {context_size}")
     n_batches_in_buffer = 32
-    print(f"n batches in buffer: {n_batches_in_buffer}")
     store_batch_size = 1
-    print(f"store_batch_size: {store_batch_size}")
     n_buffers = 3
-    print(f"n_buffers: {n_buffers}")
 
     tokens_in_buffer = n_batches_in_buffer * store_batch_size * context_size
     total_training_tokens = n_buffers * tokens_in_buffer


### PR DESCRIPTION
# Description


Deletes `print()` in unit tests. In https://github.com/jbloomAus/SAELens/issues/43, we decided we should delete `print()` in unit tests.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.




# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 