### PR TITLE
fix: add neuronpedia links for gemmascope 32plus

### DIFF
--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -3756,6 +3756,7 @@ gemma-scope-9b-pt-res:
   - id: layer_0/width_131k/average_l0_30
     path: layer_0/width_131k/average_l0_30
     l0: 30
+    neuronpedia: gemma-2-9b/0-gemmascope-res-131k-l0_32plus
   - id: layer_0/width_131k/average_l0_41
     path: layer_0/width_131k/average_l0_41
     l0: 41
@@ -3774,6 +3775,7 @@ gemma-scope-9b-pt-res:
   - id: layer_0/width_16k/average_l0_35
     path: layer_0/width_16k/average_l0_35
     l0: 35
+    neuronpedia: gemma-2-9b/0-gemmascope-res-16k-l0_32plus
   - id: layer_0/width_16k/average_l0_68
     path: layer_0/width_16k/average_l0_68
     l0: 68
@@ -3786,6 +3788,7 @@ gemma-scope-9b-pt-res:
   - id: layer_1/width_131k/average_l0_33
     path: layer_1/width_131k/average_l0_33
     l0: 33
+    neuronpedia: gemma-2-9b/1-gemmascope-res-131k-l0_32plus
   - id: layer_1/width_131k/average_l0_56
     path: layer_1/width_131k/average_l0_56
     l0: 56
@@ -3807,6 +3810,7 @@ gemma-scope-9b-pt-res:
   - id: layer_1/width_16k/average_l0_69
     path: layer_1/width_16k/average_l0_69
     l0: 69
+    neuronpedia: gemma-2-9b/1-gemmascope-res-16k-l0_32plus
   - id: layer_1/width_16k/average_l0_9
     path: layer_1/width_16k/average_l0_9
     l0: 9
@@ -3822,6 +3826,7 @@ gemma-scope-9b-pt-res:
   - id: layer_10/width_131k/average_l0_47
     path: layer_10/width_131k/average_l0_47
     l0: 47
+    neuronpedia: gemma-2-9b/10-gemmascope-res-131k-l0_32plus
   - id: layer_10/width_131k/average_l0_84
     path: layer_10/width_131k/average_l0_84
     l0: 84
@@ -3846,6 +3851,7 @@ gemma-scope-9b-pt-res:
   - id: layer_10/width_16k/average_l0_57
     path: layer_10/width_16k/average_l0_57
     l0: 57
+    neuronpedia: gemma-2-9b/10-gemmascope-res-16k-l0_32plus
   - id: layer_11/width_131k/average_l0_16
     path: layer_11/width_131k/average_l0_16
     l0: 16
@@ -3858,6 +3864,7 @@ gemma-scope-9b-pt-res:
   - id: layer_11/width_131k/average_l0_49
     path: layer_11/width_131k/average_l0_49
     l0: 49
+    neuronpedia: gemma-2-9b/11-gemmascope-res-131k-l0_32plus
   - id: layer_11/width_131k/average_l0_88
     path: layer_11/width_131k/average_l0_88
     l0: 88
@@ -3879,6 +3886,7 @@ gemma-scope-9b-pt-res:
   - id: layer_11/width_16k/average_l0_32
     path: layer_11/width_16k/average_l0_32
     l0: 32
+    neuronpedia: gemma-2-9b/11-gemmascope-res-16k-l0_32plus
   - id: layer_11/width_16k/average_l0_60
     path: layer_11/width_16k/average_l0_60
     l0: 60
@@ -3897,6 +3905,7 @@ gemma-scope-9b-pt-res:
   - id: layer_12/width_131k/average_l0_52
     path: layer_12/width_131k/average_l0_52
     l0: 52
+    neuronpedia: gemma-2-9b/12-gemmascope-res-131k-l0_32plus
   - id: layer_12/width_131k/average_l0_96
     path: layer_12/width_131k/average_l0_96
     l0: 96
@@ -3915,6 +3924,7 @@ gemma-scope-9b-pt-res:
   - id: layer_12/width_16k/average_l0_33
     path: layer_12/width_16k/average_l0_33
     l0: 33
+    neuronpedia: gemma-2-9b/12-gemmascope-res-16k-l0_32plus
   - id: layer_12/width_16k/average_l0_64
     path: layer_12/width_16k/average_l0_64
     l0: 64
@@ -3930,6 +3940,7 @@ gemma-scope-9b-pt-res:
   - id: layer_13/width_131k/average_l0_30
     path: layer_13/width_131k/average_l0_30
     l0: 30
+    neuronpedia: gemma-2-9b/13-gemmascope-res-131k-l0_32plus
   - id: layer_13/width_131k/average_l0_54
     path: layer_13/width_131k/average_l0_54
     l0: 54
@@ -3951,6 +3962,7 @@ gemma-scope-9b-pt-res:
   - id: layer_13/width_16k/average_l0_34
     path: layer_13/width_16k/average_l0_34
     l0: 34
+    neuronpedia: gemma-2-9b/13-gemmascope-res-16k-l0_32plus
   - id: layer_13/width_16k/average_l0_65
     path: layer_13/width_16k/average_l0_65
     l0: 65
@@ -3972,6 +3984,7 @@ gemma-scope-9b-pt-res:
   - id: layer_14/width_131k/average_l0_56
     path: layer_14/width_131k/average_l0_56
     l0: 56
+    neuronpedia: gemma-2-9b/14-gemmascope-res-131k-l0_32plus
   - id: layer_14/width_16k/average_l0_11
     path: layer_14/width_16k/average_l0_11
     l0: 11
@@ -3987,6 +4000,7 @@ gemma-scope-9b-pt-res:
   - id: layer_14/width_16k/average_l0_35
     path: layer_14/width_16k/average_l0_35
     l0: 35
+    neuronpedia: gemma-2-9b/14-gemmascope-res-16k-l0_32plus
   - id: layer_14/width_16k/average_l0_67
     path: layer_14/width_16k/average_l0_67
     l0: 67
@@ -4008,6 +4022,7 @@ gemma-scope-9b-pt-res:
   - id: layer_15/width_131k/average_l0_55
     path: layer_15/width_131k/average_l0_55
     l0: 55
+    neuronpedia: gemma-2-9b/15-gemmascope-res-131k-l0_32plus
   - id: layer_15/width_16k/average_l0_10
     path: layer_15/width_16k/average_l0_10
     l0: 10
@@ -4023,6 +4038,7 @@ gemma-scope-9b-pt-res:
   - id: layer_15/width_16k/average_l0_34
     path: layer_15/width_16k/average_l0_34
     l0: 34
+    neuronpedia: gemma-2-9b/15-gemmascope-res-16k-l0_32plus
   - id: layer_15/width_16k/average_l0_65
     path: layer_15/width_16k/average_l0_65
     l0: 65
@@ -4041,6 +4057,7 @@ gemma-scope-9b-pt-res:
   - id: layer_16/width_131k/average_l0_35
     path: layer_16/width_131k/average_l0_35
     l0: 35
+    neuronpedia: gemma-2-9b/16-gemmascope-res-131k-l0_32plus
   - id: layer_16/width_131k/average_l0_65
     path: layer_16/width_131k/average_l0_65
     l0: 65
@@ -4059,6 +4076,7 @@ gemma-scope-9b-pt-res:
   - id: layer_16/width_16k/average_l0_39
     path: layer_16/width_16k/average_l0_39
     l0: 39
+    neuronpedia: gemma-2-9b/16-gemmascope-res-16k-l0_32plus
   - id: layer_16/width_16k/average_l0_75
     path: layer_16/width_16k/average_l0_75
     l0: 75
@@ -4077,6 +4095,7 @@ gemma-scope-9b-pt-res:
   - id: layer_17/width_131k/average_l0_35
     path: layer_17/width_131k/average_l0_35
     l0: 35
+    neuronpedia: gemma-2-9b/17-gemmascope-res-131k-l0_32plus
   - id: layer_17/width_131k/average_l0_64
     path: layer_17/width_131k/average_l0_64
     l0: 64
@@ -4095,6 +4114,7 @@ gemma-scope-9b-pt-res:
   - id: layer_17/width_16k/average_l0_38
     path: layer_17/width_16k/average_l0_38
     l0: 38
+    neuronpedia: gemma-2-9b/17-gemmascope-res-16k-l0_32plus
   - id: layer_17/width_16k/average_l0_73
     path: layer_17/width_16k/average_l0_73
     l0: 73
@@ -4113,6 +4133,7 @@ gemma-scope-9b-pt-res:
   - id: layer_18/width_131k/average_l0_34
     path: layer_18/width_131k/average_l0_34
     l0: 34
+    neuronpedia: gemma-2-9b/18-gemmascope-res-131k-l0_32plus
   - id: layer_18/width_131k/average_l0_62
     path: layer_18/width_131k/average_l0_62
     l0: 62
@@ -4131,6 +4152,7 @@ gemma-scope-9b-pt-res:
   - id: layer_18/width_16k/average_l0_37
     path: layer_18/width_16k/average_l0_37
     l0: 37
+    neuronpedia: gemma-2-9b/18-gemmascope-res-16k-l0_32plus
   - id: layer_18/width_16k/average_l0_71
     path: layer_18/width_16k/average_l0_71
     l0: 71
@@ -4149,6 +4171,7 @@ gemma-scope-9b-pt-res:
   - id: layer_19/width_131k/average_l0_32
     path: layer_19/width_131k/average_l0_32
     l0: 32
+    neuronpedia: gemma-2-9b/19-gemmascope-res-131k-l0_32plus
   - id: layer_19/width_131k/average_l0_60
     path: layer_19/width_131k/average_l0_60
     l0: 60
@@ -4167,6 +4190,7 @@ gemma-scope-9b-pt-res:
   - id: layer_19/width_16k/average_l0_35
     path: layer_19/width_16k/average_l0_35
     l0: 35
+    neuronpedia: gemma-2-9b/19-gemmascope-res-16k-l0_32plus
   - id: layer_19/width_16k/average_l0_67
     path: layer_19/width_16k/average_l0_67
     l0: 67
@@ -4179,6 +4203,7 @@ gemma-scope-9b-pt-res:
   - id: layer_2/width_131k/average_l0_36
     path: layer_2/width_131k/average_l0_36
     l0: 36
+    neuronpedia: gemma-2-9b/2-gemmascope-res-131k-l0_32plus
   - id: layer_2/width_131k/average_l0_5
     path: layer_2/width_131k/average_l0_5
     l0: 5
@@ -4200,6 +4225,7 @@ gemma-scope-9b-pt-res:
   - id: layer_2/width_16k/average_l0_67
     path: layer_2/width_16k/average_l0_67
     l0: 67
+    neuronpedia: gemma-2-9b/2-gemmascope-res-16k-l0_32plus
   - id: layer_2/width_16k/average_l0_8
     path: layer_2/width_16k/average_l0_8
     l0: 8
@@ -4233,6 +4259,7 @@ gemma-scope-9b-pt-res:
   - id: layer_20/width_131k/average_l0_34
     path: layer_20/width_131k/average_l0_34
     l0: 34
+    neuronpedia: gemma-2-9b/20-gemmascope-res-131k-l0_32plus
   - id: layer_20/width_131k/average_l0_51
     path: layer_20/width_131k/average_l0_51
     l0: 51
@@ -4260,6 +4287,7 @@ gemma-scope-9b-pt-res:
   - id: layer_20/width_16k/average_l0_36
     path: layer_20/width_16k/average_l0_36
     l0: 36
+    neuronpedia: gemma-2-9b/20-gemmascope-res-16k-l0_32plus
   - id: layer_20/width_16k/average_l0_393
     path: layer_20/width_16k/average_l0_393
     l0: 393
@@ -4398,6 +4426,7 @@ gemma-scope-9b-pt-res:
   - id: layer_21/width_131k/average_l0_33
     path: layer_21/width_131k/average_l0_33
     l0: 33
+    neuronpedia: gemma-2-9b/21-gemmascope-res-131k-l0_32plus
   - id: layer_21/width_131k/average_l0_58
     path: layer_21/width_131k/average_l0_58
     l0: 58
@@ -4416,6 +4445,7 @@ gemma-scope-9b-pt-res:
   - id: layer_21/width_16k/average_l0_36
     path: layer_21/width_16k/average_l0_36
     l0: 36
+    neuronpedia: gemma-2-9b/21-gemmascope-res-16k-l0_32plus
   - id: layer_21/width_16k/average_l0_66
     path: layer_21/width_16k/average_l0_66
     l0: 66
@@ -4434,6 +4464,7 @@ gemma-scope-9b-pt-res:
   - id: layer_22/width_131k/average_l0_32
     path: layer_22/width_131k/average_l0_32
     l0: 32
+    neuronpedia: gemma-2-9b/22-gemmascope-res-131k-l0_32plus
   - id: layer_22/width_131k/average_l0_58
     path: layer_22/width_131k/average_l0_58
     l0: 58
@@ -4452,6 +4483,7 @@ gemma-scope-9b-pt-res:
   - id: layer_22/width_16k/average_l0_35
     path: layer_22/width_16k/average_l0_35
     l0: 35
+    neuronpedia: gemma-2-9b/22-gemmascope-res-16k-l0_32plus
   - id: layer_22/width_16k/average_l0_65
     path: layer_22/width_16k/average_l0_65
     l0: 65
@@ -4470,6 +4502,7 @@ gemma-scope-9b-pt-res:
   - id: layer_23/width_131k/average_l0_32
     path: layer_23/width_131k/average_l0_32
     l0: 32
+    neuronpedia: gemma-2-9b/23-gemmascope-res-131k-l0_32plus
   - id: layer_23/width_131k/average_l0_56
     path: layer_23/width_131k/average_l0_56
     l0: 56
@@ -4488,6 +4521,7 @@ gemma-scope-9b-pt-res:
   - id: layer_23/width_16k/average_l0_35
     path: layer_23/width_16k/average_l0_35
     l0: 35
+    neuronpedia: gemma-2-9b/23-gemmascope-res-16k-l0_32plus
   - id: layer_23/width_16k/average_l0_63
     path: layer_23/width_16k/average_l0_63
     l0: 63
@@ -4506,6 +4540,7 @@ gemma-scope-9b-pt-res:
   - id: layer_24/width_131k/average_l0_55
     path: layer_24/width_131k/average_l0_55
     l0: 55
+    neuronpedia: gemma-2-9b/24-gemmascope-res-131k-l0_32plus
   - id: layer_24/width_131k/average_l0_97
     path: layer_24/width_131k/average_l0_97
     l0: 97
@@ -4524,6 +4559,7 @@ gemma-scope-9b-pt-res:
   - id: layer_24/width_16k/average_l0_34
     path: layer_24/width_16k/average_l0_34
     l0: 34
+    neuronpedia: gemma-2-9b/24-gemmascope-res-16k-l0_32plus
   - id: layer_24/width_16k/average_l0_61
     path: layer_24/width_16k/average_l0_61
     l0: 61
@@ -4542,6 +4578,7 @@ gemma-scope-9b-pt-res:
   - id: layer_25/width_131k/average_l0_54
     path: layer_25/width_131k/average_l0_54
     l0: 54
+    neuronpedia: gemma-2-9b/25-gemmascope-res-131k-l0_32plus
   - id: layer_25/width_131k/average_l0_96
     path: layer_25/width_131k/average_l0_96
     l0: 96
@@ -4560,6 +4597,7 @@ gemma-scope-9b-pt-res:
   - id: layer_25/width_16k/average_l0_34
     path: layer_25/width_16k/average_l0_34
     l0: 34
+    neuronpedia: gemma-2-9b/25-gemmascope-res-16k-l0_32plus
   - id: layer_25/width_16k/average_l0_61
     path: layer_25/width_16k/average_l0_61
     l0: 61
@@ -4575,6 +4613,7 @@ gemma-scope-9b-pt-res:
   - id: layer_26/width_131k/average_l0_32
     path: layer_26/width_131k/average_l0_32
     l0: 32
+    neuronpedia: gemma-2-9b/26-gemmascope-res-131k-l0_32plus
   - id: layer_26/width_131k/average_l0_55
     path: layer_26/width_131k/average_l0_55
     l0: 55
@@ -4596,6 +4635,7 @@ gemma-scope-9b-pt-res:
   - id: layer_26/width_16k/average_l0_35
     path: layer_26/width_16k/average_l0_35
     l0: 35
+    neuronpedia: gemma-2-9b/26-gemmascope-res-16k-l0_32plus
   - id: layer_26/width_16k/average_l0_63
     path: layer_26/width_16k/average_l0_63
     l0: 63
@@ -4611,6 +4651,7 @@ gemma-scope-9b-pt-res:
   - id: layer_27/width_131k/average_l0_33
     path: layer_27/width_131k/average_l0_33
     l0: 33
+    neuronpedia: gemma-2-9b/27-gemmascope-res-131k-l0_32plus
   - id: layer_27/width_131k/average_l0_56
     path: layer_27/width_131k/average_l0_56
     l0: 56
@@ -4632,6 +4673,7 @@ gemma-scope-9b-pt-res:
   - id: layer_27/width_16k/average_l0_36
     path: layer_27/width_16k/average_l0_36
     l0: 36
+    neuronpedia: gemma-2-9b/27-gemmascope-res-16k-l0_32plus
   - id: layer_27/width_16k/average_l0_65
     path: layer_27/width_16k/average_l0_65
     l0: 65
@@ -4647,6 +4689,7 @@ gemma-scope-9b-pt-res:
   - id: layer_28/width_131k/average_l0_32
     path: layer_28/width_131k/average_l0_32
     l0: 32
+    neuronpedia: gemma-2-9b/28-gemmascope-res-131k-l0_32plus
   - id: layer_28/width_131k/average_l0_57
     path: layer_28/width_131k/average_l0_57
     l0: 57
@@ -4668,6 +4711,7 @@ gemma-scope-9b-pt-res:
   - id: layer_28/width_16k/average_l0_37
     path: layer_28/width_16k/average_l0_37
     l0: 37
+    neuronpedia: gemma-2-9b/28-gemmascope-res-16k-l0_32plus
   - id: layer_28/width_16k/average_l0_65
     path: layer_28/width_16k/average_l0_65
     l0: 65
@@ -4683,6 +4727,7 @@ gemma-scope-9b-pt-res:
   - id: layer_29/width_131k/average_l0_33
     path: layer_29/width_131k/average_l0_33
     l0: 33
+    neuronpedia: gemma-2-9b/29-gemmascope-res-131k-l0_32plus
   - id: layer_29/width_131k/average_l0_56
     path: layer_29/width_131k/average_l0_56
     l0: 56
@@ -4704,6 +4749,7 @@ gemma-scope-9b-pt-res:
   - id: layer_29/width_16k/average_l0_38
     path: layer_29/width_16k/average_l0_38
     l0: 38
+    neuronpedia: gemma-2-9b/29-gemmascope-res-16k-l0_32plus
   - id: layer_29/width_16k/average_l0_66
     path: layer_29/width_16k/average_l0_66
     l0: 66
@@ -4719,6 +4765,7 @@ gemma-scope-9b-pt-res:
   - id: layer_3/width_131k/average_l0_46
     path: layer_3/width_131k/average_l0_46
     l0: 46
+    neuronpedia: gemma-2-9b/3-gemmascope-res-131k-l0_32plus
   - id: layer_3/width_131k/average_l0_6
     path: layer_3/width_131k/average_l0_6
     l0: 6
@@ -4737,6 +4784,7 @@ gemma-scope-9b-pt-res:
   - id: layer_3/width_16k/average_l0_37
     path: layer_3/width_16k/average_l0_37
     l0: 37
+    neuronpedia: gemma-2-9b/3-gemmascope-res-16k-l0_32plus
   - id: layer_3/width_16k/average_l0_90
     path: layer_3/width_16k/average_l0_90
     l0: 90
@@ -4752,6 +4800,7 @@ gemma-scope-9b-pt-res:
   - id: layer_30/width_131k/average_l0_32
     path: layer_30/width_131k/average_l0_32
     l0: 32
+    neuronpedia: gemma-2-9b/30-gemmascope-res-131k-l0_32plus
   - id: layer_30/width_131k/average_l0_56
     path: layer_30/width_131k/average_l0_56
     l0: 56
@@ -4773,6 +4822,7 @@ gemma-scope-9b-pt-res:
   - id: layer_30/width_16k/average_l0_37
     path: layer_30/width_16k/average_l0_37
     l0: 37
+    neuronpedia: gemma-2-9b/30-gemmascope-res-16k-l0_32plus
   - id: layer_30/width_16k/average_l0_66
     path: layer_30/width_16k/average_l0_66
     l0: 66
@@ -4791,6 +4841,7 @@ gemma-scope-9b-pt-res:
   - id: layer_31/width_131k/average_l0_52
     path: layer_31/width_131k/average_l0_52
     l0: 52
+    neuronpedia: gemma-2-9b/31-gemmascope-res-131k-l0_32plus
   - id: layer_31/width_131k/average_l0_92
     path: layer_31/width_131k/average_l0_92
     l0: 92
@@ -4809,6 +4860,7 @@ gemma-scope-9b-pt-res:
   - id: layer_31/width_16k/average_l0_35
     path: layer_31/width_16k/average_l0_35
     l0: 35
+    neuronpedia: gemma-2-9b/31-gemmascope-res-16k-l0_32plus
   - id: layer_31/width_16k/average_l0_63
     path: layer_31/width_16k/average_l0_63
     l0: 63
@@ -4845,6 +4897,7 @@ gemma-scope-9b-pt-res:
   - id: layer_32/width_131k/average_l0_51
     path: layer_32/width_131k/average_l0_51
     l0: 51
+    neuronpedia: gemma-2-9b/32-gemmascope-res-131k-l0_32plus
   - id: layer_32/width_131k/average_l0_88
     path: layer_32/width_131k/average_l0_88
     l0: 88
@@ -4863,6 +4916,7 @@ gemma-scope-9b-pt-res:
   - id: layer_32/width_16k/average_l0_34
     path: layer_32/width_16k/average_l0_34
     l0: 34
+    neuronpedia: gemma-2-9b/32-gemmascope-res-16k-l0_32plus
   - id: layer_32/width_16k/average_l0_61
     path: layer_32/width_16k/average_l0_61
     l0: 61
@@ -4881,6 +4935,7 @@ gemma-scope-9b-pt-res:
   - id: layer_33/width_131k/average_l0_51
     path: layer_33/width_131k/average_l0_51
     l0: 51
+    neuronpedia: gemma-2-9b/33-gemmascope-res-131k-l0_32plus
   - id: layer_33/width_131k/average_l0_91
     path: layer_33/width_131k/average_l0_91
     l0: 91
@@ -4899,6 +4954,7 @@ gemma-scope-9b-pt-res:
   - id: layer_33/width_16k/average_l0_34
     path: layer_33/width_16k/average_l0_34
     l0: 34
+    neuronpedia: gemma-2-9b/33-gemmascope-res-16k-l0_32plus
   - id: layer_33/width_16k/average_l0_63
     path: layer_33/width_16k/average_l0_63
     l0: 63
@@ -4917,6 +4973,7 @@ gemma-scope-9b-pt-res:
   - id: layer_34/width_131k/average_l0_51
     path: layer_34/width_131k/average_l0_51
     l0: 51
+    neuronpedia: gemma-2-9b/34-gemmascope-res-131k-l0_32plus
   - id: layer_34/width_131k/average_l0_89
     path: layer_34/width_131k/average_l0_89
     l0: 89
@@ -4935,6 +4992,7 @@ gemma-scope-9b-pt-res:
   - id: layer_34/width_16k/average_l0_34
     path: layer_34/width_16k/average_l0_34
     l0: 34
+    neuronpedia: gemma-2-9b/34-gemmascope-res-16k-l0_32plus
   - id: layer_34/width_16k/average_l0_60
     path: layer_34/width_16k/average_l0_60
     l0: 60
@@ -4953,6 +5011,7 @@ gemma-scope-9b-pt-res:
   - id: layer_35/width_131k/average_l0_51
     path: layer_35/width_131k/average_l0_51
     l0: 51
+    neuronpedia: gemma-2-9b/35-gemmascope-res-131k-l0_32plus
   - id: layer_35/width_131k/average_l0_94
     path: layer_35/width_131k/average_l0_94
     l0: 94
@@ -4971,6 +5030,7 @@ gemma-scope-9b-pt-res:
   - id: layer_35/width_16k/average_l0_34
     path: layer_35/width_16k/average_l0_34
     l0: 34
+    neuronpedia: gemma-2-9b/35-gemmascope-res-16k-l0_32plus
   - id: layer_35/width_16k/average_l0_61
     path: layer_35/width_16k/average_l0_61
     l0: 61
@@ -4989,6 +5049,7 @@ gemma-scope-9b-pt-res:
   - id: layer_36/width_131k/average_l0_51
     path: layer_36/width_131k/average_l0_51
     l0: 51
+    neuronpedia: gemma-2-9b/36-gemmascope-res-131k-l0_32plus
   - id: layer_36/width_131k/average_l0_93
     path: layer_36/width_131k/average_l0_93
     l0: 93
@@ -5007,6 +5068,7 @@ gemma-scope-9b-pt-res:
   - id: layer_36/width_16k/average_l0_34
     path: layer_36/width_16k/average_l0_34
     l0: 34
+    neuronpedia: gemma-2-9b/36-gemmascope-res-16k-l0_32plus
   - id: layer_36/width_16k/average_l0_61
     path: layer_36/width_16k/average_l0_61
     l0: 61
@@ -5025,6 +5087,7 @@ gemma-scope-9b-pt-res:
   - id: layer_37/width_131k/average_l0_53
     path: layer_37/width_131k/average_l0_53
     l0: 53
+    neuronpedia: gemma-2-9b/37-gemmascope-res-131k-l0_32plus
   - id: layer_37/width_131k/average_l0_96
     path: layer_37/width_131k/average_l0_96
     l0: 96
@@ -5043,6 +5106,7 @@ gemma-scope-9b-pt-res:
   - id: layer_37/width_16k/average_l0_34
     path: layer_37/width_16k/average_l0_34
     l0: 34
+    neuronpedia: gemma-2-9b/37-gemmascope-res-16k-l0_32plus
   - id: layer_37/width_16k/average_l0_63
     path: layer_37/width_16k/average_l0_63
     l0: 63
@@ -5064,6 +5128,7 @@ gemma-scope-9b-pt-res:
   - id: layer_38/width_131k/average_l0_53
     path: layer_38/width_131k/average_l0_53
     l0: 53
+    neuronpedia: gemma-2-9b/38-gemmascope-res-131k-l0_32plus
   - id: layer_38/width_16k/average_l0_11
     path: layer_38/width_16k/average_l0_11
     l0: 11
@@ -5079,6 +5144,7 @@ gemma-scope-9b-pt-res:
   - id: layer_38/width_16k/average_l0_34
     path: layer_38/width_16k/average_l0_34
     l0: 34
+    neuronpedia: gemma-2-9b/38-gemmascope-res-16k-l0_32plus
   - id: layer_38/width_16k/average_l0_64
     path: layer_38/width_16k/average_l0_64
     l0: 64
@@ -5097,6 +5163,7 @@ gemma-scope-9b-pt-res:
   - id: layer_39/width_131k/average_l0_54
     path: layer_39/width_131k/average_l0_54
     l0: 54
+    neuronpedia: gemma-2-9b/39-gemmascope-res-131k-l0_32plus
   - id: layer_39/width_131k/average_l0_99
     path: layer_39/width_131k/average_l0_99
     l0: 99
@@ -5115,6 +5182,7 @@ gemma-scope-9b-pt-res:
   - id: layer_39/width_16k/average_l0_34
     path: layer_39/width_16k/average_l0_34
     l0: 34
+    neuronpedia: gemma-2-9b/39-gemmascope-res-16k-l0_32plus
   - id: layer_39/width_16k/average_l0_64
     path: layer_39/width_16k/average_l0_64
     l0: 64
@@ -5130,6 +5198,7 @@ gemma-scope-9b-pt-res:
   - id: layer_4/width_131k/average_l0_51
     path: layer_4/width_131k/average_l0_51
     l0: 51
+    neuronpedia: gemma-2-9b/4-gemmascope-res-131k-l0_32plus
   - id: layer_4/width_131k/average_l0_6
     path: layer_4/width_131k/average_l0_6
     l0: 6
@@ -5148,6 +5217,7 @@ gemma-scope-9b-pt-res:
   - id: layer_4/width_16k/average_l0_37
     path: layer_4/width_16k/average_l0_37
     l0: 37
+    neuronpedia: gemma-2-9b/4-gemmascope-res-16k-l0_32plus
   - id: layer_4/width_16k/average_l0_91
     path: layer_4/width_16k/average_l0_91
     l0: 91
@@ -5166,6 +5236,7 @@ gemma-scope-9b-pt-res:
   - id: layer_40/width_131k/average_l0_49
     path: layer_40/width_131k/average_l0_49
     l0: 49
+    neuronpedia: gemma-2-9b/40-gemmascope-res-131k-l0_32plus
   - id: layer_40/width_131k/average_l0_94
     path: layer_40/width_131k/average_l0_94
     l0: 94
@@ -5184,6 +5255,7 @@ gemma-scope-9b-pt-res:
   - id: layer_40/width_16k/average_l0_32
     path: layer_40/width_16k/average_l0_32
     l0: 32
+    neuronpedia: gemma-2-9b/40-gemmascope-res-16k-l0_32plus
   - id: layer_40/width_16k/average_l0_61
     path: layer_40/width_16k/average_l0_61
     l0: 61
@@ -5202,6 +5274,7 @@ gemma-scope-9b-pt-res:
   - id: layer_41/width_131k/average_l0_45
     path: layer_41/width_131k/average_l0_45
     l0: 45
+    neuronpedia: gemma-2-9b/41-gemmascope-res-131k-l0_32plus
   - id: layer_41/width_131k/average_l0_84
     path: layer_41/width_131k/average_l0_84
     l0: 84
@@ -5223,6 +5296,7 @@ gemma-scope-9b-pt-res:
   - id: layer_41/width_16k/average_l0_52
     path: layer_41/width_16k/average_l0_52
     l0: 52
+    neuronpedia: gemma-2-9b/41-gemmascope-res-16k-l0_32plus
   - id: layer_5/width_131k/average_l0_10
     path: layer_5/width_131k/average_l0_10
     l0: 10
@@ -5235,6 +5309,7 @@ gemma-scope-9b-pt-res:
   - id: layer_5/width_131k/average_l0_51
     path: layer_5/width_131k/average_l0_51
     l0: 51
+    neuronpedia: gemma-2-9b/5-gemmascope-res-131k-l0_32plus
   - id: layer_5/width_131k/average_l0_6
     path: layer_5/width_131k/average_l0_6
     l0: 6
@@ -5253,6 +5328,7 @@ gemma-scope-9b-pt-res:
   - id: layer_5/width_16k/average_l0_37
     path: layer_5/width_16k/average_l0_37
     l0: 37
+    neuronpedia: gemma-2-9b/5-gemmascope-res-16k-l0_32plus
   - id: layer_5/width_16k/average_l0_77
     path: layer_5/width_16k/average_l0_77
     l0: 77
@@ -5271,6 +5347,7 @@ gemma-scope-9b-pt-res:
   - id: layer_6/width_131k/average_l0_66
     path: layer_6/width_131k/average_l0_66
     l0: 66
+    neuronpedia: gemma-2-9b/6-gemmascope-res-131k-l0_32plus
   - id: layer_6/width_131k/average_l0_7
     path: layer_6/width_131k/average_l0_7
     l0: 7
@@ -5286,6 +5363,7 @@ gemma-scope-9b-pt-res:
   - id: layer_6/width_16k/average_l0_47
     path: layer_6/width_16k/average_l0_47
     l0: 47
+    neuronpedia: gemma-2-9b/6-gemmascope-res-16k-l0_32plus
   - id: layer_6/width_16k/average_l0_8
     path: layer_6/width_16k/average_l0_8
     l0: 8
@@ -5304,6 +5382,7 @@ gemma-scope-9b-pt-res:
   - id: layer_7/width_131k/average_l0_38
     path: layer_7/width_131k/average_l0_38
     l0: 38
+    neuronpedia: gemma-2-9b/7-gemmascope-res-131k-l0_32plus
   - id: layer_7/width_131k/average_l0_65
     path: layer_7/width_131k/average_l0_65
     l0: 65
@@ -5322,6 +5401,7 @@ gemma-scope-9b-pt-res:
   - id: layer_7/width_16k/average_l0_46
     path: layer_7/width_16k/average_l0_46
     l0: 46
+    neuronpedia: gemma-2-9b/7-gemmascope-res-16k-l0_32plus
   - id: layer_7/width_16k/average_l0_8
     path: layer_7/width_16k/average_l0_8
     l0: 8
@@ -5340,6 +5420,7 @@ gemma-scope-9b-pt-res:
   - id: layer_8/width_131k/average_l0_41
     path: layer_8/width_131k/average_l0_41
     l0: 41
+    neuronpedia: gemma-2-9b/8-gemmascope-res-131k-l0_32plus
   - id: layer_8/width_131k/average_l0_72
     path: layer_8/width_131k/average_l0_72
     l0: 72
@@ -5358,6 +5439,7 @@ gemma-scope-9b-pt-res:
   - id: layer_8/width_16k/average_l0_51
     path: layer_8/width_16k/average_l0_51
     l0: 51
+    neuronpedia: gemma-2-9b/8-gemmascope-res-16k-l0_32plus
   - id: layer_8/width_16k/average_l0_9
     path: layer_8/width_16k/average_l0_9
     l0: 9
@@ -5376,6 +5458,7 @@ gemma-scope-9b-pt-res:
   - id: layer_9/width_131k/average_l0_42
     path: layer_9/width_131k/average_l0_42
     l0: 42
+    neuronpedia: gemma-2-9b/9-gemmascope-res-131k-l0_32plus
   - id: layer_9/width_131k/average_l0_75
     path: layer_9/width_131k/average_l0_75
     l0: 75
@@ -5397,6 +5480,7 @@ gemma-scope-9b-pt-res:
   - id: layer_9/width_16k/average_l0_51
     path: layer_9/width_16k/average_l0_51
     l0: 51
+    neuronpedia: gemma-2-9b/9-gemmascope-res-16k-l0_32plus
   - id: layer_9/width_16k/average_l0_9
     path: layer_9/width_16k/average_l0_9
     l0: 9
@@ -7461,6 +7545,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_0/width_16k/average_l0_50
     path: layer_0/width_16k/average_l0_50
     l0: 50
+    neuronpedia: gemma-2-9b/0-gemmascope-mlp-16k-l0_32plus
   - id: layer_0/width_131k/average_l0_3
     path: layer_0/width_131k/average_l0_3
     l0: 3
@@ -7488,6 +7573,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_1/width_16k/average_l0_56
     path: layer_1/width_16k/average_l0_56
     l0: 56
+    neuronpedia: gemma-2-9b/1-gemmascope-mlp-16k-l0_32plus
   - id: layer_1/width_16k/average_l0_128
     path: layer_1/width_16k/average_l0_128
     l0: 128
@@ -7521,6 +7607,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_10/width_16k/average_l0_49
     path: layer_10/width_16k/average_l0_49
     l0: 49
+    neuronpedia: gemma-2-9b/10-gemmascope-mlp-16k-l0_32plus
   - id: layer_10/width_16k/average_l0_114
     path: layer_10/width_16k/average_l0_114
     l0: 114
@@ -7551,6 +7638,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_11/width_16k/average_l0_34
     path: layer_11/width_16k/average_l0_34
     l0: 34
+    neuronpedia: gemma-2-9b/11-gemmascope-mlp-16k-l0_32plus
   - id: layer_11/width_16k/average_l0_76
     path: layer_11/width_16k/average_l0_76
     l0: 76
@@ -7584,6 +7672,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_12/width_16k/average_l0_42
     path: layer_12/width_16k/average_l0_42
     l0: 42
+    neuronpedia: gemma-2-9b/12-gemmascope-mlp-16k-l0_32plus
   - id: layer_12/width_16k/average_l0_96
     path: layer_12/width_16k/average_l0_96
     l0: 96
@@ -7620,6 +7709,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_13/width_16k/average_l0_40
     path: layer_13/width_16k/average_l0_40
     l0: 40
+    neuronpedia: gemma-2-9b/13-gemmascope-mlp-16k-l0_32plus
   - id: layer_13/width_16k/average_l0_94
     path: layer_13/width_16k/average_l0_94
     l0: 94
@@ -7656,6 +7746,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_14/width_16k/average_l0_41
     path: layer_14/width_16k/average_l0_41
     l0: 41
+    neuronpedia: gemma-2-9b/14-gemmascope-mlp-16k-l0_32plus
   - id: layer_14/width_16k/average_l0_97
     path: layer_14/width_16k/average_l0_97
     l0: 97
@@ -7692,6 +7783,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_15/width_16k/average_l0_45
     path: layer_15/width_16k/average_l0_45
     l0: 45
+    neuronpedia: gemma-2-9b/15-gemmascope-mlp-16k-l0_32plus
   - id: layer_15/width_16k/average_l0_107
     path: layer_15/width_16k/average_l0_107
     l0: 107
@@ -7728,6 +7820,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_16/width_16k/average_l0_37
     path: layer_16/width_16k/average_l0_37
     l0: 37
+    neuronpedia: gemma-2-9b/16-gemmascope-mlp-16k-l0_32plus
   - id: layer_16/width_16k/average_l0_91
     path: layer_16/width_16k/average_l0_91
     l0: 91
@@ -7764,6 +7857,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_17/width_16k/average_l0_41
     path: layer_17/width_16k/average_l0_41
     l0: 41
+    neuronpedia: gemma-2-9b/17-gemmascope-mlp-16k-l0_32plus
   - id: layer_17/width_16k/average_l0_104
     path: layer_17/width_16k/average_l0_104
     l0: 104
@@ -7800,6 +7894,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_18/width_16k/average_l0_36
     path: layer_18/width_16k/average_l0_36
     l0: 36
+    neuronpedia: gemma-2-9b/18-gemmascope-mlp-16k-l0_32plus
   - id: layer_18/width_16k/average_l0_89
     path: layer_18/width_16k/average_l0_89
     l0: 89
@@ -7836,6 +7931,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_19/width_16k/average_l0_38
     path: layer_19/width_16k/average_l0_38
     l0: 38
+    neuronpedia: gemma-2-9b/19-gemmascope-mlp-16k-l0_32plus
   - id: layer_19/width_16k/average_l0_98
     path: layer_19/width_16k/average_l0_98
     l0: 98
@@ -7875,6 +7971,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_2/width_16k/average_l0_33
     path: layer_2/width_16k/average_l0_33
     l0: 33
+    neuronpedia: gemma-2-9b/2-gemmascope-mlp-16k-l0_32plus
   - id: layer_2/width_16k/average_l0_81
     path: layer_2/width_16k/average_l0_81
     l0: 81
@@ -7905,6 +8002,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_20/width_16k/average_l0_41
     path: layer_20/width_16k/average_l0_41
     l0: 41
+    neuronpedia: gemma-2-9b/20-gemmascope-mlp-16k-l0_32plus
   - id: layer_20/width_16k/average_l0_108
     path: layer_20/width_16k/average_l0_108
     l0: 108
@@ -7941,6 +8039,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_21/width_16k/average_l0_34
     path: layer_21/width_16k/average_l0_34
     l0: 34
+    neuronpedia: gemma-2-9b/21-gemmascope-mlp-16k-l0_32plus
   - id: layer_21/width_16k/average_l0_88
     path: layer_21/width_16k/average_l0_88
     l0: 88
@@ -7977,6 +8076,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_22/width_16k/average_l0_34
     path: layer_22/width_16k/average_l0_34
     l0: 34
+    neuronpedia: gemma-2-9b/22-gemmascope-mlp-16k-l0_32plus
   - id: layer_22/width_16k/average_l0_85
     path: layer_22/width_16k/average_l0_85
     l0: 85
@@ -8016,6 +8116,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_23/width_16k/average_l0_73
     path: layer_23/width_16k/average_l0_73
     l0: 73
+    neuronpedia: gemma-2-9b/23-gemmascope-mlp-16k-l0_32plus
   - id: layer_23/width_16k/average_l0_190
     path: layer_23/width_16k/average_l0_190
     l0: 190
@@ -8049,6 +8150,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_24/width_16k/average_l0_32
     path: layer_24/width_16k/average_l0_32
     l0: 32
+    neuronpedia: gemma-2-9b/24-gemmascope-mlp-16k-l0_32plus
   - id: layer_24/width_16k/average_l0_73
     path: layer_24/width_16k/average_l0_73
     l0: 73
@@ -8088,6 +8190,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_25/width_16k/average_l0_72
     path: layer_25/width_16k/average_l0_72
     l0: 72
+    neuronpedia: gemma-2-9b/25-gemmascope-mlp-16k-l0_32plus
   - id: layer_25/width_16k/average_l0_184
     path: layer_25/width_16k/average_l0_184
     l0: 184
@@ -8124,6 +8227,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_26/width_16k/average_l0_57
     path: layer_26/width_16k/average_l0_57
     l0: 57
+    neuronpedia: gemma-2-9b/26-gemmascope-mlp-16k-l0_32plus
   - id: layer_26/width_16k/average_l0_142
     path: layer_26/width_16k/average_l0_142
     l0: 142
@@ -8160,6 +8264,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_27/width_16k/average_l0_52
     path: layer_27/width_16k/average_l0_52
     l0: 52
+    neuronpedia: gemma-2-9b/27-gemmascope-mlp-16k-l0_32plus
   - id: layer_27/width_16k/average_l0_126
     path: layer_27/width_16k/average_l0_126
     l0: 126
@@ -8196,6 +8301,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_28/width_16k/average_l0_50
     path: layer_28/width_16k/average_l0_50
     l0: 50
+    neuronpedia: gemma-2-9b/28-gemmascope-mlp-16k-l0_32plus
   - id: layer_28/width_16k/average_l0_115
     path: layer_28/width_16k/average_l0_115
     l0: 115
@@ -8232,6 +8338,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_29/width_16k/average_l0_49
     path: layer_29/width_16k/average_l0_49
     l0: 49
+    neuronpedia: gemma-2-9b/29-gemmascope-mlp-16k-l0_32plus
   - id: layer_29/width_16k/average_l0_111
     path: layer_29/width_16k/average_l0_111
     l0: 111
@@ -8268,6 +8375,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_3/width_16k/average_l0_55
     path: layer_3/width_16k/average_l0_55
     l0: 55
+    neuronpedia: gemma-2-9b/3-gemmascope-mlp-16k-l0_32plus
   - id: layer_3/width_16k/average_l0_126
     path: layer_3/width_16k/average_l0_126
     l0: 126
@@ -8301,6 +8409,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_30/width_16k/average_l0_51
     path: layer_30/width_16k/average_l0_51
     l0: 51
+    neuronpedia: gemma-2-9b/30-gemmascope-mlp-16k-l0_32plus
   - id: layer_30/width_16k/average_l0_116
     path: layer_30/width_16k/average_l0_116
     l0: 116
@@ -8337,6 +8446,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_31/width_16k/average_l0_43
     path: layer_31/width_16k/average_l0_43
     l0: 43
+    neuronpedia: gemma-2-9b/31-gemmascope-mlp-16k-l0_32plus
   - id: layer_31/width_16k/average_l0_94
     path: layer_31/width_16k/average_l0_94
     l0: 94
@@ -8373,6 +8483,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_32/width_16k/average_l0_44
     path: layer_32/width_16k/average_l0_44
     l0: 44
+    neuronpedia: gemma-2-9b/32-gemmascope-mlp-16k-l0_32plus
   - id: layer_32/width_16k/average_l0_98
     path: layer_32/width_16k/average_l0_98
     l0: 98
@@ -8409,6 +8520,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_33/width_16k/average_l0_48
     path: layer_33/width_16k/average_l0_48
     l0: 48
+    neuronpedia: gemma-2-9b/33-gemmascope-mlp-16k-l0_32plus
   - id: layer_33/width_16k/average_l0_107
     path: layer_33/width_16k/average_l0_107
     l0: 107
@@ -8445,6 +8557,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_34/width_16k/average_l0_47
     path: layer_34/width_16k/average_l0_47
     l0: 47
+    neuronpedia: gemma-2-9b/34-gemmascope-mlp-16k-l0_32plus
   - id: layer_34/width_16k/average_l0_107
     path: layer_34/width_16k/average_l0_107
     l0: 107
@@ -8481,6 +8594,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_35/width_16k/average_l0_46
     path: layer_35/width_16k/average_l0_46
     l0: 46
+    neuronpedia: gemma-2-9b/35-gemmascope-mlp-16k-l0_32plus
   - id: layer_35/width_16k/average_l0_108
     path: layer_35/width_16k/average_l0_108
     l0: 108
@@ -8517,6 +8631,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_36/width_16k/average_l0_47
     path: layer_36/width_16k/average_l0_47
     l0: 47
+    neuronpedia: gemma-2-9b/36-gemmascope-mlp-16k-l0_32plus
   - id: layer_36/width_16k/average_l0_109
     path: layer_36/width_16k/average_l0_109
     l0: 109
@@ -8553,6 +8668,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_37/width_16k/average_l0_53
     path: layer_37/width_16k/average_l0_53
     l0: 53
+    neuronpedia: gemma-2-9b/37-gemmascope-mlp-16k-l0_32plus
   - id: layer_37/width_16k/average_l0_119
     path: layer_37/width_16k/average_l0_119
     l0: 119
@@ -8589,6 +8705,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_38/width_16k/average_l0_45
     path: layer_38/width_16k/average_l0_45
     l0: 45
+    neuronpedia: gemma-2-9b/38-gemmascope-mlp-16k-l0_32plus
   - id: layer_38/width_16k/average_l0_98
     path: layer_38/width_16k/average_l0_98
     l0: 98
@@ -8625,6 +8742,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_39/width_16k/average_l0_43
     path: layer_39/width_16k/average_l0_43
     l0: 43
+    neuronpedia: gemma-2-9b/39-gemmascope-mlp-16k-l0_32plus
   - id: layer_39/width_16k/average_l0_90
     path: layer_39/width_16k/average_l0_90
     l0: 90
@@ -8661,6 +8779,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_4/width_16k/average_l0_66
     path: layer_4/width_16k/average_l0_66
     l0: 66
+    neuronpedia: gemma-2-9b/4-gemmascope-mlp-16k-l0_32plus
   - id: layer_4/width_16k/average_l0_151
     path: layer_4/width_16k/average_l0_151
     l0: 151
@@ -8694,6 +8813,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_40/width_16k/average_l0_37
     path: layer_40/width_16k/average_l0_37
     l0: 37
+    neuronpedia: gemma-2-9b/40-gemmascope-mlp-16k-l0_32plus
   - id: layer_40/width_16k/average_l0_74
     path: layer_40/width_16k/average_l0_74
     l0: 74
@@ -8733,6 +8853,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_41/width_16k/average_l0_58
     path: layer_41/width_16k/average_l0_58
     l0: 58
+    neuronpedia: gemma-2-9b/41-gemmascope-mlp-16k-l0_32plus
   - id: layer_41/width_16k/average_l0_126
     path: layer_41/width_16k/average_l0_126
     l0: 126
@@ -8766,6 +8887,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_5/width_16k/average_l0_46
     path: layer_5/width_16k/average_l0_46
     l0: 46
+    neuronpedia: gemma-2-9b/5-gemmascope-mlp-16k-l0_32plus
   - id: layer_5/width_16k/average_l0_93
     path: layer_5/width_16k/average_l0_93
     l0: 93
@@ -8799,6 +8921,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_6/width_16k/average_l0_46
     path: layer_6/width_16k/average_l0_46
     l0: 46
+    neuronpedia: gemma-2-9b/6-gemmascope-mlp-16k-l0_32plus
   - id: layer_6/width_16k/average_l0_96
     path: layer_6/width_16k/average_l0_96
     l0: 96
@@ -8832,6 +8955,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_7/width_16k/average_l0_47
     path: layer_7/width_16k/average_l0_47
     l0: 47
+    neuronpedia: gemma-2-9b/7-gemmascope-mlp-16k-l0_32plus
   - id: layer_7/width_16k/average_l0_101
     path: layer_7/width_16k/average_l0_101
     l0: 101
@@ -8865,6 +8989,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_8/width_16k/average_l0_55
     path: layer_8/width_16k/average_l0_55
     l0: 55
+    neuronpedia: gemma-2-9b/8-gemmascope-mlp-16k-l0_32plus
   - id: layer_8/width_16k/average_l0_124
     path: layer_8/width_16k/average_l0_124
     l0: 124
@@ -8901,6 +9026,7 @@ gemma-scope-9b-pt-mlp:
   - id: layer_9/width_16k/average_l0_83
     path: layer_9/width_16k/average_l0_83
     l0: 83
+    neuronpedia: gemma-2-9b/9-gemmascope-mlp-16k-l0_32plus
   - id: layer_9/width_16k/average_l0_200
     path: layer_9/width_16k/average_l0_200
     l0: 200


### PR DESCRIPTION
# Description

We're adding more Gemma Scope SAEs to neuronpedia. Specifically, res-16k, mlp-16k, res-131k of L0 >=32 (the closest one).
We're calling these `gemmascope-mlp-16k-l0_32plus` (replace mlp-16k with res-16k, etc).

This is not quite a "fix" but also not a new feature or breaking change, but I do want it to deploy a new build.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

