### PR TITLE
fix: fix duplicate np ids

### DIFF
--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -1167,7 +1167,6 @@ gemma-scope-2b-pt-res:
     l0: 9
   - id: layer_12/width_1m/average_l0_107
     path: layer_12/width_1m/average_l0_107
-    neuronpedia: gemma-2-2b/12-gemmascope-res-1m
     l0: 107
   - id: layer_12/width_1m/average_l0_19
     path: layer_12/width_1m/average_l0_19
@@ -1207,7 +1206,6 @@ gemma-scope-2b-pt-res:
     l0: 11
   - id: layer_12/width_262k/average_l0_121
     path: layer_12/width_262k/average_l0_121
-    neuronpedia: gemma-2-2b/12-gemmascope-res-262k
     l0: 121
   - id: layer_12/width_262k/average_l0_21
     path: layer_12/width_262k/average_l0_21
@@ -1238,11 +1236,9 @@ gemma-scope-2b-pt-res:
     l0: 40
   - id: layer_12/width_32k/average_l0_76
     path: layer_12/width_32k/average_l0_76
-    neuronpedia: gemma-2-2b/12-gemmascope-res-32k
     l0: 76
   - id: layer_12/width_524k/average_l0_115
     path: layer_12/width_524k/average_l0_115
-    neuronpedia: gemma-2-2b/12-gemmascope-res-524k
     l0: 115
   - id: layer_12/width_524k/average_l0_22
     path: layer_12/width_524k/average_l0_22


### PR DESCRIPTION
# Description

Removes duplicate NP ids from non-canonical gemma-scope SAEs.
