### PR TITLE
Add logic to train JumpReLU SAEs

### DIFF
--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -162,7 +162,7 @@ class LanguageModelSAERunnerConfig:
     seed: int = 42
     dtype: str = "float32"  # type: ignore #
     prepend_bos: bool = True
-    initial_threshold: float = 0.5
+    initial_threshold: float = 0.001
 
     # Performance - see compilation section of lm_runner.py for info
     autocast: bool = False  # autocast to autocast_dtype during training
@@ -411,6 +411,7 @@ class LanguageModelSAERunnerConfig:
             "decoder_heuristic_init": self.decoder_heuristic_init,
             "init_encoder_as_decoder_transpose": self.init_encoder_as_decoder_transpose,
             "normalize_activations": self.normalize_activations,
+            "initial_threshold": self.initial_threshold,
         }
 
     def to_dict(self) -> dict[str, Any]:

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -66,7 +66,7 @@ class LanguageModelSAERunnerConfig:
         seed (int): The seed to use.
         dtype (str): The data type to use.
         prepend_bos (bool): Whether to prepend the beginning of sequence token. You should use whatever the model was trained with.
-        threshold (float): Threshold for training JumpReLU SAEs.
+        jumprelu_init_threshold (float): The threshold to initialize for training JumpReLU SAEs.
         autocast (bool): Whether to use autocast during training. Saves vram.
         autocast_lm (bool): Whether to use autocast during activation fetching.
         compile_llm (bool): Whether to compile the LLM.
@@ -163,7 +163,7 @@ class LanguageModelSAERunnerConfig:
     seed: int = 42
     dtype: str = "float32"  # type: ignore #
     prepend_bos: bool = True
-    threshold: float = 0.001
+    jumprelu_init_threshold: float = 0.001
 
     # Performance - see compilation section of lm_runner.py for info
     autocast: bool = False  # autocast to autocast_dtype during training
@@ -412,7 +412,7 @@ class LanguageModelSAERunnerConfig:
             "decoder_heuristic_init": self.decoder_heuristic_init,
             "init_encoder_as_decoder_transpose": self.init_encoder_as_decoder_transpose,
             "normalize_activations": self.normalize_activations,
-            "threshold": self.threshold,
+            "jumprelu_init_threshold": self.jumprelu_init_threshold,
         }
 
     def to_dict(self) -> dict[str, Any]:

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -162,6 +162,7 @@ class LanguageModelSAERunnerConfig:
     seed: int = 42
     dtype: str = "float32"  # type: ignore #
     prepend_bos: bool = True
+    initial_threshold: float = 0.5
 
     # Performance - see compilation section of lm_runner.py for info
     autocast: bool = False  # autocast to autocast_dtype during training

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -66,6 +66,7 @@ class LanguageModelSAERunnerConfig:
         seed (int): The seed to use.
         dtype (str): The data type to use.
         prepend_bos (bool): Whether to prepend the beginning of sequence token. You should use whatever the model was trained with.
+        threshold (float): Threshold for training JumpReLU SAEs.
         autocast (bool): Whether to use autocast during training. Saves vram.
         autocast_lm (bool): Whether to use autocast during activation fetching.
         compile_llm (bool): Whether to compile the LLM.
@@ -162,7 +163,7 @@ class LanguageModelSAERunnerConfig:
     seed: int = 42
     dtype: str = "float32"  # type: ignore #
     prepend_bos: bool = True
-    initial_threshold: float = 0.001
+    threshold: float = 0.001
 
     # Performance - see compilation section of lm_runner.py for info
     autocast: bool = False  # autocast to autocast_dtype during training
@@ -411,7 +412,7 @@ class LanguageModelSAERunnerConfig:
             "decoder_heuristic_init": self.decoder_heuristic_init,
             "init_encoder_as_decoder_transpose": self.init_encoder_as_decoder_transpose,
             "normalize_activations": self.normalize_activations,
-            "initial_threshold": self.initial_threshold,
+            "threshold": self.threshold,
         }
 
     def to_dict(self) -> dict[str, Any]:

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -130,7 +130,7 @@ class LanguageModelSAERunnerConfig:
     )
 
     # SAE Parameters
-    architecture: Literal["standard", "gated"] = "standard"
+    architecture: Literal["standard", "gated", "jumprelu"] = "standard"
     d_in: int = 512
     d_sae: Optional[int] = None
     b_dec_init_method: str = "geometric_median"

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -67,6 +67,7 @@ class LanguageModelSAERunnerConfig:
         dtype (str): The data type to use.
         prepend_bos (bool): Whether to prepend the beginning of sequence token. You should use whatever the model was trained with.
         jumprelu_init_threshold (float): The threshold to initialize for training JumpReLU SAEs.
+        jumprelu_bandwidth (float): Bandwidth for training JumpReLU SAEs.
         autocast (bool): Whether to use autocast during training. Saves vram.
         autocast_lm (bool): Whether to use autocast during activation fetching.
         compile_llm (bool): Whether to compile the LLM.
@@ -164,6 +165,7 @@ class LanguageModelSAERunnerConfig:
     dtype: str = "float32"  # type: ignore #
     prepend_bos: bool = True
     jumprelu_init_threshold: float = 0.001
+    jumprelu_bandwidth: float = 0.001
 
     # Performance - see compilation section of lm_runner.py for info
     autocast: bool = False  # autocast to autocast_dtype during training
@@ -413,6 +415,7 @@ class LanguageModelSAERunnerConfig:
             "init_encoder_as_decoder_transpose": self.init_encoder_as_decoder_transpose,
             "normalize_activations": self.normalize_activations,
             "jumprelu_init_threshold": self.jumprelu_init_threshold,
+            "jumprelu_bandwidth": self.jumprelu_bandwidth,
         }
 
     def to_dict(self) -> dict[str, Any]:

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -556,17 +556,6 @@ class SAE(HookedRootModule):
 
         sae = cls(sae_cfg)
 
-        if sae_cfg.architecture == "jumprelu":
-            # Ensure 'threshold' is in state_dict
-            if "threshold" in state_dict:
-                sae.threshold = nn.Parameter(state_dict["threshold"])
-                # Remove 'threshold' from state_dict to prevent errors during load_state_dict
-                del state_dict["threshold"]
-            else:
-                raise ValueError(
-                    "Threshold not found in state_dict for 'jumprelu' architecture."
-                )
-
         sae.load_state_dict(state_dict)
 
         return sae

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -555,6 +555,18 @@ class SAE(HookedRootModule):
         sae_cfg = SAEConfig.from_dict(cfg_dict)
 
         sae = cls(sae_cfg)
+
+        if sae_cfg.architecture == "jumprelu":
+            # Ensure 'threshold' is in state_dict
+            if "threshold" in state_dict:
+                sae.threshold = nn.Parameter(state_dict["threshold"])
+                # Remove 'threshold' from state_dict to prevent errors during load_state_dict
+                del state_dict["threshold"]
+            else:
+                raise ValueError(
+                    "Threshold not found in state_dict for 'jumprelu' architecture."
+                )
+
         sae.load_state_dict(state_dict)
 
         return sae

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -114,7 +114,7 @@ class TrainingSAEConfig(SAEConfig):
     decoder_heuristic_init: bool = False
     init_encoder_as_decoder_transpose: bool = False
     scale_sparsity_penalty_by_decoder_norm: bool = False
-    initial_threshold: float = 0.5
+    initial_threshold: float = 0.001
 
     @classmethod
     def from_sae_runner_config(
@@ -247,9 +247,8 @@ class TrainingSAE(SAE):
             self.encode_with_hidden_pre_fn = self.encode_with_hidden_pre_jumprelu
             initial_threshold = cfg.initial_threshold
             self.log_threshold = nn.Parameter(
-                torch.tensor(
-                    np.log(initial_threshold), dtype=self.dtype, device=self.device
-                )
+                torch.ones(cfg.d_sae, dtype=self.dtype, device=self.device)
+                * np.log(initial_threshold)
             )
         else:
             raise ValueError(f"Unknown architecture: {cfg.architecture}")

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -114,7 +114,7 @@ class TrainingSAEConfig(SAEConfig):
     decoder_heuristic_init: bool = False
     init_encoder_as_decoder_transpose: bool = False
     scale_sparsity_penalty_by_decoder_norm: bool = False
-    threshold: float = 0.001
+    jumprelu_init_threshold: float = 0.001
 
     @classmethod
     def from_sae_runner_config(
@@ -155,7 +155,7 @@ class TrainingSAEConfig(SAEConfig):
             normalize_activations=cfg.normalize_activations,
             dataset_trust_remote_code=cfg.dataset_trust_remote_code,
             model_from_pretrained_kwargs=cfg.model_from_pretrained_kwargs,
-            threshold=cfg.threshold,
+            jumprelu_init_threshold=cfg.jumprelu_init_threshold,
         )
 
     @classmethod
@@ -245,10 +245,9 @@ class TrainingSAE(SAE):
             self.encode_with_hidden_pre_fn = self.encode_with_hidden_pre_gated
         elif cfg.architecture == "jumprelu":
             self.encode_with_hidden_pre_fn = self.encode_with_hidden_pre_jumprelu
-            threshold = cfg.threshold
             self.log_threshold = nn.Parameter(
                 torch.ones(cfg.d_sae, dtype=self.dtype, device=self.device)
-                * np.log(threshold)
+                * np.log(cfg.jumprelu_init_threshold)
             )
         else:
             raise ValueError(f"Unknown architecture: {cfg.architecture}")

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -47,15 +47,14 @@ class Step(torch.autograd.Function):
         ctx.bandwidth = bandwidth
 
     @staticmethod
-    def backward(ctx: Any, grad_output: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, None]:  # type: ignore[override]
+    def backward(ctx: Any, grad_output: torch.Tensor) -> tuple[None, torch.Tensor, None]:  # type: ignore[override]
         x, threshold = ctx.saved_tensors
         bandwidth = ctx.bandwidth
-        x_grad = 0.0 * grad_output  # We don't apply STE to x input
         threshold_grad = torch.sum(
             -(1.0 / bandwidth) * rectangle((x - threshold) / bandwidth) * grad_output,
             dim=0,
         )
-        return x_grad, threshold_grad, None
+        return None, threshold_grad, None
 
 
 class JumpReLU(torch.autograd.Function):

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -114,7 +114,7 @@ class TrainingSAEConfig(SAEConfig):
     decoder_heuristic_init: bool = False
     init_encoder_as_decoder_transpose: bool = False
     scale_sparsity_penalty_by_decoder_norm: bool = False
-    jumprelu_init_threshold: float = 0.001
+    jumprelu_init_threshold: float
     jumprelu_bandwidth: float
 
     @classmethod

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -114,7 +114,7 @@ class TrainingSAEConfig(SAEConfig):
     decoder_heuristic_init: bool = False
     init_encoder_as_decoder_transpose: bool = False
     scale_sparsity_penalty_by_decoder_norm: bool = False
-    initial_threshold: float = 0.001
+    threshold: float = 0.001
 
     @classmethod
     def from_sae_runner_config(
@@ -155,7 +155,7 @@ class TrainingSAEConfig(SAEConfig):
             normalize_activations=cfg.normalize_activations,
             dataset_trust_remote_code=cfg.dataset_trust_remote_code,
             model_from_pretrained_kwargs=cfg.model_from_pretrained_kwargs,
-            initial_threshold=cfg.initial_threshold,
+            threshold=cfg.threshold,
         )
 
     @classmethod
@@ -245,10 +245,10 @@ class TrainingSAE(SAE):
             self.encode_with_hidden_pre_fn = self.encode_with_hidden_pre_gated
         elif cfg.architecture == "jumprelu":
             self.encode_with_hidden_pre_fn = self.encode_with_hidden_pre_jumprelu
-            initial_threshold = cfg.initial_threshold
+            threshold = cfg.threshold
             self.log_threshold = nn.Parameter(
                 torch.ones(cfg.d_sae, dtype=self.dtype, device=self.device)
-                * np.log(initial_threshold)
+                * np.log(threshold)
             )
         else:
             raise ValueError(f"Unknown architecture: {cfg.architecture}")

--- a/tests/unit/test_jumprelu_sae.py
+++ b/tests/unit/test_jumprelu_sae.py
@@ -26,7 +26,7 @@ def test_jumprelu_sae_encoding():
     threshold = torch.exp(sae.log_threshold)
     expected_feature_acts = JumpReLU.apply(expected_hidden_pre, threshold)
 
-    assert torch.allclose(feature_acts, expected_feature_acts, atol=1e-6) #type: ignore
+    assert torch.allclose(feature_acts, expected_feature_acts, atol=1e-6)  # type: ignore
 
 
 def test_jumprelu_sae_training_forward_pass():
@@ -45,8 +45,7 @@ def test_jumprelu_sae_training_forward_pass():
     assert train_step_output.sae_out.shape == (batch_size, d_in)
     assert train_step_output.feature_acts.shape == (batch_size, sae.cfg.d_sae)
     assert pytest.approx(train_step_output.loss.detach(), rel=1e-3) == (
-        train_step_output.mse_loss
-        + train_step_output.l1_loss
+        train_step_output.mse_loss + train_step_output.l1_loss
     )
 
     expected_mse_loss = (

--- a/tests/unit/test_jumprelu_sae.py
+++ b/tests/unit/test_jumprelu_sae.py
@@ -6,8 +6,7 @@ from tests.unit.helpers import build_sae_cfg
 
 
 def test_jumprelu_sae_encoding():
-    cfg = build_sae_cfg()
-    setattr(cfg, "architecture", "jumprelu")
+    cfg = build_sae_cfg(architecture="jumprelu")
     sae = TrainingSAE.from_dict(cfg.get_training_sae_cfg_dict())
 
     batch_size = 32

--- a/tests/unit/test_jumprelu_sae.py
+++ b/tests/unit/test_jumprelu_sae.py
@@ -1,0 +1,60 @@
+import pytest
+import torch
+
+from sae_lens.training.training_sae import JumpReLU, TrainingSAE
+from tests.unit.helpers import build_sae_cfg
+
+
+def test_jumprelu_sae_encoding():
+    cfg = build_sae_cfg()
+    setattr(cfg, "architecture", "jumprelu")
+    sae = TrainingSAE.from_dict(cfg.get_training_sae_cfg_dict())
+
+    batch_size = 32
+    d_in = sae.cfg.d_in
+    d_sae = sae.cfg.d_sae
+
+    x = torch.randn(batch_size, d_in)
+    feature_acts, hidden_pre = sae.encode_with_hidden_pre_jumprelu(x)
+
+    assert feature_acts.shape == (batch_size, d_sae)
+    assert hidden_pre.shape == (batch_size, d_sae)
+
+    # Check the JumpReLU thresholding
+    sae_in = sae.process_sae_in(x)
+    expected_hidden_pre = sae_in @ sae.W_enc + sae.b_enc
+    threshold = torch.exp(sae.log_threshold)
+    expected_feature_acts = JumpReLU.apply(expected_hidden_pre, threshold)
+
+    assert torch.allclose(feature_acts, expected_feature_acts, atol=1e-6) #type: ignore
+
+
+def test_jumprelu_sae_training_forward_pass():
+    cfg = build_sae_cfg(architecture="jumprelu")
+    sae = TrainingSAE.from_dict(cfg.get_training_sae_cfg_dict())
+
+    batch_size = 32
+    d_in = sae.cfg.d_in
+
+    x = torch.randn(batch_size, d_in)
+    train_step_output = sae.training_forward_pass(
+        sae_in=x,
+        current_l1_coefficient=sae.cfg.l1_coefficient,
+    )
+
+    assert train_step_output.sae_out.shape == (batch_size, d_in)
+    assert train_step_output.feature_acts.shape == (batch_size, sae.cfg.d_sae)
+    assert pytest.approx(train_step_output.loss.detach(), rel=1e-3) == (
+        train_step_output.mse_loss
+        + train_step_output.l1_loss
+    )
+
+    expected_mse_loss = (
+        (torch.pow((train_step_output.sae_out - x.float()), 2))
+        .sum(dim=-1)
+        .mean()
+        .detach()
+        .float()
+    )
+
+    assert pytest.approx(train_step_output.mse_loss) == expected_mse_loss

--- a/tests/unit/test_jumprelu_sae.py
+++ b/tests/unit/test_jumprelu_sae.py
@@ -23,7 +23,9 @@ def test_jumprelu_sae_encoding():
     sae_in = sae.process_sae_in(x)
     expected_hidden_pre = sae_in @ sae.W_enc + sae.b_enc
     threshold = torch.exp(sae.log_threshold)
-    expected_feature_acts = JumpReLU.apply(expected_hidden_pre, threshold)
+    expected_feature_acts = JumpReLU.apply(
+        expected_hidden_pre, threshold, sae.bandwidth
+    )
 
     assert torch.allclose(feature_acts, expected_feature_acts, atol=1e-6)  # type: ignore
 

--- a/tests/unit/training/test_sae_basic.py
+++ b/tests/unit/training/test_sae_basic.py
@@ -197,6 +197,35 @@ def test_sae_save_and_load_from_pretrained_gated(tmp_path: Path) -> None:
     sae_out_2 = sae_loaded(sae_in)
     assert torch.allclose(sae_out_1, sae_out_2)
 
+def test_sae_save_and_load_from_pretrained_jumprelu(tmp_path: Path) -> None:
+    cfg = build_sae_cfg(architecture="jumprelu")
+    model_path = str(tmp_path)
+    sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
+    sae_state_dict = sae.state_dict()
+    sae.save_model(model_path)
+
+    assert os.path.exists(model_path)
+
+    sae_loaded = SAE.load_from_pretrained(model_path, device="cpu")
+
+    sae_loaded_state_dict = sae_loaded.state_dict()
+
+    # check state_dict matches the original, excluding threshold
+    for key in sae.state_dict().keys():
+        assert torch.allclose(
+            sae_state_dict[key],
+            sae_loaded_state_dict[key],
+        )
+
+    assert torch.allclose(
+        sae.threshold, sae_loaded.threshold
+    )
+
+    sae_in = torch.randn(10, cfg.d_in, device=cfg.device)
+    sae_out_1 = sae(sae_in)
+    sae_out_2 = sae_loaded(sae_in)
+    assert torch.allclose(sae_out_1, sae_out_2)
+
 
 def test_sae_save_and_load_from_pretrained_topk(tmp_path: Path) -> None:
     cfg = build_sae_cfg(activation_fn_kwargs={"k": 30})

--- a/tests/unit/training/test_sae_basic.py
+++ b/tests/unit/training/test_sae_basic.py
@@ -197,35 +197,6 @@ def test_sae_save_and_load_from_pretrained_gated(tmp_path: Path) -> None:
     sae_out_2 = sae_loaded(sae_in)
     assert torch.allclose(sae_out_1, sae_out_2)
 
-def test_sae_save_and_load_from_pretrained_jumprelu(tmp_path: Path) -> None:
-    cfg = build_sae_cfg(architecture="jumprelu")
-    model_path = str(tmp_path)
-    sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
-    sae_state_dict = sae.state_dict()
-    sae.save_model(model_path)
-
-    assert os.path.exists(model_path)
-
-    sae_loaded = SAE.load_from_pretrained(model_path, device="cpu")
-
-    sae_loaded_state_dict = sae_loaded.state_dict()
-
-    # check state_dict matches the original, excluding threshold
-    for key in sae.state_dict().keys():
-        assert torch.allclose(
-            sae_state_dict[key],
-            sae_loaded_state_dict[key],
-        )
-
-    assert torch.allclose(
-        sae.threshold, sae_loaded.threshold
-    )
-
-    sae_in = torch.randn(10, cfg.d_in, device=cfg.device)
-    sae_out_1 = sae(sae_in)
-    sae_out_2 = sae_loaded(sae_in)
-    assert torch.allclose(sae_out_1, sae_out_2)
-
 
 def test_sae_save_and_load_from_pretrained_topk(tmp_path: Path) -> None:
     cfg = build_sae_cfg(activation_fn_kwargs={"k": 30})

--- a/tests/unit/training/test_sae_basic.py
+++ b/tests/unit/training/test_sae_basic.py
@@ -9,6 +9,7 @@ from transformer_lens.hook_points import HookPoint
 
 from sae_lens.config import LanguageModelSAERunnerConfig
 from sae_lens.sae import SAE, _disable_hooks
+from sae_lens.training.training_sae import TrainingSAE
 from tests.unit.helpers import build_sae_cfg
 
 
@@ -176,6 +177,32 @@ def test_sae_save_and_load_from_pretrained_gated(tmp_path: Path) -> None:
     cfg = build_sae_cfg(architecture="gated")
     model_path = str(tmp_path)
     sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
+    sae_state_dict = sae.state_dict()
+    sae.save_model(model_path)
+
+    assert os.path.exists(model_path)
+
+    sae_loaded = SAE.load_from_pretrained(model_path, device="cpu")
+
+    sae_loaded_state_dict = sae_loaded.state_dict()
+
+    # check state_dict matches the original
+    for key in sae.state_dict().keys():
+        assert torch.allclose(
+            sae_state_dict[key],
+            sae_loaded_state_dict[key],
+        )
+
+    sae_in = torch.randn(10, cfg.d_in, device=cfg.device)
+    sae_out_1 = sae(sae_in)
+    sae_out_2 = sae_loaded(sae_in)
+    assert torch.allclose(sae_out_1, sae_out_2)
+
+
+def test_sae_save_and_load_from_pretrained_jumprelu(tmp_path: Path) -> None:
+    cfg = build_sae_cfg(architecture="gated")
+    model_path = str(tmp_path)
+    sae = TrainingSAE.from_dict(cfg.get_training_sae_cfg_dict())
     sae_state_dict = sae.state_dict()
     sae.save_model(model_path)
 

--- a/tests/unit/training/test_sae_initialization.py
+++ b/tests/unit/training/test_sae_initialization.py
@@ -64,6 +64,35 @@ def test_SparseAutoencoder_initialization_gated():
     assert not torch.allclose(unit_normed_W_enc, unit_normed_W_dec, atol=1e-6)
 
 
+def test_SparseAutoencoder_initialization_jumprelu():
+    cfg = build_sae_cfg(architecture="jumprelu")
+    sae = TrainingSAE.from_dict(cfg.get_training_sae_cfg_dict())
+
+    assert sae.W_enc.shape == (cfg.d_in, cfg.d_sae)
+    assert sae.W_dec.shape == (cfg.d_sae, cfg.d_in)
+    assert isinstance(sae.log_threshold, torch.nn.Parameter)
+    assert sae.log_threshold.shape == (cfg.d_sae,)
+    assert sae.b_enc.shape == (cfg.d_sae,)
+    assert sae.b_dec.shape == (cfg.d_in,)
+    assert isinstance(sae.activation_fn, torch.nn.ReLU)
+    assert sae.device == torch.device("cpu")
+    assert sae.dtype == torch.float32
+
+    # biases
+    assert torch.allclose(sae.b_dec, torch.zeros_like(sae.b_dec), atol=1e-6)
+    assert torch.allclose(sae.b_enc, torch.zeros_like(sae.b_enc), atol=1e-6)
+
+    # check if the decoder weight norm is 1 by default
+    assert torch.allclose(
+        sae.W_dec.norm(dim=1), torch.ones_like(sae.W_dec.norm(dim=1)), atol=1e-6
+    )
+
+    #  Default currently shouldn't be tranpose initialization
+    unit_normed_W_enc = sae.W_enc / torch.norm(sae.W_enc, dim=0)
+    unit_normed_W_dec = sae.W_dec.T
+    assert not torch.allclose(unit_normed_W_enc, unit_normed_W_dec, atol=1e-6)
+
+
 def test_SparseAutoencoder_initialization_orthogonal_enc_dec():
     cfg = build_sae_cfg(decoder_orthogonal_init=True, expansion_factor=2)
 

--- a/tests/unit/training/test_sae_training.py
+++ b/tests/unit/training/test_sae_training.py
@@ -9,7 +9,7 @@ from transformer_lens import HookedTransformer
 from sae_lens.config import LanguageModelSAERunnerConfig
 from sae_lens.training.activations_store import ActivationsStore
 from sae_lens.training.sae_trainer import SAETrainer
-from sae_lens.training.training_sae import BANDWIDTH, JumpReLU, TrainingSAE
+from sae_lens.training.training_sae import JumpReLU, TrainingSAE
 from tests.unit.helpers import build_sae_cfg
 
 

--- a/tests/unit/training/test_sae_training.py
+++ b/tests/unit/training/test_sae_training.py
@@ -408,15 +408,15 @@ def test_jumprelu_backward():
 
 
 def test_jumprelu_backward_with_threshold_grad():
-    BANDWIDTH = 1e-3
+    bandwidth = 1e-3
     threshold_value = 1.0
     threshold = torch.tensor(threshold_value, requires_grad=True)
 
     epsilon = 1e-8
     x = torch.tensor(
         [
-            threshold_value - BANDWIDTH / 2 + epsilon,
-            threshold_value + BANDWIDTH / 2 - epsilon,
+            threshold_value - bandwidth / 2 + epsilon,
+            threshold_value + bandwidth / 2 - epsilon,
         ],
         requires_grad=True,
     )
@@ -428,5 +428,5 @@ def test_jumprelu_backward_with_threshold_grad():
     expected_grad_threshold = torch.tensor(-2000.0)
 
     atol = 1e-2
-    assert torch.allclose(x.grad, expected_grad_x, atol=atol), "Gradient w.r.t x does not match expected"  # type: ignore
-    assert torch.isclose(threshold.grad, expected_grad_threshold, atol=atol), "Gradient w.r.t threshold does not match expected"  # type: ignore
+    assert torch.allclose(x.grad, expected_grad_x, atol=atol)  # type: ignore
+    assert torch.isclose(threshold.grad, expected_grad_threshold, atol=atol)  # type: ignore

--- a/tests/unit/training/test_sae_training.py
+++ b/tests/unit/training/test_sae_training.py
@@ -394,14 +394,14 @@ def test_jumprelu_forward():
     x = torch.tensor([-1.0, 0.5, 1.5, 2.5])
     threshold = torch.tensor(1.0)
     expected_output = torch.tensor([0.0, 0.0, 1.5, 2.5])
-    output = JumpReLU.apply(x, threshold)
+    output = JumpReLU.apply(x, threshold, 0.001)
     assert torch.allclose(output, expected_output)  # type: ignore
 
 
 def test_jumprelu_backward():
     x = torch.tensor([-1.0, 0.5, 1.5, 2.5], requires_grad=True)
     threshold = torch.tensor(1.0)
-    output = JumpReLU.apply(x, threshold)
+    output = JumpReLU.apply(x, threshold, 0.001)
     output.sum().backward()  # type: ignore
     expected_grad_x = torch.tensor([0.0, 0.0, 1.0, 1.0])
     assert torch.allclose(x.grad, expected_grad_x)  # type: ignore
@@ -421,7 +421,7 @@ def test_jumprelu_backward_with_threshold_grad():
         requires_grad=True,
     )
 
-    output = JumpReLU.apply(x, threshold)
+    output = JumpReLU.apply(x, threshold, bandwidth)
     output.sum().backward()  # type: ignore
 
     expected_grad_x = torch.tensor([0.0, 1.0])


### PR DESCRIPTION
# Description

Adds logic to train JumpReLU SAEs. JumpReLU is a state-of-the-art architecture, so users should be able to train JumpReLU SAEs. Currently, they can load pre-trained JumpReLU SAEs and perform inference with them.

Fixes #330

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 