### PR TITLE
Dedupe code to get config

### DIFF
--- a/docs/generate_sae_table.py
+++ b/docs/generate_sae_table.py
@@ -57,8 +57,8 @@ def generate_sae_table():
         markdown_content += "\n"
 
         for info in tqdm(model_info["saes"]):
-            folder_name = info["path"]
             # can remove this by explicitly overriding config in yaml. Do this later.
+            folder_name = info["path"]
             cfg = get_sae_config(
                 model_info,
                 folder_name=folder_name,

--- a/docs/generate_sae_table.py
+++ b/docs/generate_sae_table.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 
 from sae_lens import SAEConfig
 from sae_lens.toolkit.pretrained_sae_loaders import (
-    get_connor_rob_hook_z_layer_config,
+    get_connor_rob_hook_z_config,
     get_dictionary_learning_config_1,
     get_gemma_2_config,
     get_sae_config_from_hf,
@@ -72,7 +72,7 @@ def generate_sae_table():
             folder_name = info["path"]
             # can remove this by explicitly overriding config in yaml. Do this later.
             if model_info["conversion_func"] == "connor_rob_hook_z":
-                cfg = get_connor_rob_hook_z_layer_config(
+                cfg = get_connor_rob_hook_z_config(
                     repo_id, folder_name=folder_name, device=None
                 )
                 cfg = handle_config_defaulting(cfg)

--- a/docs/generate_sae_table.py
+++ b/docs/generate_sae_table.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 
 from sae_lens import SAEConfig
 from sae_lens.toolkit.pretrained_sae_loaders import (
-    get_sae_config
+    get_sae_config,
     handle_config_defaulting,
 )
 
@@ -56,11 +56,11 @@ def generate_sae_table():
         markdown_content += "\n"
 
         for info in tqdm(model_info["saes"]):
-            repo_id = model_info["repo_id"]
             folder_name = info["path"]
             # can remove this by explicitly overriding config in yaml. Do this later.
             cfg = get_sae_config(
-                model_info, folder_name=folder_name,
+                model_info,
+                folder_name=folder_name,
             )
             cfg = handle_config_defaulting(cfg)
             cfg = SAEConfig.from_dict(cfg).to_dict()

--- a/docs/generate_sae_table.py
+++ b/docs/generate_sae_table.py
@@ -43,9 +43,9 @@ def generate_sae_table():
     markdown_content += "*This file contains the contents of `sae_lens/pretrained_saes.yaml` in Markdown*\n\n"
 
     # Generate content for each model
-    for model_name, model_info in tqdm(data.items()):
+    for release, model_info in tqdm(data.items()):
         repo_link = f"https://huggingface.co/{model_info['repo_id']}"
-        markdown_content += f"## [{model_name}]({repo_link})\n\n"
+        markdown_content += f"## [{release}]({repo_link})\n\n"
         markdown_content += f"- **Huggingface Repo**: {model_info['repo_id']}\n"
         markdown_content += f"- **model**: {model_info['model']}\n"
 
@@ -58,10 +58,10 @@ def generate_sae_table():
 
         for info in tqdm(model_info["saes"]):
             # can remove this by explicitly overriding config in yaml. Do this later.
-            folder_name = info["path"]
+            sae_id = info["id"]
             cfg = get_sae_config(
-                model_info,
-                folder_name=folder_name,
+                release,
+                sae_id=sae_id,
                 options=SAEConfigLoadOptions(),
             )
             cfg = handle_config_defaulting(cfg)

--- a/docs/generate_sae_table.py
+++ b/docs/generate_sae_table.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 
 from sae_lens import SAEConfig
 from sae_lens.toolkit.pretrained_sae_loaders import (
-    SAEConfigParams,
+    SAEConfigLoadOptions,
     get_sae_config,
     handle_config_defaulting,
 )
@@ -62,7 +62,7 @@ def generate_sae_table():
             cfg = get_sae_config(
                 model_info,
                 folder_name=folder_name,
-                params=SAEConfigParams(),
+                options=SAEConfigLoadOptions(),
             )
             cfg = handle_config_defaulting(cfg)
             cfg = SAEConfig.from_dict(cfg).to_dict()

--- a/docs/generate_sae_table.py
+++ b/docs/generate_sae_table.py
@@ -68,11 +68,10 @@ def generate_sae_table():
         #     )
 
         for info in tqdm(model_info["saes"]):
-
+            repo_id = model_info["repo_id"]
+            folder_name = info["path"]
             # can remove this by explicitly overriding config in yaml. Do this later.
             if model_info["conversion_func"] == "connor_rob_hook_z":
-                repo_id = model_info["repo_id"]
-                folder_name = info["path"]
                 cfg = get_connor_rob_hook_z_layer_config(
                     repo_id, folder_name=folder_name, device=None
                 )
@@ -80,22 +79,18 @@ def generate_sae_table():
                 cfg = SAEConfig.from_dict(cfg).to_dict()
                 info.update(cfg)
             elif model_info["conversion_func"] == "dictionary_learning_1":
-                repo_id = model_info["repo_id"]
-                folder_name = info["path"]
                 cfg = get_dictionary_learning_config_1(repo_id, folder_name=folder_name)
                 cfg = SAEConfig.from_dict(cfg).to_dict()
 
             elif model_info["conversion_func"] == "gemma_2":
-                repo_id = model_info["repo_id"]
-                folder_name = info["path"]
-                cfg = get_gemma_2_config(repo_id, folder_name)
+                cfg = get_gemma_2_config(repo_id, folder_name=folder_name)
                 cfg = handle_config_defaulting(cfg)
                 cfg = SAEConfig.from_dict(cfg).to_dict()
                 info.update(cfg)
             else:
                 cfg = get_sae_config_from_hf(
-                    model_info["repo_id"],
-                    info["path"],
+                    repo_id,
+                    folder_name=folder_name,
                 )
                 cfg = handle_config_defaulting(cfg)
                 cfg = SAEConfig.from_dict(cfg).to_dict()

--- a/docs/generate_sae_table.py
+++ b/docs/generate_sae_table.py
@@ -7,10 +7,7 @@ from tqdm import tqdm
 
 from sae_lens import SAEConfig
 from sae_lens.toolkit.pretrained_sae_loaders import (
-    get_connor_rob_hook_z_config,
-    get_dictionary_learning_config_1,
-    get_gemma_2_config,
-    get_sae_config_from_hf,
+    get_sae_config
     handle_config_defaulting,
 )
 
@@ -18,7 +15,6 @@ INCLUDED_CFG = [
     "id",
     "architecture",
     "neuronpedia",
-    # "model_name",
     "hook_name",
     "hook_layer",
     "d_sae",
@@ -59,55 +55,27 @@ def generate_sae_table():
 
         markdown_content += "\n"
 
-        # get the config
-
-        # for sae_info in model_info["saes"]:
-        #     sae_cfg = get_sae_config_from_hf(
-        #         model_info["repo_id"],
-        #         sae_info["path"],
-        #     )
-
         for info in tqdm(model_info["saes"]):
             repo_id = model_info["repo_id"]
             folder_name = info["path"]
             # can remove this by explicitly overriding config in yaml. Do this later.
-            if model_info["conversion_func"] == "connor_rob_hook_z":
-                cfg = get_connor_rob_hook_z_config(
-                    repo_id, folder_name=folder_name, device=None
-                )
-                cfg = handle_config_defaulting(cfg)
-                cfg = SAEConfig.from_dict(cfg).to_dict()
-                info.update(cfg)
-            elif model_info["conversion_func"] == "dictionary_learning_1":
-                cfg = get_dictionary_learning_config_1(repo_id, folder_name=folder_name)
-                cfg = SAEConfig.from_dict(cfg).to_dict()
-
-            elif model_info["conversion_func"] == "gemma_2":
-                cfg = get_gemma_2_config(repo_id, folder_name=folder_name)
-                cfg = handle_config_defaulting(cfg)
-                cfg = SAEConfig.from_dict(cfg).to_dict()
-                info.update(cfg)
-            else:
-                cfg = get_sae_config_from_hf(
-                    repo_id,
-                    folder_name=folder_name,
-                )
-                cfg = handle_config_defaulting(cfg)
-                cfg = SAEConfig.from_dict(cfg).to_dict()
+            cfg = get_sae_config(
+                model_info, folder_name=folder_name,
+            )
+            cfg = handle_config_defaulting(cfg)
+            cfg = SAEConfig.from_dict(cfg).to_dict()
+            info.update(cfg)
 
             if "neuronpedia" not in info.keys():
                 info["neuronpedia"] = None
 
             info.update(cfg)
 
-        # cfg_to_in
-        # Create DataFrame for SAEs
         df = pd.DataFrame(model_info["saes"])
 
         # Keep only 'id' and 'path' columns
         df = df[INCLUDED_CFG]
 
-        # Generate Markdown table
         table = df.to_markdown(index=False)
         markdown_content += table + "\n\n"
 

--- a/docs/generate_sae_table.py
+++ b/docs/generate_sae_table.py
@@ -7,6 +7,7 @@ from tqdm import tqdm
 
 from sae_lens import SAEConfig
 from sae_lens.toolkit.pretrained_sae_loaders import (
+    SAEConfigParams,
     get_sae_config,
     handle_config_defaulting,
 )
@@ -61,6 +62,7 @@ def generate_sae_table():
             cfg = get_sae_config(
                 model_info,
                 folder_name=folder_name,
+                params=SAEConfigParams(),
             )
             cfg = handle_config_defaulting(cfg)
             cfg = SAEConfig.from_dict(cfg).to_dict()

--- a/docs/generate_sae_table.py
+++ b/docs/generate_sae_table.py
@@ -64,7 +64,6 @@ def generate_sae_table():
             )
             cfg = handle_config_defaulting(cfg)
             cfg = SAEConfig.from_dict(cfg).to_dict()
-            info.update(cfg)
 
             if "neuronpedia" not in info.keys():
                 info["neuronpedia"] = None

--- a/docs/generate_sae_table.py
+++ b/docs/generate_sae_table.py
@@ -9,6 +9,7 @@ from tqdm import tqdm
 
 from sae_lens import SAEConfig
 from sae_lens.toolkit.pretrained_sae_loaders import (
+    get_connor_rob_hook_z_layer_config,
     get_dictionary_learning_config_1,
     get_gemma_2_config,
     get_sae_config_from_hf,
@@ -74,30 +75,9 @@ def generate_sae_table():
             if model_info["conversion_func"] == "connor_rob_hook_z":
                 repo_id = model_info["repo_id"]
                 folder_name = info["path"]
-                config_path = folder_name.split(".pt")[0] + "_cfg.json"
-                config_path = hf_hub_download(repo_id, config_path)
-                old_cfg_dict = json.load(open(config_path, "r"))
-
-                cfg = {
-                    "architecture": "standard",
-                    "d_in": old_cfg_dict["act_size"],
-                    "d_sae": old_cfg_dict["dict_size"],
-                    "dtype": "float32",
-                    "device": "cpu",
-                    "model_name": "gpt2-small",
-                    "hook_name": old_cfg_dict["act_name"],
-                    "hook_layer": old_cfg_dict["layer"],
-                    "hook_head_index": None,
-                    "activation_fn_str": "relu",
-                    "apply_b_dec_to_input": True,
-                    "finetuning_scaling_factor": False,
-                    "sae_lens_training_version": None,
-                    "prepend_bos": True,
-                    "dataset_path": "Skylion007/openwebtext",
-                    "context_size": 128,
-                    "normalize_activations": "none",
-                    "dataset_trust_remote_code": True,
-                }
+                cfg = get_connor_rob_hook_z_layer_config(
+                    repo_id, folder_name=folder_name, device=None
+                )
                 cfg = handle_config_defaulting(cfg)
                 cfg = SAEConfig.from_dict(cfg).to_dict()
                 info.update(cfg)

--- a/docs/generate_sae_table.py
+++ b/docs/generate_sae_table.py
@@ -1,10 +1,8 @@
 # type: ignore
-import json
 from pathlib import Path
 
 import pandas as pd
 import yaml
-from huggingface_hub import hf_hub_download
 from tqdm import tqdm
 
 from sae_lens import SAEConfig
@@ -84,12 +82,7 @@ def generate_sae_table():
             elif model_info["conversion_func"] == "dictionary_learning_1":
                 repo_id = model_info["repo_id"]
                 folder_name = info["path"]
-                config_path = hf_hub_download(
-                    repo_id=repo_id,
-                    filename=f"{folder_name}/config.json",
-                )
-                with open(config_path, "r") as f:
-                    cfg = get_dictionary_learning_config_1(json.load(f))
+                cfg = get_dictionary_learning_config_1(repo_id, folder_name=folder_name)
                 cfg = SAEConfig.from_dict(cfg).to_dict()
 
             elif model_info["conversion_func"] == "gemma_2":

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -19,6 +19,7 @@ from transformer_lens.hook_points import HookedRootModule, HookPoint
 from sae_lens.config import DTYPE_MAP
 from sae_lens.toolkit.pretrained_sae_loaders import (
     NAMED_PRETRAINED_SAE_LOADERS,
+    get_conversion_loader_name,
     handle_config_defaulting,
     read_sae_from_disk,
 )
@@ -708,13 +709,7 @@ class SAE(HookedRootModule):
             sae_info.neuronpedia_id[sae_id] if sae_info is not None else None
         )
 
-        conversion_loader_name = "sae_lens"
-        if sae_info is not None and sae_info.conversion_func is not None:
-            conversion_loader_name = sae_info.conversion_func
-        if conversion_loader_name not in NAMED_PRETRAINED_SAE_LOADERS:
-            raise ValueError(
-                f"Conversion func {conversion_loader_name} not found in NAMED_PRETRAINED_SAE_LOADERS."
-            )
+        conversion_loader_name = get_conversion_loader_name(sae_info)
         conversion_loader = NAMED_PRETRAINED_SAE_LOADERS[conversion_loader_name]
 
         cfg_dict, state_dict, log_sparsities = conversion_loader(

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -703,8 +703,6 @@ class SAE(HookedRootModule):
                 + value_suffix
             )
         sae_info = sae_directory.get(release, None)
-        hf_repo_id = sae_info.repo_id if sae_info is not None else release
-        hf_path = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
         config_overrides = sae_info.config_overrides if sae_info is not None else None
         neuronpedia_id = (
             sae_info.neuronpedia_id[sae_id] if sae_info is not None else None
@@ -720,8 +718,8 @@ class SAE(HookedRootModule):
         conversion_loader = NAMED_PRETRAINED_SAE_LOADERS[conversion_loader_name]
 
         cfg_dict, state_dict, log_sparsities = conversion_loader(
-            repo_id=hf_repo_id,
-            folder_name=hf_path,
+            release,
+            sae_id=sae_id,
             device=device,
             force_download=False,
             cfg_overrides=config_overrides,

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -130,78 +130,15 @@ def handle_config_defaulting(cfg_dict: dict[str, Any]) -> dict[str, Any]:
     return cfg_dict
 
 
-def connor_rob_hook_z_loader(
-    repo_id: str,
-    folder_name: str,
-    device: Optional[str] = None,
-    force_download: bool = False,
-    cfg_overrides: Optional[dict[str, Any]] = None,
-) -> tuple[dict[str, Any], dict[str, torch.Tensor], None]:
-
-    file_path = hf_hub_download(
-        repo_id=repo_id, filename=folder_name, force_download=force_download
-    )
+def get_connor_rob_hook_z_config(
+    repo_id: str, folder_name: str, device: Optional[str]
+) -> dict[str, Any]:
     config_path = folder_name.split(".pt")[0] + "_cfg.json"
     config_path = hf_hub_download(repo_id, config_path)
+
     old_cfg_dict = json.load(open(config_path, "r"))
 
-    weights = torch.load(file_path, map_location=device)
-    # weights_filename = f"{folder_name}/sae_weights.safetensors"
-    # sae_path = hf_hub_download(
-    #     repo_id=repo_id, filename=weights_filename, force_download=force_download
-    # )
-    # if device is None:
-    #     device = "cuda" if torch.cuda.is_available() else "cpu"
-
-    # return load_pretrained_sae_lens_sae_components(cfg_path, sae_path, device)
-
-    # old_cfg_dict = {
-    #     "seed": 49,
-    #     "batch_size": 4096,
-    #     "buffer_mult": 384,
-    #     "lr": 0.0012,
-    #     "num_tokens": 2000000000,
-    #     "l1_coeff": 1.8,
-    #     "beta1": 0.9,
-    #     "beta2": 0.99,
-    #     "dict_mult": 32,
-    #     "seq_len": 128,
-    #     "enc_dtype": "fp32",
-    #     "model_name": "gpt2-small",
-    #     "site": "z",
-    #     "layer": 0,
-    #     "device": "cuda",
-    #     "reinit": "reinit",
-    #     "head": "cat",
-    #     "concat_heads": True,
-    #     "resample_scheme": "anthropic",
-    #     "anthropic_neuron_resample_scale": 0.2,
-    #     "dead_direction_cutoff": 1e-06,
-    #     "re_init_every": 25000,
-    #     "anthropic_resample_last": 12500,
-    #     "resample_factor": 0.01,
-    #     "num_resamples": 4,
-    #     "wandb_project_name": "gpt2-L0-20240117",
-    #     "wandb_entity": "ckkissane",
-    #     "save_state_dict_every": 50000,
-    #     "b_dec_init": "zeros",
-    #     "sched_type": "cosine_warmup",
-    #     "sched_epochs": 1000,
-    #     "sched_lr_factor": 0.1,
-    #     "sched_warmup_epochs": 1000,
-    #     "sched_finish": True,
-    #     "anthropic_resample_batches": 100,
-    #     "eval_every": 1000,
-    #     "model_batch_size": 512,
-    #     "buffer_size": 1572864,
-    #     "buffer_batches": 12288,
-    #     "act_name": "blocks.0.attn.hook_z",
-    #     "act_size": 768,
-    #     "dict_size": 24576,
-    #     "name": "gpt2-small_0_24576_z",
-    # }
-
-    cfg_dict = {
+    return {
         "architecture": "standard",
         "d_in": old_cfg_dict["act_size"],
         "d_sae": old_cfg_dict["dict_size"],
@@ -221,6 +158,24 @@ def connor_rob_hook_z_loader(
         "normalize_activations": "none",
         "dataset_trust_remote_code": True,
     }
+
+
+def connor_rob_hook_z_loader(
+    repo_id: str,
+    folder_name: str,
+    device: Optional[str] = None,
+    force_download: bool = False,
+    cfg_overrides: Optional[dict[str, Any]] = None,
+) -> tuple[dict[str, Any], dict[str, torch.Tensor], None]:
+
+    file_path = hf_hub_download(
+        repo_id=repo_id, filename=folder_name, force_download=force_download
+    )
+    cfg_dict = get_connor_rob_hook_z_config(
+        repo_id, folder_name=folder_name, device=device
+    )
+
+    weights = torch.load(file_path, map_location=device)
 
     return cfg_dict, weights, None
 

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -47,10 +47,6 @@ def sae_lens_loader(
     """
     Get's SAEs from HF, loads them.
     """
-    saes_directory = get_pretrained_saes_directory()
-    sae_info = saes_directory.get(release, None)
-    repo_id = sae_info.repo_id if sae_info is not None else release
-    folder_name = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
     options = SAEConfigLoadOptions(
         force_download=force_download,
     )
@@ -60,6 +56,11 @@ def sae_lens_loader(
         cfg_dict.update(cfg_overrides)
     cfg_dict["device"] = device
     cfg_dict = handle_config_defaulting(cfg_dict)
+
+    saes_directory = get_pretrained_saes_directory()
+    sae_info = saes_directory.get(release, None)
+    repo_id = sae_info.repo_id if sae_info is not None else release
+    folder_name = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
 
     weights_filename = f"{folder_name}/sae_weights.safetensors"
     sae_path = hf_hub_download(
@@ -185,10 +186,6 @@ def connor_rob_hook_z_loader(
     force_download: bool = False,
     cfg_overrides: Optional[dict[str, Any]] = None,
 ) -> tuple[dict[str, Any], dict[str, torch.Tensor], None]:
-    saes_directory = get_pretrained_saes_directory()
-    sae_info = saes_directory.get(release, None)
-    repo_id = sae_info.repo_id if sae_info is not None else release
-    folder_name = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
     options = SAEConfigLoadOptions(
         force_download=force_download,
     )
@@ -197,6 +194,11 @@ def connor_rob_hook_z_loader(
         sae_id=sae_id,
         options=options,
     )
+
+    saes_directory = get_pretrained_saes_directory()
+    sae_info = saes_directory.get(release, None)
+    repo_id = sae_info.repo_id if sae_info is not None else release
+    folder_name = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
 
     file_path = hf_hub_download(
         repo_id=repo_id, filename=folder_name, force_download=force_download
@@ -343,10 +345,6 @@ def gemma_2_sae_loader(
     """
     Custom loader for Gemma 2 SAEs.
     """
-    saes_directory = get_pretrained_saes_directory()
-    sae_info = saes_directory.get(release, None)
-    repo_id = sae_info.repo_id if sae_info is not None else release
-    folder_name = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
     options = SAEConfigLoadOptions(
         d_sae_override=d_sae_override,
         layer_override=layer_override,
@@ -361,6 +359,11 @@ def gemma_2_sae_loader(
     # Apply overrides if provided
     if cfg_overrides is not None:
         cfg_dict.update(cfg_overrides)
+
+    saes_directory = get_pretrained_saes_directory()
+    sae_info = saes_directory.get(release, None)
+    repo_id = sae_info.repo_id if sae_info is not None else release
+    folder_name = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
 
     # Download the SAE weights
     sae_path = hf_hub_download(
@@ -487,16 +490,17 @@ def dictionary_learning_sae_loader_1(
     """
     Suitable for SAEs from https://huggingface.co/canrager/lm_sae.
     """
-    saes_directory = get_pretrained_saes_directory()
-    sae_info = saes_directory.get(release, None)
-    repo_id = sae_info.repo_id if sae_info is not None else release
-    folder_name = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
     options = SAEConfigLoadOptions(
         force_download=force_download,
     )
     cfg_dict = get_sae_config(release, sae_id=sae_id, options=options)
     if cfg_overrides:
         cfg_dict.update(cfg_overrides)
+
+    saes_directory = get_pretrained_saes_directory()
+    sae_info = saes_directory.get(release, None)
+    repo_id = sae_info.repo_id if sae_info is not None else release
+    folder_name = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
 
     encoder_path = hf_hub_download(
         repo_id=repo_id, filename=f"{folder_name}/ae.pt", force_download=force_download

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -12,6 +12,7 @@ from safetensors import safe_open
 from sae_lens.toolkit.pretrained_saes_directory import (
     PretrainedSAELookup,
     get_pretrained_saes_directory,
+    get_repo_id_and_folder_name,
 )
 
 
@@ -57,10 +58,7 @@ def sae_lens_loader(
     cfg_dict["device"] = device
     cfg_dict = handle_config_defaulting(cfg_dict)
 
-    saes_directory = get_pretrained_saes_directory()
-    sae_info = saes_directory.get(release, None)
-    repo_id = sae_info.repo_id if sae_info is not None else release
-    folder_name = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
+    repo_id, folder_name = get_repo_id_and_folder_name(release, sae_id=sae_id)
 
     weights_filename = f"{folder_name}/sae_weights.safetensors"
     sae_path = hf_hub_download(
@@ -195,10 +193,7 @@ def connor_rob_hook_z_loader(
         options=options,
     )
 
-    saes_directory = get_pretrained_saes_directory()
-    sae_info = saes_directory.get(release, None)
-    repo_id = sae_info.repo_id if sae_info is not None else release
-    folder_name = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
+    repo_id, folder_name = get_repo_id_and_folder_name(release, sae_id=sae_id)
 
     file_path = hf_hub_download(
         repo_id=repo_id, filename=folder_name, force_download=force_download
@@ -360,10 +355,7 @@ def gemma_2_sae_loader(
     if cfg_overrides is not None:
         cfg_dict.update(cfg_overrides)
 
-    saes_directory = get_pretrained_saes_directory()
-    sae_info = saes_directory.get(release, None)
-    repo_id = sae_info.repo_id if sae_info is not None else release
-    folder_name = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
+    repo_id, folder_name = get_repo_id_and_folder_name(release, sae_id=sae_id)
 
     # Download the SAE weights
     sae_path = hf_hub_download(
@@ -473,8 +465,7 @@ def get_sae_config(
 ) -> dict[str, Any]:
     saes_directory = get_pretrained_saes_directory()
     sae_info = saes_directory.get(release, None)
-    repo_id = sae_info.repo_id if sae_info is not None else release
-    folder_name = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
+    repo_id, folder_name = get_repo_id_and_folder_name(release, sae_id=sae_id)
     conversion_loader_name = get_conversion_loader_name(sae_info)
     config_getter = NAMED_PRETRAINED_SAE_CONFIG_GETTERS[conversion_loader_name]
     return config_getter(repo_id, folder_name=folder_name, options=options)
@@ -497,10 +488,7 @@ def dictionary_learning_sae_loader_1(
     if cfg_overrides:
         cfg_dict.update(cfg_overrides)
 
-    saes_directory = get_pretrained_saes_directory()
-    sae_info = saes_directory.get(release, None)
-    repo_id = sae_info.repo_id if sae_info is not None else release
-    folder_name = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
+    repo_id, folder_name = get_repo_id_and_folder_name(release, sae_id=sae_id)
 
     encoder_path = hf_hub_download(
         repo_id=repo_id, filename=f"{folder_name}/ae.pt", force_download=force_download

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -473,20 +473,8 @@ def get_sae_config(
     repo_id = sae_info.repo_id if sae_info is not None else release
     folder_name = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
     conversion_loader_name = get_conversion_loader_name(sae_info)
-
-    if conversion_loader_name == "connor_rob_hook_z":
-        cfg = get_connor_rob_hook_z_config(
-            repo_id, folder_name=folder_name, options=options
-        )
-    elif conversion_loader_name == "dictionary_learning_1":
-        cfg = get_dictionary_learning_config_1(
-            repo_id, folder_name=folder_name, options=options
-        )
-    elif conversion_loader_name == "gemma_2":
-        cfg = get_gemma_2_config(repo_id, folder_name=folder_name, options=options)
-    else:
-        cfg = get_sae_config_from_hf(repo_id, folder_name=folder_name, options=options)
-    return cfg
+    config_getter = NAMED_PRETRAINED_SAE_CONFIG_GETTERS[conversion_loader_name]
+    return config_getter(repo_id, folder_name=folder_name, options=options)
 
 
 def dictionary_learning_sae_loader_1(
@@ -549,4 +537,11 @@ NAMED_PRETRAINED_SAE_LOADERS: dict[str, PretrainedSaeLoader] = {
     "connor_rob_hook_z": connor_rob_hook_z_loader,  # type: ignore
     "gemma_2": gemma_2_sae_loader,
     "dictionary_learning_1": dictionary_learning_sae_loader_1,
+}
+
+NAMED_PRETRAINED_SAE_CONFIG_GETTERS = {
+    "sae_lens": get_sae_config_from_hf,
+    "connor_rob_hook_z": get_connor_rob_hook_z_config,
+    "gemma_2": get_gemma_2_config,
+    "dictionary_learning_1": get_dictionary_learning_config_1,
 }

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -415,6 +415,21 @@ def get_dictionary_learning_config_1(
         "neuronpedia_id": None,
     }
 
+def get_sae_config(model_info: dict[str, Any], folder_name: str, **kwargs: Any) -> dict[str, Any]:
+    repo_id = model_info["repo_id"]
+    conversion_func = model_info["conversion_func"]
+
+    if conversion_func == "connor_rob_hook_z":
+        cfg = get_connor_rob_hook_z_config(
+            repo_id, folder_name=folder_name, device=None
+        )
+    elif conversion_func == "dictionary_learning_1":
+        cfg = get_dictionary_learning_config_1(repo_id, folder_name=folder_name)
+    elif conversion_func == "gemma_2":
+        cfg = get_gemma_2_config(repo_id, folder_name=folder_name)
+    else:
+        cfg = get_sae_config_from_hf(repo_id, folder_name=folder_name)
+    return cfg
 
 def dictionary_learning_sae_loader_1(
     repo_id: str,

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -101,10 +101,9 @@ def get_sae_config_from_hf(
     Returns:
         Dict[str, Any]: The configuration dictionary for the SAE.
     """
-    force_download = params.force_download
     cfg_filename = f"{folder_name}/cfg.json"
     cfg_path = hf_hub_download(
-        repo_id=repo_id, filename=cfg_filename, force_download=force_download
+        repo_id=repo_id, filename=cfg_filename, force_download=params.force_download
     )
 
     with open(cfg_path, "r") as f:
@@ -243,9 +242,6 @@ def get_gemma_2_config(
     folder_name: str,
     params: SAEConfigParams,
 ) -> Dict[str, Any]:
-    d_sae_override = params.d_sae_override
-    layer_override = params.layer_override
-
     # Detect width from folder_name
     width_map = {
         "width_4k": 4096,
@@ -260,6 +256,7 @@ def get_gemma_2_config(
     d_sae = next(
         (width for key, width in width_map.items() if key in folder_name), None
     )
+    d_sae_override = params.d_sae_override
     if d_sae is None:
         if not d_sae_override:
             raise ValueError("Width not found in folder_name and no override provided.")
@@ -267,7 +264,7 @@ def get_gemma_2_config(
 
     # Detect layer from folder_name
     match = re.search(r"layer_(\d+)", folder_name)
-    layer = int(match.group(1)) if match else layer_override
+    layer = int(match.group(1)) if match else params.layer_override
     if layer is None:
         if "embedding" in folder_name:
             layer = 0
@@ -408,11 +405,10 @@ def get_dictionary_learning_config_1(
     """
     Suitable for SAEs from https://huggingface.co/canrager/lm_sae.
     """
-    force_download = params.force_download
     config_path = hf_hub_download(
         repo_id=repo_id,
         filename=f"{folder_name}/config.json",
-        force_download=force_download,
+        force_download=params.force_download,
     )
     with open(config_path, "r") as f:
         config = json.load(f)

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -32,11 +32,10 @@ def sae_lens_loader(
     """
     Get's SAEs from HF, loads them.
     """
+    model_info = {"repo_id": repo_id, "conversion_func": "sae_lens"}
     # Get the config
-    cfg_dict = get_sae_config_from_hf(
-        repo_id,
-        folder_name,
-        force_download,
+    cfg_dict = get_sae_config(
+        model_info, folder_name=folder_name, force_download=force_download
     )
     # Apply overrides if provided
     if cfg_overrides is not None:
@@ -77,7 +76,7 @@ def sae_lens_loader(
 def get_sae_config_from_hf(
     repo_id: str,
     folder_name: str,
-    force_download: bool = False,
+    **kwargs: Any,
 ) -> Dict[str, Any]:
     """
     Retrieve the configuration for a Sparse Autoencoder (SAE) from a Hugging Face repository.
@@ -91,6 +90,7 @@ def get_sae_config_from_hf(
     Returns:
         Dict[str, Any]: The configuration dictionary for the SAE.
     """
+    force_download = kwargs.get("force_download", False)
     cfg_filename = f"{folder_name}/cfg.json"
     cfg_path = hf_hub_download(
         repo_id=repo_id, filename=cfg_filename, force_download=force_download
@@ -131,8 +131,9 @@ def handle_config_defaulting(cfg_dict: dict[str, Any]) -> dict[str, Any]:
 
 
 def get_connor_rob_hook_z_config(
-    repo_id: str, folder_name: str, device: Optional[str]
+    repo_id: str, folder_name: str, **kwargs: Any
 ) -> dict[str, Any]:
+    device = kwargs.get("device", None)
     config_path = folder_name.split(".pt")[0] + "_cfg.json"
     config_path = hf_hub_download(repo_id, config_path)
 
@@ -167,14 +168,20 @@ def connor_rob_hook_z_loader(
     force_download: bool = False,
     cfg_overrides: Optional[dict[str, Any]] = None,
 ) -> tuple[dict[str, Any], dict[str, torch.Tensor], None]:
+    model_info = {
+        "repo_id": repo_id,
+        "conversion_func": "connor_rob_hook_z",
+    }
+    cfg_dict = get_sae_config(
+        model_info,
+        folder_name=folder_name,
+        device=device,
+        force_download=force_download,
+    )
 
     file_path = hf_hub_download(
         repo_id=repo_id, filename=folder_name, force_download=force_download
     )
-    cfg_dict = get_connor_rob_hook_z_config(
-        repo_id, folder_name=folder_name, device=device
-    )
-
     weights = torch.load(file_path, map_location=device)
 
     return cfg_dict, weights, None
@@ -221,9 +228,11 @@ def read_sae_from_disk(
 def get_gemma_2_config(
     repo_id: str,
     folder_name: str,
-    d_sae_override: Optional[int] = None,
-    layer_override: Optional[int] = None,
+    **kwargs: Any,
 ) -> Dict[str, Any]:
+    d_sae_override = kwargs.get("d_sae_override", None)
+    layer_override = kwargs.get("layer_override", None)
+
     # Detect width from folder_name
     width_map = {
         "width_4k": 4096,
@@ -317,7 +326,16 @@ def gemma_2_sae_loader(
     """
     Custom loader for Gemma 2 SAEs.
     """
-    cfg_dict = get_gemma_2_config(repo_id, folder_name, d_sae_override, layer_override)
+    model_info = {
+        "repo_id": repo_id,
+        "conversion_func": "gemma_2",
+    }
+    cfg_dict = get_sae_config(
+        model_info,
+        folder_name=folder_name,
+        d_sae_override=d_sae_override,
+        layer_override=layer_override,
+    )
     cfg_dict["device"] = device
 
     # Apply overrides if provided
@@ -369,11 +387,12 @@ def gemma_2_sae_loader(
 
 
 def get_dictionary_learning_config_1(
-    repo_id: str, folder_name: str, force_download: bool = False
+    repo_id: str, folder_name: str, **kwargs: Any
 ) -> dict[str, Any]:
     """
     Suitable for SAEs from https://huggingface.co/canrager/lm_sae.
     """
+    force_download = kwargs.get("force_download", False)
     config_path = hf_hub_download(
         repo_id=repo_id,
         filename=f"{folder_name}/config.json",
@@ -415,21 +434,25 @@ def get_dictionary_learning_config_1(
         "neuronpedia_id": None,
     }
 
-def get_sae_config(model_info: dict[str, Any], folder_name: str, **kwargs: Any) -> dict[str, Any]:
+
+def get_sae_config(
+    model_info: dict[str, Any], folder_name: str, **kwargs: Any
+) -> dict[str, Any]:
     repo_id = model_info["repo_id"]
     conversion_func = model_info["conversion_func"]
 
     if conversion_func == "connor_rob_hook_z":
-        cfg = get_connor_rob_hook_z_config(
-            repo_id, folder_name=folder_name, device=None
-        )
+        cfg = get_connor_rob_hook_z_config(repo_id, folder_name=folder_name, **kwargs)
     elif conversion_func == "dictionary_learning_1":
-        cfg = get_dictionary_learning_config_1(repo_id, folder_name=folder_name)
+        cfg = get_dictionary_learning_config_1(
+            repo_id, folder_name=folder_name, **kwargs
+        )
     elif conversion_func == "gemma_2":
-        cfg = get_gemma_2_config(repo_id, folder_name=folder_name)
+        cfg = get_gemma_2_config(repo_id, folder_name=folder_name, **kwargs)
     else:
-        cfg = get_sae_config_from_hf(repo_id, folder_name=folder_name)
+        cfg = get_sae_config_from_hf(repo_id, folder_name=folder_name, **kwargs)
     return cfg
+
 
 def dictionary_learning_sae_loader_1(
     repo_id: str,

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -368,10 +368,20 @@ def gemma_2_sae_loader(
     return cfg_dict, state_dict, log_sparsity
 
 
-def get_dictionary_learning_config_1(config: dict[str, Any]) -> dict[str, Any]:
+def get_dictionary_learning_config_1(
+    repo_id: str, folder_name: str, force_download: bool = False
+) -> dict[str, Any]:
     """
     Suitable for SAEs from https://huggingface.co/canrager/lm_sae.
     """
+    config_path = hf_hub_download(
+        repo_id=repo_id,
+        filename=f"{folder_name}/config.json",
+        force_download=force_download,
+    )
+    with open(config_path, "r") as f:
+        config = json.load(f)
+
     trainer = config["trainer"]
     buffer = config["buffer"]
 
@@ -416,19 +426,13 @@ def dictionary_learning_sae_loader_1(
     """
     Suitable for SAEs from https://huggingface.co/canrager/lm_sae.
     """
-    config_path = hf_hub_download(
-        repo_id=repo_id,
-        filename=f"{folder_name}/config.json",
-        force_download=force_download,
-    )
     encoder_path = hf_hub_download(
         repo_id=repo_id, filename=f"{folder_name}/ae.pt", force_download=force_download
     )
 
-    with open(config_path, "r") as f:
-        config = json.load(f)
-
-    cfg_dict = get_dictionary_learning_config_1(config)
+    cfg_dict = get_dictionary_learning_config_1(
+        repo_id, folder_name=folder_name, force_download=force_download
+    )
     if cfg_overrides:
         cfg_dict.update(cfg_overrides)
 

--- a/sae_lens/toolkit/pretrained_saes_directory.py
+++ b/sae_lens/toolkit/pretrained_saes_directory.py
@@ -79,6 +79,13 @@ def get_norm_scaling_factor(release: str, sae_id: str) -> Optional[float]:
 def get_repo_id_and_folder_name(release: str, sae_id: str) -> tuple[str, str]:
     saes_directory = get_pretrained_saes_directory()
     sae_info = saes_directory.get(release, None)
-    repo_id = sae_info.repo_id if sae_info is not None else release
-    folder_name = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
+
+    if sae_info is None:
+        return release, sae_id
+
+    if sae_id not in sae_info.saes_map:
+        raise ValueError(f"SAE ID '{sae_id}' not found in release '{release}'")
+
+    repo_id = sae_info.repo_id
+    folder_name = sae_info.saes_map[sae_id]
     return repo_id, folder_name

--- a/sae_lens/toolkit/pretrained_saes_directory.py
+++ b/sae_lens/toolkit/pretrained_saes_directory.py
@@ -74,3 +74,11 @@ def get_norm_scaling_factor(release: str, sae_id: str) -> Optional[float]:
                 if sae_info["id"] == sae_id:
                     return sae_info.get("norm_scaling_factor")
     return None
+
+
+def get_repo_id_and_folder_name(release: str, sae_id: str) -> tuple[str, str]:
+    saes_directory = get_pretrained_saes_directory()
+    sae_info = saes_directory.get(release, None)
+    repo_id = sae_info.repo_id if sae_info is not None else release
+    folder_name = sae_info.saes_map[sae_id] if sae_info is not None else sae_id
+    return repo_id, folder_name

--- a/tests/benchmark/test_eval_all_loadable_saes.py
+++ b/tests/benchmark/test_eval_all_loadable_saes.py
@@ -7,7 +7,10 @@ import torch
 from sae_lens.analysis.neuronpedia_integration import open_neuronpedia_feature_dashboard
 from sae_lens.evals import all_loadable_saes
 from sae_lens.sae import SAE
-from sae_lens.toolkit.pretrained_sae_loaders import get_sae_config_from_hf
+from sae_lens.toolkit.pretrained_sae_loaders import (
+    SAEConfigParams,
+    get_sae_config_from_hf,
+)
 
 # from sae_lens.training.activations_store import ActivationsStore
 from tests.unit.helpers import load_model_cached
@@ -30,8 +33,7 @@ because they just didn't hold with such nonsense.
 def test_get_sae_config():
     repo_id = "jbloom/GPT2-Small-SAEs-Reformatted"
     cfg = get_sae_config_from_hf(
-        repo_id=repo_id,
-        folder_name="blocks.0.hook_resid_pre",
+        repo_id=repo_id, folder_name="blocks.0.hook_resid_pre", params=SAEConfigParams()
     )
     assert cfg is not None
 

--- a/tests/benchmark/test_eval_all_loadable_saes.py
+++ b/tests/benchmark/test_eval_all_loadable_saes.py
@@ -8,7 +8,7 @@ from sae_lens.analysis.neuronpedia_integration import open_neuronpedia_feature_d
 from sae_lens.evals import all_loadable_saes
 from sae_lens.sae import SAE
 from sae_lens.toolkit.pretrained_sae_loaders import (
-    SAEConfigParams,
+    SAEConfigLoadOptions,
     get_sae_config_from_hf,
 )
 
@@ -33,7 +33,9 @@ because they just didn't hold with such nonsense.
 def test_get_sae_config():
     repo_id = "jbloom/GPT2-Small-SAEs-Reformatted"
     cfg = get_sae_config_from_hf(
-        repo_id=repo_id, folder_name="blocks.0.hook_resid_pre", params=SAEConfigParams()
+        repo_id=repo_id,
+        folder_name="blocks.0.hook_resid_pre",
+        options=SAEConfigLoadOptions(),
     )
     assert cfg is not None
 

--- a/tests/unit/toolkit/test_pretrained_sae_loaders.py
+++ b/tests/unit/toolkit/test_pretrained_sae_loaders.py
@@ -1,0 +1,149 @@
+from sae_lens.toolkit.pretrained_sae_loaders import SAEConfigLoadOptions, get_sae_config
+
+
+def test_get_sae_config_sae_lens():
+    cfg_dict = get_sae_config(
+        "gpt2-small-res-jb",
+        sae_id="blocks.0.hook_resid_pre",
+        options=SAEConfigLoadOptions(),
+    )
+
+    expected_cfg_dict = {
+        "model_name": "gpt2-small",
+        "hook_point": "blocks.0.hook_resid_pre",
+        "hook_point_layer": 0,
+        "hook_point_head_index": None,
+        "dataset_path": "Skylion007/openwebtext",
+        "is_dataset_tokenized": False,
+        "context_size": 128,
+        "use_cached_activations": False,
+        "cached_activations_path": "activations/Skylion007_openwebtext/gpt2-small/blocks.0.hook_resid_pre",
+        "d_in": 768,
+        "n_batches_in_buffer": 128,
+        "total_training_tokens": 300000000,
+        "store_batch_size": 32,
+        "device": "mps",
+        "seed": 42,
+        "dtype": "torch.float32",
+        "b_dec_init_method": "geometric_median",
+        "expansion_factor": 32,
+        "from_pretrained_path": None,
+        "l1_coefficient": 8e-05,
+        "lr": 0.0004,
+        "lr_scheduler_name": None,
+        "lr_warm_up_steps": 5000,
+        "train_batch_size": 4096,
+        "use_ghost_grads": False,
+        "feature_sampling_window": 1000,
+        "feature_sampling_method": None,
+        "resample_batches": 1028,
+        "feature_reinit_scale": 0.2,
+        "dead_feature_window": 5000,
+        "dead_feature_estimation_method": "no_fire",
+        "dead_feature_threshold": 1e-08,
+        "log_to_wandb": True,
+        "wandb_project": "mats_sae_training_gpt2_small_resid_pre_5",
+        "wandb_entity": None,
+        "wandb_log_frequency": 100,
+        "n_checkpoints": 10,
+        "checkpoint_path": "checkpoints/y1t51byy",
+        "d_sae": 24576,
+        "tokens_per_buffer": 67108864,
+        "run_name": "24576-L1-8e-05-LR-0.0004-Tokens-3.000e+08",
+    }
+
+    assert cfg_dict == expected_cfg_dict
+
+
+def test_get_sae_config_connor_rob_hook_z():
+    cfg_dict = get_sae_config(
+        "gpt2-small-hook-z-kk",
+        sae_id="blocks.0.hook_z",
+        options=SAEConfigLoadOptions(),
+    )
+
+    expected_cfg_dict = {
+        "architecture": "standard",
+        "d_in": 768,
+        "d_sae": 24576,
+        "dtype": "float32",
+        "device": "cpu",
+        "model_name": "gpt2-small",
+        "hook_name": "blocks.0.attn.hook_z",
+        "hook_layer": 0,
+        "hook_head_index": None,
+        "activation_fn_str": "relu",
+        "apply_b_dec_to_input": True,
+        "finetuning_scaling_factor": False,
+        "sae_lens_training_version": None,
+        "prepend_bos": True,
+        "dataset_path": "Skylion007/openwebtext",
+        "context_size": 128,
+        "normalize_activations": "none",
+        "dataset_trust_remote_code": True,
+    }
+
+    assert cfg_dict == expected_cfg_dict
+
+
+def test_get_sae_config_gemma_2():
+    cfg_dict = get_sae_config(
+        "gemma-scope-2b-pt-res",
+        sae_id="embedding/width_4k/average_l0_6",
+        options=SAEConfigLoadOptions(),
+    )
+
+    expected_cfg_dict = {
+        "architecture": "jumprelu",
+        "d_in": 2304,
+        "d_sae": 4096,
+        "dtype": "float32",
+        "model_name": "gemma-2-2b",
+        "hook_name": "hook_embed",
+        "hook_layer": 0,
+        "hook_head_index": None,
+        "activation_fn_str": "relu",
+        "finetuning_scaling_factor": False,
+        "sae_lens_training_version": None,
+        "prepend_bos": True,
+        "dataset_path": "monology/pile-uncopyrighted",
+        "context_size": 1024,
+        "dataset_trust_remote_code": True,
+        "apply_b_dec_to_input": False,
+        "normalize_activations": None,
+    }
+
+    assert cfg_dict == expected_cfg_dict
+
+
+def test_get_sae_config_dictionary_learning_1():
+    cfg_dict = get_sae_config(
+        "sae_bench_gemma-2-2b_sweep_standard_ctx128_ef2_0824",
+        sae_id="blocks.3.hook_resid_post__trainer_1_step_29292",
+        options=SAEConfigLoadOptions(),
+    )
+
+    expected_cfg_dict = {
+        "architecture": "standard",
+        "d_in": 2304,
+        "d_sae": 4608,
+        "dtype": "float32",
+        "device": "cpu",
+        "model_name": "gemma-2-2b",
+        "hook_name": "blocks.3.hook_resid_post",
+        "hook_layer": 3,
+        "hook_head_index": None,
+        "activation_fn_str": "relu",
+        "activation_fn_kwargs": {},
+        "apply_b_dec_to_input": True,
+        "finetuning_scaling_factor": False,
+        "sae_lens_training_version": None,
+        "prepend_bos": True,
+        "dataset_path": "monology/pile-uncopyrighted",
+        "dataset_trust_remote_code": False,
+        "context_size": 128,
+        "normalize_activations": "none",
+        "neuronpedia_id": None,
+    }
+
+    assert cfg_dict == expected_cfg_dict

--- a/tests/unit/toolkit/test_pretrained_saes_directory.py
+++ b/tests/unit/toolkit/test_pretrained_saes_directory.py
@@ -138,8 +138,6 @@ def test_get_repo_id_and_folder_name_release_not_found():
     assert folder_name == "sae1"
 
 
-@patch("sae_lens.toolkit.pretrained_saes_directory.get_pretrained_saes_directory")
 def test_get_repo_id_and_folder_name_raises_error_if_sae_id_not_found():
-
     with pytest.raises(ValueError):
         get_repo_id_and_folder_name("gpt2-small-res-jb", sae_id="sae1")

--- a/tests/unit/toolkit/test_pretrained_saes_directory.py
+++ b/tests/unit/toolkit/test_pretrained_saes_directory.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pandas as pd
 import pytest
 

--- a/tests/unit/toolkit/test_pretrained_saes_directory.py
+++ b/tests/unit/toolkit/test_pretrained_saes_directory.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -124,51 +124,22 @@ def test_get_pretrained_saes_directory_unique_np_ids():
     ), f"Duplicate IDs found: {duplicate_ids[duplicate_ids > 1]}"
 
 
-@pytest.fixture
-def mock_saes_directory() -> dict[str, PretrainedSAELookup]:
-    return {
-        "release1": PretrainedSAELookup(
-            release="release1",
-            repo_id="repo1",
-            model="model1",
-            conversion_func=None,
-            saes_map={"sae1": "folder1"},
-            expected_var_explained={},
-            expected_l0={},
-            neuronpedia_id={},
-            config_overrides={},
-        ),
-    }
+def test_get_repo_id_and_folder_name_release_found():
+    repo_id, folder_name = get_repo_id_and_folder_name(
+        "gpt2-small-res-jb", sae_id="blocks.0.hook_resid_pre"
+    )
+    assert repo_id == "jbloom/GPT2-Small-SAEs-Reformatted"
+    assert folder_name == "blocks.0.hook_resid_pre"
 
 
-@patch("sae_lens.toolkit.pretrained_saes_directory.get_pretrained_saes_directory")
-def test_get_repo_id_and_folder_name_release_found(
-    mock_get_pretrained_saes_directory: MagicMock,
-    mock_saes_directory: dict[str, PretrainedSAELookup],
-):
-    mock_get_pretrained_saes_directory.return_value = mock_saes_directory
-
+def test_get_repo_id_and_folder_name_release_not_found():
     repo_id, folder_name = get_repo_id_and_folder_name("release1", "sae1")
-    assert repo_id == "repo1"
-    assert folder_name == "folder1"
+    assert repo_id == "release1"
+    assert folder_name == "sae1"
 
 
 @patch("sae_lens.toolkit.pretrained_saes_directory.get_pretrained_saes_directory")
-def test_get_repo_id_and_folder_name_release_not_found(
-    mock_get_directory: MagicMock, mock_saes_directory: dict[str, PretrainedSAELookup]
-):
-    mock_get_directory.return_value = mock_saes_directory
-
-    repo_id, folder_name = get_repo_id_and_folder_name("release2", "sae5")
-    assert repo_id == "release2"
-    assert folder_name == "sae5"
-
-
-@patch("sae_lens.toolkit.pretrained_saes_directory.get_pretrained_saes_directory")
-def test_get_repo_id_and_folder_name_raises_error_if_sae_id_not_found(
-    mock_get_directory: MagicMock, mock_saes_directory: dict[str, PretrainedSAELookup]
-):
-    mock_get_directory.return_value = mock_saes_directory
+def test_get_repo_id_and_folder_name_raises_error_if_sae_id_not_found():
 
     with pytest.raises(ValueError):
-        get_repo_id_and_folder_name("release1", "sae2")
+        get_repo_id_and_folder_name("gpt2-small-res-jb", sae_id="sae1")


### PR DESCRIPTION
# Description


Adds a new function `get_sae_config()` which takes a `release` and `sae_id` and returns the config for an SAE. To get the config for an SAE, one shouldn't have to know the conversion function or download the weights, and one is more likely to know the `release` and `sae_id` than `repo_id` and `folder_name`. We also currently duplicate a lot of code across `pretrained_sae_loaders.py` and `generate_sae_table.py`.

Fixes #305, fixes #315 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 