### PR TITLE
Supply `device` to `SAEConfigLoadOptions`

### DIFF
--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -19,7 +19,6 @@ from sae_lens.toolkit.pretrained_saes_directory import (
 
 # loaders take in a release, sae_id, device, and whether to force download, and returns a tuple of config, state_dict, and log sparsity
 class PretrainedSaeLoader(Protocol):
-
     def __call__(
         self,
         release: str,
@@ -50,6 +49,7 @@ def sae_lens_loader(
     Get's SAEs from HF, loads them.
     """
     options = SAEConfigLoadOptions(
+        device=device,
         force_download=force_download,
     )
     cfg_dict = get_sae_config(release, sae_id=sae_id, options=options)
@@ -120,7 +120,6 @@ def get_sae_config_from_hf(
 
 
 def handle_config_defaulting(cfg_dict: dict[str, Any]) -> dict[str, Any]:
-
     # Set default values for backwards compatibility
     cfg_dict.setdefault("prepend_bos", True)
     cfg_dict.setdefault("dataset_trust_remote_code", True)
@@ -186,6 +185,7 @@ def connor_rob_hook_z_loader(
     cfg_overrides: Optional[dict[str, Any]] = None,
 ) -> tuple[dict[str, Any], dict[str, torch.Tensor], None]:
     options = SAEConfigLoadOptions(
+        device=device,
         force_download=force_download,
     )
     cfg_dict = get_sae_config(
@@ -344,6 +344,7 @@ def gemma_2_sae_loader(
     Custom loader for Gemma 2 SAEs.
     """
     options = SAEConfigLoadOptions(
+        device=device,
         d_sae_override=d_sae_override,
         layer_override=layer_override,
     )
@@ -485,6 +486,7 @@ def dictionary_learning_sae_loader_1(
     Suitable for SAEs from https://huggingface.co/canrager/lm_sae.
     """
     options = SAEConfigLoadOptions(
+        device=device,
         force_download=force_download,
     )
     cfg_dict = get_sae_config(release, sae_id=sae_id, options=options)


### PR DESCRIPTION
This is a bug which was introduced last week. The issue seems to be that the `SAEConfigLoadOptions` class was introduced which contains the `device` field (default `None`), and this field wasn't set when device is not None. Before this change, the config was just loaded directly from HuggingFace without overriding its `device` value (which on HuggingFace presumably is "cuda").

Would be great if this PR could be merged soon if possible, and I can try to add tests for this kind of failure mode afterwards.