### PR TITLE
`hook_sae_acts_post` for Gated models should be post-masking

### DIFF
--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -441,10 +441,8 @@ class SAE(HookedRootModule):
                 magnitude_pre_activation = self.hook_sae_acts_pre(
                     sae_in @ (self.W_enc * self.r_mag.exp()) + self.b_mag
                 )
-                feature_magnitudes = self.hook_sae_acts_post(
-                    self.activation_fn(magnitude_pre_activation)
-                )
-                feature_acts_clean = active_features * feature_magnitudes
+                feature_magnitudes = self.activation_fn(magnitude_pre_activation)
+                feature_acts_clean = self.hook_sae_acts_post(active_features * feature_magnitudes)
                 x_reconstruct_clean = self.reshape_fn_out(
                     self.apply_finetuning_scaling_factor(feature_acts_clean)
                     @ self.W_dec

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -442,7 +442,9 @@ class SAE(HookedRootModule):
                     sae_in @ (self.W_enc * self.r_mag.exp()) + self.b_mag
                 )
                 feature_magnitudes = self.activation_fn(magnitude_pre_activation)
-                feature_acts_clean = self.hook_sae_acts_post(active_features * feature_magnitudes)
+                feature_acts_clean = self.hook_sae_acts_post(
+                    active_features * feature_magnitudes
+                )
                 x_reconstruct_clean = self.reshape_fn_out(
                     self.apply_finetuning_scaling_factor(feature_acts_clean)
                     @ self.W_dec


### PR DESCRIPTION
This changes the `hook_sae_acts_post` so that it applies to the gated activations after you've multiplied by the masking values.

This problem comes about because "output of encoder" and "output of nonlinear activation function on feature magnitudes" aren't the same thing. Long term solution is to have 2 different hook points, but as a quick fix, I think this hook point should be here (and I would appreciate a quick fix if possible, since it'll make the [new ARENA material](https://colab.research.google.com/drive/1z3kK8MM5aCLX3LbIqqGZKTNvAI-fFCVY) work when it get to the visualization section!).