### PR TITLE
chore: more flexible training losses

### DIFF
--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -402,9 +402,11 @@ class SAETrainer:
     def _update_pbar(self, step_output: TrainStepOutput, pbar: tqdm, update_interval: int = 100):  # type: ignore
 
         if self.n_training_steps % update_interval == 0:
-            pbar.set_description(
-                f"{self.n_training_steps}| MSE Loss {step_output.mse_loss:.3f} | L1 {step_output.l1_loss:.3f}"
+            loss_strs = " | ".join(
+                f"{loss_name}: {loss_value:.5f}"
+                for loss_name, loss_value in step_output.losses.items()
             )
+            pbar.set_description(f"{self.n_training_steps}| {loss_strs}")
             pbar.update(update_interval * self.cfg.train_batch_size_tokens)
 
     def _begin_finetuning_if_needed(self):

--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -318,6 +318,7 @@ class SAETrainer:
                 log_dict[f"losses/{loss_name}"] = (
                     loss_item / self.current_l1_coefficient
                 )
+                log_dict[f"losses/raw_{loss_name}"] = loss_item
             else:
                 log_dict[f"losses/{loss_name}"] = loss_item
 

--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -312,13 +312,14 @@ class SAETrainer:
             "details/n_training_tokens": n_training_tokens,
         }
         for loss_name, loss_value in output.losses.items():
+            loss_item = _unwrap_item(loss_value)
             # special case for l1 loss, which we normalize by the l1 coefficient
             if loss_name == "l1_loss":
                 log_dict[f"losses/{loss_name}"] = (
-                    loss_value / self.current_l1_coefficient
+                    loss_item / self.current_l1_coefficient
                 )
             else:
-                log_dict[f"losses/{loss_name}"] = loss_value
+                log_dict[f"losses/{loss_name}"] = loss_item
 
         return log_dict
 
@@ -403,7 +404,7 @@ class SAETrainer:
 
         if self.n_training_steps % update_interval == 0:
             loss_strs = " | ".join(
-                f"{loss_name}: {loss_value:.5f}"
+                f"{loss_name}: {_unwrap_item(loss_value):.5f}"
                 for loss_name, loss_value in step_output.losses.items()
             )
             pbar.set_description(f"{self.n_training_steps}| {loss_strs}")
@@ -427,3 +428,7 @@ class SAETrainer:
                     param.requires_grad = False
 
             self.finetuning = True
+
+
+def _unwrap_item(item: float | torch.Tensor) -> float:
+    return item.item() if isinstance(item, torch.Tensor) else item

--- a/tests/unit/training/test_gated_sae.py
+++ b/tests/unit/training/test_gated_sae.py
@@ -88,7 +88,9 @@ def test_gated_sae_loss():
     ).mean()
 
     expected_loss = (
-        train_step_output.mse_loss + preactivation_l1_loss + aux_reconstruction_loss
+        train_step_output.losses["mse_loss"]
+        + preactivation_l1_loss
+        + aux_reconstruction_loss
     )
     assert (
         pytest.approx(train_step_output.loss.item(), rel=1e-3) == expected_loss.item()
@@ -129,9 +131,14 @@ def test_gated_sae_training_forward_pass():
     # Detach the loss tensor and convert to numpy for comparison
     detached_loss = train_step_output.loss.detach().cpu().numpy()
     expected_loss = (
-        train_step_output.mse_loss
-        + train_step_output.l1_loss
-        + train_step_output.auxiliary_reconstruction_loss
+        (
+            train_step_output.losses["mse_loss"]
+            + train_step_output.losses["l1_loss"]
+            + train_step_output.losses["auxiliary_reconstruction_loss"]
+        )
+        .detach()  # type: ignore
+        .cpu()
+        .numpy()
     )
 
     assert pytest.approx(detached_loss, rel=1e-3) == expected_loss

--- a/tests/unit/training/test_sae_trainer.py
+++ b/tests/unit/training/test_sae_trainer.py
@@ -112,7 +112,7 @@ def test_train_step__output_looks_reasonable(trainer: SAETrainer) -> None:
     assert output.sae_out.shape == output.sae_in.shape
     assert output.feature_acts.shape == (4, 128)  # batch_size, d_sae
     # ghots grads shouldn't trigger until dead_feature_window, which hasn't been reached yet
-    assert output.ghost_grad_loss == 0
+    assert output.losses.get("ghost_grad_loss", 0) == 0
     assert trainer.n_frac_active_tokens == 4
     assert trainer.act_freq_scores.sum() > 0  # at least SOME acts should have fired
     assert torch.allclose(
@@ -169,9 +169,11 @@ def test_build_train_step_log_dict(trainer: SAETrainer) -> None:
         sae_out=torch.tensor([[0, 0], [0, 2], [0.5, 1]]).float(),
         feature_acts=torch.tensor([[0, 0, 0, 1], [1, 0, 0, 1], [1, 0, 1, 1]]).float(),
         loss=torch.tensor(0.5),
-        mse_loss=0.25,
-        l1_loss=0.1,
-        ghost_grad_loss=0.15,
+        losses={
+            "mse_loss": 0.25,
+            "l1_loss": 0.1,
+            "ghost_grad_loss": 0.15,
+        },
     )
 
     # we're relying on the trainer only for some of the metrics here
@@ -183,9 +185,9 @@ def test_build_train_step_log_dict(trainer: SAETrainer) -> None:
     assert log_dict == {
         "losses/mse_loss": 0.25,
         # l1 loss is scaled by l1_coefficient
-        "losses/l1_loss": train_output.l1_loss / trainer.cfg.l1_coefficient,
-        "losses/auxiliary_reconstruction_loss": 0.0,
+        "losses/l1_loss": train_output.losses["l1_loss"] / trainer.cfg.l1_coefficient,
         "losses/overall_loss": 0.5,
+        "losses/ghost_grad_loss": 0.15,
         "metrics/explained_variance": 0.75,
         "metrics/explained_variance_std": 0.25,
         "metrics/l0": 2.0,

--- a/tests/unit/training/test_sae_trainer.py
+++ b/tests/unit/training/test_sae_trainer.py
@@ -186,6 +186,7 @@ def test_build_train_step_log_dict(trainer: SAETrainer) -> None:
         "losses/mse_loss": 0.25,
         # l1 loss is scaled by l1_coefficient
         "losses/l1_loss": train_output.losses["l1_loss"] / trainer.cfg.l1_coefficient,
+        "losses/raw_l1_loss": train_output.losses["l1_loss"],
         "losses/overall_loss": 0.5,
         "losses/ghost_grad_loss": 0.15,
         "metrics/explained_variance": 0.75,


### PR DESCRIPTION
# Description

This PR refactors the `TrainStepOutput` in `TrainingSAE.training_forward_pass()` to allow passing `losses` as a dict rather than a hardcoded set of specific losses. The current implementation requires always providing values for ghost grad loss and auxiliary loss, even when it doesn't make sense for the training method. As SAELens supports more architectures, there will likely be more losses like this that only make sense for certain architectures, so it makes sense to let the train forward step define the losses that make sense for the circumstances.

This should also make it easier for researchers to hack on the SAELens SAEs since it means they can define any losses they want to track.

This PR also allows the losses to remain as tensors rather than being floats. The current implementation requires calling `.item()` on each loss, which forces a synchronization with the GPU and likely slows down training slightly. We only ever use the losses for logging, which happens by default once every 100 steps, so this synchronization is unnecessary.

## Type of change

Please delete options that are not relevant.

- [x] Refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)