### PR TITLE
chore: reduce test space usage in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,16 +32,16 @@ jobs:
       - name: Cache Huggingface assets
         uses: actions/cache@v4
         with:
-          key: huggingface-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+          key: huggingface-0-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
           path: ~/.cache/huggingface
           restore-keys: |
-            huggingface-${{ runner.os }}-${{ matrix.python-version }}-
+            huggingface-0-${{ runner.os }}-${{ matrix.python-version }}-
       - name: Load cached Poetry installation
         id: cached-poetry
         uses: actions/cache@v4
         with:
           path: ~/.local  # the path depends on the OS
-          key: poetry-${{ runner.os }}-${{ matrix.python-version }}-0  # increment to reset cache
+          key: poetry-${{ runner.os }}-${{ matrix.python-version }}-1  # increment to reset cache
       - name: Install Poetry
         if: steps.cached-poetry.outputs.cache-hit != 'true'
         uses: snok/install-poetry@v1
@@ -54,9 +54,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+          key: venv-0-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: |
-            venv-${{ runner.os }}-${{ matrix.python-version }}-
+            venv-0-${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,6 @@
 import random
+import shutil
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -28,3 +30,15 @@ def reproducibility():
 @pytest.fixture
 def ts_model():
     return load_model_cached(TINYSTORIES_MODEL)
+
+
+# we started running out of space in CI, try cleaing up tmp paths after each test
+@pytest.fixture(autouse=True)
+def cleanup_tmp_path(tmp_path: Path):
+    yield  # This line allows the test to run and use tmp_path
+    # After the test is done, clean up the directory
+    for item in tmp_path.iterdir():
+        if item.is_file():
+            item.unlink()
+        elif item.is_dir():
+            shutil.rmtree(item)

--- a/tests/unit/training/test_cache_activations_runner.py
+++ b/tests/unit/training/test_cache_activations_runner.py
@@ -24,10 +24,10 @@ def _create_dataset(tmp_path: Path) -> Dataset:
     dataset_path = "NeelNanda/c4-tokenized-2b"
     batch_size = 1
     batches_in_buffer = 2
-    context_size = 32
+    context_size = 8
     num_buffers = 4
 
-    train_batch_size_tokens = 512
+    train_batch_size_tokens = 32
 
     tokens_in_buffer = batches_in_buffer * batch_size * context_size
     num_tokens = tokens_in_buffer * num_buffers
@@ -91,7 +91,7 @@ def test_cache_activations_runner(tmp_path: Path):
         is_dataset_tokenized=True,
         prepend_bos=True,  # I used to train GPT2 SAEs with a prepended-bos but no longer think we should do this.
         training_tokens=total_training_tokens,  # For initial testing I think this is a good number.
-        train_batch_size_tokens=4096,
+        train_batch_size_tokens=32,
         # Loss Function
         ## Reconstruction Coefficient.
         # Buffer details won't matter in we cache / shuffle our activations ahead of time.
@@ -117,7 +117,7 @@ def test_cache_activations_runner(tmp_path: Path):
 def test_load_cached_activations(tmp_path: Path):
 
     # total_training_steps = 20_000
-    context_size = 32
+    context_size = 8
     n_batches_in_buffer = 4
     store_batch_size = 1
     n_buffers = 4
@@ -174,10 +174,10 @@ def test_load_cached_activations(tmp_path: Path):
 
 def test_activations_store_refreshes_dataset_when_it_runs_out(tmp_path: Path):
 
-    context_size = 32
+    context_size = 8
     n_batches_in_buffer = 4
     store_batch_size = 1
-    total_training_steps = 200
+    total_training_steps = 4
     batch_size = 4
     total_training_tokens = total_training_steps * batch_size
 
@@ -255,7 +255,7 @@ def test_compare_cached_activations_end_to_end_with_ground_truth(tmp_path: Path)
     dataset_path = "NeelNanda/c4-tokenized-2b"
     batch_size = 8
     batches_in_buffer = 4
-    context_size = 32
+    context_size = 8
     num_buffers = 4
 
     train_batch_size_tokens = 4096
@@ -360,7 +360,7 @@ def test_cache_activations_runner_with_nonempty_directory(tmp_path: Path):
 
 def test_cache_activations_runner_with_incorrect_d_in(tmp_path: Path):
     d_in = 512
-    context_size = 32
+    context_size = 8
     n_batches_in_buffer = 4
     batch_size = 8
     num_buffers = 4
@@ -469,10 +469,10 @@ def test_cache_activations_runner_load_dataset_with_incorrect_config(tmp_path: P
 
 
 def test_cache_activations_runner_with_valid_seqpos(tmp_path: Path):
-    context_size = 1024
+    context_size = 32
     seqpos_slice = (12, -12)
     training_context_size = len(range(context_size)[slice(*seqpos_slice)])
-    n_batches_in_buffer = 32
+    n_batches_in_buffer = 4
     store_batch_size = 1
     n_buffers = 3
 
@@ -509,5 +509,5 @@ def test_cache_activations_runner_with_valid_seqpos(tmp_path: Path):
 
     assert len(dataset_acts) == n_buffers * n_batches_in_buffer
     for act in dataset_acts:
-        # should be 1024 - 12 - 12 = 1000
-        assert act.shape == (1000, cfg.d_in)
+        # should be 32 - 12 - 12 = 8
+        assert act.shape == (8, cfg.d_in)

--- a/tests/unit/training/test_cache_activations_runner.py
+++ b/tests/unit/training/test_cache_activations_runner.py
@@ -21,7 +21,7 @@ def _create_dataset(tmp_path: Path) -> Dataset:
 
     model_name = "gelu-1l"
     hook_name = "blocks.0.hook_mlp_out"
-    dataset_path = "NeelNanda/c4-tokenized-2b"
+    dataset_path = "NeelNanda/c4-10k"
     batch_size = 1
     batches_in_buffer = 2
     context_size = 8
@@ -46,7 +46,7 @@ def _create_dataset(tmp_path: Path) -> Dataset:
         hook_layer=0,
         d_in=512,
         context_size=context_size,
-        is_dataset_tokenized=True,
+        is_dataset_tokenized=False,
         prepend_bos=False,
         normalize_activations="none",
         device="cpu",
@@ -86,9 +86,9 @@ def test_cache_activations_runner(tmp_path: Path):
         hook_name="blocks.0.hook_mlp_out",
         hook_layer=0,
         d_in=512,
-        dataset_path="NeelNanda/c4-tokenized-2b",
+        dataset_path="NeelNanda/c4-10k",
         context_size=context_size,  # Speed things up.
-        is_dataset_tokenized=True,
+        is_dataset_tokenized=False,
         prepend_bos=True,  # I used to train GPT2 SAEs with a prepended-bos but no longer think we should do this.
         training_tokens=total_training_tokens,  # For initial testing I think this is a good number.
         train_batch_size_tokens=32,
@@ -138,7 +138,7 @@ def test_load_cached_activations(tmp_path: Path):
         d_in=512,
         dataset_path="NeelNanda/c4-10k",
         context_size=context_size,
-        is_dataset_tokenized=True,
+        is_dataset_tokenized=False,
         prepend_bos=True,  # I used to train GPT2 SAEs with a prepended-bos but no longer think we should do this.
         training_tokens=total_training_tokens,  # For initial testing I think this is a good number.
         train_batch_size_tokens=total_training_tokens // 2,
@@ -317,7 +317,7 @@ def test_load_activations_store_with_nonexistent_dataset(tmp_path: Path):
     cfg = CacheActivationsRunnerConfig(
         model_name="gelu-1l",
         hook_name="blocks.0.hook_mlp_out",
-        dataset_path="NeelNanda/c4-tokenized-2b",
+        dataset_path="NeelNanda/c4-10k",
         cached_activations_path=str(tmp_path),
     )
 
@@ -341,7 +341,7 @@ def test_cache_activations_runner_with_nonempty_directory(tmp_path: Path):
         new_cached_activations_path=str(tmp_path),
         model_name="gelu-1l",
         hook_name="blocks.0.hook_mlp_out",
-        dataset_path="NeelNanda/c4-tokenized-2b",
+        dataset_path="NeelNanda/c4-10k",
     )
     runner = CacheActivationsRunner(cfg)
 
@@ -372,7 +372,7 @@ def test_cache_activations_runner_with_incorrect_d_in(tmp_path: Path):
         context_size=context_size,
         model_name="gelu-1l",
         hook_name="blocks.0.hook_mlp_out",
-        dataset_path="NeelNanda/c4-tokenized-2b",
+        dataset_path="NeelNanda/c4-10k",
         training_tokens=num_tokens,
         n_batches_in_buffer=n_batches_in_buffer,
         store_batch_size_prompts=batch_size,
@@ -410,7 +410,7 @@ def test_cache_activations_runner_load_dataset_with_incorrect_config(tmp_path: P
         context_size=context_size,
         model_name="gelu-1l",
         hook_name="blocks.0.hook_mlp_out",
-        dataset_path="NeelNanda/c4-tokenized-2b",
+        dataset_path="NeelNanda/c4-10k",
         training_tokens=num_tokens,
         n_batches_in_buffer=n_batches_in_buffer,
         store_batch_size_prompts=batch_size,
@@ -485,7 +485,7 @@ def test_cache_activations_runner_with_valid_seqpos(tmp_path: Path):
         context_size=context_size,
         model_name="gelu-1l",
         hook_name="blocks.0.hook_mlp_out",
-        dataset_path="NeelNanda/c4-tokenized-2b",
+        dataset_path="NeelNanda/c4-10k",
         training_tokens=total_training_tokens,
         n_batches_in_buffer=n_batches_in_buffer,
         store_batch_size_prompts=store_batch_size,

--- a/tests/unit/training/test_cache_activations_runner.py
+++ b/tests/unit/training/test_cache_activations_runner.py
@@ -63,7 +63,7 @@ def _create_dataset(tmp_path: Path) -> Dataset:
 def test_cache_activations_runner(tmp_path: Path):
 
     # total_training_steps = 20_000
-    context_size = 1024
+    context_size = 8
     n_batches_in_buffer = 32
     store_batch_size = 1
     n_buffers = 3
@@ -195,7 +195,7 @@ def test_activations_store_refreshes_dataset_when_it_runs_out(tmp_path: Path):
         is_dataset_tokenized=True,
         prepend_bos=True,
         training_tokens=total_training_tokens // 2,
-        train_batch_size_tokens=512,
+        train_batch_size_tokens=8,
         n_batches_in_buffer=n_batches_in_buffer,
         store_batch_size_prompts=store_batch_size,
         normalize_activations="none",
@@ -258,7 +258,7 @@ def test_compare_cached_activations_end_to_end_with_ground_truth(tmp_path: Path)
     context_size = 8
     num_buffers = 4
 
-    train_batch_size_tokens = 4096
+    train_batch_size_tokens = 8
 
     tokens_in_buffer = batches_in_buffer * batch_size * context_size
     num_tokens = tokens_in_buffer * num_buffers


### PR DESCRIPTION
# Description

CI has started failing since merge #320 due to running out of space. It looks like this is due to loading and processing large datasets (c4-tokenized-2b). This PR replaces that dataset with a tiny tokenized version of c4-10k: https://huggingface.co/datasets/chanind/c4-10k-mini-tokenized-16-ctx-gelu-1l-tests. This is a tokenized version of the first 1k rows of the c4-10k dataset. It's split into 64 pieces, and the total dataset size is onlly 250kb (vs 2gb for c4-tokenized-2b)