### PR TITLE
fix: normalize decoder bias in fold_norm_scaling_factor

### DIFF
--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -509,6 +509,7 @@ class SAE(HookedRootModule):
         self.W_enc.data = self.W_enc.data * activation_norm_scaling_factor
         # previously weren't doing this.
         self.W_dec.data = self.W_dec.data / activation_norm_scaling_factor
+        self.b_dec.data = self.b_dec.data / activation_norm_scaling_factor
 
         # once we normalize, we shouldn't need to scale activations.
         self.cfg.normalize_activations = "none"

--- a/tests/unit/training/test_sae_basic.py
+++ b/tests/unit/training/test_sae_basic.py
@@ -107,11 +107,15 @@ def test_sae_fold_w_dec_norm(cfg: LanguageModelSAERunnerConfig):
     torch.testing.assert_close(sae_out_1, sae_out_2)
 
 
+@torch.no_grad()
 def test_sae_fold_norm_scaling_factor(cfg: LanguageModelSAERunnerConfig):
 
     norm_scaling_factor = 3.0
 
     sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
+    # make sure b_dec and b_enc are not 0s
+    sae.b_dec.data = torch.randn(cfg.d_in, device=cfg.device)
+    sae.b_enc.data = torch.randn(cfg.d_sae, device=cfg.device)  # type: ignore
     sae.turn_off_forward_pass_hook_z_reshaping()  # hook z reshaping not needed here.
 
     sae2 = deepcopy(sae)

--- a/tests/unit/training/test_sae_basic.py
+++ b/tests/unit/training/test_sae_basic.py
@@ -144,7 +144,7 @@ def test_sae_fold_norm_scaling_factor(cfg: LanguageModelSAERunnerConfig):
     torch.testing.assert_close(feature_activations_2, feature_activations_1)
 
     sae_out_1 = sae.decode(feature_activations_1)
-    sae_out_2 = sae2.decode(feature_activations_2 * norm_scaling_factor)
+    sae_out_2 = norm_scaling_factor * sae2.decode(feature_activations_2)
 
     # but actual outputs should be the same
     torch.testing.assert_close(sae_out_1, sae_out_2)


### PR DESCRIPTION
# Description

This PR implements the fix specified in #354 and updates tests.

Fixes #354

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
