### PR TITLE
chore: add-neuronpedia-ids-correct-gemma-2-2b-model-name

### DIFF
--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -9574,1709 +9574,2549 @@ sae_bench_gemma-2-2b_sweep_standard_ctx128_ef2_0824:
   conversion_func: dictionary_learning_1
   links:
     model: https://huggingface.co/google/gemma-2-2b
-  model: gemma-2b
+  model: gemma-2-2b
   repo_id: canrager/lm_sae
   saes:
   - id: blocks.3.hook_resid_post__trainer_1_step_29292
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_1_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_1_step_29292
   - id: blocks.3.hook_resid_post__trainer_1_step_19528
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_1_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_1_step_19528
   - id: blocks.3.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_1_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_1_step_0
   - id: blocks.3.hook_resid_post__trainer_0_step_9764
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_0_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_0_step_9764
   - id: blocks.3.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_0_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_0_step_4882
   - id: blocks.3.hook_resid_post__trainer_0_step_29292
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_0_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_0_step_29292
   - id: blocks.3.hook_resid_post__trainer_0_step_19528
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_0_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_0_step_19528
   - id: blocks.3.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_0_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_0_step_0
   - id: blocks.3.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_5_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3/trainer_5
   - id: blocks.3.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_4_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3/trainer_4
   - id: blocks.3.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_3_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3/trainer_3
   - id: blocks.3.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_2_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3/trainer_2
   - id: blocks.3.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_1_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3/trainer_1
   - id: blocks.3.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_0_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3/trainer_0
   - id: blocks.3.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_1_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_1_step_4882
   - id: blocks.3.hook_resid_post__trainer_1_step_9764
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_1_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_1_step_9764
   - id: blocks.3.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_2_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_2_step_0
   - id: blocks.3.hook_resid_post__trainer_2_step_29292
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_2_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_2_step_29292
   - id: blocks.3.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_3_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_3_step_0
   - id: blocks.3.hook_resid_post__trainer_3_step_19528
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_3_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_3_step_19528
   - id: blocks.3.hook_resid_post__trainer_3_step_29292
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_3_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_3_step_29292
   - id: blocks.3.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_3_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_3_step_4882
   - id: blocks.3.hook_resid_post__trainer_3_step_9764
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_3_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_3_step_9764
   - id: blocks.3.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_4_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_4_step_0
   - id: blocks.3.hook_resid_post__trainer_4_step_19528
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_4_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_4_step_19528
   - id: blocks.3.hook_resid_post__trainer_4_step_29292
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_4_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_4_step_29292
   - id: blocks.3.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_4_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_4_step_4882
   - id: blocks.3.hook_resid_post__trainer_4_step_9764
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_4_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_4_step_9764
   - id: blocks.3.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_5_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_5_step_0
   - id: blocks.3.hook_resid_post__trainer_5_step_19528
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_5_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_5_step_19528
   - id: blocks.3.hook_resid_post__trainer_5_step_29292
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_5_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_5_step_29292
   - id: blocks.3.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_5_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_5_step_4882
   - id: blocks.3.hook_resid_post__trainer_5_step_9764
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_5_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_5_step_9764
   - id: blocks.3.hook_resid_post__trainer_2_step_19528
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_2_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_2_step_19528
   - id: blocks.3.hook_resid_post__trainer_2_step_9764
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_2_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_2_step_9764
   - id: blocks.3.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-4k-trainer_2_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_2_step_4882
   - id: blocks.7.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_4_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_4_step_0
   - id: blocks.7.hook_resid_post__trainer_4_step_19528
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_4_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_4_step_19528
   - id: blocks.7.hook_resid_post__trainer_4_step_29292
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_4_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_4_step_29292
   - id: blocks.7.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_4_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_4_step_4882
   - id: blocks.7.hook_resid_post__trainer_4_step_9764
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_4_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_4_step_9764
   - id: blocks.7.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_5_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_5_step_0
   - id: blocks.7.hook_resid_post__trainer_5_step_19528
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_5_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_5_step_19528
   - id: blocks.7.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_5_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_5_step_4882
   - id: blocks.7.hook_resid_post__trainer_3_step_9764
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_3_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_3_step_9764
   - id: blocks.7.hook_resid_post__trainer_5_step_9764
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_5_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_5_step_9764
   - id: blocks.7.hook_resid_post__trainer_5_step_29292
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_5_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_5_step_29292
   - id: blocks.7.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_3_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_3_step_4882
   - id: blocks.7.hook_resid_post__trainer_2_step_19528
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_2_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_2_step_19528
   - id: blocks.7.hook_resid_post__trainer_3_step_19528
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_3_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_3_step_19528
   - id: blocks.7.hook_resid_post__trainer_0_step_29292
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_0_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_0_step_29292
   - id: blocks.7.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_0_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_0_step_4882
   - id: blocks.7.hook_resid_post__trainer_0_step_9764
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_0_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_0_step_9764
   - id: blocks.7.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_1_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_1_step_0
   - id: blocks.7.hook_resid_post__trainer_1_step_19528
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_1_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_1_step_19528
   - id: blocks.7.hook_resid_post__trainer_3_step_29292
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_3_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_3_step_29292
   - id: blocks.7.hook_resid_post__trainer_1_step_29292
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_1_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_1_step_29292
   - id: blocks.7.hook_resid_post__trainer_1_step_9764
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_1_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_1_step_9764
   - id: blocks.7.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_2_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_2_step_0
   - id: blocks.7.hook_resid_post__trainer_2_step_29292
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_2_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_2_step_29292
   - id: blocks.7.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_2_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_2_step_4882
   - id: blocks.7.hook_resid_post__trainer_2_step_9764
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_2_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_2_step_9764
   - id: blocks.7.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_3_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_3_step_0
   - id: blocks.7.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_1_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_1_step_4882
   - id: blocks.7.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_5_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7/trainer_5
   - id: blocks.7.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_0_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_0_step_0
   - id: blocks.7.hook_resid_post__trainer_0_step_19528
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_0_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_0_step_19528
   - id: blocks.7.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_4_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7/trainer_4
   - id: blocks.7.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_3_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7/trainer_3
   - id: blocks.7.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_2_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7/trainer_2
   - id: blocks.7.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_1_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7/trainer_1
   - id: blocks.7.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-4k-trainer_0_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_7/trainer_0
   - id: blocks.11.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_0_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11/trainer_0
   - id: blocks.11.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_4_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_4_step_4882
   - id: blocks.11.hook_resid_post__trainer_4_step_29292
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_4_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_4_step_29292
   - id: blocks.11.hook_resid_post__trainer_4_step_19528
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_4_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_4_step_19528
   - id: blocks.11.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_4_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_4_step_0
   - id: blocks.11.hook_resid_post__trainer_3_step_9764
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_3_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_3_step_9764
   - id: blocks.11.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_3_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_3_step_4882
   - id: blocks.11.hook_resid_post__trainer_3_step_29292
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_3_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_3_step_29292
   - id: blocks.11.hook_resid_post__trainer_3_step_19528
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_3_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_3_step_19528
   - id: blocks.11.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_3_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_3_step_0
   - id: blocks.11.hook_resid_post__trainer_2_step_9764
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_2_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_2_step_9764
   - id: blocks.11.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_2_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_2_step_4882
   - id: blocks.11.hook_resid_post__trainer_2_step_29292
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_2_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_2_step_29292
   - id: blocks.11.hook_resid_post__trainer_2_step_19528
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_2_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_2_step_19528
   - id: blocks.11.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_2_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_2_step_0
   - id: blocks.11.hook_resid_post__trainer_1_step_9764
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_1_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_1_step_9764
   - id: blocks.11.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_1_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_1_step_4882
   - id: blocks.11.hook_resid_post__trainer_1_step_29292
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_1_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_1_step_29292
   - id: blocks.11.hook_resid_post__trainer_1_step_19528
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_1_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_1_step_19528
   - id: blocks.11.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_1_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_1_step_0
   - id: blocks.11.hook_resid_post__trainer_0_step_9764
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_0_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_0_step_9764
   - id: blocks.11.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_0_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_0_step_4882
   - id: blocks.11.hook_resid_post__trainer_0_step_29292
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_0_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_0_step_29292
   - id: blocks.11.hook_resid_post__trainer_0_step_19528
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_0_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_0_step_19528
   - id: blocks.11.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_0_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_0_step_0
   - id: blocks.11.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_5_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11/trainer_5
   - id: blocks.11.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_4_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11/trainer_4
   - id: blocks.11.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_3_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11/trainer_3
   - id: blocks.11.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_2_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11/trainer_2
   - id: blocks.11.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_1_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11/trainer_1
   - id: blocks.11.hook_resid_post__trainer_4_step_9764
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_4_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_4_step_9764
   - id: blocks.11.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_5_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_5_step_0
   - id: blocks.11.hook_resid_post__trainer_5_step_29292
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_5_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_5_step_29292
   - id: blocks.11.hook_resid_post__trainer_5_step_9764
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_5_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_5_step_9764
   - id: blocks.11.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_5_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_5_step_4882
   - id: blocks.11.hook_resid_post__trainer_5_step_19528
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-4k-trainer_5_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_5_step_19528
   - id: blocks.15.hook_resid_post__trainer_2_step_19528
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_2_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_2_step_19528
   - id: blocks.15.hook_resid_post__trainer_5_step_9764
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_5_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_5_step_9764
   - id: blocks.15.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_5_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_5_step_4882
   - id: blocks.15.hook_resid_post__trainer_5_step_29292
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_5_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_5_step_29292
   - id: blocks.15.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_5_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_5_step_0
   - id: blocks.15.hook_resid_post__trainer_4_step_9764
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_4_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_4_step_9764
   - id: blocks.15.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_4_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_4_step_4882
   - id: blocks.15.hook_resid_post__trainer_4_step_19528
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_4_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_4_step_19528
   - id: blocks.15.hook_resid_post__trainer_2_step_29292
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_2_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_2_step_29292
   - id: blocks.15.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_4_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_4_step_0
   - id: blocks.15.hook_resid_post__trainer_3_step_9764
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_3_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_3_step_9764
   - id: blocks.15.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_3_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_3_step_4882
   - id: blocks.15.hook_resid_post__trainer_3_step_29292
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_3_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_3_step_29292
   - id: blocks.15.hook_resid_post__trainer_3_step_19528
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_3_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_3_step_19528
   - id: blocks.15.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_3_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_3_step_0
   - id: blocks.15.hook_resid_post__trainer_2_step_9764
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_2_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_2_step_9764
   - id: blocks.15.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_2_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_2_step_4882
   - id: blocks.15.hook_resid_post__trainer_1_step_9764
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_1_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_1_step_9764
   - id: blocks.15.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_2_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_2_step_0
   - id: blocks.15.hook_resid_post__trainer_4_step_29292
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_4_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_4_step_29292
   - id: blocks.15.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_1_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_1_step_4882
   - id: blocks.15.hook_resid_post__trainer_1_step_29292
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_1_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_1_step_29292
   - id: blocks.15.hook_resid_post__trainer_5_step_19528
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_5_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_5_step_19528
   - id: blocks.15.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_1_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_1_step_0
   - id: blocks.15.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_0_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15/trainer_0
   - id: blocks.15.hook_resid_post__trainer_1_step_19528
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_1_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_1_step_19528
   - id: blocks.15.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_1_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15/trainer_1
   - id: blocks.15.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_2_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15/trainer_2
   - id: blocks.15.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_3_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15/trainer_3
   - id: blocks.15.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_4_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15/trainer_4
   - id: blocks.15.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_5_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15/trainer_5
   - id: blocks.15.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_0_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_0_step_0
   - id: blocks.15.hook_resid_post__trainer_0_step_19528
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_0_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_0_step_19528
   - id: blocks.15.hook_resid_post__trainer_0_step_29292
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_0_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_0_step_29292
   - id: blocks.15.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_0_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_0_step_4882
   - id: blocks.15.hook_resid_post__trainer_0_step_9764
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-4k-trainer_0_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_0_step_9764
   - id: blocks.19.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_2_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_2_step_0
   - id: blocks.19.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_0_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19/trainer_0
   - id: blocks.19.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_1_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19/trainer_1
   - id: blocks.19.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_2_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19/trainer_2
   - id: blocks.19.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_3_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19/trainer_3
   - id: blocks.19.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_4_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19/trainer_4
   - id: blocks.19.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_5_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19/trainer_5
   - id: blocks.19.hook_resid_post__trainer_0_step_19528
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_0_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_0_step_19528
   - id: blocks.19.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_2_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_2_step_4882
   - id: blocks.19.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_0_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_0_step_0
   - id: blocks.19.hook_resid_post__trainer_2_step_9764
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_2_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_2_step_9764
   - id: blocks.19.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_5_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_5_step_4882
   - id: blocks.19.hook_resid_post__trainer_5_step_9764
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_5_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_5_step_9764
   - id: blocks.19.hook_resid_post__trainer_5_step_29292
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_5_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_5_step_29292
   - id: blocks.19.hook_resid_post__trainer_5_step_19528
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_5_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_5_step_19528
   - id: blocks.19.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_5_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_5_step_0
   - id: blocks.19.hook_resid_post__trainer_4_step_9764
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_4_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_4_step_9764
   - id: blocks.19.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_4_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_4_step_4882
   - id: blocks.19.hook_resid_post__trainer_4_step_29292
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_4_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_4_step_29292
   - id: blocks.19.hook_resid_post__trainer_4_step_19528
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_4_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_4_step_19528
   - id: blocks.19.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_4_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_4_step_0
   - id: blocks.19.hook_resid_post__trainer_3_step_9764
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_3_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_3_step_9764
   - id: blocks.19.hook_resid_post__trainer_3_step_19528
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_3_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_3_step_19528
   - id: blocks.19.hook_resid_post__trainer_3_step_29292
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_3_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_3_step_29292
   - id: blocks.19.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_3_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_3_step_4882
   - id: blocks.19.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_3_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_3_step_0
   - id: blocks.19.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_0_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_0_step_4882
   - id: blocks.19.hook_resid_post__trainer_0_step_9764
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_0_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_0_step_9764
   - id: blocks.19.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_1_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_1_step_0
   - id: blocks.19.hook_resid_post__trainer_1_step_19528
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_1_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_1_step_19528
   - id: blocks.19.hook_resid_post__trainer_1_step_29292
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_1_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_1_step_29292
   - id: blocks.19.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_1_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_1_step_4882
   - id: blocks.19.hook_resid_post__trainer_1_step_9764
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_1_step_9764
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_1_step_9764
   - id: blocks.19.hook_resid_post__trainer_0_step_29292
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_0_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_0_step_29292
   - id: blocks.19.hook_resid_post__trainer_2_step_19528
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_2_step_19528
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_2_step_19528
   - id: blocks.19.hook_resid_post__trainer_2_step_29292
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k-trainer_2_step_29292
     path: gemma-2-2b_sweep_standard_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_2_step_29292
 sae_bench_gemma-2-2b_sweep_standard_ctx128_ef8_0824:
   conversion_func: dictionary_learning_1
   links:
     model: https://huggingface.co/google/gemma-2-2b
-  model: gemma-2b
+  model: gemma-2-2b
   repo_id: canrager/lm_sae
   saes:
   - id: blocks.3.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_5_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_5_step_4882
   - id: blocks.3.hook_resid_post__trainer_5_step_488
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_5_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_5_step_488
   - id: blocks.3.hook_resid_post__trainer_5_step_48
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_5_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_5_step_48
   - id: blocks.3.hook_resid_post__trainer_5_step_15440
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_5_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_5_step_15440
   - id: blocks.3.hook_resid_post__trainer_5_step_1544
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_5_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_5_step_1544
   - id: blocks.3.hook_resid_post__trainer_5_step_154
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_5_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_5_step_154
   - id: blocks.3.hook_resid_post__trainer_1_step_488
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_1_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_1_step_488
   - id: blocks.3.hook_resid_post__trainer_1_step_48
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_1_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_1_step_48
   - id: blocks.3.hook_resid_post__trainer_1_step_15440
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_1_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_1_step_15440
   - id: blocks.3.hook_resid_post__trainer_1_step_1544
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_1_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_1_step_1544
   - id: blocks.3.hook_resid_post__trainer_1_step_154
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_1_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_1_step_154
   - id: blocks.3.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_1_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_1_step_0
   - id: blocks.3.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_0_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_0_step_4882
   - id: blocks.3.hook_resid_post__trainer_0_step_488
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_0_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_0_step_488
   - id: blocks.3.hook_resid_post__trainer_0_step_48
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_0_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_0_step_48
   - id: blocks.3.hook_resid_post__trainer_0_step_15440
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_0_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_0_step_15440
   - id: blocks.3.hook_resid_post__trainer_0_step_1544
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_0_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_0_step_1544
   - id: blocks.3.hook_resid_post__trainer_0_step_154
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_0_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_0_step_154
   - id: blocks.3.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_0_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_0_step_0
   - id: blocks.3.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_5_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3/trainer_5
   - id: blocks.3.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_4_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3/trainer_4
   - id: blocks.3.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_3_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3/trainer_3
   - id: blocks.3.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_2_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3/trainer_2
   - id: blocks.3.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_1_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3/trainer_1
   - id: blocks.3.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_0_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3/trainer_0
   - id: blocks.3.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_1_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_1_step_4882
   - id: blocks.3.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_2_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_2_step_0
   - id: blocks.3.hook_resid_post__trainer_2_step_1544
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_2_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_2_step_1544
   - id: blocks.3.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_5_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_5_step_0
   - id: blocks.3.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_4_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_4_step_4882
   - id: blocks.3.hook_resid_post__trainer_4_step_488
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_4_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_4_step_488
   - id: blocks.3.hook_resid_post__trainer_4_step_48
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_4_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_4_step_48
   - id: blocks.3.hook_resid_post__trainer_4_step_15440
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_4_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_4_step_15440
   - id: blocks.3.hook_resid_post__trainer_4_step_1544
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_4_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_4_step_1544
   - id: blocks.3.hook_resid_post__trainer_4_step_154
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_4_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_4_step_154
   - id: blocks.3.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_4_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_4_step_0
   - id: blocks.3.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_3_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_3_step_4882
   - id: blocks.3.hook_resid_post__trainer_3_step_488
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_3_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_3_step_488
   - id: blocks.3.hook_resid_post__trainer_3_step_48
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_3_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_3_step_48
   - id: blocks.3.hook_resid_post__trainer_3_step_15440
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_3_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_3_step_15440
   - id: blocks.3.hook_resid_post__trainer_3_step_1544
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_3_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_3_step_1544
   - id: blocks.3.hook_resid_post__trainer_3_step_154
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_3_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_3_step_154
   - id: blocks.3.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_3_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_3_step_0
   - id: blocks.3.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_2_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_2_step_4882
   - id: blocks.3.hook_resid_post__trainer_2_step_488
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_2_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_2_step_488
   - id: blocks.3.hook_resid_post__trainer_2_step_48
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_2_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_2_step_48
   - id: blocks.3.hook_resid_post__trainer_2_step_15440
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_2_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_2_step_15440
   - id: blocks.3.hook_resid_post__trainer_2_step_154
+    neuronpedia: gemma-2-2b/3-sae_bench-standard-res-18k-trainer_2_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_2_step_154
   - id: blocks.7.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_0_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7/trainer_0
   - id: blocks.7.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_1_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7/trainer_1
   - id: blocks.7.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_2_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7/trainer_2
   - id: blocks.7.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_3_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7/trainer_3
   - id: blocks.7.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_4_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7/trainer_4
   - id: blocks.7.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_5_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7/trainer_5
   - id: blocks.7.hook_resid_post__trainer_0_step_154
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_0_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_0_step_154
   - id: blocks.7.hook_resid_post__trainer_0_step_1544
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_0_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_0_step_1544
   - id: blocks.7.hook_resid_post__trainer_0_step_15440
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_0_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_0_step_15440
   - id: blocks.7.hook_resid_post__trainer_0_step_48
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_0_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_0_step_48
   - id: blocks.7.hook_resid_post__trainer_0_step_488
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_0_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_0_step_488
   - id: blocks.7.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_0_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_0_step_4882
   - id: blocks.7.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_1_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_1_step_0
   - id: blocks.7.hook_resid_post__trainer_1_step_154
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_1_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_1_step_154
   - id: blocks.7.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_0_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_0_step_0
   - id: blocks.7.hook_resid_post__trainer_1_step_1544
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_1_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_1_step_1544
   - id: blocks.7.hook_resid_post__trainer_1_step_15440
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_1_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_1_step_15440
   - id: blocks.7.hook_resid_post__trainer_1_step_48
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_1_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_1_step_48
   - id: blocks.7.hook_resid_post__trainer_1_step_488
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_1_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_1_step_488
   - id: blocks.7.hook_resid_post__trainer_5_step_154
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_5_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_5_step_154
   - id: blocks.7.hook_resid_post__trainer_5_step_1544
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_5_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_5_step_1544
   - id: blocks.7.hook_resid_post__trainer_5_step_48
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_5_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_5_step_48
   - id: blocks.7.hook_resid_post__trainer_5_step_488
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_5_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_5_step_488
   - id: blocks.7.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_5_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_5_step_4882
   - id: blocks.7.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_5_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_5_step_0
   - id: blocks.7.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_4_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_4_step_4882
   - id: blocks.7.hook_resid_post__trainer_4_step_48
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_4_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_4_step_48
   - id: blocks.7.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_1_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_1_step_4882
   - id: blocks.7.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_2_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_2_step_0
   - id: blocks.7.hook_resid_post__trainer_2_step_154
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_2_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_2_step_154
   - id: blocks.7.hook_resid_post__trainer_2_step_1544
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_2_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_2_step_1544
   - id: blocks.7.hook_resid_post__trainer_2_step_15440
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_2_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_2_step_15440
   - id: blocks.7.hook_resid_post__trainer_2_step_48
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_2_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_2_step_48
   - id: blocks.7.hook_resid_post__trainer_2_step_488
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_2_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_2_step_488
   - id: blocks.7.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_2_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_2_step_4882
   - id: blocks.7.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_3_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_3_step_0
   - id: blocks.7.hook_resid_post__trainer_3_step_154
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_3_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_3_step_154
   - id: blocks.7.hook_resid_post__trainer_3_step_1544
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_3_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_3_step_1544
   - id: blocks.7.hook_resid_post__trainer_3_step_15440
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_3_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_3_step_15440
   - id: blocks.7.hook_resid_post__trainer_3_step_48
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_3_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_3_step_48
   - id: blocks.7.hook_resid_post__trainer_3_step_488
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_3_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_3_step_488
   - id: blocks.7.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_3_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_3_step_4882
   - id: blocks.7.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_4_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_4_step_0
   - id: blocks.7.hook_resid_post__trainer_4_step_154
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_4_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_4_step_154
   - id: blocks.7.hook_resid_post__trainer_4_step_1544
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_4_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_4_step_1544
   - id: blocks.7.hook_resid_post__trainer_4_step_15440
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_4_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_4_step_15440
   - id: blocks.7.hook_resid_post__trainer_4_step_488
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_4_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_4_step_488
   - id: blocks.7.hook_resid_post__trainer_5_step_15440
+    neuronpedia: gemma-2-2b/7-sae_bench-standard-res-18k-trainer_5_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_5_step_15440
   - id: blocks.11.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_5_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_5_step_4882
   - id: blocks.11.hook_resid_post__trainer_5_step_488
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_5_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_5_step_488
   - id: blocks.11.hook_resid_post__trainer_5_step_48
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_5_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_5_step_48
   - id: blocks.11.hook_resid_post__trainer_5_step_15440
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_5_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_5_step_15440
   - id: blocks.11.hook_resid_post__trainer_5_step_1544
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_5_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_5_step_1544
   - id: blocks.11.hook_resid_post__trainer_5_step_154
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_5_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_5_step_154
   - id: blocks.11.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_5_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_5_step_0
   - id: blocks.11.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_4_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_4_step_4882
   - id: blocks.11.hook_resid_post__trainer_4_step_488
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_4_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_4_step_488
   - id: blocks.11.hook_resid_post__trainer_4_step_48
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_4_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_4_step_48
   - id: blocks.11.hook_resid_post__trainer_4_step_15440
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_4_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_4_step_15440
   - id: blocks.11.hook_resid_post__trainer_4_step_1544
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_4_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_4_step_1544
   - id: blocks.11.hook_resid_post__trainer_4_step_154
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_4_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_4_step_154
   - id: blocks.11.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_4_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_4_step_0
   - id: blocks.11.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_3_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_3_step_4882
   - id: blocks.11.hook_resid_post__trainer_3_step_488
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_3_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_3_step_488
   - id: blocks.11.hook_resid_post__trainer_3_step_48
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_3_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_3_step_48
   - id: blocks.11.hook_resid_post__trainer_3_step_15440
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_3_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_3_step_15440
   - id: blocks.11.hook_resid_post__trainer_3_step_1544
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_3_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_3_step_1544
   - id: blocks.11.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_3_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_3_step_0
   - id: blocks.11.hook_resid_post__trainer_3_step_154
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_3_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_3_step_154
   - id: blocks.11.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_2_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_2_step_4882
   - id: blocks.11.hook_resid_post__trainer_2_step_488
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_2_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_2_step_488
   - id: blocks.11.hook_resid_post__trainer_2_step_48
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_2_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_2_step_48
   - id: blocks.11.hook_resid_post__trainer_2_step_15440
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_2_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_2_step_15440
   - id: blocks.11.hook_resid_post__trainer_2_step_1544
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_2_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_2_step_1544
   - id: blocks.11.hook_resid_post__trainer_2_step_154
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_2_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_2_step_154
   - id: blocks.11.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_2_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_2_step_0
   - id: blocks.11.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_1_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_1_step_4882
   - id: blocks.11.hook_resid_post__trainer_1_step_488
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_1_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_1_step_488
   - id: blocks.11.hook_resid_post__trainer_1_step_48
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_1_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_1_step_48
   - id: blocks.11.hook_resid_post__trainer_1_step_15440
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_1_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_1_step_15440
   - id: blocks.11.hook_resid_post__trainer_1_step_1544
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_1_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_1_step_1544
   - id: blocks.11.hook_resid_post__trainer_1_step_154
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_1_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_1_step_154
   - id: blocks.11.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_1_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_1_step_0
   - id: blocks.11.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_0_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_0_step_4882
   - id: blocks.11.hook_resid_post__trainer_0_step_488
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_0_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_0_step_488
   - id: blocks.11.hook_resid_post__trainer_0_step_48
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_0_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_0_step_48
   - id: blocks.11.hook_resid_post__trainer_0_step_15440
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_0_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_0_step_15440
   - id: blocks.11.hook_resid_post__trainer_0_step_1544
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_0_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_0_step_1544
   - id: blocks.11.hook_resid_post__trainer_0_step_154
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_0_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_0_step_154
   - id: blocks.11.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_0_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_0_step_0
   - id: blocks.11.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_5_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11/trainer_5
   - id: blocks.11.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_4_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11/trainer_4
   - id: blocks.11.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_3_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11/trainer_3
   - id: blocks.11.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_2_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11/trainer_2
   - id: blocks.11.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_1_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11/trainer_1
   - id: blocks.11.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/11-sae_bench-standard-res-18k-trainer_0_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_11/trainer_0
   - id: blocks.15.hook_resid_post__trainer_5_step_1544
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_5_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_5_step_1544
   - id: blocks.15.hook_resid_post__trainer_5_step_15440
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_5_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_5_step_15440
   - id: blocks.15.hook_resid_post__trainer_5_step_48
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_5_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_5_step_48
   - id: blocks.15.hook_resid_post__trainer_5_step_488
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_5_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_5_step_488
   - id: blocks.15.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_5_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_5_step_4882
   - id: blocks.15.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_1_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15/trainer_1
   - id: blocks.15.hook_resid_post__trainer_5_step_154
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_5_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_5_step_154
   - id: blocks.15.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_5_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_5_step_0
   - id: blocks.15.hook_resid_post__trainer_4_step_1544
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_4_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_4_step_1544
   - id: blocks.15.hook_resid_post__trainer_4_step_488
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_4_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_4_step_488
   - id: blocks.15.hook_resid_post__trainer_2_step_48
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_2_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_2_step_48
   - id: blocks.15.hook_resid_post__trainer_2_step_15440
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_2_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_2_step_15440
   - id: blocks.15.hook_resid_post__trainer_2_step_1544
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_2_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_2_step_1544
   - id: blocks.15.hook_resid_post__trainer_2_step_154
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_2_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_2_step_154
   - id: blocks.15.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_2_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_2_step_0
   - id: blocks.15.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_1_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_1_step_4882
   - id: blocks.15.hook_resid_post__trainer_1_step_488
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_1_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_1_step_488
   - id: blocks.15.hook_resid_post__trainer_1_step_48
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_1_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_1_step_48
   - id: blocks.15.hook_resid_post__trainer_1_step_15440
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_1_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_1_step_15440
   - id: blocks.15.hook_resid_post__trainer_1_step_1544
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_1_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_1_step_1544
   - id: blocks.15.hook_resid_post__trainer_1_step_154
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_1_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_1_step_154
   - id: blocks.15.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_1_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_1_step_0
   - id: blocks.15.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_0_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_0_step_4882
   - id: blocks.15.hook_resid_post__trainer_0_step_488
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_0_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_0_step_488
   - id: blocks.15.hook_resid_post__trainer_0_step_48
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_0_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_0_step_48
   - id: blocks.15.hook_resid_post__trainer_0_step_15440
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_0_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_0_step_15440
   - id: blocks.15.hook_resid_post__trainer_0_step_1544
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_0_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_0_step_1544
   - id: blocks.15.hook_resid_post__trainer_0_step_154
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_0_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_0_step_154
   - id: blocks.15.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_0_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_0_step_0
   - id: blocks.15.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_5_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15/trainer_5
   - id: blocks.15.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_4_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15/trainer_4
   - id: blocks.15.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_3_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15/trainer_3
   - id: blocks.15.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_2_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15/trainer_2
   - id: blocks.15.hook_resid_post__trainer_2_step_488
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_2_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_2_step_488
   - id: blocks.15.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_4_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_4_step_4882
   - id: blocks.15.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_2_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_2_step_4882
   - id: blocks.15.hook_resid_post__trainer_3_step_154
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_3_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_3_step_154
   - id: blocks.15.hook_resid_post__trainer_4_step_48
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_4_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_4_step_48
   - id: blocks.15.hook_resid_post__trainer_4_step_15440
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_4_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_4_step_15440
   - id: blocks.15.hook_resid_post__trainer_4_step_154
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_4_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_4_step_154
   - id: blocks.15.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_4_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_4_step_0
   - id: blocks.15.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_3_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_3_step_4882
   - id: blocks.15.hook_resid_post__trainer_3_step_488
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_3_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_3_step_488
   - id: blocks.15.hook_resid_post__trainer_3_step_48
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_3_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_3_step_48
   - id: blocks.15.hook_resid_post__trainer_3_step_15440
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_3_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_3_step_15440
   - id: blocks.15.hook_resid_post__trainer_3_step_1544
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_3_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_3_step_1544
   - id: blocks.15.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_3_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_3_step_0
   - id: blocks.15.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/15-sae_bench-standard-res-18k-trainer_0_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_15/trainer_0
   - id: blocks.19.hook_resid_post__trainer_5_step_154
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_5_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_5_step_154
   - id: blocks.19.hook_resid_post__trainer_5_step_1544
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_5_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_5_step_1544
   - id: blocks.19.hook_resid_post__trainer_5_step_15440
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_5_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_5_step_15440
   - id: blocks.19.hook_resid_post__trainer_5_step_48
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_5_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_5_step_48
   - id: blocks.19.hook_resid_post__trainer_5_step_488
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_5_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_5_step_488
   - id: blocks.19.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_5_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_5_step_4882
   - id: blocks.19.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_5_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_5_step_0
   - id: blocks.19.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_4_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_4_step_4882
   - id: blocks.19.hook_resid_post__trainer_4_step_488
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_4_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_4_step_488
   - id: blocks.19.hook_resid_post__trainer_4_step_48
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_4_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_4_step_48
   - id: blocks.19.hook_resid_post__trainer_2_step_1544
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_2_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_2_step_1544
   - id: blocks.19.hook_resid_post__trainer_2_step_15440
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_2_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_2_step_15440
   - id: blocks.19.hook_resid_post__trainer_2_step_48
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_2_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_2_step_48
   - id: blocks.19.hook_resid_post__trainer_2_step_488
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_2_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_2_step_488
   - id: blocks.19.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_2_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_2_step_4882
   - id: blocks.19.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_3_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_3_step_0
   - id: blocks.19.hook_resid_post__trainer_3_step_154
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_3_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_3_step_154
   - id: blocks.19.hook_resid_post__trainer_3_step_1544
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_3_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_3_step_1544
   - id: blocks.19.hook_resid_post__trainer_3_step_48
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_3_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_3_step_48
   - id: blocks.19.hook_resid_post__trainer_3_step_488
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_3_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_3_step_488
   - id: blocks.19.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_3_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_3_step_4882
   - id: blocks.19.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_4_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_4_step_0
   - id: blocks.19.hook_resid_post__trainer_4_step_154
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_4_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_4_step_154
   - id: blocks.19.hook_resid_post__trainer_4_step_1544
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_4_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_4_step_1544
   - id: blocks.19.hook_resid_post__trainer_4_step_15440
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_4_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_4_step_15440
   - id: blocks.19.hook_resid_post__trainer_3_step_15440
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_3_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_3_step_15440
   - id: blocks.19.hook_resid_post__trainer_2_step_154
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_2_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_2_step_154
   - id: blocks.19.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_2_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_2_step_0
   - id: blocks.19.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_1_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_1_step_4882
   - id: blocks.19.hook_resid_post__trainer_1_step_488
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_1_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_1_step_488
   - id: blocks.19.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_2_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19/trainer_2
   - id: blocks.19.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_3_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19/trainer_3
   - id: blocks.19.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_4_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19/trainer_4
   - id: blocks.19.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_5_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19/trainer_5
   - id: blocks.19.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_0_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_0_step_0
   - id: blocks.19.hook_resid_post__trainer_0_step_154
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_0_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_0_step_154
   - id: blocks.19.hook_resid_post__trainer_0_step_1544
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_0_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_0_step_1544
   - id: blocks.19.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_1_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19/trainer_1
   - id: blocks.19.hook_resid_post__trainer_0_step_15440
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_0_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_0_step_15440
   - id: blocks.19.hook_resid_post__trainer_0_step_488
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_0_step_488
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_0_step_488
   - id: blocks.19.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_0_step_4882
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_0_step_4882
   - id: blocks.19.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_1_step_0
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_1_step_0
   - id: blocks.19.hook_resid_post__trainer_1_step_154
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_1_step_154
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_1_step_154
   - id: blocks.19.hook_resid_post__trainer_1_step_1544
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_1_step_1544
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_1_step_1544
   - id: blocks.19.hook_resid_post__trainer_1_step_48
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_1_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_1_step_48
   - id: blocks.19.hook_resid_post__trainer_0_step_48
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_0_step_48
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_0_step_48
   - id: blocks.19.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_0_step_final
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19/trainer_0
   - id: blocks.19.hook_resid_post__trainer_1_step_15440
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-18k-trainer_1_step_15440
     path: gemma-2-2b_sweep_standard_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_1_step_15440
 sae_bench_gemma-2-2b_sweep_topk_ctx128_ef2_0824:
   conversion_func: dictionary_learning_1
   links:
     model: https://huggingface.co/google/gemma-2-2b
-  model: gemma-2b
+  model: gemma-2-2b
   repo_id: canrager/lm_sae
   saes:
   - id: blocks.3.hook_resid_post__trainer_2_step_9764
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_2_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_2_step_9764
   - id: blocks.3.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_3_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_3_step_0
   - id: blocks.3.hook_resid_post__trainer_3_step_19528
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_3_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_3_step_19528
   - id: blocks.3.hook_resid_post__trainer_3_step_29292
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_3_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_3_step_29292
   - id: blocks.3.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_3_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_3_step_4882
   - id: blocks.3.hook_resid_post__trainer_3_step_9764
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_3_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_3_step_9764
   - id: blocks.3.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_4_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_4_step_0
   - id: blocks.3.hook_resid_post__trainer_4_step_19528
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_4_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_4_step_19528
   - id: blocks.3.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_2_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_2_step_4882
   - id: blocks.3.hook_resid_post__trainer_4_step_29292
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_4_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_4_step_29292
   - id: blocks.3.hook_resid_post__trainer_4_step_9764
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_4_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_4_step_9764
   - id: blocks.3.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_5_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_5_step_0
   - id: blocks.3.hook_resid_post__trainer_5_step_19528
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_5_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_5_step_19528
   - id: blocks.3.hook_resid_post__trainer_5_step_29292
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_5_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_5_step_29292
   - id: blocks.3.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_5_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_5_step_4882
   - id: blocks.3.hook_resid_post__trainer_5_step_9764
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_5_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_5_step_9764
   - id: blocks.3.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_4_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_4_step_4882
   - id: blocks.3.hook_resid_post__trainer_2_step_29292
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_2_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_2_step_29292
   - id: blocks.3.hook_resid_post__trainer_2_step_19528
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_2_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_2_step_19528
   - id: blocks.3.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_2_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_2_step_0
   - id: blocks.3.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_0_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3/trainer_0
   - id: blocks.3.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_1_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3/trainer_1
   - id: blocks.3.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_2_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3/trainer_2
   - id: blocks.3.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_3_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3/trainer_3
   - id: blocks.3.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_4_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3/trainer_4
   - id: blocks.3.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_5_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3/trainer_5
   - id: blocks.3.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_0_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_0_step_0
   - id: blocks.3.hook_resid_post__trainer_0_step_19528
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_0_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_0_step_19528
   - id: blocks.3.hook_resid_post__trainer_0_step_29292
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_0_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_0_step_29292
   - id: blocks.3.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_0_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_0_step_4882
   - id: blocks.3.hook_resid_post__trainer_0_step_9764
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_0_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_0_step_9764
   - id: blocks.3.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_1_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_1_step_0
   - id: blocks.3.hook_resid_post__trainer_1_step_19528
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_1_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_1_step_19528
   - id: blocks.3.hook_resid_post__trainer_1_step_29292
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_1_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_1_step_29292
   - id: blocks.3.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_1_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_1_step_4882
   - id: blocks.3.hook_resid_post__trainer_1_step_9764
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-4k-trainer_1_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_3_checkpoints/trainer_1_step_9764
   - id: blocks.7.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_0_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7/trainer_0
   - id: blocks.7.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_1_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7/trainer_1
   - id: blocks.7.hook_resid_post__trainer_4_step_9764
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_4_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_4_step_9764
   - id: blocks.7.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_3_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7/trainer_3
   - id: blocks.7.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_4_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_4_step_4882
   - id: blocks.7.hook_resid_post__trainer_4_step_29292
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_4_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_4_step_29292
   - id: blocks.7.hook_resid_post__trainer_4_step_19528
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_4_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_4_step_19528
   - id: blocks.7.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_4_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_4_step_0
   - id: blocks.7.hook_resid_post__trainer_3_step_9764
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_3_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_3_step_9764
   - id: blocks.7.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_3_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_3_step_4882
   - id: blocks.7.hook_resid_post__trainer_3_step_29292
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_3_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_3_step_29292
   - id: blocks.7.hook_resid_post__trainer_3_step_19528
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_3_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_3_step_19528
   - id: blocks.7.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_3_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_3_step_0
   - id: blocks.7.hook_resid_post__trainer_2_step_9764
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_2_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_2_step_9764
   - id: blocks.7.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_2_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_2_step_4882
   - id: blocks.7.hook_resid_post__trainer_2_step_29292
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_2_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_2_step_29292
   - id: blocks.7.hook_resid_post__trainer_5_step_19528
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_5_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_5_step_19528
   - id: blocks.7.hook_resid_post__trainer_2_step_19528
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_2_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_2_step_19528
   - id: blocks.7.hook_resid_post__trainer_5_step_29292
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_5_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_5_step_29292
   - id: blocks.7.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_5_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_5_step_4882
   - id: blocks.7.hook_resid_post__trainer_5_step_9764
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_5_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_5_step_9764
   - id: blocks.7.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_5_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_5_step_0
   - id: blocks.7.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_2_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_2_step_0
   - id: blocks.7.hook_resid_post__trainer_1_step_9764
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_1_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_1_step_9764
   - id: blocks.7.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_1_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_1_step_4882
   - id: blocks.7.hook_resid_post__trainer_1_step_29292
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_1_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_1_step_29292
   - id: blocks.7.hook_resid_post__trainer_1_step_19528
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_1_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_1_step_19528
   - id: blocks.7.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_1_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_1_step_0
   - id: blocks.7.hook_resid_post__trainer_0_step_9764
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_0_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_0_step_9764
   - id: blocks.7.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_0_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_0_step_4882
   - id: blocks.7.hook_resid_post__trainer_0_step_29292
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_0_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_0_step_29292
   - id: blocks.7.hook_resid_post__trainer_0_step_19528
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_0_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_0_step_19528
   - id: blocks.7.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_0_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7_checkpoints/trainer_0_step_0
   - id: blocks.7.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_5_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7/trainer_5
   - id: blocks.7.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_4_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7/trainer_4
   - id: blocks.7.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-4k-trainer_2_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_7/trainer_2
   - id: blocks.11.hook_resid_post__trainer_0_step_9764
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_0_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_0_step_9764
   - id: blocks.11.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_0_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_0_step_4882
   - id: blocks.11.hook_resid_post__trainer_0_step_29292
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_0_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_0_step_29292
   - id: blocks.11.hook_resid_post__trainer_0_step_19528
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_0_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_0_step_19528
   - id: blocks.11.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_0_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_0_step_0
   - id: blocks.11.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_5_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11/trainer_5
   - id: blocks.11.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_4_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11/trainer_4
   - id: blocks.11.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_3_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11/trainer_3
   - id: blocks.11.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_2_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11/trainer_2
   - id: blocks.11.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_1_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11/trainer_1
   - id: blocks.11.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_0_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11/trainer_0
   - id: blocks.11.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_1_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_1_step_0
   - id: blocks.11.hook_resid_post__trainer_1_step_19528
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_1_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_1_step_19528
   - id: blocks.11.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_1_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_1_step_4882
   - id: blocks.11.hook_resid_post__trainer_5_step_9764
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_5_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_5_step_9764
   - id: blocks.11.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_5_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_5_step_4882
   - id: blocks.11.hook_resid_post__trainer_5_step_29292
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_5_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_5_step_29292
   - id: blocks.11.hook_resid_post__trainer_5_step_19528
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_5_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_5_step_19528
   - id: blocks.11.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_5_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_5_step_0
   - id: blocks.11.hook_resid_post__trainer_4_step_9764
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_4_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_4_step_9764
   - id: blocks.11.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_4_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_4_step_4882
   - id: blocks.11.hook_resid_post__trainer_4_step_29292
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_4_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_4_step_29292
   - id: blocks.11.hook_resid_post__trainer_4_step_19528
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_4_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_4_step_19528
   - id: blocks.11.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_4_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_4_step_0
   - id: blocks.11.hook_resid_post__trainer_3_step_9764
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_3_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_3_step_9764
   - id: blocks.11.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_3_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_3_step_4882
   - id: blocks.11.hook_resid_post__trainer_3_step_29292
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_3_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_3_step_29292
   - id: blocks.11.hook_resid_post__trainer_3_step_19528
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_3_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_3_step_19528
   - id: blocks.11.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_3_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_3_step_0
   - id: blocks.11.hook_resid_post__trainer_2_step_9764
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_2_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_2_step_9764
   - id: blocks.11.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_2_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_2_step_4882
   - id: blocks.11.hook_resid_post__trainer_2_step_29292
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_2_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_2_step_29292
   - id: blocks.11.hook_resid_post__trainer_2_step_19528
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_2_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_2_step_19528
   - id: blocks.11.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_2_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_2_step_0
   - id: blocks.11.hook_resid_post__trainer_1_step_9764
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_1_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_1_step_9764
   - id: blocks.11.hook_resid_post__trainer_1_step_29292
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-4k-trainer_1_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_11_checkpoints/trainer_1_step_29292
   - id: blocks.15.hook_resid_post__trainer_5_step_9764
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_5_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_5_step_9764
   - id: blocks.15.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_5_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_5_step_4882
   - id: blocks.15.hook_resid_post__trainer_5_step_29292
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_5_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_5_step_29292
   - id: blocks.15.hook_resid_post__trainer_5_step_19528
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_5_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_5_step_19528
   - id: blocks.15.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_5_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_5_step_0
   - id: blocks.15.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_4_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_4_step_4882
   - id: blocks.15.hook_resid_post__trainer_4_step_29292
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_4_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_4_step_29292
   - id: blocks.15.hook_resid_post__trainer_4_step_19528
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_4_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_4_step_19528
   - id: blocks.15.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_4_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_4_step_0
   - id: blocks.15.hook_resid_post__trainer_3_step_9764
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_3_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_3_step_9764
   - id: blocks.15.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_3_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_3_step_4882
   - id: blocks.15.hook_resid_post__trainer_3_step_29292
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_3_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_3_step_29292
   - id: blocks.15.hook_resid_post__trainer_3_step_19528
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_3_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_3_step_19528
   - id: blocks.15.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_3_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_3_step_0
   - id: blocks.15.hook_resid_post__trainer_2_step_9764
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_2_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_2_step_9764
   - id: blocks.15.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_2_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_2_step_4882
   - id: blocks.15.hook_resid_post__trainer_4_step_9764
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_4_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_4_step_9764
   - id: blocks.15.hook_resid_post__trainer_2_step_19528
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_2_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_2_step_19528
   - id: blocks.15.hook_resid_post__trainer_0_step_9764
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_0_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_0_step_9764
   - id: blocks.15.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_0_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_0_step_4882
   - id: blocks.15.hook_resid_post__trainer_0_step_29292
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_0_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_0_step_29292
   - id: blocks.15.hook_resid_post__trainer_0_step_19528
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_0_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_0_step_19528
   - id: blocks.15.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_0_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_0_step_0
   - id: blocks.15.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_5_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15/trainer_5
   - id: blocks.15.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_4_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15/trainer_4
   - id: blocks.15.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_3_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15/trainer_3
   - id: blocks.15.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_2_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15/trainer_2
   - id: blocks.15.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_1_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15/trainer_1
   - id: blocks.15.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_0_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15/trainer_0
   - id: blocks.15.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_1_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_1_step_0
   - id: blocks.15.hook_resid_post__trainer_2_step_29292
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_2_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_2_step_29292
   - id: blocks.15.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_2_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_2_step_0
   - id: blocks.15.hook_resid_post__trainer_1_step_9764
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_1_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_1_step_9764
   - id: blocks.15.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_1_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_1_step_4882
   - id: blocks.15.hook_resid_post__trainer_1_step_29292
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_1_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_1_step_29292
   - id: blocks.15.hook_resid_post__trainer_1_step_19528
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-4k-trainer_1_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_15_checkpoints/trainer_1_step_19528
   - id: blocks.19.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_0_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19/trainer_0
   - id: blocks.19.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_3_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_3_step_0
   - id: blocks.19.hook_resid_post__trainer_3_step_19528
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_3_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_3_step_19528
   - id: blocks.19.hook_resid_post__trainer_3_step_29292
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_3_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_3_step_29292
   - id: blocks.19.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_3_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_3_step_4882
   - id: blocks.19.hook_resid_post__trainer_3_step_9764
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_3_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_3_step_9764
   - id: blocks.19.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_4_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_4_step_0
   - id: blocks.19.hook_resid_post__trainer_4_step_19528
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_4_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_4_step_19528
   - id: blocks.19.hook_resid_post__trainer_4_step_29292
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_4_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_4_step_29292
   - id: blocks.19.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_4_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_4_step_4882
   - id: blocks.19.hook_resid_post__trainer_4_step_9764
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_4_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_4_step_9764
   - id: blocks.19.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_5_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_5_step_0
   - id: blocks.19.hook_resid_post__trainer_5_step_19528
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_5_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_5_step_19528
   - id: blocks.19.hook_resid_post__trainer_5_step_29292
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_5_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_5_step_29292
   - id: blocks.19.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_5_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_5_step_4882
   - id: blocks.19.hook_resid_post__trainer_5_step_9764
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_5_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_5_step_9764
   - id: blocks.19.hook_resid_post__trainer_2_step_9764
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_2_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_2_step_9764
   - id: blocks.19.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_2_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_2_step_4882
   - id: blocks.19.hook_resid_post__trainer_2_step_29292
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_2_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_2_step_29292
   - id: blocks.19.hook_resid_post__trainer_2_step_19528
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_2_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_2_step_19528
   - id: blocks.19.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_1_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19/trainer_1
   - id: blocks.19.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_2_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19/trainer_2
   - id: blocks.19.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_3_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19/trainer_3
   - id: blocks.19.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_4_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19/trainer_4
   - id: blocks.19.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_5_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19/trainer_5
   - id: blocks.19.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_0_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_0_step_0
   - id: blocks.19.hook_resid_post__trainer_0_step_19528
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_0_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_0_step_19528
   - id: blocks.19.hook_resid_post__trainer_0_step_29292
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_0_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_0_step_29292
   - id: blocks.19.hook_resid_post__trainer_0_step_9764
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_0_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_0_step_9764
   - id: blocks.19.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_1_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_1_step_0
   - id: blocks.19.hook_resid_post__trainer_1_step_19528
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_1_step_19528
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_1_step_19528
   - id: blocks.19.hook_resid_post__trainer_1_step_29292
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_1_step_29292
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_1_step_29292
   - id: blocks.19.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_1_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_1_step_4882
   - id: blocks.19.hook_resid_post__trainer_1_step_9764
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_1_step_9764
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_1_step_9764
   - id: blocks.19.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_2_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_2_step_0
   - id: blocks.19.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k-trainer_0_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef2_0824/resid_post_layer_19_checkpoints/trainer_0_step_4882
 sae_bench_gemma-2-2b_sweep_topk_ctx128_ef8_0824:
   conversion_func: dictionary_learning_1
   links:
     model: https://huggingface.co/google/gemma-2-2b
-  model: gemma-2b
+  model: gemma-2-2b
   repo_id: canrager/lm_sae
   saes:
   - id: blocks.3.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_3_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3/trainer_3
   - id: blocks.3.hook_resid_post__trainer_1_step_48
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_1_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_1_step_48
   - id: blocks.3.hook_resid_post__trainer_1_step_15440
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_1_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_1_step_15440
   - id: blocks.3.hook_resid_post__trainer_1_step_1544
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_1_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_1_step_1544
   - id: blocks.3.hook_resid_post__trainer_1_step_154
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_1_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_1_step_154
   - id: blocks.3.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_1_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_1_step_0
   - id: blocks.3.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_0_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_0_step_4882
   - id: blocks.3.hook_resid_post__trainer_0_step_488
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_0_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_0_step_488
   - id: blocks.3.hook_resid_post__trainer_0_step_48
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_0_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_0_step_48
   - id: blocks.3.hook_resid_post__trainer_1_step_488
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_1_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_1_step_488
   - id: blocks.3.hook_resid_post__trainer_0_step_15440
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_0_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_0_step_15440
   - id: blocks.3.hook_resid_post__trainer_0_step_154
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_0_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_0_step_154
   - id: blocks.3.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_0_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_0_step_0
   - id: blocks.3.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_5_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3/trainer_5
   - id: blocks.3.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_4_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3/trainer_4
   - id: blocks.3.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_2_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3/trainer_2
   - id: blocks.3.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_1_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3/trainer_1
   - id: blocks.3.hook_resid_post__trainer_0_step_1544
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_0_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_0_step_1544
   - id: blocks.3.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_1_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_1_step_4882
   - id: blocks.3.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_2_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_2_step_0
   - id: blocks.3.hook_resid_post__trainer_2_step_154
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_2_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_2_step_154
   - id: blocks.3.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_4_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_4_step_4882
   - id: blocks.3.hook_resid_post__trainer_4_step_488
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_4_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_4_step_488
   - id: blocks.3.hook_resid_post__trainer_4_step_48
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_4_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_4_step_48
   - id: blocks.3.hook_resid_post__trainer_4_step_15440
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_4_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_4_step_15440
   - id: blocks.3.hook_resid_post__trainer_4_step_1544
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_4_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_4_step_1544
   - id: blocks.3.hook_resid_post__trainer_4_step_154
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_4_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_4_step_154
   - id: blocks.3.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_4_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_4_step_0
   - id: blocks.3.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_3_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_3_step_4882
   - id: blocks.3.hook_resid_post__trainer_3_step_488
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_3_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_3_step_488
   - id: blocks.3.hook_resid_post__trainer_3_step_48
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_3_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_3_step_48
   - id: blocks.3.hook_resid_post__trainer_3_step_15440
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_3_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_3_step_15440
   - id: blocks.3.hook_resid_post__trainer_3_step_1544
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_3_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_3_step_1544
   - id: blocks.3.hook_resid_post__trainer_3_step_154
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_3_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_3_step_154
   - id: blocks.3.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_3_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_3_step_0
   - id: blocks.3.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_2_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_2_step_4882
   - id: blocks.3.hook_resid_post__trainer_2_step_488
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_2_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_2_step_488
   - id: blocks.3.hook_resid_post__trainer_2_step_48
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_2_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_2_step_48
   - id: blocks.3.hook_resid_post__trainer_2_step_15440
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_2_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_2_step_15440
   - id: blocks.3.hook_resid_post__trainer_2_step_1544
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_2_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_2_step_1544
   - id: blocks.3.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_5_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_5_step_0
   - id: blocks.3.hook_resid_post__trainer_5_step_154
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_5_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_5_step_154
   - id: blocks.3.hook_resid_post__trainer_5_step_1544
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_5_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_5_step_1544
   - id: blocks.3.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_0_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3/trainer_0
   - id: blocks.3.hook_resid_post__trainer_5_step_488
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_5_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_5_step_488
   - id: blocks.3.hook_resid_post__trainer_5_step_48
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_5_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_5_step_48
   - id: blocks.3.hook_resid_post__trainer_5_step_15440
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_5_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_5_step_15440
   - id: blocks.3.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/3-sae_bench-topk-res-18k-trainer_5_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_3_checkpoints/trainer_5_step_4882
   - id: blocks.7.hook_resid_post__trainer_0_step_154
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_0_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_0_step_154
   - id: blocks.7.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_0_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_0_step_0
   - id: blocks.7.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_5_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7/trainer_5
   - id: blocks.7.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_4_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7/trainer_4
   - id: blocks.7.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_3_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7/trainer_3
   - id: blocks.7.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_1_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7/trainer_1
   - id: blocks.7.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_2_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7/trainer_2
   - id: blocks.7.hook_resid_post__trainer_0_step_1544
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_0_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_0_step_1544
   - id: blocks.7.hook_resid_post__trainer_0_step_15440
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_0_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_0_step_15440
   - id: blocks.7.hook_resid_post__trainer_5_step_154
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_5_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_5_step_154
   - id: blocks.7.hook_resid_post__trainer_0_step_488
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_0_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_0_step_488
   - id: blocks.7.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_0_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_0_step_4882
   - id: blocks.7.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_1_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_1_step_0
   - id: blocks.7.hook_resid_post__trainer_1_step_154
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_1_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_1_step_154
   - id: blocks.7.hook_resid_post__trainer_1_step_1544
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_1_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_1_step_1544
   - id: blocks.7.hook_resid_post__trainer_1_step_15440
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_1_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_1_step_15440
   - id: blocks.7.hook_resid_post__trainer_1_step_48
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_1_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_1_step_48
   - id: blocks.7.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_3_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_3_step_0
   - id: blocks.7.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_2_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_2_step_4882
   - id: blocks.7.hook_resid_post__trainer_2_step_48
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_2_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_2_step_48
   - id: blocks.7.hook_resid_post__trainer_2_step_15440
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_2_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_2_step_15440
   - id: blocks.7.hook_resid_post__trainer_2_step_1544
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_2_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_2_step_1544
   - id: blocks.7.hook_resid_post__trainer_2_step_154
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_2_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_2_step_154
   - id: blocks.7.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_2_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_2_step_0
   - id: blocks.7.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_1_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_1_step_4882
   - id: blocks.7.hook_resid_post__trainer_1_step_488
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_1_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_1_step_488
   - id: blocks.7.hook_resid_post__trainer_2_step_488
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_2_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_2_step_488
   - id: blocks.7.hook_resid_post__trainer_0_step_48
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_0_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_0_step_48
   - id: blocks.7.hook_resid_post__trainer_3_step_154
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_3_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_3_step_154
   - id: blocks.7.hook_resid_post__trainer_3_step_15440
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_3_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_3_step_15440
   - id: blocks.7.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_5_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_5_step_4882
   - id: blocks.7.hook_resid_post__trainer_5_step_488
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_5_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_5_step_488
   - id: blocks.7.hook_resid_post__trainer_5_step_48
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_5_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_5_step_48
   - id: blocks.7.hook_resid_post__trainer_5_step_15440
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_5_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_5_step_15440
   - id: blocks.7.hook_resid_post__trainer_5_step_1544
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_5_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_5_step_1544
   - id: blocks.7.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_5_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_5_step_0
   - id: blocks.7.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_4_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_4_step_4882
   - id: blocks.7.hook_resid_post__trainer_3_step_1544
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_3_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_3_step_1544
   - id: blocks.7.hook_resid_post__trainer_4_step_488
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_4_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_4_step_488
   - id: blocks.7.hook_resid_post__trainer_4_step_15440
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_4_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_4_step_15440
   - id: blocks.7.hook_resid_post__trainer_4_step_1544
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_4_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_4_step_1544
   - id: blocks.7.hook_resid_post__trainer_4_step_154
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_4_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_4_step_154
   - id: blocks.7.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_4_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_4_step_0
   - id: blocks.7.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_3_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_3_step_4882
   - id: blocks.7.hook_resid_post__trainer_3_step_488
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_3_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_3_step_488
   - id: blocks.7.hook_resid_post__trainer_3_step_48
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_3_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_3_step_48
   - id: blocks.7.hook_resid_post__trainer_4_step_48
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_4_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7_checkpoints/trainer_4_step_48
   - id: blocks.7.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/7-sae_bench-topk-res-18k-trainer_0_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_7/trainer_0
   - id: blocks.11.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_5_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_5_step_4882
   - id: blocks.11.hook_resid_post__trainer_5_step_48
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_5_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_5_step_48
   - id: blocks.11.hook_resid_post__trainer_5_step_488
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_5_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_5_step_488
   - id: blocks.11.hook_resid_post__trainer_0_step_1544
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_0_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_0_step_1544
   - id: blocks.11.hook_resid_post__trainer_0_step_154
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_0_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_0_step_154
   - id: blocks.11.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_0_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_0_step_0
   - id: blocks.11.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_5_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11/trainer_5
   - id: blocks.11.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_3_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11/trainer_3
   - id: blocks.11.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_2_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11/trainer_2
   - id: blocks.11.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_1_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11/trainer_1
   - id: blocks.11.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_0_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11/trainer_0
   - id: blocks.11.hook_resid_post__trainer_0_step_15440
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_0_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_0_step_15440
   - id: blocks.11.hook_resid_post__trainer_0_step_48
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_0_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_0_step_48
   - id: blocks.11.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_4_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11/trainer_4
   - id: blocks.11.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_0_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_0_step_4882
   - id: blocks.11.hook_resid_post__trainer_4_step_48
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_4_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_4_step_48
   - id: blocks.11.hook_resid_post__trainer_4_step_15440
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_4_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_4_step_15440
   - id: blocks.11.hook_resid_post__trainer_4_step_1544
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_4_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_4_step_1544
   - id: blocks.11.hook_resid_post__trainer_4_step_154
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_4_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_4_step_154
   - id: blocks.11.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_4_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_4_step_0
   - id: blocks.11.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_3_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_3_step_4882
   - id: blocks.11.hook_resid_post__trainer_3_step_48
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_3_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_3_step_48
   - id: blocks.11.hook_resid_post__trainer_3_step_15440
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_3_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_3_step_15440
   - id: blocks.11.hook_resid_post__trainer_4_step_488
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_4_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_4_step_488
   - id: blocks.11.hook_resid_post__trainer_3_step_1544
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_3_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_3_step_1544
   - id: blocks.11.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_3_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_3_step_0
   - id: blocks.11.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_2_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_2_step_4882
   - id: blocks.11.hook_resid_post__trainer_2_step_488
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_2_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_2_step_488
   - id: blocks.11.hook_resid_post__trainer_2_step_48
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_2_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_2_step_48
   - id: blocks.11.hook_resid_post__trainer_0_step_488
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_0_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_0_step_488
   - id: blocks.11.hook_resid_post__trainer_2_step_15440
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_2_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_2_step_15440
   - id: blocks.11.hook_resid_post__trainer_2_step_1544
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_2_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_2_step_1544
   - id: blocks.11.hook_resid_post__trainer_2_step_154
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_2_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_2_step_154
   - id: blocks.11.hook_resid_post__trainer_3_step_154
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_3_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_3_step_154
   - id: blocks.11.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_4_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_4_step_4882
   - id: blocks.11.hook_resid_post__trainer_3_step_488
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_3_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_3_step_488
   - id: blocks.11.hook_resid_post__trainer_5_step_154
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_5_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_5_step_154
   - id: blocks.11.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_1_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_1_step_0
   - id: blocks.11.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_5_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_5_step_0
   - id: blocks.11.hook_resid_post__trainer_1_step_1544
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_1_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_1_step_1544
   - id: blocks.11.hook_resid_post__trainer_1_step_15440
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_1_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_1_step_15440
   - id: blocks.11.hook_resid_post__trainer_1_step_48
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_1_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_1_step_48
   - id: blocks.11.hook_resid_post__trainer_1_step_488
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_1_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_1_step_488
   - id: blocks.11.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_1_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_1_step_4882
   - id: blocks.11.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_2_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_2_step_0
   - id: blocks.11.hook_resid_post__trainer_1_step_154
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_1_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_1_step_154
   - id: blocks.11.hook_resid_post__trainer_5_step_15440
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_5_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_5_step_15440
   - id: blocks.11.hook_resid_post__trainer_5_step_1544
+    neuronpedia: gemma-2-2b/11-sae_bench-topk-res-18k-trainer_5_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_11_checkpoints/trainer_5_step_1544
   - id: blocks.15.hook_resid_post__trainer_4_step_154
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_4_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_4_step_154
   - id: blocks.15.hook_resid_post__trainer_4_step_1544
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_4_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_4_step_1544
   - id: blocks.15.hook_resid_post__trainer_4_step_15440
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_4_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_4_step_15440
   - id: blocks.15.hook_resid_post__trainer_4_step_48
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_4_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_4_step_48
   - id: blocks.15.hook_resid_post__trainer_4_step_488
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_4_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_4_step_488
   - id: blocks.15.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_4_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_4_step_4882
   - id: blocks.15.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_5_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_5_step_0
   - id: blocks.15.hook_resid_post__trainer_5_step_154
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_5_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_5_step_154
   - id: blocks.15.hook_resid_post__trainer_5_step_1544
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_5_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_5_step_1544
   - id: blocks.15.hook_resid_post__trainer_5_step_15440
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_5_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_5_step_15440
   - id: blocks.15.hook_resid_post__trainer_5_step_48
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_5_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_5_step_48
   - id: blocks.15.hook_resid_post__trainer_5_step_488
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_5_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_5_step_488
   - id: blocks.15.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_5_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_5_step_4882
   - id: blocks.15.hook_resid_post__trainer_3_step_154
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_3_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_3_step_154
   - id: blocks.15.hook_resid_post__trainer_3_step_1544
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_3_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_3_step_1544
   - id: blocks.15.hook_resid_post__trainer_3_step_15440
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_3_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_3_step_15440
   - id: blocks.15.hook_resid_post__trainer_3_step_48
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_3_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_3_step_48
   - id: blocks.15.hook_resid_post__trainer_3_step_488
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_3_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_3_step_488
   - id: blocks.15.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_3_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_3_step_4882
   - id: blocks.15.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_4_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_4_step_0
   - id: blocks.15.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_3_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_3_step_0
   - id: blocks.15.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_2_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_2_step_4882
   - id: blocks.15.hook_resid_post__trainer_2_step_488
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_2_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_2_step_488
   - id: blocks.15.hook_resid_post__trainer_2_step_48
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_2_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_2_step_48
   - id: blocks.15.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_0_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15/trainer_0
   - id: blocks.15.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_1_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15/trainer_1
   - id: blocks.15.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_2_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15/trainer_2
   - id: blocks.15.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_3_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15/trainer_3
   - id: blocks.15.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_4_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15/trainer_4
   - id: blocks.15.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_5_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15/trainer_5
   - id: blocks.15.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_0_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_0_step_0
   - id: blocks.15.hook_resid_post__trainer_0_step_154
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_0_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_0_step_154
   - id: blocks.15.hook_resid_post__trainer_0_step_1544
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_0_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_0_step_1544
   - id: blocks.15.hook_resid_post__trainer_0_step_15440
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_0_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_0_step_15440
   - id: blocks.15.hook_resid_post__trainer_0_step_48
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_0_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_0_step_48
   - id: blocks.15.hook_resid_post__trainer_0_step_488
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_0_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_0_step_488
   - id: blocks.15.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_1_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_1_step_0
   - id: blocks.15.hook_resid_post__trainer_1_step_154
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_1_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_1_step_154
   - id: blocks.15.hook_resid_post__trainer_1_step_1544
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_1_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_1_step_1544
   - id: blocks.15.hook_resid_post__trainer_1_step_15440
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_1_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_1_step_15440
   - id: blocks.15.hook_resid_post__trainer_1_step_48
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_1_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_1_step_48
   - id: blocks.15.hook_resid_post__trainer_1_step_488
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_1_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_1_step_488
   - id: blocks.15.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_1_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_1_step_4882
   - id: blocks.15.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_2_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_2_step_0
   - id: blocks.15.hook_resid_post__trainer_2_step_154
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_2_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_2_step_154
   - id: blocks.15.hook_resid_post__trainer_2_step_1544
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_2_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_2_step_1544
   - id: blocks.15.hook_resid_post__trainer_2_step_15440
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_2_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_2_step_15440
   - id: blocks.15.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/15-sae_bench-topk-res-18k-trainer_0_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_15_checkpoints/trainer_0_step_4882
   - id: blocks.19.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_4_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_4_step_0
   - id: blocks.19.hook_resid_post__trainer_3_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_3_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_3_step_4882
   - id: blocks.19.hook_resid_post__trainer_3_step_488
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_3_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_3_step_488
   - id: blocks.19.hook_resid_post__trainer_3_step_48
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_3_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_3_step_48
   - id: blocks.19.hook_resid_post__trainer_3_step_15440
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_3_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_3_step_15440
   - id: blocks.19.hook_resid_post__trainer_3_step_1544
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_3_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_3_step_1544
   - id: blocks.19.hook_resid_post__trainer_3_step_154
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_3_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_3_step_154
   - id: blocks.19.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_3_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_3_step_0
   - id: blocks.19.hook_resid_post__trainer_0_step_154
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_0_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_0_step_154
   - id: blocks.19.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_0_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_0_step_0
   - id: blocks.19.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_5_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19/trainer_5
   - id: blocks.19.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_4_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19/trainer_4
   - id: blocks.19.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_3_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19/trainer_3
   - id: blocks.19.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_2_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19/trainer_2
   - id: blocks.19.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_1_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19/trainer_1
   - id: blocks.19.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_0_step_final
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19/trainer_0
   - id: blocks.19.hook_resid_post__trainer_0_step_1544
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_0_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_0_step_1544
   - id: blocks.19.hook_resid_post__trainer_0_step_15440
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_0_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_0_step_15440
   - id: blocks.19.hook_resid_post__trainer_0_step_48
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_0_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_0_step_48
   - id: blocks.19.hook_resid_post__trainer_2_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_2_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_2_step_4882
   - id: blocks.19.hook_resid_post__trainer_2_step_488
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_2_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_2_step_488
   - id: blocks.19.hook_resid_post__trainer_2_step_48
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_2_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_2_step_48
   - id: blocks.19.hook_resid_post__trainer_2_step_15440
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_2_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_2_step_15440
   - id: blocks.19.hook_resid_post__trainer_2_step_1544
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_2_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_2_step_1544
   - id: blocks.19.hook_resid_post__trainer_2_step_154
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_2_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_2_step_154
   - id: blocks.19.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_2_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_2_step_0
   - id: blocks.19.hook_resid_post__trainer_1_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_1_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_1_step_4882
   - id: blocks.19.hook_resid_post__trainer_1_step_48
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_1_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_1_step_48
   - id: blocks.19.hook_resid_post__trainer_1_step_1544
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_1_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_1_step_1544
   - id: blocks.19.hook_resid_post__trainer_1_step_154
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_1_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_1_step_154
   - id: blocks.19.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_1_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_1_step_0
   - id: blocks.19.hook_resid_post__trainer_0_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_0_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_0_step_4882
   - id: blocks.19.hook_resid_post__trainer_0_step_488
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_0_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_0_step_488
   - id: blocks.19.hook_resid_post__trainer_1_step_488
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_1_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_1_step_488
   - id: blocks.19.hook_resid_post__trainer_1_step_15440
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_1_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_1_step_15440
   - id: blocks.19.hook_resid_post__trainer_4_step_1544
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_4_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_4_step_1544
   - id: blocks.19.hook_resid_post__trainer_4_step_15440
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_4_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_4_step_15440
   - id: blocks.19.hook_resid_post__trainer_4_step_48
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_4_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_4_step_48
   - id: blocks.19.hook_resid_post__trainer_4_step_488
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_4_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_4_step_488
   - id: blocks.19.hook_resid_post__trainer_4_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_4_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_4_step_4882
   - id: blocks.19.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_5_step_0
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_5_step_0
   - id: blocks.19.hook_resid_post__trainer_5_step_154
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_5_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_5_step_154
   - id: blocks.19.hook_resid_post__trainer_5_step_1544
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_5_step_1544
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_5_step_1544
   - id: blocks.19.hook_resid_post__trainer_5_step_15440
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_5_step_15440
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_5_step_15440
   - id: blocks.19.hook_resid_post__trainer_5_step_48
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_5_step_48
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_5_step_48
   - id: blocks.19.hook_resid_post__trainer_5_step_488
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_5_step_488
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_5_step_488
   - id: blocks.19.hook_resid_post__trainer_5_step_4882
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_5_step_4882
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_5_step_4882
   - id: blocks.19.hook_resid_post__trainer_4_step_154
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-18k-trainer_4_step_154
     path: gemma-2-2b_sweep_topk_ctx128_ef8_0824/resid_post_layer_19_checkpoints/trainer_4_step_154
 sae_bench_pythia70m_sweep_gated_ctx128_0730:
   conversion_func: dictionary_learning_1
@@ -11286,85 +12126,125 @@ sae_bench_pythia70m_sweep_gated_ctx128_0730:
   repo_id: canrager/lm_sae
   saes:
   - id: blocks.3.hook_resid_post__trainer_0
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_0_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_0
   - id: blocks.3.hook_resid_post__trainer_1
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_1_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_1
   - id: blocks.3.hook_resid_post__trainer_10
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_10_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_10
-  - id: blocks.3.hook_resid_post__trainer_11
-    path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_11
   - id: blocks.3.hook_resid_post__trainer_12
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_12_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_12
   - id: blocks.3.hook_resid_post__trainer_13
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_13_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_13
   - id: blocks.3.hook_resid_post__trainer_14
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_14_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_14
   - id: blocks.3.hook_resid_post__trainer_15
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_15_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_15
   - id: blocks.3.hook_resid_post__trainer_16
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_16_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_16
   - id: blocks.3.hook_resid_post__trainer_17
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_17_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_17
   - id: blocks.3.hook_resid_post__trainer_18
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_18_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_18
   - id: blocks.3.hook_resid_post__trainer_19
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_19_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_19
   - id: blocks.3.hook_resid_post__trainer_2
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_2_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_2
   - id: blocks.3.hook_resid_post__trainer_3
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_3_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_3
   - id: blocks.3.hook_resid_post__trainer_4
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_4_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_4
   - id: blocks.3.hook_resid_post__trainer_5
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_5_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_5
   - id: blocks.3.hook_resid_post__trainer_6
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_6_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_6
   - id: blocks.3.hook_resid_post__trainer_7
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_7_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_7
   - id: blocks.3.hook_resid_post__trainer_8
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_8_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_8
   - id: blocks.3.hook_resid_post__trainer_9
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_9_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_9
+  - id: blocks.3.hook_resid_post__trainer_11
+    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_11_step_final
+    path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_11
   - id: blocks.4.hook_resid_post__trainer_0
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_0_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_0
   - id: blocks.4.hook_resid_post__trainer_1
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_1_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_1
   - id: blocks.4.hook_resid_post__trainer_10
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_10_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_10
   - id: blocks.4.hook_resid_post__trainer_11
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_11_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_11
   - id: blocks.4.hook_resid_post__trainer_12
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_12_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_12
   - id: blocks.4.hook_resid_post__trainer_13
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_13_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_13
   - id: blocks.4.hook_resid_post__trainer_14
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_14_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_14
   - id: blocks.4.hook_resid_post__trainer_15
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_15_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_15
   - id: blocks.4.hook_resid_post__trainer_16
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_16_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_16
   - id: blocks.4.hook_resid_post__trainer_17
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_17_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_17
   - id: blocks.4.hook_resid_post__trainer_18
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_18_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_18
   - id: blocks.4.hook_resid_post__trainer_19
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_19_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_19
   - id: blocks.4.hook_resid_post__trainer_2
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_2_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_2
   - id: blocks.4.hook_resid_post__trainer_3
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_3_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_3
   - id: blocks.4.hook_resid_post__trainer_4
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_4_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_4
   - id: blocks.4.hook_resid_post__trainer_5
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_5_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_5
   - id: blocks.4.hook_resid_post__trainer_6
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_6_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_6
-  - id: blocks.4.hook_resid_post__trainer_7
-    path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_7
-  - id: blocks.4.hook_resid_post__trainer_8
-    path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_8
   - id: blocks.4.hook_resid_post__trainer_9
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_9_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_9
+  - id: blocks.4.hook_resid_post__trainer_8
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_8_step_final
+    path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_8
+  - id: blocks.4.hook_resid_post__trainer_7
+    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_7_step_final
+    path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_7
 sae_bench_pythia70m_sweep_panneal_ctx128_0730:
   conversion_func: dictionary_learning_1
   links:
@@ -11372,118 +12252,174 @@ sae_bench_pythia70m_sweep_panneal_ctx128_0730:
   model: pythia-70m
   repo_id: canrager/lm_sae
   saes:
-  - id: blocks.3.hook_resid_post__trainer_0
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_0
-  - id: blocks.3.hook_resid_post__trainer_1
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_1
-  - id: blocks.3.hook_resid_post__trainer_10
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_10
-  - id: blocks.3.hook_resid_post__trainer_11
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_11
-  - id: blocks.3.hook_resid_post__trainer_12
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_12
-  - id: blocks.3.hook_resid_post__trainer_13
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_13
-  - id: blocks.3.hook_resid_post__trainer_14
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_14
-  - id: blocks.3.hook_resid_post__trainer_15
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_15
   - id: blocks.3.hook_resid_post__trainer_16
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_16_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_16
   - id: blocks.3.hook_resid_post__trainer_17
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_17_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_17
   - id: blocks.3.hook_resid_post__trainer_18
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_18_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_18
   - id: blocks.3.hook_resid_post__trainer_19
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_19_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_19
   - id: blocks.3.hook_resid_post__trainer_2
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_2_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_2
   - id: blocks.3.hook_resid_post__trainer_20
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_20_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_20
   - id: blocks.3.hook_resid_post__trainer_21
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_21_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_21
   - id: blocks.3.hook_resid_post__trainer_22
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_22_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_22
+  - id: blocks.3.hook_resid_post__trainer_15
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_15_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_15
   - id: blocks.3.hook_resid_post__trainer_23
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_23_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_23
-  - id: blocks.3.hook_resid_post__trainer_24
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_24
   - id: blocks.3.hook_resid_post__trainer_25
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_25_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_25
   - id: blocks.3.hook_resid_post__trainer_26
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_26_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_26
   - id: blocks.3.hook_resid_post__trainer_27
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_27_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_27
   - id: blocks.3.hook_resid_post__trainer_3
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_3_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_3
   - id: blocks.3.hook_resid_post__trainer_4
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_4_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_4
   - id: blocks.3.hook_resid_post__trainer_5
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_5_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_5
   - id: blocks.3.hook_resid_post__trainer_6
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_6_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_6
   - id: blocks.3.hook_resid_post__trainer_7
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_7_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_7
+  - id: blocks.3.hook_resid_post__trainer_24
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_24_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_24
+  - id: blocks.3.hook_resid_post__trainer_14
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_14_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_14
+  - id: blocks.3.hook_resid_post__trainer_13
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_13_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_13
+  - id: blocks.3.hook_resid_post__trainer_12
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_12_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_12
+  - id: blocks.3.hook_resid_post__trainer_0
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_0_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_0
+  - id: blocks.3.hook_resid_post__trainer_1
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_1_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_1
+  - id: blocks.3.hook_resid_post__trainer_10
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_10_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_10
+  - id: blocks.3.hook_resid_post__trainer_11
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_11_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_11
   - id: blocks.3.hook_resid_post__trainer_8
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_8_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_8
   - id: blocks.3.hook_resid_post__trainer_9
+    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_9_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_9
-  - id: blocks.4.hook_resid_post__trainer_0
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_0
-  - id: blocks.4.hook_resid_post__trainer_1
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_1
-  - id: blocks.4.hook_resid_post__trainer_10
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_10
-  - id: blocks.4.hook_resid_post__trainer_11
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_11
-  - id: blocks.4.hook_resid_post__trainer_12
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_12
-  - id: blocks.4.hook_resid_post__trainer_13
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_13
-  - id: blocks.4.hook_resid_post__trainer_14
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_14
-  - id: blocks.4.hook_resid_post__trainer_15
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_15
-  - id: blocks.4.hook_resid_post__trainer_16
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_16
   - id: blocks.4.hook_resid_post__trainer_17
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_17_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_17
   - id: blocks.4.hook_resid_post__trainer_18
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_18_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_18
   - id: blocks.4.hook_resid_post__trainer_19
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_19_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_19
+  - id: blocks.4.hook_resid_post__trainer_16
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_16_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_16
+  - id: blocks.4.hook_resid_post__trainer_15
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_15_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_15
+  - id: blocks.4.hook_resid_post__trainer_14
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_14_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_14
+  - id: blocks.4.hook_resid_post__trainer_13
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_13_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_13
+  - id: blocks.4.hook_resid_post__trainer_12
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_12_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_12
+  - id: blocks.4.hook_resid_post__trainer_11
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_11_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_11
+  - id: blocks.4.hook_resid_post__trainer_10
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_10_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_10
+  - id: blocks.4.hook_resid_post__trainer_1
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_1_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_1
+  - id: blocks.4.hook_resid_post__trainer_0
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_0_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_0
   - id: blocks.4.hook_resid_post__trainer_2
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_2_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_2
   - id: blocks.4.hook_resid_post__trainer_20
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_20_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_20
-  - id: blocks.4.hook_resid_post__trainer_21
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_21
   - id: blocks.4.hook_resid_post__trainer_22
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_22_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_22
-  - id: blocks.4.hook_resid_post__trainer_23
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_23
-  - id: blocks.4.hook_resid_post__trainer_24
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_24
-  - id: blocks.4.hook_resid_post__trainer_25
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_25
-  - id: blocks.4.hook_resid_post__trainer_26
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_26
-  - id: blocks.4.hook_resid_post__trainer_27
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_27
-  - id: blocks.4.hook_resid_post__trainer_3
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_3
-  - id: blocks.4.hook_resid_post__trainer_4
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_4
-  - id: blocks.4.hook_resid_post__trainer_5
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_5
-  - id: blocks.4.hook_resid_post__trainer_6
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_6
-  - id: blocks.4.hook_resid_post__trainer_7
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_7
-  - id: blocks.4.hook_resid_post__trainer_8
-    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_8
   - id: blocks.4.hook_resid_post__trainer_9
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_9_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_9
+  - id: blocks.4.hook_resid_post__trainer_8
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_8_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_8
+  - id: blocks.4.hook_resid_post__trainer_7
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_7_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_7
+  - id: blocks.4.hook_resid_post__trainer_6
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_6_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_6
+  - id: blocks.4.hook_resid_post__trainer_5
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_5_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_5
+  - id: blocks.4.hook_resid_post__trainer_4
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_4_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_4
+  - id: blocks.4.hook_resid_post__trainer_27
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_27_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_27
+  - id: blocks.4.hook_resid_post__trainer_26
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_26_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_26
+  - id: blocks.4.hook_resid_post__trainer_25
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_25_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_25
+  - id: blocks.4.hook_resid_post__trainer_3
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_3_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_3
+  - id: blocks.4.hook_resid_post__trainer_24
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_24_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_24
+  - id: blocks.4.hook_resid_post__trainer_21
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_21_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_21
+  - id: blocks.4.hook_resid_post__trainer_23
+    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_23_step_final
+    path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_23
 sae_bench_pythia70m_sweep_standard_ctx128_0712:
   conversion_func: dictionary_learning_1
   links:
@@ -11491,94 +12427,138 @@ sae_bench_pythia70m_sweep_standard_ctx128_0712:
   model: pythia-70m
   repo_id: canrager/lm_sae
   saes:
-  - id: blocks.3.hook_resid_post__trainer_0
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_0
-  - id: blocks.3.hook_resid_post__trainer_1
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_1
   - id: blocks.3.hook_resid_post__trainer_10
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_10_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_10
   - id: blocks.3.hook_resid_post__trainer_11
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_11_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_11
-  - id: blocks.3.hook_resid_post__trainer_12
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_12
-  - id: blocks.3.hook_resid_post__trainer_13
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_13
-  - id: blocks.3.hook_resid_post__trainer_14
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_14
-  - id: blocks.3.hook_resid_post__trainer_15
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_15
-  - id: blocks.3.hook_resid_post__trainer_16
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_16
-  - id: blocks.3.hook_resid_post__trainer_17
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_17
-  - id: blocks.3.hook_resid_post__trainer_18
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_18
-  - id: blocks.3.hook_resid_post__trainer_19
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_19
-  - id: blocks.3.hook_resid_post__trainer_2
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_2
-  - id: blocks.3.hook_resid_post__trainer_3
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_3
-  - id: blocks.3.hook_resid_post__trainer_4
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_4
-  - id: blocks.3.hook_resid_post__trainer_5
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_5
-  - id: blocks.3.hook_resid_post__trainer_6
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_6
-  - id: blocks.3.hook_resid_post__trainer_7
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_7
   - id: blocks.3.hook_resid_post__trainer_8
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_8_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_8
+  - id: blocks.3.hook_resid_post__trainer_7
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_7_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_7
+  - id: blocks.3.hook_resid_post__trainer_6
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_6_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_6
+  - id: blocks.3.hook_resid_post__trainer_5
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_5_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_5
+  - id: blocks.3.hook_resid_post__trainer_4
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_4_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_4
+  - id: blocks.3.hook_resid_post__trainer_3
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_3_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_3
+  - id: blocks.3.hook_resid_post__trainer_2
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_2_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_2
+  - id: blocks.3.hook_resid_post__trainer_19
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_19_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_19
+  - id: blocks.3.hook_resid_post__trainer_18
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_18_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_18
+  - id: blocks.3.hook_resid_post__trainer_17
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_17_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_17
+  - id: blocks.3.hook_resid_post__trainer_16
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_16_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_16
+  - id: blocks.3.hook_resid_post__trainer_15
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_15_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_15
+  - id: blocks.3.hook_resid_post__trainer_14
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_14_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_14
+  - id: blocks.3.hook_resid_post__trainer_0
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_0_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_0
+  - id: blocks.3.hook_resid_post__trainer_1
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_1_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_1
+  - id: blocks.3.hook_resid_post__trainer_13
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_13_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_13
+  - id: blocks.3.hook_resid_post__trainer_12
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_12_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_12
   - id: blocks.3.hook_resid_post__trainer_9
+    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_9_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_9
   - id: blocks.4.hook_resid_post__trainer_0
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_0_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_0
-  - id: blocks.4.hook_resid_post__trainer_1
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_1
-  - id: blocks.4.hook_resid_post__trainer_10
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_10
   - id: blocks.4.hook_resid_post__trainer_11
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_11_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_11
-  - id: blocks.4.hook_resid_post__trainer_12
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_12
+  - id: blocks.4.hook_resid_post__trainer_10
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_10_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_10
+  - id: blocks.4.hook_resid_post__trainer_1
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_1_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_1
   - id: blocks.4.hook_resid_post__trainer_13
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_13_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_13
   - id: blocks.4.hook_resid_post__trainer_14
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_14_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_14
-  - id: blocks.4.hook_resid_post__trainer_15
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_15
   - id: blocks.4.hook_resid_post__trainer_16
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_16_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_16
   - id: blocks.4.hook_resid_post__trainer_17
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_17_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_17
   - id: blocks.4.hook_resid_post__trainer_18
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_18_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_18
-  - id: blocks.4.hook_resid_post__trainer_19
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_19
   - id: blocks.4.hook_resid_post__trainer_2
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_2_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_2
   - id: blocks.4.hook_resid_post__trainer_20
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_20_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_20
   - id: blocks.4.hook_resid_post__trainer_21
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_21_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_21
+  - id: blocks.4.hook_resid_post__trainer_12
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_12_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_12
   - id: blocks.4.hook_resid_post__trainer_22
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_22_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_22
-  - id: blocks.4.hook_resid_post__trainer_23
-    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_23
   - id: blocks.4.hook_resid_post__trainer_3
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_3_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_3
   - id: blocks.4.hook_resid_post__trainer_4
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_4_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_4
   - id: blocks.4.hook_resid_post__trainer_5
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_5_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_5
   - id: blocks.4.hook_resid_post__trainer_6
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_6_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_6
   - id: blocks.4.hook_resid_post__trainer_7
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_7_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_7
   - id: blocks.4.hook_resid_post__trainer_8
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_8_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_8
   - id: blocks.4.hook_resid_post__trainer_9
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_9_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_9
+  - id: blocks.4.hook_resid_post__trainer_23
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_23_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_23
+  - id: blocks.4.hook_resid_post__trainer_15
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_15_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_15
+  - id: blocks.4.hook_resid_post__trainer_19
+    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_19_step_final
+    path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_19
 sae_bench_pythia70m_sweep_topk_ctx128_0730:
   conversion_func: dictionary_learning_1
   links:
@@ -11587,101 +12567,149 @@ sae_bench_pythia70m_sweep_topk_ctx128_0730:
   repo_id: canrager/lm_sae
   saes:
   - id: blocks.3.hook_resid_post__trainer_0
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_0_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_0
   - id: blocks.3.hook_resid_post__trainer_1
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_1_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_1
   - id: blocks.3.hook_resid_post__trainer_10
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_10_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_10
   - id: blocks.3.hook_resid_post__trainer_11
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_11_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_11
   - id: blocks.3.hook_resid_post__trainer_12
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_12_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_12
   - id: blocks.3.hook_resid_post__trainer_13
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_13_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_13
   - id: blocks.3.hook_resid_post__trainer_14
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_14_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_14
-  - id: blocks.3.hook_resid_post__trainer_15
-    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_15
-  - id: blocks.3.hook_resid_post__trainer_16
-    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_16
-  - id: blocks.3.hook_resid_post__trainer_17
-    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_17
-  - id: blocks.3.hook_resid_post__trainer_18
-    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_18
+  - id: blocks.3.hook_resid_post__trainer_22
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_22_step_final
+    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_22
   - id: blocks.3.hook_resid_post__trainer_19
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_19_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_19
   - id: blocks.3.hook_resid_post__trainer_2
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_2_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_2
   - id: blocks.3.hook_resid_post__trainer_20
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_20_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_20
   - id: blocks.3.hook_resid_post__trainer_21
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_21_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_21
-  - id: blocks.3.hook_resid_post__trainer_22
-    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_22
+  - id: blocks.3.hook_resid_post__trainer_16
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_16_step_final
+    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_16
   - id: blocks.3.hook_resid_post__trainer_23
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_23_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_23
+  - id: blocks.3.hook_resid_post__trainer_18
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_18_step_final
+    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_18
   - id: blocks.3.hook_resid_post__trainer_3
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_3_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_3
-  - id: blocks.3.hook_resid_post__trainer_4
-    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_4
   - id: blocks.3.hook_resid_post__trainer_5
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_5_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_5
   - id: blocks.3.hook_resid_post__trainer_6
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_6_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_6
   - id: blocks.3.hook_resid_post__trainer_7
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_7_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_7
   - id: blocks.3.hook_resid_post__trainer_8
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_8_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_8
   - id: blocks.3.hook_resid_post__trainer_9
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_9_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_9
-  - id: blocks.4.hook_resid_post__trainer_0
-    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_0
-  - id: blocks.4.hook_resid_post__trainer_1
-    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_1
-  - id: blocks.4.hook_resid_post__trainer_10
-    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_10
-  - id: blocks.4.hook_resid_post__trainer_11
-    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_11
-  - id: blocks.4.hook_resid_post__trainer_12
-    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_12
+  - id: blocks.3.hook_resid_post__trainer_15
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_15_step_final
+    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_15
+  - id: blocks.3.hook_resid_post__trainer_4
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_4_step_final
+    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_4
+  - id: blocks.3.hook_resid_post__trainer_17
+    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_17_step_final
+    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_17
   - id: blocks.4.hook_resid_post__trainer_13
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_13_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_13
   - id: blocks.4.hook_resid_post__trainer_14
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_14_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_14
   - id: blocks.4.hook_resid_post__trainer_15
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_15_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_15
   - id: blocks.4.hook_resid_post__trainer_16
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_16_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_16
   - id: blocks.4.hook_resid_post__trainer_17
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_17_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_17
   - id: blocks.4.hook_resid_post__trainer_18
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_18_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_18
   - id: blocks.4.hook_resid_post__trainer_19
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_19_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_19
   - id: blocks.4.hook_resid_post__trainer_2
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_2_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_2
   - id: blocks.4.hook_resid_post__trainer_20
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_20_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_20
   - id: blocks.4.hook_resid_post__trainer_21
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_21_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_21
   - id: blocks.4.hook_resid_post__trainer_22
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_22_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_22
   - id: blocks.4.hook_resid_post__trainer_23
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_23_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_23
   - id: blocks.4.hook_resid_post__trainer_3
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_3_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_3
   - id: blocks.4.hook_resid_post__trainer_4
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_4_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_4
   - id: blocks.4.hook_resid_post__trainer_5
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_5_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_5
   - id: blocks.4.hook_resid_post__trainer_6
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_6_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_6
   - id: blocks.4.hook_resid_post__trainer_7
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_7_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_7
-  - id: blocks.4.hook_resid_post__trainer_8
-    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_8
+  - id: blocks.4.hook_resid_post__trainer_12
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_12_step_final
+    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_12
+  - id: blocks.4.hook_resid_post__trainer_11
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_11_step_final
+    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_11
+  - id: blocks.4.hook_resid_post__trainer_10
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_10_step_final
+    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_10
+  - id: blocks.4.hook_resid_post__trainer_1
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_1_step_final
+    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_1
+  - id: blocks.4.hook_resid_post__trainer_0
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_0_step_final
+    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_0
   - id: blocks.4.hook_resid_post__trainer_9
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_9_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_9
+  - id: blocks.4.hook_resid_post__trainer_8
+    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_8_step_final
+    path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_8
 llama-3-8b-it-res-jh:
   repo_id: Juliushanhanhan/llama-3-8b-it-res
   model: "meta-llama/Meta-Llama-3-8B-Instruct"


### PR DESCRIPTION
Adding Neuronpedia IDs for SAE Bench SAEs (facilitating dashboard generation). 
Gemma-2b not Gemma-2-2b was listed as the model so fixed that too.