### PR TITLE
fix: use the correct layer for new gemma scope SAE sparsities

### DIFF
--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -815,22 +815,18 @@ gemma-scope-2b-pt-res:
     l0: 281
   - id: layer_4/width_16k/average_l0_31
     path: layer_4/width_16k/average_l0_31
-    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-34
     l0: 31
   - id: layer_4/width_16k/average_l0_60
     path: layer_4/width_16k/average_l0_60
     l0: 60
   - id: layer_5/width_16k/average_l0_143
     path: layer_5/width_16k/average_l0_143
-    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-143
     l0: 143
   - id: layer_5/width_16k/average_l0_18
     path: layer_5/width_16k/average_l0_18
-    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-18
     l0: 18
   - id: layer_5/width_16k/average_l0_309
     path: layer_5/width_16k/average_l0_309
-    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-309
     l0: 309
   - id: layer_5/width_16k/average_l0_34
     path: layer_5/width_16k/average_l0_34
@@ -930,15 +926,19 @@ gemma-scope-2b-pt-res:
     l0: 80
   - id: layer_12/width_16k/average_l0_176
     path: layer_12/width_16k/average_l0_176
+    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-176
     l0: 176
   - id: layer_12/width_16k/average_l0_22
     path: layer_12/width_16k/average_l0_22
+    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-22
     l0: 22
   - id: layer_12/width_16k/average_l0_41
     path: layer_12/width_16k/average_l0_41
+    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-41
     l0: 41
   - id: layer_12/width_16k/average_l0_445
     path: layer_12/width_16k/average_l0_445
+    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-445
     l0: 445
   - id: layer_12/width_16k/average_l0_82
     path: layer_12/width_16k/average_l0_82
@@ -1335,19 +1335,15 @@ gemma-scope-2b-pt-res:
     l0: 105
   - id: layer_5/width_65k/average_l0_17
     path: layer_5/width_65k/average_l0_17
-    neuronpedia: gemma-2-2b/12-gemmascope-res-65k__l0-17
     l0: 17
   - id: layer_5/width_65k/average_l0_211
     path: layer_5/width_65k/average_l0_211
-    neuronpedia: gemma-2-2b/12-gemmascope-res-65k__l0-211
     l0: 211
   - id: layer_5/width_65k/average_l0_29
     path: layer_5/width_65k/average_l0_29
-    neuronpedia: gemma-2-2b/12-gemmascope-res-65k__l0-29
     l0: 29
   - id: layer_5/width_65k/average_l0_53
     path: layer_5/width_65k/average_l0_53
-    neuronpedia: gemma-2-2b/12-gemmascope-res-65k__l0-53
     l0: 53
   - id: layer_6/width_65k/average_l0_107
     path: layer_6/width_65k/average_l0_107
@@ -1441,15 +1437,19 @@ gemma-scope-2b-pt-res:
     l0: 70
   - id: layer_12/width_65k/average_l0_141
     path: layer_12/width_65k/average_l0_141
+    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-141
     l0: 141
   - id: layer_12/width_65k/average_l0_21
     path: layer_12/width_65k/average_l0_21
+    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-21
     l0: 21
   - id: layer_12/width_65k/average_l0_297
     path: layer_12/width_65k/average_l0_297
+    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-297
     l0: 297
   - id: layer_12/width_65k/average_l0_38
     path: layer_12/width_65k/average_l0_38
+    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-38
     l0: 38
   - id: layer_12/width_65k/average_l0_72
     path: layer_12/width_65k/average_l0_72


### PR DESCRIPTION
# Description

Fixes the incorrect layer 5 and uses the correct layer 12 for sparsity experiment instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
