### PR TITLE
Correctly load SAE Bench TopK SAEs

### DIFF
--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -422,7 +422,7 @@ def get_dictionary_learning_config_1(config: dict[str, Any]) -> dict[str, Any]:
 
     hook_point_name = f"blocks.{trainer['layer']}.hook_resid_post"
 
-    activation_fn_str = "topk" if "topk" in config.get("path", "") else "relu"
+    activation_fn_str = "topk" if trainer["dict_class"] == "AutoEncoderTopK" else "relu"
     activation_fn_kwargs = {"k": trainer["k"]} if activation_fn_str == "topk" else {}
 
     return {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

When loading the SAE bench TopK SAEs, such as the following:

```
sae, cfg_dict, sparsity = SAE.from_pretrained(
        release = "sae_bench_pythia70m_sweep_topk_ctx128_0730",
        sae_id = "blocks.4.hook_resid_post__trainer_10",
        device = device
)
```

And using this [notebook](https://github.com/jbloomAus/SAELens/blob/main/tutorials/basic_loading_and_analysing.ipynb), I get an L0 of ~600, when it is supposed to be a TopK SAE, with [K=80.](https://huggingface.co/canrager/lm_sae/blob/main/pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_10/config.json) 

Printing the config, I see that: 'activation_fn_str': 'relu'

By making this change, the L0 is now 80 and 'activation_fn_str': 'topk'.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
