### PR TITLE
Faster cleanup of sharded datasets

### DIFF
--- a/tests/benchmark/test_cache_activations_runner.py
+++ b/tests/benchmark/test_cache_activations_runner.py
@@ -70,8 +70,11 @@ def test_cache_activations_runner():
         dtype="float32",
     )
 
-    # look at the next cell to see some instruction for what to do while this is running.
+    start_time = time.perf_counter()
     CacheActivationsRunner(cfg).run()
+    end_time = time.perf_counter()
+    elapsed_time = end_time - start_time
+    print(f"Caching activations took: {elapsed_time:.4f}")
 
 
 def test_hf_dataset_save_vs_safetensors(tmp_path: Path):

--- a/tests/unit/training/test_cache_activations_runner.py
+++ b/tests/unit/training/test_cache_activations_runner.py
@@ -511,7 +511,12 @@ def test_cache_activations_runner_with_valid_seqpos(tmp_path: Path):
     assert os.path.exists(tmp_path)
 
     # assert that there are n_buffer files in the directory.
-    assert len(os.listdir(tmp_path)) == n_buffers
+    buffer_files = [
+        f
+        for f in os.listdir(tmp_path)
+        if f.startswith("data-") and f.endswith(".arrow")
+    ]
+    assert len(buffer_files) == n_buffers
 
     assert len(dataset_acts) == n_buffers * n_batches_in_buffer
     for act in dataset_acts:


### PR DESCRIPTION
# Description

Builds upon #321. Previously I used `dataset.save_to_disk` to write the final dataset, but this will rewrite the entire dataset to disk, which is very slow. Instead I manually move the shards to the standard hf format which allows us not to resave the entire dataset.

## Type of change

- [X] Performance improvement

This should be externally identical, but just saving the dataset faster. My previous cached activation runner tests validate the change well.

Benchmarking cached activation benchmark on my mac:

```
poetry run py.test tests/benchmark/test_cache_activations_runner.py::test_cache_activations_runner -s

Old: Caching activations took: 81.5707

New: Caching activations took: 68.0761
```

I expect this to be even more pronounced for larger runs, where computing activations scales faster than disk speed.

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [X] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
