### PR TITLE
Fix context size of a tokenized dataset

### DIFF
--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -219,6 +219,10 @@ class ActivationsStore:
                     f"""pretokenized dataset has context_size {ds_context_size}, but the provided context_size is {self.context_size}. 
                         The context_size {ds_context_size} is expected to be larger than or equal to the provided context size {self.context_size}."""
                 )
+            if self.context_size<0:
+                raise ValueError(
+                    f"The provided context_size is {self.context_size} is negative. Expecting positive context_size"
+                )
             # TODO: investigate if this can work for iterable datasets, or if this is even worthwhile as a perf improvement
             if hasattr(self.dataset, "set_format"):
                 self.dataset.set_format(type="torch", columns=[self.tokens_column])  # type: ignore

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -214,9 +214,10 @@ class ActivationsStore:
             )
         if self.is_dataset_tokenized:
             ds_context_size = len(dataset_sample[self.tokens_column])
-            if ds_context_size != self.context_size:
+            if ds_context_size < self.context_size:
                 raise ValueError(
-                    f"pretokenized dataset has context_size {ds_context_size}, but the provided context_size is {self.context_size}."
+                    f"""pretokenized dataset has context_size {ds_context_size}, but the provided context_size is {self.context_size}. 
+                        The context_size {ds_context_size} is expected to be larger than or equal to the provided context size {self.context_size}."""
                 )
             # TODO: investigate if this can work for iterable datasets, or if this is even worthwhile as a perf improvement
             if hasattr(self.dataset, "set_format"):
@@ -276,12 +277,13 @@ class ActivationsStore:
         """
         Generator which iterates over full sequence of context_size tokens
         """
-        # If the datset is pretokenized, we can just return each row as a tensor, no further processing is needed.
+        # If the datset is pretokenized, we will slice the dataset to the length of the context window if needed. 
+        # Otherwise, no further processing is needed.
         # We assume that all necessary BOS/EOS/SEP tokens have been added during pretokenization.
         if self.is_dataset_tokenized:
             for row in self._iterate_raw_dataset():
                 yield torch.tensor(
-                    row,
+                    row[:self.context_size], # If self.context_size = None, this line simply returns the whole row
                     dtype=torch.long,
                     device=self.device,
                     requires_grad=False,

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -216,10 +216,10 @@ class ActivationsStore:
             ds_context_size = len(dataset_sample[self.tokens_column])
             if ds_context_size < self.context_size:
                 raise ValueError(
-                    f"""pretokenized dataset has context_size {ds_context_size}, but the provided context_size is {self.context_size}. 
-                        The context_size {ds_context_size} is expected to be larger than or equal to the provided context size {self.context_size}."""
+                    f"""pretokenized dataset has context_size {ds_context_size}, but the provided context_size is {self.context_size}.
+                    The context_size {ds_context_size} is expected to be larger than or equal to the provided context size {self.context_size}."""
                 )
-            if self.context_size<0:
+            if self.context_size < 0:
                 raise ValueError(
                     f"The provided context_size is {self.context_size} is negative. Expecting positive context_size"
                 )
@@ -281,13 +281,14 @@ class ActivationsStore:
         """
         Generator which iterates over full sequence of context_size tokens
         """
-        # If the datset is pretokenized, we will slice the dataset to the length of the context window if needed. 
-        # Otherwise, no further processing is needed.
+        # If the datset is pretokenized, we will slice the dataset to the length of the context window if needed. Otherwise, no further processing is needed.
         # We assume that all necessary BOS/EOS/SEP tokens have been added during pretokenization.
         if self.is_dataset_tokenized:
             for row in self._iterate_raw_dataset():
                 yield torch.tensor(
-                    row[:self.context_size], # If self.context_size = None, this line simply returns the whole row
+                    row[
+                        : self.context_size
+                    ],  # If self.context_size = None, this line simply returns the whole row
                     dtype=torch.long,
                     device=self.device,
                     requires_grad=False,

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import warnings
 from typing import Any, Generator, Iterator, Literal, cast
 
 import numpy as np
@@ -222,6 +223,11 @@ class ActivationsStore:
             if self.context_size < 0:
                 raise ValueError(
                     f"The provided context_size is {self.context_size} is negative. Expecting positive context_size"
+                )
+            if self.context_size != ds_context_size:
+                warnings.warn(
+                    f"""pretokenized dataset has context_size {ds_context_size}, but the provided context_size is {self.context_size}. Some data will be discarded in this case.""",
+                    RuntimeWarning,
                 )
             # TODO: investigate if this can work for iterable datasets, or if this is even worthwhile as a perf improvement
             if hasattr(self.dataset, "set_format"):

--- a/tests/unit/training/test_activations_store.py
+++ b/tests/unit/training/test_activations_store.py
@@ -349,13 +349,14 @@ def test_activations_store___iterate_tokenized_sequences__yields_sequences_of_co
         assert toks.shape == (5,)
 
 
-# We expect the code to work for context_size being less than or equal to the 
+# We expect the code to work for context_size being less than or equal to the
 # length of the dataset
-@pytest.mark.parametrize("context_size, expected_error", [(-1, ValueError), (5, None), (10, None), (15, ValueError)])
+@pytest.mark.parametrize(
+    "context_size, expected_error",
+    [(-1, ValueError), (5, None), (10, None), (15, ValueError)],
+)
 def test_activations_store__errors_on_context_size_mismatch(
-    ts_model: HookedTransformer,
-    context_size: int,
-    expected_error: Optional[ValueError]
+    ts_model: HookedTransformer, context_size: int, expected_error: Optional[ValueError]
 ):
     tokenizer = ts_model.tokenizer
     assert tokenizer is not None
@@ -371,14 +372,14 @@ def test_activations_store__errors_on_context_size_mismatch(
     pretokenize_cfg = PretokenizeRunnerConfig(context_size=10)
     tokenized_dataset = pretokenize_dataset(dataset, tokenizer, cfg=pretokenize_cfg)
 
-    # This context_size should raise an error since it's larger than the 
-    # dataset size
+    # This context_size should raise an error since it's larger than the dataset size
     if expected_error is ValueError:
         with pytest.raises(ValueError):
-            ActivationsStore.from_config(ts_model, cfg, override_dataset=tokenized_dataset)
+            ActivationsStore.from_config(
+                ts_model, cfg, override_dataset=tokenized_dataset
+            )
     else:
-    # If the context_size is greater than zero and less than the dataset size 
-    # the function should pass
+        # If the context_size is greater than zero and less than the dataset size the function should pass
         ActivationsStore.from_config(ts_model, cfg, override_dataset=tokenized_dataset)
 
 


### PR DESCRIPTION
# Description

Allowing for a `context_size` to be smaller than a dataset sample length in the case of a tokenized dataset. Adjusted tests to check for different cases of `context_size`. The motivation of this is to allow different applications like othelloGPT.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)