### PR TITLE
fix: previous saebench yaml fixes were incomplete for pythia-70m-deduped

### DIFF
--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -12252,124 +12252,124 @@ sae_bench_pythia70m_sweep_gated_ctx128_0730:
   repo_id: canrager/lm_sae
   saes:
   - id: blocks.3.hook_resid_post__trainer_0
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_0_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-4k-trainer_0_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_0
   - id: blocks.3.hook_resid_post__trainer_1
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_1_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-4k-trainer_1_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_1
   - id: blocks.3.hook_resid_post__trainer_10
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_10_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-16k-trainer_10_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_10
   - id: blocks.3.hook_resid_post__trainer_12
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_12_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-4k-trainer_12_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_12
   - id: blocks.3.hook_resid_post__trainer_13
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_13_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-4k-trainer_13_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_13
   - id: blocks.3.hook_resid_post__trainer_14
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_14_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-16k-trainer_14_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_14
   - id: blocks.3.hook_resid_post__trainer_15
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_15_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-16k-trainer_15_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_15
   - id: blocks.3.hook_resid_post__trainer_16
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_16_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-4k-trainer_16_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_16
   - id: blocks.3.hook_resid_post__trainer_17
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_17_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-4k-trainer_17_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_17
   - id: blocks.3.hook_resid_post__trainer_18
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_18_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-16k-trainer_18_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_18
   - id: blocks.3.hook_resid_post__trainer_19
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_19_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-16k-trainer_19_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_19
   - id: blocks.3.hook_resid_post__trainer_2
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_2_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-16k-trainer_2_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_2
   - id: blocks.3.hook_resid_post__trainer_3
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_3_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-16k-trainer_3_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_3
   - id: blocks.3.hook_resid_post__trainer_4
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_4_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-4k-trainer_4_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_4
   - id: blocks.3.hook_resid_post__trainer_5
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_5_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-4k-trainer_5_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_5
   - id: blocks.3.hook_resid_post__trainer_6
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_6_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-16k-trainer_6_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_6
   - id: blocks.3.hook_resid_post__trainer_7
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_7_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-16k-trainer_7_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_7
   - id: blocks.3.hook_resid_post__trainer_8
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_8_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-4k-trainer_8_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_8
   - id: blocks.3.hook_resid_post__trainer_9
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-4k-trainer_9_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-4k-trainer_9_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_9
   - id: blocks.3.hook_resid_post__trainer_11
-    neuronpedia: pythia-70m/3-sae_bench-gated-res-16k-trainer_11_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-gated-res-16k-trainer_11_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_3/trainer_11
   - id: blocks.4.hook_resid_post__trainer_0
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_0_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-4k-trainer_0_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_0
   - id: blocks.4.hook_resid_post__trainer_1
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_1_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-4k-trainer_1_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_1
   - id: blocks.4.hook_resid_post__trainer_10
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_10_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-16k-trainer_10_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_10
   - id: blocks.4.hook_resid_post__trainer_11
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_11_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-16k-trainer_11_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_11
   - id: blocks.4.hook_resid_post__trainer_12
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_12_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-4k-trainer_12_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_12
   - id: blocks.4.hook_resid_post__trainer_13
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_13_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-4k-trainer_13_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_13
   - id: blocks.4.hook_resid_post__trainer_14
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_14_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-16k-trainer_14_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_14
   - id: blocks.4.hook_resid_post__trainer_15
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_15_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-16k-trainer_15_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_15
   - id: blocks.4.hook_resid_post__trainer_16
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_16_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-4k-trainer_16_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_16
   - id: blocks.4.hook_resid_post__trainer_17
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_17_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-4k-trainer_17_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_17
   - id: blocks.4.hook_resid_post__trainer_18
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_18_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-16k-trainer_18_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_18
   - id: blocks.4.hook_resid_post__trainer_19
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_19_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-16k-trainer_19_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_19
   - id: blocks.4.hook_resid_post__trainer_2
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_2_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-16k-trainer_2_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_2
   - id: blocks.4.hook_resid_post__trainer_3
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_3_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-16k-trainer_3_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_3
   - id: blocks.4.hook_resid_post__trainer_4
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_4_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-4k-trainer_4_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_4
   - id: blocks.4.hook_resid_post__trainer_5
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_5_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-4k-trainer_5_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_5
   - id: blocks.4.hook_resid_post__trainer_6
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_6_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-16k-trainer_6_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_6
   - id: blocks.4.hook_resid_post__trainer_9
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_9_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-4k-trainer_9_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_9
   - id: blocks.4.hook_resid_post__trainer_8
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-4k-trainer_8_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-4k-trainer_8_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_8
   - id: blocks.4.hook_resid_post__trainer_7
-    neuronpedia: pythia-70m/4-sae_bench-gated-res-16k-trainer_7_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-gated-res-16k-trainer_7_step_final
     path: pythia70m_sweep_gated_ctx128_0730/resid_post_layer_4/trainer_7
 sae_bench_pythia70m_sweep_panneal_ctx128_0730:
   conversion_func: dictionary_learning_1
@@ -12379,172 +12379,172 @@ sae_bench_pythia70m_sweep_panneal_ctx128_0730:
   repo_id: canrager/lm_sae
   saes:
   - id: blocks.3.hook_resid_post__trainer_16
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_16_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-4k-trainer_16_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_16
   - id: blocks.3.hook_resid_post__trainer_17
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_17_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-4k-trainer_17_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_17
   - id: blocks.3.hook_resid_post__trainer_18
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_18_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-16k-trainer_18_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_18
   - id: blocks.3.hook_resid_post__trainer_19
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_19_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-16k-trainer_19_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_19
   - id: blocks.3.hook_resid_post__trainer_2
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_2_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-16k-trainer_2_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_2
   - id: blocks.3.hook_resid_post__trainer_20
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_20_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-4k-trainer_20_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_20
   - id: blocks.3.hook_resid_post__trainer_21
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_21_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-4k-trainer_21_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_21
   - id: blocks.3.hook_resid_post__trainer_22
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_22_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-16k-trainer_22_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_22
   - id: blocks.3.hook_resid_post__trainer_15
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_15_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-16k-trainer_15_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_15
   - id: blocks.3.hook_resid_post__trainer_23
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_23_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-16k-trainer_23_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_23
   - id: blocks.3.hook_resid_post__trainer_25
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_25_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-4k-trainer_25_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_25
   - id: blocks.3.hook_resid_post__trainer_26
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_26_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-16k-trainer_26_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_26
   - id: blocks.3.hook_resid_post__trainer_27
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_27_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-16k-trainer_27_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_27
   - id: blocks.3.hook_resid_post__trainer_3
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_3_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-16k-trainer_3_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_3
   - id: blocks.3.hook_resid_post__trainer_4
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_4_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-4k-trainer_4_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_4
   - id: blocks.3.hook_resid_post__trainer_5
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_5_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-4k-trainer_5_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_5
   - id: blocks.3.hook_resid_post__trainer_6
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_6_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-16k-trainer_6_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_6
   - id: blocks.3.hook_resid_post__trainer_7
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_7_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-16k-trainer_7_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_7
   - id: blocks.3.hook_resid_post__trainer_24
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_24_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-4k-trainer_24_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_24
   - id: blocks.3.hook_resid_post__trainer_14
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_14_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-16k-trainer_14_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_14
   - id: blocks.3.hook_resid_post__trainer_13
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_13_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-4k-trainer_13_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_13
   - id: blocks.3.hook_resid_post__trainer_12
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_12_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-4k-trainer_12_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_12
   - id: blocks.3.hook_resid_post__trainer_0
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_0_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-4k-trainer_0_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_0
   - id: blocks.3.hook_resid_post__trainer_1
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_1_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-4k-trainer_1_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_1
   - id: blocks.3.hook_resid_post__trainer_10
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_10_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-16k-trainer_10_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_10
   - id: blocks.3.hook_resid_post__trainer_11
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-16k-trainer_11_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-16k-trainer_11_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_11
   - id: blocks.3.hook_resid_post__trainer_8
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_8_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-4k-trainer_8_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_8
   - id: blocks.3.hook_resid_post__trainer_9
-    neuronpedia: pythia-70m/3-sae_bench-panneal-res-4k-trainer_9_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-panneal-res-4k-trainer_9_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_3/trainer_9
   - id: blocks.4.hook_resid_post__trainer_17
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_17_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-4k-trainer_17_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_17
   - id: blocks.4.hook_resid_post__trainer_18
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_18_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-16k-trainer_18_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_18
   - id: blocks.4.hook_resid_post__trainer_19
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_19_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-16k-trainer_19_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_19
   - id: blocks.4.hook_resid_post__trainer_16
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_16_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-4k-trainer_16_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_16
   - id: blocks.4.hook_resid_post__trainer_15
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_15_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-16k-trainer_15_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_15
   - id: blocks.4.hook_resid_post__trainer_14
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_14_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-16k-trainer_14_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_14
   - id: blocks.4.hook_resid_post__trainer_13
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_13_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-4k-trainer_13_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_13
   - id: blocks.4.hook_resid_post__trainer_12
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_12_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-4k-trainer_12_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_12
   - id: blocks.4.hook_resid_post__trainer_11
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_11_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-16k-trainer_11_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_11
   - id: blocks.4.hook_resid_post__trainer_10
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_10_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-16k-trainer_10_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_10
   - id: blocks.4.hook_resid_post__trainer_1
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_1_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-4k-trainer_1_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_1
   - id: blocks.4.hook_resid_post__trainer_0
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_0_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-4k-trainer_0_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_0
   - id: blocks.4.hook_resid_post__trainer_2
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_2_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-16k-trainer_2_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_2
   - id: blocks.4.hook_resid_post__trainer_20
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_20_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-4k-trainer_20_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_20
   - id: blocks.4.hook_resid_post__trainer_22
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_22_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-16k-trainer_22_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_22
   - id: blocks.4.hook_resid_post__trainer_9
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_9_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-4k-trainer_9_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_9
   - id: blocks.4.hook_resid_post__trainer_8
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_8_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-4k-trainer_8_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_8
   - id: blocks.4.hook_resid_post__trainer_7
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_7_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-16k-trainer_7_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_7
   - id: blocks.4.hook_resid_post__trainer_6
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_6_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-16k-trainer_6_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_6
   - id: blocks.4.hook_resid_post__trainer_5
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_5_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-4k-trainer_5_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_5
   - id: blocks.4.hook_resid_post__trainer_4
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_4_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-4k-trainer_4_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_4
   - id: blocks.4.hook_resid_post__trainer_27
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_27_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-16k-trainer_27_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_27
   - id: blocks.4.hook_resid_post__trainer_26
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_26_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-16k-trainer_26_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_26
   - id: blocks.4.hook_resid_post__trainer_25
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_25_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-4k-trainer_25_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_25
   - id: blocks.4.hook_resid_post__trainer_3
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_3_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-16k-trainer_3_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_3
   - id: blocks.4.hook_resid_post__trainer_24
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_24_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-4k-trainer_24_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_24
   - id: blocks.4.hook_resid_post__trainer_21
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-4k-trainer_21_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-4k-trainer_21_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_21
   - id: blocks.4.hook_resid_post__trainer_23
-    neuronpedia: pythia-70m/4-sae_bench-panneal-res-16k-trainer_23_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-panneal-res-16k-trainer_23_step_final
     path: pythia70m_sweep_panneal_ctx128_0730/resid_post_layer_4/trainer_23
 sae_bench_pythia70m_sweep_standard_ctx128_0712:
   conversion_func: dictionary_learning_1
@@ -12554,136 +12554,136 @@ sae_bench_pythia70m_sweep_standard_ctx128_0712:
   repo_id: canrager/lm_sae
   saes:
   - id: blocks.3.hook_resid_post__trainer_10
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_10_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-16k-trainer_10_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_10
   - id: blocks.3.hook_resid_post__trainer_11
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_11_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-16k-trainer_11_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_11
   - id: blocks.3.hook_resid_post__trainer_8
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_8_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-4k-trainer_8_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_8
   - id: blocks.3.hook_resid_post__trainer_7
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_7_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-16k-trainer_7_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_7
   - id: blocks.3.hook_resid_post__trainer_6
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_6_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-16k-trainer_6_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_6
   - id: blocks.3.hook_resid_post__trainer_5
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_5_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-4k-trainer_5_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_5
   - id: blocks.3.hook_resid_post__trainer_4
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_4_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-4k-trainer_4_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_4
   - id: blocks.3.hook_resid_post__trainer_3
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_3_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-16k-trainer_3_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_3
   - id: blocks.3.hook_resid_post__trainer_2
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_2_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-16k-trainer_2_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_2
   - id: blocks.3.hook_resid_post__trainer_19
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_19_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-16k-trainer_19_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_19
   - id: blocks.3.hook_resid_post__trainer_18
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_18_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-16k-trainer_18_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_18
   - id: blocks.3.hook_resid_post__trainer_17
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_17_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-4k-trainer_17_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_17
   - id: blocks.3.hook_resid_post__trainer_16
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_16_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-4k-trainer_16_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_16
   - id: blocks.3.hook_resid_post__trainer_15
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_15_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-16k-trainer_15_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_15
   - id: blocks.3.hook_resid_post__trainer_14
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-16k-trainer_14_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-16k-trainer_14_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_14
   - id: blocks.3.hook_resid_post__trainer_0
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_0_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-4k-trainer_0_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_0
   - id: blocks.3.hook_resid_post__trainer_1
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_1_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-4k-trainer_1_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_1
   - id: blocks.3.hook_resid_post__trainer_13
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_13_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-4k-trainer_13_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_13
   - id: blocks.3.hook_resid_post__trainer_12
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_12_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-4k-trainer_12_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_12
   - id: blocks.3.hook_resid_post__trainer_9
-    neuronpedia: pythia-70m/3-sae_bench-standard-res-4k-trainer_9_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-standard-res-4k-trainer_9_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_3/trainer_9
   - id: blocks.4.hook_resid_post__trainer_0
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_0_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-4k-trainer_0_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_0
   - id: blocks.4.hook_resid_post__trainer_11
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_11_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-16k-trainer_11_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_11
   - id: blocks.4.hook_resid_post__trainer_10
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_10_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-16k-trainer_10_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_10
   - id: blocks.4.hook_resid_post__trainer_1
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_1_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-4k-trainer_1_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_1
   - id: blocks.4.hook_resid_post__trainer_13
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_13_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-4k-trainer_13_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_13
   - id: blocks.4.hook_resid_post__trainer_14
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_14_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-16k-trainer_14_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_14
   - id: blocks.4.hook_resid_post__trainer_16
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_16_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-4k-trainer_16_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_16
   - id: blocks.4.hook_resid_post__trainer_17
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_17_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-4k-trainer_17_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_17
   - id: blocks.4.hook_resid_post__trainer_18
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_18_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-16k-trainer_18_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_18
   - id: blocks.4.hook_resid_post__trainer_2
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_2_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-16k-trainer_2_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_2
   - id: blocks.4.hook_resid_post__trainer_20
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_20_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-4k-trainer_20_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_20
   - id: blocks.4.hook_resid_post__trainer_21
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_21_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-4k-trainer_21_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_21
   - id: blocks.4.hook_resid_post__trainer_12
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_12_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-4k-trainer_12_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_12
   - id: blocks.4.hook_resid_post__trainer_22
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_22_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-16k-trainer_22_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_22
   - id: blocks.4.hook_resid_post__trainer_3
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_3_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-16k-trainer_3_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_3
   - id: blocks.4.hook_resid_post__trainer_4
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_4_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-4k-trainer_4_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_4
   - id: blocks.4.hook_resid_post__trainer_5
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_5_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-4k-trainer_5_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_5
   - id: blocks.4.hook_resid_post__trainer_6
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_6_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-16k-trainer_6_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_6
   - id: blocks.4.hook_resid_post__trainer_7
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_7_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-16k-trainer_7_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_7
   - id: blocks.4.hook_resid_post__trainer_8
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_8_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-4k-trainer_8_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_8
   - id: blocks.4.hook_resid_post__trainer_9
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-4k-trainer_9_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-4k-trainer_9_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_9
   - id: blocks.4.hook_resid_post__trainer_23
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_23_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-16k-trainer_23_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_23
   - id: blocks.4.hook_resid_post__trainer_15
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_15_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-16k-trainer_15_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_15
   - id: blocks.4.hook_resid_post__trainer_19
-    neuronpedia: pythia-70m/4-sae_bench-standard-res-16k-trainer_19_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-standard-res-16k-trainer_19_step_final
     path: pythia70m_sweep_standard_ctx128_0712/resid_post_layer_4/trainer_19
 sae_bench_pythia70m_sweep_topk_ctx128_0730:
   conversion_func: dictionary_learning_1
@@ -12693,148 +12693,148 @@ sae_bench_pythia70m_sweep_topk_ctx128_0730:
   repo_id: canrager/lm_sae
   saes:
   - id: blocks.3.hook_resid_post__trainer_0
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_0_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-4k-trainer_0_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_0
   - id: blocks.3.hook_resid_post__trainer_1
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_1_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-4k-trainer_1_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_1
   - id: blocks.3.hook_resid_post__trainer_10
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_10_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-16k-trainer_10_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_10
   - id: blocks.3.hook_resid_post__trainer_11
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_11_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-16k-trainer_11_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_11
   - id: blocks.3.hook_resid_post__trainer_12
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_12_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-4k-trainer_12_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_12
   - id: blocks.3.hook_resid_post__trainer_13
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_13_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-4k-trainer_13_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_13
   - id: blocks.3.hook_resid_post__trainer_14
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_14_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-16k-trainer_14_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_14
   - id: blocks.3.hook_resid_post__trainer_22
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_22_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-16k-trainer_22_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_22
   - id: blocks.3.hook_resid_post__trainer_19
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_19_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-16k-trainer_19_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_19
   - id: blocks.3.hook_resid_post__trainer_2
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_2_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-16k-trainer_2_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_2
   - id: blocks.3.hook_resid_post__trainer_20
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_20_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-4k-trainer_20_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_20
   - id: blocks.3.hook_resid_post__trainer_21
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_21_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-4k-trainer_21_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_21
   - id: blocks.3.hook_resid_post__trainer_16
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_16_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-4k-trainer_16_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_16
   - id: blocks.3.hook_resid_post__trainer_23
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_23_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-16k-trainer_23_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_23
   - id: blocks.3.hook_resid_post__trainer_18
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_18_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-16k-trainer_18_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_18
   - id: blocks.3.hook_resid_post__trainer_3
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_3_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-16k-trainer_3_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_3
   - id: blocks.3.hook_resid_post__trainer_5
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_5_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-4k-trainer_5_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_5
   - id: blocks.3.hook_resid_post__trainer_6
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_6_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-16k-trainer_6_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_6
   - id: blocks.3.hook_resid_post__trainer_7
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_7_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-16k-trainer_7_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_7
   - id: blocks.3.hook_resid_post__trainer_8
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_8_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-4k-trainer_8_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_8
   - id: blocks.3.hook_resid_post__trainer_9
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_9_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-4k-trainer_9_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_9
   - id: blocks.3.hook_resid_post__trainer_15
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-16k-trainer_15_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-16k-trainer_15_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_15
   - id: blocks.3.hook_resid_post__trainer_4
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_4_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-4k-trainer_4_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_4
   - id: blocks.3.hook_resid_post__trainer_17
-    neuronpedia: pythia-70m/3-sae_bench-topk-res-4k-trainer_17_step_final
+    neuronpedia: pythia-70m-deduped/3-sae_bench-topk-res-4k-trainer_17_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_3/trainer_17
   - id: blocks.4.hook_resid_post__trainer_13
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_13_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-4k-trainer_13_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_13
   - id: blocks.4.hook_resid_post__trainer_14
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_14_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-16k-trainer_14_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_14
   - id: blocks.4.hook_resid_post__trainer_15
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_15_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-16k-trainer_15_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_15
   - id: blocks.4.hook_resid_post__trainer_16
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_16_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-4k-trainer_16_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_16
   - id: blocks.4.hook_resid_post__trainer_17
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_17_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-4k-trainer_17_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_17
   - id: blocks.4.hook_resid_post__trainer_18
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_18_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-16k-trainer_18_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_18
   - id: blocks.4.hook_resid_post__trainer_19
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_19_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-16k-trainer_19_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_19
   - id: blocks.4.hook_resid_post__trainer_2
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_2_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-16k-trainer_2_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_2
   - id: blocks.4.hook_resid_post__trainer_20
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_20_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-4k-trainer_20_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_20
   - id: blocks.4.hook_resid_post__trainer_21
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_21_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-4k-trainer_21_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_21
   - id: blocks.4.hook_resid_post__trainer_22
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_22_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-16k-trainer_22_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_22
   - id: blocks.4.hook_resid_post__trainer_23
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_23_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-16k-trainer_23_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_23
   - id: blocks.4.hook_resid_post__trainer_3
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_3_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-16k-trainer_3_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_3
   - id: blocks.4.hook_resid_post__trainer_4
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_4_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-4k-trainer_4_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_4
   - id: blocks.4.hook_resid_post__trainer_5
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_5_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-4k-trainer_5_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_5
   - id: blocks.4.hook_resid_post__trainer_6
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_6_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-16k-trainer_6_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_6
   - id: blocks.4.hook_resid_post__trainer_7
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_7_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-16k-trainer_7_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_7
   - id: blocks.4.hook_resid_post__trainer_12
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_12_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-4k-trainer_12_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_12
   - id: blocks.4.hook_resid_post__trainer_11
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_11_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-16k-trainer_11_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_11
   - id: blocks.4.hook_resid_post__trainer_10
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-16k-trainer_10_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-16k-trainer_10_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_10
   - id: blocks.4.hook_resid_post__trainer_1
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_1_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-4k-trainer_1_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_1
   - id: blocks.4.hook_resid_post__trainer_0
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_0_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-4k-trainer_0_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_0
   - id: blocks.4.hook_resid_post__trainer_9
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_9_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-4k-trainer_9_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_9
   - id: blocks.4.hook_resid_post__trainer_8
-    neuronpedia: pythia-70m/4-sae_bench-topk-res-4k-trainer_8_step_final
+    neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-4k-trainer_8_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_8
 llama-3-8b-it-res-jh:
   repo_id: Juliushanhanhan/llama-3-8b-it-res


### PR DESCRIPTION
# Description

Previous fix to update pythia-70m -> pythia-70m-deduped was incomplete. This fixes it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

