### PR TITLE
fix: load the same config from_pretrained and get_sae_config

### DIFF
--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -620,9 +620,6 @@ class SAE(HookedRootModule):
             )
         sae_info = sae_directory.get(release, None)
         config_overrides = sae_info.config_overrides if sae_info is not None else None
-        neuronpedia_id = (
-            sae_info.neuronpedia_id[sae_id] if sae_info is not None else None
-        )
 
         conversion_loader_name = get_conversion_loader_name(sae_info)
         conversion_loader = NAMED_PRETRAINED_SAE_LOADERS[conversion_loader_name]
@@ -637,7 +634,6 @@ class SAE(HookedRootModule):
 
         sae = cls(SAEConfig.from_dict(cfg_dict))
         sae.load_state_dict(state_dict)
-        sae.cfg.neuronpedia_id = neuronpedia_id
 
         # Check if normalization is 'expected_average_only_in'
         if cfg_dict.get("normalize_activations") == "expected_average_only_in":

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -474,7 +474,8 @@ def get_sae_config(
     repo_id, folder_name = get_repo_id_and_folder_name(release, sae_id=sae_id)
     cfg_overrides = options.cfg_overrides or {}
     if sae_info is not None:
-        sae_info_overrides: dict[str, Any] = sae_info.config_overrides or {}
+        # avoid modifying the original dict
+        sae_info_overrides: dict[str, Any] = {**(sae_info.config_overrides or {})}
         if sae_info.neuronpedia_id is not None:
             sae_info_overrides["neuronpedia_id"] = sae_info.neuronpedia_id.get(sae_id)
         cfg_overrides = {**sae_info_overrides, **cfg_overrides}

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -126,7 +126,7 @@ def handle_config_defaulting(cfg_dict: dict[str, Any]) -> dict[str, Any]:
     cfg_dict.setdefault("sae_lens_training_version", None)
     cfg_dict.setdefault("activation_fn_str", cfg_dict.get("activation_fn", "relu"))
     cfg_dict.setdefault("architecture", "standard")
-    cfg_dict.setdefault("neuronpedia", None)
+    cfg_dict.setdefault("neuronpedia_id", None)
 
     if "normalize_activations" in cfg_dict and isinstance(
         cfg_dict["normalize_activations"], bool
@@ -474,7 +474,10 @@ def get_sae_config(
     repo_id, folder_name = get_repo_id_and_folder_name(release, sae_id=sae_id)
     cfg_overrides = options.cfg_overrides or {}
     if sae_info is not None:
-        cfg_overrides = {**(sae_info.config_overrides or {}), **cfg_overrides}
+        sae_info_overrides: dict[str, Any] = sae_info.config_overrides or {}
+        if sae_info.neuronpedia_id is not None:
+            sae_info_overrides["neuronpedia_id"] = sae_info.neuronpedia_id.get(sae_id)
+        cfg_overrides = {**sae_info_overrides, **cfg_overrides}
 
     conversion_loader_name = get_conversion_loader_name(sae_info)
     config_getter = NAMED_PRETRAINED_SAE_CONFIG_GETTERS[conversion_loader_name]

--- a/tests/unit/toolkit/test_pretrained_sae_loaders.py
+++ b/tests/unit/toolkit/test_pretrained_sae_loaders.py
@@ -59,7 +59,7 @@ def test_get_sae_config_sae_lens():
         "d_sae": 24576,
         "tokens_per_buffer": 67108864,
         "run_name": "24576-L1-8e-05-LR-0.0004-Tokens-3.000e+08",
-        "neuronpedia": None,
+        "neuronpedia_id": "gpt2-small/0-res-jb",
         "normalize_activations": "none",
         "prepend_bos": True,
         "sae_lens_training_version": None,
@@ -94,7 +94,7 @@ def test_get_sae_config_connor_rob_hook_z():
         "context_size": 128,
         "normalize_activations": "none",
         "dataset_trust_remote_code": True,
-        "neuronpedia": None,
+        "neuronpedia_id": "gpt2-small/0-att-kk",
     }
 
     assert cfg_dict == expected_cfg_dict
@@ -126,7 +126,7 @@ def test_get_sae_config_gemma_2():
         "apply_b_dec_to_input": False,
         "normalize_activations": None,
         "device": "cpu",
-        "neuronpedia": None,
+        "neuronpedia_id": None,
     }
 
     assert cfg_dict == expected_cfg_dict
@@ -159,8 +159,7 @@ def test_get_sae_config_dictionary_learning_1():
         "dataset_trust_remote_code": True,
         "context_size": 128,
         "normalize_activations": "none",
-        "neuronpedia_id": None,
-        "neuronpedia": None,
+        "neuronpedia_id": "gemma-2-2b/3-sae_bench-standard-res-4k__trainer_1_step_29292",
     }
 
     assert cfg_dict == expected_cfg_dict

--- a/tests/unit/toolkit/test_pretrained_sae_loaders.py
+++ b/tests/unit/toolkit/test_pretrained_sae_loaders.py
@@ -1,3 +1,4 @@
+from sae_lens.sae import SAE
 from sae_lens.toolkit.pretrained_sae_loaders import SAEConfigLoadOptions, get_sae_config
 
 
@@ -9,11 +10,15 @@ def test_get_sae_config_sae_lens():
     )
 
     expected_cfg_dict = {
+        "activation_fn_str": "relu",
+        "apply_b_dec_to_input": True,
+        "architecture": "standard",
         "model_name": "gpt2-small",
         "hook_point": "blocks.0.hook_resid_pre",
         "hook_point_layer": 0,
         "hook_point_head_index": None,
         "dataset_path": "Skylion007/openwebtext",
+        "dataset_trust_remote_code": True,
         "is_dataset_tokenized": False,
         "context_size": 128,
         "use_cached_activations": False,
@@ -32,9 +37,13 @@ def test_get_sae_config_sae_lens():
         "lr": 0.0004,
         "lr_scheduler_name": None,
         "lr_warm_up_steps": 5000,
+        "model_from_pretrained_kwargs": {
+            "center_writing_weights": True,
+        },
         "train_batch_size": 4096,
         "use_ghost_grads": False,
         "feature_sampling_window": 1000,
+        "finetuning_scaling_factor": False,
         "feature_sampling_method": None,
         "resample_batches": 1028,
         "feature_reinit_scale": 0.2,
@@ -50,6 +59,10 @@ def test_get_sae_config_sae_lens():
         "d_sae": 24576,
         "tokens_per_buffer": 67108864,
         "run_name": "24576-L1-8e-05-LR-0.0004-Tokens-3.000e+08",
+        "neuronpedia": None,
+        "normalize_activations": "none",
+        "prepend_bos": True,
+        "sae_lens_training_version": None,
     }
 
     assert cfg_dict == expected_cfg_dict
@@ -81,6 +94,7 @@ def test_get_sae_config_connor_rob_hook_z():
         "context_size": 128,
         "normalize_activations": "none",
         "dataset_trust_remote_code": True,
+        "neuronpedia": None,
     }
 
     assert cfg_dict == expected_cfg_dict
@@ -111,6 +125,8 @@ def test_get_sae_config_gemma_2():
         "dataset_trust_remote_code": True,
         "apply_b_dec_to_input": False,
         "normalize_activations": None,
+        "device": "cpu",
+        "neuronpedia": None,
     }
 
     assert cfg_dict == expected_cfg_dict
@@ -144,6 +160,22 @@ def test_get_sae_config_dictionary_learning_1():
         "context_size": 128,
         "normalize_activations": "none",
         "neuronpedia_id": None,
+        "neuronpedia": None,
     }
 
     assert cfg_dict == expected_cfg_dict
+
+
+def test_get_sae_config_matches_from_pretrained():
+    from_pretrained_cfg_dict = SAE.from_pretrained(
+        "gpt2-small-res-jb",
+        sae_id="blocks.0.hook_resid_pre",
+        device="cpu",
+    )[1]
+    direct_sae_cfg = get_sae_config(
+        "gpt2-small-res-jb",
+        sae_id="blocks.0.hook_resid_pre",
+        options=SAEConfigLoadOptions(device="cpu"),
+    )
+
+    assert direct_sae_cfg == from_pretrained_cfg_dict


### PR DESCRIPTION
# Description

This PR unifies the code path for `from_pretrained` and `get_sae_config` so the config dict should match, and adds a test asserting this for a jbloom/gpt2 SAE.

Fixes #351

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)