### PR TITLE
Add tests for evals

### DIFF
--- a/tests/unit/test_evals.py
+++ b/tests/unit/test_evals.py
@@ -73,7 +73,7 @@ TRAINER_EVAL_CONFIG = EvalConfig(
         {
             "model_name": "tiny-stories-1M",
             "dataset_path": "roneneldan/TinyStories",
-            "hook_name": "blocks..attn.hook_q",
+            "hook_name": "blocks.1.attn.hook_q",
             "hook_layer": 1,
             "d_in": 4,
             "hook_head_index": 2,

--- a/tests/unit/test_evals.py
+++ b/tests/unit/test_evals.py
@@ -70,6 +70,14 @@ TRAINER_EVAL_CONFIG = EvalConfig(
             "hook_layer": 1,
             "d_in": 16 * 4,
         },
+        {
+            "model_name": "tiny-stories-1M",
+            "dataset_path": "roneneldan/TinyStories",
+            "hook_name": "blocks..attn.hook_q",
+            "hook_layer": 1,
+            "d_in": 4,
+            "hook_head_index": 2,
+        },
     ],
     ids=[
         "tiny-stories-1M-resid-pre",
@@ -77,6 +85,7 @@ TRAINER_EVAL_CONFIG = EvalConfig(
         "tiny-stories-1M-resid-pre-pretokenized",
         "tiny-stories-1M-hook-z",
         "tiny-stories-1M-hook-q",
+        "tiny-stories-1M-hook-q-head-index-2",
     ],
 )
 def cfg(request: pytest.FixtureRequest):


### PR DESCRIPTION
# Description

Adds unit tests for `all_loadable_saes()` and `get_saes_from_regex()`, and another test for `run_evals()`. There's no coverage for the first two functions, and there's no coverage for `single_head_replacement_hook()` and `single_head_zero_ablate_hook()` defined inside of the third function, at https://app.codecov.io/gh/jbloomAus/SAELens/blob/main/sae_lens%2Fevals.py.

Fixes #82

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 