### PR TITLE
updated SAE Bench pythia model names (and loader device cfg)

### DIFF
--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -12247,8 +12247,8 @@ sae_bench_gemma-2-2b_sweep_topk_ctx128_ef8_0824:
 sae_bench_pythia70m_sweep_gated_ctx128_0730:
   conversion_func: dictionary_learning_1
   links:
-    model: https://huggingface.co/EleutherAI/pythia-70m
-  model: pythia-70m
+    model: https://huggingface.co/EleutherAI/pythia-70m-deduped
+  model: pythia-70m-deduped
   repo_id: canrager/lm_sae
   saes:
   - id: blocks.3.hook_resid_post__trainer_0
@@ -12374,8 +12374,8 @@ sae_bench_pythia70m_sweep_gated_ctx128_0730:
 sae_bench_pythia70m_sweep_panneal_ctx128_0730:
   conversion_func: dictionary_learning_1
   links:
-    model: https://huggingface.co/EleutherAI/pythia-70m
-  model: pythia-70m
+    model: https://huggingface.co/EleutherAI/pythia-70m-deduped
+  model: pythia-70m-deduped
   repo_id: canrager/lm_sae
   saes:
   - id: blocks.3.hook_resid_post__trainer_16
@@ -12549,8 +12549,8 @@ sae_bench_pythia70m_sweep_panneal_ctx128_0730:
 sae_bench_pythia70m_sweep_standard_ctx128_0712:
   conversion_func: dictionary_learning_1
   links:
-    model: https://huggingface.co/EleutherAI/pythia-70m
-  model: pythia-70m
+    model: https://huggingface.co/EleutherAI/pythia-70m-deduped
+  model: pythia-70m-deduped
   repo_id: canrager/lm_sae
   saes:
   - id: blocks.3.hook_resid_post__trainer_10
@@ -12688,8 +12688,8 @@ sae_bench_pythia70m_sweep_standard_ctx128_0712:
 sae_bench_pythia70m_sweep_topk_ctx128_0730:
   conversion_func: dictionary_learning_1
   links:
-    model: https://huggingface.co/EleutherAI/pythia-70m
-  model: pythia-70m
+    model: https://huggingface.co/EleutherAI/pythia-70m-deduped
+  model: pythia-70m-deduped
   repo_id: canrager/lm_sae
   saes:
   - id: blocks.3.hook_resid_post__trainer_0

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -485,6 +485,7 @@ def dictionary_learning_sae_loader_1(
         force_download=force_download,
     )
     cfg_dict = get_sae_config(release, sae_id=sae_id, options=options)
+    cfg_dict["device"] = device
     if cfg_overrides:
         cfg_dict.update(cfg_overrides)
 


### PR DESCRIPTION
# Description

SAE Bench Pythia models will now refer to the correct (deduped) version of Pythia-70m. In addition, I've updated the loader function so that the passed-in device arg actually works.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)