### PR TITLE
Add entity argument to wandb.init

### DIFF
--- a/sae_lens/sae_training_runner.py
+++ b/sae_lens/sae_training_runner.py
@@ -89,6 +89,7 @@ class SAETrainingRunner:
         if self.cfg.log_to_wandb:
             wandb.init(
                 project=self.cfg.wandb_project,
+                entity=self.cfg.wandb_entity,
                 config=cast(Any, self.cfg),
                 name=self.cfg.run_name,
                 id=self.cfg.wandb_id,


### PR DESCRIPTION
# Description

The training runner does not respect the W&B entity argument, even when it is specified in the configuration.

This change just uses the already defined entity argument from the configuration and feeds it to `wandb.init()`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)