### PR TITLE
fix: properly manage pyproject.toml version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ typing-extensions = "^4.10.0"
 
 
 [tool.poetry.group.dev.dependencies]
-black = { version = "3.23.2", extras = ["jupyter"] }
+black = { version = "24.4.0", extras = ["jupyter"] }
 pytest = "^8.0.2"
 pytest-cov = "^4.1.0"
 pre-commit = "^3.6.2"
@@ -95,7 +95,9 @@ build-backend = "poetry.core.masonry.api"
 [tool.semantic_release]
 version_variables = [
     "sae_lens/__init__.py:__version__",
-    "pyproject.toml:version",
+]
+version_toml = [
+    "pyproject.toml:tool.poetry.version",
 ]
 branch = "main"
 build_command = "pip install poetry && poetry build"


### PR DESCRIPTION
# Description

Our previous semantic release setup updates the `pyproject.toml:version` variable. However, this also has the unintended side-effect of replacing any `version = ` string in pyproject.toml with the new SAELens version. This broke black, since it now has an explicit `version = ` string set, as can be seen here: https://github.com/jbloomAus/SAELens/commit/e2a692a825dd8b138547c88188dfdf50b075cae5#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R44.

Fortunately, semantic-release has a [version_toml](https://python-semantic-release.readthedocs.io/en/latest/configuration.html#version-toml) option which handles exactly this situation (their example even includes a Poetry pyproject.toml).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)