### PR TITLE
fix: Test JumpReLU/Gated SAE and fix sae forward with error term

### DIFF
--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -5,10 +5,10 @@ https://github.com/ArthurConmy/sae/blob/main/sae/model.py
 import json
 import os
 import warnings
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Callable, Literal, Optional, Tuple, TypeVar, Union, overload
 
-T = TypeVar("T", bound="SAE")
 import einops
 import torch
 from jaxtyping import Float
@@ -30,6 +30,8 @@ from sae_lens.toolkit.pretrained_saes_directory import (
 SPARSITY_PATH = "sparsity.safetensors"
 SAE_WEIGHTS_PATH = "sae_weights.safetensors"
 SAE_CFG_PATH = "cfg.json"
+
+T = TypeVar("T", bound="SAE")
 
 
 @dataclass
@@ -158,7 +160,7 @@ class SAE(HookedRootModule):
             self.initialize_weights_jumprelu()
             self.encode = self.encode_jumprelu
         else:
-            raise (ValueError)
+            raise ValueError(f"Invalid architecture: {self.cfg.architecture}")
 
         # handle presence / absence of scaling factor.
         if self.cfg.finetuning_scaling_factor:
@@ -390,78 +392,23 @@ class SAE(HookedRootModule):
         sae_out = self.decode(feature_acts)
 
         # TEMP
-        if self.use_error_term and self.cfg.architecture == "standard":
+        if self.use_error_term:
             with torch.no_grad():
                 # Recompute everything without hooks to get true error term
                 # Otherwise, the output with error term will always equal input, even for causal interventions that affect x_reconstruct
                 # This is in a no_grad context to detach the error, so we can compute SAE feature gradients (eg for attribution patching). See A.3 in https://arxiv.org/pdf/2403.19647.pdf for more detail
                 # NOTE: we can't just use `sae_error = input - x_reconstruct.detach()` or something simpler, since this would mean intervening on features would mean ablating features still results in perfect reconstruction.
-                sae_in = self.process_sae_in(x, apply_hooks=False)
-
-                # "... d_in, d_in d_sae -> ... d_sae",
-                hidden_pre = sae_in @ self.W_enc + self.b_enc
-                feature_acts = self.activation_fn(hidden_pre)
-                x_reconstruct_clean = self.reshape_fn_out(
-                    self.apply_finetuning_scaling_factor(feature_acts) @ self.W_dec
-                    + self.b_dec,
-                    d_head=self.d_head,
-                )
-
-                sae_out = self.run_time_activation_norm_fn_out(sae_out)
+                with _disable_hooks(self):
+                    feature_acts = self.encode(x)
+                    x_reconstruct_clean = self.decode(feature_acts)
                 sae_error = self.hook_sae_error(x - x_reconstruct_clean)
-            return self.hook_sae_output(sae_out + sae_error)
-
-        elif self.use_error_term and self.cfg.architecture == "gated":
-            with torch.no_grad():
-                sae_in = self.process_sae_in(x, apply_hooks=False)
-
-                gating_pre_activation = sae_in @ self.W_enc + self.b_gate
-                active_features = (gating_pre_activation > 0).float()
-
-                # Magnitude path with weight sharing
-                magnitude_pre_activation = self.hook_sae_acts_pre(
-                    sae_in @ (self.W_enc * self.r_mag.exp()) + self.b_mag
-                )
-                feature_magnitudes = self.activation_fn(magnitude_pre_activation)
-                feature_acts_clean = self.hook_sae_acts_post(
-                    active_features * feature_magnitudes
-                )
-                x_reconstruct_clean = self.reshape_fn_out(
-                    self.apply_finetuning_scaling_factor(feature_acts_clean)
-                    @ self.W_dec
-                    + self.b_dec,
-                    d_head=self.d_head,
-                )
-
-                sae_error = self.hook_sae_error(x - x_reconstruct_clean)
-            return self.hook_sae_output(sae_out + sae_error)
-
-        elif self.use_error_term and self.cfg.architecture == "jumprelu":
-            with torch.no_grad():
-                sae_in = self.process_sae_in(x, apply_hooks=False)
-
-                # "... d_in, d_in d_sae -> ... d_sae",
-                hidden_pre = sae_in @ self.W_enc + self.b_enc
-                feature_acts = self.hook_sae_acts_post(
-                    self.activation_fn(hidden_pre) * (hidden_pre > self.threshold)
-                )
-                x_reconstruct_clean = self.reshape_fn_out(
-                    self.apply_finetuning_scaling_factor(feature_acts) @ self.W_dec
-                    + self.b_dec,
-                    d_head=self.d_head,  # TODO(conmy): d_head?! Eh?
-                )
-                sae_error = self.hook_sae_error(x - x_reconstruct_clean)
-            return self.hook_sae_output(sae_out + sae_error)
-        elif self.use_error_term:
-            raise ValueError(f"No error term implemented for {self.cfg.architecture=}")
-
+            sae_out = sae_out + sae_error
         return self.hook_sae_output(sae_out)
 
     def encode_gated(
         self, x: Float[torch.Tensor, "... d_in"]
     ) -> Float[torch.Tensor, "... d_sae"]:
-
-        sae_in = self.process_sae_in(x, apply_hooks=True)
+        sae_in = self.process_sae_in(x)
 
         # Gating path
         gating_pre_activation = sae_in @ self.W_enc + self.b_gate
@@ -483,8 +430,7 @@ class SAE(HookedRootModule):
         """
         Calculate SAE features from inputs
         """
-
-        sae_in = self.process_sae_in(x, apply_hooks=True)
+        sae_in = self.process_sae_in(x)
 
         # "... d_in, d_in d_sae -> ... d_sae",
         hidden_pre = self.hook_sae_acts_pre(sae_in @ self.W_enc + self.b_enc)
@@ -501,7 +447,7 @@ class SAE(HookedRootModule):
         """
         Calculate SAE features from inputs
         """
-        sae_in = self.process_sae_in(x, apply_hooks=True)
+        sae_in = self.process_sae_in(x)
 
         # "... d_in, d_in d_sae -> ... d_sae",
         hidden_pre = self.hook_sae_acts_pre(sae_in @ self.W_enc + self.b_enc)
@@ -510,12 +456,11 @@ class SAE(HookedRootModule):
         return feature_acts
 
     def process_sae_in(
-        self, sae_in: Float[torch.Tensor, "... d_in"], apply_hooks: bool = True
+        self, sae_in: Float[torch.Tensor, "... d_in"]
     ) -> Float[torch.Tensor, "... d_sae"]:
         sae_in = sae_in.to(self.dtype)
         sae_in = self.reshape_fn_in(sae_in)
-        if apply_hooks:
-            sae_in = self.hook_sae_input(sae_in)
+        sae_in = self.hook_sae_input(sae_in)
         sae_in = self.run_time_activation_norm_fn_in(sae_in)
         sae_in = sae_in - (self.b_dec * self.cfg.apply_b_dec_to_input)
         return sae_in
@@ -781,3 +726,20 @@ def get_activation_fn(
         return TopK(k, postact_fn)
     else:
         raise ValueError(f"Unknown activation function: {activation_fn}")
+
+
+_blank_hook = nn.Identity()
+
+
+@contextmanager
+def _disable_hooks(sae: SAE):
+    """
+    Temporarily disable hooks for the SAE. Swaps out all the hooks with a fake modules that does nothing.
+    """
+    try:
+        for hook_name in sae.hook_dict.keys():
+            setattr(sae, hook_name, _blank_hook)
+        yield
+    finally:
+        for hook_name, hook in sae.hook_dict.items():
+            setattr(sae, hook_name, hook)

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -399,8 +399,8 @@ class SAE(HookedRootModule):
                 # This is in a no_grad context to detach the error, so we can compute SAE feature gradients (eg for attribution patching). See A.3 in https://arxiv.org/pdf/2403.19647.pdf for more detail
                 # NOTE: we can't just use `sae_error = input - x_reconstruct.detach()` or something simpler, since this would mean intervening on features would mean ablating features still results in perfect reconstruction.
                 with _disable_hooks(self):
-                    feature_acts = self.encode(x)
-                    x_reconstruct_clean = self.decode(feature_acts)
+                    feature_acts_clean = self.encode(x)
+                    x_reconstruct_clean = self.decode(feature_acts_clean)
                 sae_error = self.hook_sae_error(x - x_reconstruct_clean)
             sae_out = sae_out + sae_error
         return self.hook_sae_output(sae_out)

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -201,14 +201,7 @@ class TrainingSAE(SAE):
     def encode_with_hidden_pre(
         self, x: Float[torch.Tensor, "... d_in"]
     ) -> tuple[Float[torch.Tensor, "... d_sae"], Float[torch.Tensor, "... d_sae"]]:
-
-        x = x.to(self.dtype)
-        x = self.reshape_fn_in(x)  # type: ignore
-        x = self.hook_sae_input(x)
-        x = self.run_time_activation_norm_fn_in(x)
-
-        # apply b_dec_to_input if using that method.
-        sae_in = x - (self.b_dec * self.cfg.apply_b_dec_to_input)
+        sae_in = self.process_sae_in(x)
 
         # "... d_in, d_in d_sae -> ... d_sae",
         hidden_pre = self.hook_sae_acts_pre(sae_in @ self.W_enc + self.b_enc)
@@ -222,11 +215,7 @@ class TrainingSAE(SAE):
     def encode_with_hidden_pre_gated(
         self, x: Float[torch.Tensor, "... d_in"]
     ) -> tuple[Float[torch.Tensor, "... d_sae"], Float[torch.Tensor, "... d_sae"]]:
-
-        x = x.to(self.dtype)
-        x = self.reshape_fn_in(x)  # type: ignore
-        x = self.hook_sae_input(x)
-        x = self.run_time_activation_norm_fn_in(x)
+        sae_in = self.process_sae_in(x)
 
         # apply b_dec_to_input if using that method.
         sae_in = x - (self.b_dec * self.cfg.apply_b_dec_to_input)

--- a/tests/unit/training/test_sae_basic.py
+++ b/tests/unit/training/test_sae_basic.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 import torch
+from torch import nn
 
 from sae_lens.config import LanguageModelSAERunnerConfig
 from sae_lens.sae import SAE
@@ -284,3 +285,120 @@ def test_sae_change_dtype() -> None:
     sae.to(dtype=torch.float16)
     assert sae.dtype == torch.float16
     assert sae.cfg.dtype == "torch.float16"
+
+
+def test_sae_jumprelu_initialization():
+    cfg = build_sae_cfg(architecture="jumprelu", device="cpu")
+    sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
+    assert isinstance(sae.W_enc, nn.Parameter)
+    assert isinstance(sae.W_dec, nn.Parameter)
+    assert isinstance(sae.b_enc, nn.Parameter)
+    assert isinstance(sae.b_dec, nn.Parameter)
+    assert isinstance(sae.threshold, nn.Parameter)
+
+    assert sae.W_enc.shape == (cfg.d_in, cfg.d_sae)
+    assert sae.W_dec.shape == (cfg.d_sae, cfg.d_in)
+    assert sae.b_enc.shape == (cfg.d_sae,)
+    assert sae.b_dec.shape == (cfg.d_in,)
+    assert sae.threshold.shape == (cfg.d_sae,)
+
+    # encoder/decoder should be initialized, everything else should be 0s
+    assert not torch.allclose(sae.W_enc, torch.zeros_like(sae.W_enc))
+    assert not torch.allclose(sae.W_dec, torch.zeros_like(sae.W_dec))
+    assert torch.allclose(sae.b_dec, torch.zeros_like(sae.b_dec))
+    assert torch.allclose(sae.b_enc, torch.zeros_like(sae.b_enc))
+    assert torch.allclose(sae.threshold, torch.zeros_like(sae.threshold))
+
+
+@pytest.mark.parametrize("use_error_term", [True, False])
+def test_sae_jumprelu_forward(use_error_term: bool):
+    cfg = build_sae_cfg(architecture="jumprelu", device="cpu", d_in=2, d_sae=3)
+    sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
+    sae.use_error_term = use_error_term
+    sae.threshold.data = torch.tensor([1.0, 0.5, 0.25])
+    sae.W_enc.data = torch.ones_like(sae.W_enc.data)
+    sae.W_dec.data = torch.ones_like(sae.W_dec.data)
+    sae.b_enc.data = torch.zeros_like(sae.b_enc.data)
+    sae.b_dec.data = torch.zeros_like(sae.b_dec.data)
+
+    sae_in = 0.3 * torch.ones(1, 2)
+    expected_recons = torch.tensor([[1.2, 1.2]])
+    # if we use error term, we should always get the same output as what we put in
+    expected_output = sae_in if use_error_term else expected_recons
+    out, cache = sae.run_with_cache(sae_in)
+    assert torch.allclose(out, expected_output)
+    assert torch.allclose(cache["hook_sae_input"], sae_in)
+    assert torch.allclose(cache["hook_sae_output"], out)
+    assert torch.allclose(cache["hook_sae_recons"], expected_recons)
+    if use_error_term:
+        assert torch.allclose(
+            cache["hook_sae_error"], expected_output - expected_recons
+        )
+
+    assert torch.allclose(cache["hook_sae_acts_pre"], torch.tensor([[0.6, 0.6, 0.6]]))
+    # the threshold of 1.0 should block the first latent from firing
+    assert torch.allclose(cache["hook_sae_acts_post"], torch.tensor([[0.0, 0.6, 0.6]]))
+
+
+def test_sae_gated_initialization():
+    cfg = build_sae_cfg(architecture="gated", device="cpu")
+    sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
+    assert isinstance(sae.W_enc, nn.Parameter)
+    assert isinstance(sae.W_dec, nn.Parameter)
+    assert isinstance(sae.b_dec, nn.Parameter)
+    assert isinstance(sae.b_gate, nn.Parameter)
+    assert isinstance(sae.r_mag, nn.Parameter)
+    assert isinstance(sae.b_mag, nn.Parameter)
+
+    assert sae.W_enc.shape == (cfg.d_in, cfg.d_sae)
+    assert sae.W_dec.shape == (cfg.d_sae, cfg.d_in)
+    assert sae.b_dec.shape == (cfg.d_in,)
+    assert sae.b_gate.shape == (cfg.d_sae,)
+    assert sae.r_mag.shape == (cfg.d_sae,)
+    assert sae.b_mag.shape == (cfg.d_sae,)
+
+    assert not torch.allclose(sae.W_enc, torch.zeros_like(sae.W_enc))
+    assert not torch.allclose(sae.W_dec, torch.zeros_like(sae.W_dec))
+    assert torch.allclose(sae.b_dec, torch.zeros_like(sae.b_dec))
+    assert torch.allclose(sae.b_gate, torch.zeros_like(sae.b_gate))
+    assert torch.allclose(sae.r_mag, torch.zeros_like(sae.r_mag))
+    assert torch.allclose(sae.b_mag, torch.zeros_like(sae.b_mag))
+
+
+@pytest.mark.parametrize("use_error_term", [True, False])
+def test_sae_gated_forward(use_error_term: bool):
+    cfg = build_sae_cfg(architecture="gated", device="cpu", d_in=2, d_sae=3)
+    sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
+    sae.use_error_term = use_error_term
+    sae.W_enc.data = torch.ones_like(sae.W_enc.data)
+    sae.W_dec.data = torch.ones_like(sae.W_dec.data)
+    sae.b_dec.data = torch.zeros_like(sae.b_dec.data)
+    sae.b_gate.data = torch.tensor([-2.0, 0.0, 1.0])
+    sae.r_mag.data = torch.tensor([1.0, 2.0, 3.0])
+    sae.b_mag.data = torch.tensor([1.0, 1.0, 1.0])
+
+    sae_in = torch.tensor([[0.3, 0.3]])
+
+    # expected gating pre acts: [0.6 - 2 = -1.4, 0.6, 0.6 + 1 = 1.6]
+    # so the first gate should be off
+    # mags should be [0.6 * exp(1), 0.6 * exp(2), 0.6 * exp(3)] + b_mag => [2.6310,  5.4334, 13.0513]
+
+    expected_recons = torch.tensor([[18.4848, 18.4848]])
+    # if we use error term, we should always get the same output as what we put in
+    expected_output = sae_in if use_error_term else expected_recons
+    out, cache = sae.run_with_cache(sae_in)
+
+    assert torch.allclose(out, expected_output, atol=1e-3)
+    assert torch.allclose(cache["hook_sae_input"], sae_in, atol=1e-3)
+    assert torch.allclose(cache["hook_sae_output"], out, atol=1e-3)
+    assert torch.allclose(cache["hook_sae_recons"], expected_recons, atol=1e-3)
+
+    assert torch.allclose(
+        cache["hook_sae_acts_pre"], torch.tensor([[2.6310, 5.4334, 13.0513]]), atol=1e-3
+    )
+    # the threshold of 1.0 should block the first latent from firing
+    assert torch.allclose(
+        cache["hook_sae_acts_post"],
+        torch.tensor([[0.0, 5.4334, 13.0513]]),
+        atol=1e-3,
+    )

--- a/tests/unit/training/test_sae_basic.py
+++ b/tests/unit/training/test_sae_basic.py
@@ -199,10 +199,7 @@ def test_sae_save_and_load_from_pretrained_gated(tmp_path: Path) -> None:
 
 
 def test_sae_save_and_load_from_pretrained_topk(tmp_path: Path) -> None:
-    cfg = build_sae_cfg(
-        activation_fn_kwargs={"k": 30},
-        device="cpu",
-    )
+    cfg = build_sae_cfg(activation_fn_kwargs={"k": 30})
     model_path = str(tmp_path)
     sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
     sae_state_dict = sae.state_dict()
@@ -228,10 +225,7 @@ def test_sae_save_and_load_from_pretrained_topk(tmp_path: Path) -> None:
 
 
 def test_sae_seqpos(tmp_path: Path) -> None:
-    cfg = build_sae_cfg(
-        seqpos_slice=(1, 3),
-        device="cpu",
-    )
+    cfg = build_sae_cfg(seqpos_slice=(1, 3))
     model_path = str(tmp_path)
     sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
 
@@ -297,7 +291,7 @@ def test_sae_move_between_devices() -> None:
 
 
 def test_sae_change_dtype() -> None:
-    cfg = build_sae_cfg(device="cpu", dtype="float64")
+    cfg = build_sae_cfg(dtype="float64")
     sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
 
     sae.to(dtype=torch.float16)
@@ -330,7 +324,7 @@ def test_sae_jumprelu_initialization():
 
 @pytest.mark.parametrize("use_error_term", [True, False])
 def test_sae_jumprelu_forward(use_error_term: bool):
-    cfg = build_sae_cfg(architecture="jumprelu", device="cpu", d_in=2, d_sae=3)
+    cfg = build_sae_cfg(architecture="jumprelu", d_in=2, d_sae=3)
     sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
     sae.use_error_term = use_error_term
     sae.threshold.data = torch.tensor([1.0, 0.5, 0.25])
@@ -359,7 +353,7 @@ def test_sae_jumprelu_forward(use_error_term: bool):
 
 
 def test_sae_gated_initialization():
-    cfg = build_sae_cfg(architecture="gated", device="cpu")
+    cfg = build_sae_cfg(architecture="gated")
     sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
     assert isinstance(sae.W_enc, nn.Parameter)
     assert isinstance(sae.W_dec, nn.Parameter)
@@ -385,7 +379,7 @@ def test_sae_gated_initialization():
 
 @pytest.mark.parametrize("use_error_term", [True, False])
 def test_sae_gated_forward(use_error_term: bool):
-    cfg = build_sae_cfg(architecture="gated", device="cpu", d_in=2, d_sae=3)
+    cfg = build_sae_cfg(architecture="gated", d_in=2, d_sae=3)
     sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
     sae.use_error_term = use_error_term
     sae.W_enc.data = torch.ones_like(sae.W_enc.data)


### PR DESCRIPTION
# Description

This PR adds test coverage to the JumpReLU and GatedSAE encode methods.

In doing this, I realized there's a lot of duplication  between all the encode variants and cleaned that up as well. I think there were some potential minor bugs in this duplication, for instance in `forward()`, when adding error term, we called `run_time_activation_norm_fn_out()`  after `reshape_fn_out()`, but we do the opposite in `decode()`.

It looks like most of the duplication between the `error` section of `forward()` and the normal `encode() / decode()` was there just to avoid triggering hooks, so I added a contextmanager `_disable_hooks()` which is used to disable hooks in this branch of the code while reusing our existing `encode() / decode()` methods. This should mean we don't need to worry about these duplicated codepaths diverging and causing bugs. 

If the refactor is out of scope, I can revert the changes to `sae.py` and just leave the test coverage.

Fixes #323 
Fixes #326 

Note: after investigating #326, it looks like this is caused by a bad copy/paste in the duplicated code for jumprelu forward, where we're accidentally including the hooks: https://github.com/jbloomAus/SAELens/blob/main/sae_lens/sae.py#L479.

## Type of change

Please delete options that are not relevant.

- [x] refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)