### PR TITLE
changes dtype default value in read_sae_from_disk()

### DIFF
--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -642,7 +642,6 @@ class SAE(HookedRootModule):
             cfg_dict=cfg_dict,
             weight_path=weight_path,
             device=device,
-            dtype=DTYPE_MAP[cfg_dict["dtype"]],
         )
 
         sae_cfg = SAEConfig.from_dict(cfg_dict)

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -9,6 +9,7 @@ from huggingface_hub import hf_hub_download
 from huggingface_hub.utils import EntryNotFoundError
 from safetensors import safe_open
 
+from sae_lens.config import DTYPE_MAP
 from sae_lens.toolkit.pretrained_saes_directory import (
     PretrainedSAELookup,
     get_pretrained_saes_directory,
@@ -207,11 +208,13 @@ def read_sae_from_disk(
     cfg_dict: dict[str, Any],
     weight_path: str,
     device: str = "cpu",
-    dtype: torch.dtype = torch.float32,
+    dtype: Optional[torch.dtype] = None,
 ) -> tuple[dict[str, Any], dict[str, torch.Tensor]]:
     """
     Given a loaded dictionary and a path to a weight file, load the weights and return the state_dict.
     """
+    if dtype is None:
+        dtype = DTYPE_MAP[cfg_dict["dtype"]]
 
     state_dict = {}
     with safe_open(weight_path, framework="pt", device=device) as f:  # type: ignore
@@ -515,14 +518,6 @@ def dictionary_learning_sae_loader_1(
         state_dict["r_mag"] = encoder["r_mag"]
 
     return cfg_dict, state_dict, None
-
-
-# Helper function to get dtype from string
-DTYPE_MAP = {
-    "float32": torch.float32,
-    "float16": torch.float16,
-    "bfloat16": torch.bfloat16,
-}
 
 
 NAMED_PRETRAINED_SAE_LOADERS: dict[str, PretrainedSaeLoader] = {

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -12,7 +12,7 @@ import torch
 from jaxtyping import Float
 from torch import nn
 
-from sae_lens.config import DTYPE_MAP, LanguageModelSAERunnerConfig
+from sae_lens.config import LanguageModelSAERunnerConfig
 from sae_lens.sae import SAE, SAEConfig
 from sae_lens.toolkit.pretrained_sae_loaders import (
     handle_config_defaulting,
@@ -436,7 +436,6 @@ class TrainingSAE(SAE):
             cfg_dict=cfg_dict,
             weight_path=weight_path,
             device=device,
-            dtype=DTYPE_MAP[cfg_dict["dtype"]],
         )
         sae_cfg = TrainingSAEConfig.from_dict(cfg_dict)
 


### PR DESCRIPTION
# Description

Changes `read_sae_from_disk()` so that the `dtype` param is of type `Optional[torch.dtype]` and has a default value of `None`, in which case the function basically sets `dtype` to `cfg_dict["dtype"]`. `dtype` should be `cfg_dict["dtype"]`, unless the caller specifies a different value.

Fixes #230 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 