### PR TITLE
Add Llama Scope SAEs & improvements to evaluating ce scores.

### DIFF
--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -319,6 +319,7 @@ def get_downstream_reconstruction_metrics(
             activation_store,
             compute_kl=compute_kl,
             compute_ce_loss=compute_ce_loss,
+            ignore_tokens=ignore_tokens
         ).items():
 
             if len(ignore_tokens) > 0:
@@ -541,6 +542,7 @@ def get_recons_loss(
     activation_store: ActivationsStore,
     compute_kl: bool,
     compute_ce_loss: bool,
+    ignore_tokens: set[int | None] = set(),
     model_kwargs: Mapping[str, Any] = {},
 ) -> dict[str, Any]:
     hook_name = sae.cfg.hook_name
@@ -549,6 +551,18 @@ def get_recons_loss(
     original_logits, original_ce_loss = model(
         batch_tokens, return_type="both", loss_per_token=True, **model_kwargs
     )
+    
+    if len(ignore_tokens) > 0:
+        mask = torch.logical_not(
+            torch.any(
+                torch.stack(
+                    [batch_tokens == token for token in ignore_tokens], dim=0
+                ),
+                dim=0,
+            )
+        )
+    else:
+        mask = torch.ones_like(batch_tokens, dtype=torch.bool)
 
     metrics = {}
 
@@ -563,13 +577,15 @@ def get_recons_loss(
             activations = activation_store.apply_norm_scaling_factor(activations)
 
         # SAE class agnost forward forward pass.
-        activations = sae.decode(sae.encode(activations)).to(activations.dtype)
+        new_activations = sae.decode(sae.encode(activations)).to(activations.dtype)
 
         # Unscale if activations were scaled prior to going into the SAE
         if activation_store.normalize_activations == "expected_average_only_in":
-            activations = activation_store.unscale(activations)
+            new_activations = activation_store.unscale(new_activations)
+        
+        new_activations = torch.where(mask[..., None], new_activations, activations)
 
-        return activations.to(original_device)
+        return new_activations.to(original_device)
 
     def all_head_replacement_hook(activations: torch.Tensor, hook: Any):
 
@@ -592,6 +608,8 @@ def get_recons_loss(
         # Unscale if activations were scaled prior to going into the SAE
         if activation_store.normalize_activations == "expected_average_only_in":
             new_activations = activation_store.unscale(new_activations)
+        
+        new_activations = torch.where(mask[..., None], new_activations, activations)
 
         return new_activations.to(original_device)
 
@@ -612,6 +630,9 @@ def get_recons_loss(
         # Unscale if activations were scaled prior to going into the SAE
         if activation_store.normalize_activations == "expected_average_only_in":
             activations = activation_store.unscale(activations)
+        
+        new_activations = torch.where(mask[..., None], new_activations, activations)
+        
         return activations.to(original_device)
 
     def standard_zero_ablate_hook(activations: torch.Tensor, hook: Any):

--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -319,7 +319,7 @@ def get_downstream_reconstruction_metrics(
             activation_store,
             compute_kl=compute_kl,
             compute_ce_loss=compute_ce_loss,
-            ignore_tokens=ignore_tokens
+            ignore_tokens=ignore_tokens,
         ).items():
 
             if len(ignore_tokens) > 0:
@@ -551,13 +551,11 @@ def get_recons_loss(
     original_logits, original_ce_loss = model(
         batch_tokens, return_type="both", loss_per_token=True, **model_kwargs
     )
-    
+
     if len(ignore_tokens) > 0:
         mask = torch.logical_not(
             torch.any(
-                torch.stack(
-                    [batch_tokens == token for token in ignore_tokens], dim=0
-                ),
+                torch.stack([batch_tokens == token for token in ignore_tokens], dim=0),
                 dim=0,
             )
         )
@@ -582,7 +580,7 @@ def get_recons_loss(
         # Unscale if activations were scaled prior to going into the SAE
         if activation_store.normalize_activations == "expected_average_only_in":
             new_activations = activation_store.unscale(new_activations)
-        
+
         new_activations = torch.where(mask[..., None], new_activations, activations)
 
         return new_activations.to(original_device)
@@ -608,8 +606,6 @@ def get_recons_loss(
         # Unscale if activations were scaled prior to going into the SAE
         if activation_store.normalize_activations == "expected_average_only_in":
             new_activations = activation_store.unscale(new_activations)
-        
-        new_activations = torch.where(mask[..., None], new_activations, activations)
 
         return new_activations.to(original_device)
 
@@ -630,9 +626,7 @@ def get_recons_loss(
         # Unscale if activations were scaled prior to going into the SAE
         if activation_store.normalize_activations == "expected_average_only_in":
             activations = activation_store.unscale(activations)
-        
-        new_activations = torch.where(mask[..., None], new_activations, activations)
-        
+
         return activations.to(original_device)
 
     def standard_zero_ablate_hook(activations: torch.Tensor, hook: Any):

--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -12854,3 +12854,801 @@ llama-3-8b-it-res-jh:
   - id: blocks.25.hook_resid_post
     path: blocks.25.hook_resid_post
     neuronpedia: llama3-8b-it/25-res-jh
+llama_scope_LXA_32x:
+  conversion_func: llama_scope
+  model: meta-llama/Llama-3.1-8B
+  repo_id: fnlp/Llama3_1-8B-Base-LXA-32x
+  saes:
+  - id: L0A_32x
+    l0: 50.0
+    norm_scaling_factor: 112.21917808219177
+    path: Llama3_1-8B-Base-L0A-32x
+  - id: L1A_32x
+    l0: 50.0
+    norm_scaling_factor: 94.70520231213872
+    path: Llama3_1-8B-Base-L1A-32x
+  - id: L2A_32x
+    l0: 50.0
+    norm_scaling_factor: 73.14285714285714
+    path: Llama3_1-8B-Base-L2A-32x
+  - id: L3A_32x
+    l0: 50.0
+    norm_scaling_factor: 55.72789115646258
+    path: Llama3_1-8B-Base-L3A-32x
+  - id: L4A_32x
+    l0: 50.0
+    norm_scaling_factor: 45.76536312849162
+    path: Llama3_1-8B-Base-L4A-32x
+  - id: L5A_32x
+    l0: 50.0
+    norm_scaling_factor: 39.9609756097561
+    path: Llama3_1-8B-Base-L5A-32x
+  - id: L6A_32x
+    l0: 50.0
+    norm_scaling_factor: 33.436734693877554
+    path: Llama3_1-8B-Base-L6A-32x
+  - id: L7A_32x
+    l0: 50.0
+    norm_scaling_factor: 27.30666666666667
+    path: Llama3_1-8B-Base-L7A-32x
+  - id: L8A_32x
+    l0: 50.0
+    norm_scaling_factor: 27.675675675675677
+    path: Llama3_1-8B-Base-L8A-32x
+  - id: L9A_32x
+    l0: 50.0
+    norm_scaling_factor: 25.440993788819874
+    path: Llama3_1-8B-Base-L9A-32x
+  - id: L10A_32x
+    l0: 50.0
+    norm_scaling_factor: 26.5974025974026
+    path: Llama3_1-8B-Base-L10A-32x
+  - id: L11A_32x
+    l0: 50.0
+    norm_scaling_factor: 25.761006289308177
+    path: Llama3_1-8B-Base-L11A-32x
+  - id: L12A_32x
+    l0: 50.0
+    norm_scaling_factor: 22.14054054054054
+    path: Llama3_1-8B-Base-L12A-32x
+  - id: L13A_32x
+    l0: 50.0
+    norm_scaling_factor: 20.582914572864322
+    path: Llama3_1-8B-Base-L13A-32x
+  - id: L14A_32x
+    l0: 50.0
+    norm_scaling_factor: 20.177339901477833
+    path: Llama3_1-8B-Base-L14A-32x
+  - id: L15A_32x
+    l0: 50.0
+    norm_scaling_factor: 20.582914572864322
+    path: Llama3_1-8B-Base-L15A-32x
+  - id: L16A_32x
+    l0: 50.0
+    norm_scaling_factor: 19.32075471698113
+    path: Llama3_1-8B-Base-L16A-32x
+  - id: L17A_32x
+    l0: 50.0
+    norm_scaling_factor: 21.005128205128205
+    path: Llama3_1-8B-Base-L17A-32x
+  - id: L18A_32x
+    l0: 50.0
+    norm_scaling_factor: 24.674698795180724
+    path: Llama3_1-8B-Base-L18A-32x
+  - id: L19A_32x
+    l0: 50.0
+    norm_scaling_factor: 28.248275862068965
+    path: Llama3_1-8B-Base-L19A-32x
+  - id: L20A_32x
+    l0: 50.0
+    norm_scaling_factor: 27.30666666666667
+    path: Llama3_1-8B-Base-L20A-32x
+  - id: L21A_32x
+    l0: 50.0
+    norm_scaling_factor: 19.14018691588785
+    path: Llama3_1-8B-Base-L21A-32x
+  - id: L22A_32x
+    l0: 50.0
+    norm_scaling_factor: 24.38095238095238
+    path: Llama3_1-8B-Base-L22A-32x
+  - id: L23A_32x
+    l0: 50.0
+    norm_scaling_factor: 22.14054054054054
+    path: Llama3_1-8B-Base-L23A-32x
+  - id: L24A_32x
+    l0: 50.0
+    norm_scaling_factor: 21.67195767195767
+    path: Llama3_1-8B-Base-L24A-32x
+  - id: L25A_32x
+    l0: 50.0
+    norm_scaling_factor: 18.367713004484305
+    path: Llama3_1-8B-Base-L25A-32x
+  - id: L26A_32x
+    l0: 50.0
+    norm_scaling_factor: 13.837837837837839
+    path: Llama3_1-8B-Base-L26A-32x
+  - id: L27A_32x
+    l0: 50.0
+    norm_scaling_factor: 13.931972789115646
+    path: Llama3_1-8B-Base-L27A-32x
+  - id: L28A_32x
+    l0: 50.0
+    norm_scaling_factor: 10.95187165775401
+    path: Llama3_1-8B-Base-L28A-32x
+  - id: L29A_32x
+    l0: 50.0
+    norm_scaling_factor: 8.569037656903765
+    path: Llama3_1-8B-Base-L29A-32x
+  - id: L30A_32x
+    l0: 50.0
+    norm_scaling_factor: 5.953488372093023
+    path: Llama3_1-8B-Base-L30A-32x
+  - id: L31A_32x
+    l0: 50.0
+    norm_scaling_factor: 3.5310344827586206
+    path: Llama3_1-8B-Base-L31A-32x
+llama_scope_LXA_8x:
+  conversion_func: llama_scope
+  model: meta-llama/Llama-3.1-8B
+  repo_id: fnlp/Llama3_1-8B-Base-LXA-8x
+  saes:
+  - id: L0A_8x
+    l0: 50.0
+    norm_scaling_factor: 112.21917808219177
+    path: Llama3_1-8B-Base-L0A-8x
+  - id: L1A_8x
+    l0: 50.0
+    norm_scaling_factor: 94.70520231213872
+    path: Llama3_1-8B-Base-L1A-8x
+  - id: L2A_8x
+    l0: 50.0
+    norm_scaling_factor: 72.81777777777778
+    path: Llama3_1-8B-Base-L2A-8x
+  - id: L3A_8x
+    l0: 50.0
+    norm_scaling_factor: 55.72789115646258
+    path: Llama3_1-8B-Base-L3A-8x
+  - id: L4A_8x
+    l0: 50.0
+    norm_scaling_factor: 45.76536312849162
+    path: Llama3_1-8B-Base-L4A-8x
+  - id: L5A_8x
+    l0: 50.0
+    norm_scaling_factor: 39.9609756097561
+    path: Llama3_1-8B-Base-L5A-8x
+  - id: L6A_8x
+    l0: 50.0
+    norm_scaling_factor: 33.436734693877554
+    path: Llama3_1-8B-Base-L6A-8x
+  - id: L7A_8x
+    l0: 50.0
+    norm_scaling_factor: 27.30666666666667
+    path: Llama3_1-8B-Base-L7A-8x
+  - id: L8A_8x
+    l0: 50.0
+    norm_scaling_factor: 27.675675675675677
+    path: Llama3_1-8B-Base-L8A-8x
+  - id: L9A_8x
+    l0: 50.0
+    norm_scaling_factor: 25.28395061728395
+    path: Llama3_1-8B-Base-L9A-8x
+  - id: L10A_8x
+    l0: 50.0
+    norm_scaling_factor: 26.5974025974026
+    path: Llama3_1-8B-Base-L10A-8x
+  - id: L11A_8x
+    l0: 50.0
+    norm_scaling_factor: 25.761006289308177
+    path: Llama3_1-8B-Base-L11A-8x
+  - id: L12A_8x
+    l0: 50.0
+    norm_scaling_factor: 22.14054054054054
+    path: Llama3_1-8B-Base-L12A-8x
+  - id: L13A_8x
+    l0: 50.0
+    norm_scaling_factor: 20.48
+    path: Llama3_1-8B-Base-L13A-8x
+  - id: L14A_8x
+    l0: 50.0
+    norm_scaling_factor: 20.177339901477833
+    path: Llama3_1-8B-Base-L14A-8x
+  - id: L15A_8x
+    l0: 50.0
+    norm_scaling_factor: 20.582914572864322
+    path: Llama3_1-8B-Base-L15A-8x
+  - id: L16A_8x
+    l0: 50.0
+    norm_scaling_factor: 19.32075471698113
+    path: Llama3_1-8B-Base-L16A-8x
+  - id: L17A_8x
+    l0: 50.0
+    norm_scaling_factor: 20.897959183673468
+    path: Llama3_1-8B-Base-L17A-8x
+  - id: L18A_8x
+    l0: 50.0
+    norm_scaling_factor: 24.674698795180724
+    path: Llama3_1-8B-Base-L18A-8x
+  - id: L19A_8x
+    l0: 50.0
+    norm_scaling_factor: 28.248275862068965
+    path: Llama3_1-8B-Base-L19A-8x
+  - id: L20A_8x
+    l0: 50.0
+    norm_scaling_factor: 27.125827814569536
+    path: Llama3_1-8B-Base-L20A-8x
+  - id: L21A_8x
+    l0: 50.0
+    norm_scaling_factor: 19.14018691588785
+    path: Llama3_1-8B-Base-L21A-8x
+  - id: L22A_8x
+    l0: 50.0
+    norm_scaling_factor: 24.38095238095238
+    path: Llama3_1-8B-Base-L22A-8x
+  - id: L23A_8x
+    l0: 50.0
+    norm_scaling_factor: 22.14054054054054
+    path: Llama3_1-8B-Base-L23A-8x
+  - id: L24A_8x
+    l0: 50.0
+    norm_scaling_factor: 21.557894736842105
+    path: Llama3_1-8B-Base-L24A-8x
+  - id: L25A_8x
+    l0: 50.0
+    norm_scaling_factor: 18.533936651583712
+    path: Llama3_1-8B-Base-L25A-8x
+  - id: L26A_8x
+    l0: 50.0
+    norm_scaling_factor: 13.837837837837839
+    path: Llama3_1-8B-Base-L26A-8x
+  - id: L27A_8x
+    l0: 50.0
+    norm_scaling_factor: 13.931972789115646
+    path: Llama3_1-8B-Base-L27A-8x
+  - id: L28A_8x
+    l0: 50.0
+    norm_scaling_factor: 10.95187165775401
+    path: Llama3_1-8B-Base-L28A-8x
+  - id: L29A_8x
+    l0: 50.0
+    norm_scaling_factor: 8.569037656903765
+    path: Llama3_1-8B-Base-L29A-8x
+  - id: L30A_8x
+    l0: 50.0
+    norm_scaling_factor: 5.953488372093023
+    path: Llama3_1-8B-Base-L30A-8x
+  - id: L31A_8x
+    l0: 50.0
+    norm_scaling_factor: 3.5555555555555554
+    path: Llama3_1-8B-Base-L31A-8x
+llama_scope_LXM_32x:
+  conversion_func: llama_scope
+  model: meta-llama/Llama-3.1-8B
+  repo_id: fnlp/Llama3_1-8B-Base-LXM-32x
+  saes:
+  - id: L0M_32x
+    l0: 50.0
+    norm_scaling_factor: 80.31372549019608
+    path: Llama3_1-8B-Base-L0M-32x
+  - id: L1M_32x
+    l0: 50.0
+    norm_scaling_factor: 71.85964912280701
+    path: Llama3_1-8B-Base-L1M-32x
+  - id: L2M_32x
+    l0: 50.0
+    norm_scaling_factor: 47.90643274853801
+    path: Llama3_1-8B-Base-L2M-32x
+  - id: L3M_32x
+    l0: 50.0
+    norm_scaling_factor: 35.46320346320346
+    path: Llama3_1-8B-Base-L3M-32x
+  - id: L4M_32x
+    l0: 50.0
+    norm_scaling_factor: 27.86394557823129
+    path: Llama3_1-8B-Base-L4M-32x
+  - id: L5M_32x
+    l0: 50.0
+    norm_scaling_factor: 23.01123595505618
+    path: Llama3_1-8B-Base-L5M-32x
+  - id: L6M_32x
+    l0: 50.0
+    norm_scaling_factor: 20.48
+    path: Llama3_1-8B-Base-L6M-32x
+  - id: L7M_32x
+    l0: 50.0
+    norm_scaling_factor: 19.692307692307693
+    path: Llama3_1-8B-Base-L7M-32x
+  - id: L8M_32x
+    l0: 50.0
+    norm_scaling_factor: 18.87557603686636
+    path: Llama3_1-8B-Base-L8M-32x
+  - id: L9M_32x
+    l0: 50.0
+    norm_scaling_factor: 17.88646288209607
+    path: Llama3_1-8B-Base-L9M-32x
+  - id: L10M_32x
+    l0: 50.0
+    norm_scaling_factor: 17.5793991416309
+    path: Llama3_1-8B-Base-L10M-32x
+  - id: L11M_32x
+    l0: 50.0
+    norm_scaling_factor: 16.855967078189302
+    path: Llama3_1-8B-Base-L11M-32x
+  - id: L12M_32x
+    l0: 50.0
+    norm_scaling_factor: 16.125984251968504
+    path: Llama3_1-8B-Base-L12M-32x
+  - id: L13M_32x
+    l0: 50.0
+    norm_scaling_factor: 14.840579710144928
+    path: Llama3_1-8B-Base-L13M-32x
+  - id: L14M_32x
+    l0: 50.0
+    norm_scaling_factor: 13.74496644295302
+    path: Llama3_1-8B-Base-L14M-32x
+  - id: L15M_32x
+    l0: 50.0
+    norm_scaling_factor: 12.118343195266272
+    path: Llama3_1-8B-Base-L15M-32x
+  - id: L16M_32x
+    l0: 50.0
+    norm_scaling_factor: 11.702857142857143
+    path: Llama3_1-8B-Base-L16M-32x
+  - id: L17M_32x
+    l0: 50.0
+    norm_scaling_factor: 10.666666666666666
+    path: Llama3_1-8B-Base-L17M-32x
+  - id: L18M_32x
+    l0: 50.0
+    norm_scaling_factor: 10.778947368421052
+    path: Llama3_1-8B-Base-L18M-32x
+  - id: L19M_32x
+    l0: 50.0
+    norm_scaling_factor: 10.502564102564103
+    path: Llama3_1-8B-Base-L19M-32x
+  - id: L20M_32x
+    l0: 50.0
+    norm_scaling_factor: 10.088669950738916
+    path: Llama3_1-8B-Base-L20M-32x
+  - id: L21M_32x
+    l0: 50.0
+    norm_scaling_factor: 9.102222222222222
+    path: Llama3_1-8B-Base-L21M-32x
+  - id: L22M_32x
+    l0: 50.0
+    norm_scaling_factor: 8.865800865800866
+    path: Llama3_1-8B-Base-L22M-32x
+  - id: L23M_32x
+    l0: 50.0
+    norm_scaling_factor: 8.677966101694915
+    path: Llama3_1-8B-Base-L23M-32x
+  - id: L24M_32x
+    l0: 50.0
+    norm_scaling_factor: 8.39344262295082
+    path: Llama3_1-8B-Base-L24M-32x
+  - id: L25M_32x
+    l0: 50.0
+    norm_scaling_factor: 8.126984126984127
+    path: Llama3_1-8B-Base-L25M-32x
+  - id: L26M_32x
+    l0: 50.0
+    norm_scaling_factor: 7.5851851851851855
+    path: Llama3_1-8B-Base-L26M-32x
+  - id: L27M_32x
+    l0: 50.0
+    norm_scaling_factor: 6.4
+    path: Llama3_1-8B-Base-L27M-32x
+  - id: L28M_32x
+    l0: 50.0
+    norm_scaling_factor: 5.505376344086022
+    path: Llama3_1-8B-Base-L28M-32x
+  - id: L29M_32x
+    l0: 50.0
+    norm_scaling_factor: 4.413793103448276
+    path: Llama3_1-8B-Base-L29M-32x
+  - id: L30M_32x
+    l0: 50.0
+    norm_scaling_factor: 2.5472636815920398
+    path: Llama3_1-8B-Base-L30M-32x
+  - id: L31M_32x
+    l0: 50.0
+    norm_scaling_factor: 1.0534979423868314
+    path: Llama3_1-8B-Base-L31M-32x
+llama_scope_LXM_8x:
+  conversion_func: llama_scope
+  model: meta-llama/Llama-3.1-8B
+  repo_id: fnlp/Llama3_1-8B-Base-LXM-8x
+  saes:
+  - id: L0M_8x
+    l0: 50.0
+    norm_scaling_factor: 80.31372549019608
+    path: Llama3_1-8B-Base-L0M-8x
+  - id: L1M_8x
+    l0: 50.0
+    norm_scaling_factor: 72.1762114537445
+    path: Llama3_1-8B-Base-L1M-8x
+  - id: L2M_8x
+    l0: 50.0
+    norm_scaling_factor: 47.90643274853801
+    path: Llama3_1-8B-Base-L2M-8x
+  - id: L3M_8x
+    l0: 50.0
+    norm_scaling_factor: 35.46320346320346
+    path: Llama3_1-8B-Base-L3M-8x
+  - id: L4M_8x
+    l0: 50.0
+    norm_scaling_factor: 27.86394557823129
+    path: Llama3_1-8B-Base-L4M-8x
+  - id: L5M_8x
+    l0: 50.0
+    norm_scaling_factor: 23.01123595505618
+    path: Llama3_1-8B-Base-L5M-8x
+  - id: L6M_8x
+    l0: 50.0
+    norm_scaling_factor: 20.48
+    path: Llama3_1-8B-Base-L6M-8x
+  - id: L7M_8x
+    l0: 50.0
+    norm_scaling_factor: 19.692307692307693
+    path: Llama3_1-8B-Base-L7M-8x
+  - id: L8M_8x
+    l0: 50.0
+    norm_scaling_factor: 18.87557603686636
+    path: Llama3_1-8B-Base-L8M-8x
+  - id: L9M_8x
+    l0: 50.0
+    norm_scaling_factor: 17.88646288209607
+    path: Llama3_1-8B-Base-L9M-8x
+  - id: L10M_8x
+    l0: 50.0
+    norm_scaling_factor: 17.5793991416309
+    path: Llama3_1-8B-Base-L10M-8x
+  - id: L11M_8x
+    l0: 50.0
+    norm_scaling_factor: 16.855967078189302
+    path: Llama3_1-8B-Base-L11M-8x
+  - id: L12M_8x
+    l0: 50.0
+    norm_scaling_factor: 16.125984251968504
+    path: Llama3_1-8B-Base-L12M-8x
+  - id: L13M_8x
+    l0: 50.0
+    norm_scaling_factor: 14.733812949640289
+    path: Llama3_1-8B-Base-L13M-8x
+  - id: L14M_8x
+    l0: 50.0
+    norm_scaling_factor: 13.74496644295302
+    path: Llama3_1-8B-Base-L14M-8x
+  - id: L15M_8x
+    l0: 50.0
+    norm_scaling_factor: 12.118343195266272
+    path: Llama3_1-8B-Base-L15M-8x
+  - id: L16M_8x
+    l0: 50.0
+    norm_scaling_factor: 11.702857142857143
+    path: Llama3_1-8B-Base-L16M-8x
+  - id: L17M_8x
+    l0: 50.0
+    norm_scaling_factor: 10.666666666666666
+    path: Llama3_1-8B-Base-L17M-8x
+  - id: L18M_8x
+    l0: 50.0
+    norm_scaling_factor: 10.778947368421052
+    path: Llama3_1-8B-Base-L18M-8x
+  - id: L19M_8x
+    l0: 50.0
+    norm_scaling_factor: 10.502564102564103
+    path: Llama3_1-8B-Base-L19M-8x
+  - id: L20M_8x
+    l0: 50.0
+    norm_scaling_factor: 10.138613861386139
+    path: Llama3_1-8B-Base-L20M-8x
+  - id: L21M_8x
+    l0: 50.0
+    norm_scaling_factor: 9.142857142857142
+    path: Llama3_1-8B-Base-L21M-8x
+  - id: L22M_8x
+    l0: 50.0
+    norm_scaling_factor: 8.904347826086957
+    path: Llama3_1-8B-Base-L22M-8x
+  - id: L23M_8x
+    l0: 50.0
+    norm_scaling_factor: 8.641350210970463
+    path: Llama3_1-8B-Base-L23M-8x
+  - id: L24M_8x
+    l0: 50.0
+    norm_scaling_factor: 8.39344262295082
+    path: Llama3_1-8B-Base-L24M-8x
+  - id: L25M_8x
+    l0: 50.0
+    norm_scaling_factor: 8.126984126984127
+    path: Llama3_1-8B-Base-L25M-8x
+  - id: L26M_8x
+    l0: 50.0
+    norm_scaling_factor: 7.5851851851851855
+    path: Llama3_1-8B-Base-L26M-8x
+  - id: L27M_8x
+    l0: 50.0
+    norm_scaling_factor: 6.4
+    path: Llama3_1-8B-Base-L27M-8x
+  - id: L28M_8x
+    l0: 50.0
+    norm_scaling_factor: 5.505376344086022
+    path: Llama3_1-8B-Base-L28M-8x
+  - id: L29M_8x
+    l0: 50.0
+    norm_scaling_factor: 4.432900432900433
+    path: Llama3_1-8B-Base-L29M-8x
+  - id: L30M_8x
+    l0: 50.0
+    norm_scaling_factor: 2.5472636815920398
+    path: Llama3_1-8B-Base-L30M-8x
+  - id: L31M_8x
+    l0: 50.0
+    norm_scaling_factor: 1.0534979423868314
+    path: Llama3_1-8B-Base-L31M-8x
+llama_scope_LXR_32x:
+  conversion_func: llama_scope
+  model: meta-llama/Llama-3.1-8B
+  repo_id: fnlp/Llama3_1-8B-Base-LXR-32x
+  saes:
+  - id: L0R_32x
+    l0: 50.0
+    norm_scaling_factor: 58.935251798561154
+    path: Llama3_1-8B-Base-L0R-32x
+  - id: L1R_32x
+    l0: 50.0
+    norm_scaling_factor: 39.9609756097561
+    path: Llama3_1-8B-Base-L1R-32x
+  - id: L2R_32x
+    l0: 50.0
+    norm_scaling_factor: 27.30666666666667
+    path: Llama3_1-8B-Base-L2R-32x
+  - id: L3R_32x
+    l0: 50.0
+    norm_scaling_factor: 20.177339901477833
+    path: Llama3_1-8B-Base-L3R-32x
+  - id: L4R_32x
+    l0: 50.0
+    norm_scaling_factor: 16.125984251968504
+    path: Llama3_1-8B-Base-L4R-32x
+  - id: L5R_32x
+    l0: 50.0
+    norm_scaling_factor: 13.653333333333334
+    path: Llama3_1-8B-Base-L5R-32x
+  - id: L6R_32x
+    l0: 50.0
+    norm_scaling_factor: 11.976608187134502
+    path: Llama3_1-8B-Base-L6R-32x
+  - id: L7R_32x
+    l0: 50.0
+    norm_scaling_factor: 10.835978835978835
+    path: Llama3_1-8B-Base-L7R-32x
+  - id: L8R_32x
+    l0: 50.0
+    norm_scaling_factor: 10.138613861386139
+    path: Llama3_1-8B-Base-L8R-32x
+  - id: L9R_32x
+    l0: 50.0
+    norm_scaling_factor: 9.266968325791856
+    path: Llama3_1-8B-Base-L9R-32x
+  - id: L10R_32x
+    l0: 50.0
+    norm_scaling_factor: 8.827586206896552
+    path: Llama3_1-8B-Base-L10R-32x
+  - id: L11R_32x
+    l0: 50.0
+    norm_scaling_factor: 8.427983539094651
+    path: Llama3_1-8B-Base-L11R-32x
+  - id: L12R_32x
+    l0: 50.0
+    norm_scaling_factor: 7.937984496124031
+    path: Llama3_1-8B-Base-L12R-32x
+  - id: L13R_32x
+    l0: 50.0
+    norm_scaling_factor: 7.26241134751773
+    path: Llama3_1-8B-Base-L13R-32x
+  - id: L14R_32x
+    l0: 50.0
+    norm_scaling_factor: 6.69281045751634
+    path: Llama3_1-8B-Base-L14R-32x
+  - id: L15R_32x
+    l0: 50.0
+    norm_scaling_factor: 5.91907514450867
+    path: Llama3_1-8B-Base-L15R-32x
+  - id: L16R_32x
+    l0: 50.0
+    norm_scaling_factor: 5.278350515463917
+    path: Llama3_1-8B-Base-L16R-32x
+  - id: L17R_32x
+    l0: 50.0
+    norm_scaling_factor: 4.633484162895928
+    path: Llama3_1-8B-Base-L17R-32x
+  - id: L18R_32x
+    l0: 50.0
+    norm_scaling_factor: 4.129032258064516
+    path: Llama3_1-8B-Base-L18R-32x
+  - id: L19R_32x
+    l0: 50.0
+    norm_scaling_factor: 3.7372262773722627
+    path: Llama3_1-8B-Base-L19R-32x
+  - id: L20R_32x
+    l0: 50.0
+    norm_scaling_factor: 3.4133333333333336
+    path: Llama3_1-8B-Base-L20R-32x
+  - id: L21R_32x
+    l0: 50.0
+    norm_scaling_factor: 2.9767441860465116
+    path: Llama3_1-8B-Base-L21R-32x
+  - id: L22R_32x
+    l0: 50.0
+    norm_scaling_factor: 2.680628272251309
+    path: Llama3_1-8B-Base-L22R-32x
+  - id: L23R_32x
+    l0: 50.0
+    norm_scaling_factor: 2.4150943396226414
+    path: Llama3_1-8B-Base-L23R-32x
+  - id: L24R_32x
+    l0: 50.0
+    norm_scaling_factor: 2.1974248927038627
+    path: Llama3_1-8B-Base-L24R-32x
+  - id: L25R_32x
+    l0: 50.0
+    norm_scaling_factor: 2.0237154150197627
+    path: Llama3_1-8B-Base-L25R-32x
+  - id: L26R_32x
+    l0: 50.0
+    norm_scaling_factor: 1.8156028368794326
+    path: Llama3_1-8B-Base-L26R-32x
+  - id: L27R_32x
+    l0: 50.0
+    norm_scaling_factor: 1.6623376623376624
+    path: Llama3_1-8B-Base-L27R-32x
+  - id: L28R_32x
+    l0: 50.0
+    norm_scaling_factor: 1.5058823529411764
+    path: Llama3_1-8B-Base-L28R-32x
+  - id: L29R_32x
+    l0: 50.0
+    norm_scaling_factor: 1.3763440860215055
+    path: Llama3_1-8B-Base-L29R-32x
+  - id: L30R_32x
+    l0: 50.0
+    norm_scaling_factor: 1.2075471698113207
+    path: Llama3_1-8B-Base-L30R-32x
+  - id: L31R_32x
+    l0: 50.0
+    norm_scaling_factor: 0.8648648648648649
+    path: Llama3_1-8B-Base-L31R-32x
+llama_scope_LXR_8x:
+  conversion_func: llama_scope
+  model: meta-llama/Llama-3.1-8B
+  repo_id: fnlp/Llama3_1-8B-Base-LXR-8x
+  saes:
+  - id: L0R_8x
+    l0: 50.0
+    norm_scaling_factor: 58.935251798561154
+    path: Llama3_1-8B-Base-L0R-8x
+  - id: L1R_8x
+    l0: 50.0
+    norm_scaling_factor: 39.76699029126213
+    path: Llama3_1-8B-Base-L1R-8x
+  - id: L2R_8x
+    l0: 50.0
+    norm_scaling_factor: 27.30666666666667
+    path: Llama3_1-8B-Base-L2R-8x
+  - id: L3R_8x
+    l0: 50.0
+    norm_scaling_factor: 20.177339901477833
+    path: Llama3_1-8B-Base-L3R-8x
+  - id: L4R_8x
+    l0: 50.0
+    norm_scaling_factor: 16.125984251968504
+    path: Llama3_1-8B-Base-L4R-8x
+  - id: L5R_8x
+    l0: 50.0
+    norm_scaling_factor: 13.653333333333334
+    path: Llama3_1-8B-Base-L5R-8x
+  - id: L6R_8x
+    l0: 50.0
+    norm_scaling_factor: 11.976608187134502
+    path: Llama3_1-8B-Base-L6R-8x
+  - id: L7R_8x
+    l0: 50.0
+    norm_scaling_factor: 10.835978835978835
+    path: Llama3_1-8B-Base-L7R-8x
+  - id: L8R_8x
+    l0: 50.0
+    norm_scaling_factor: 10.138613861386139
+    path: Llama3_1-8B-Base-L8R-8x
+  - id: L9R_8x
+    l0: 50.0
+    norm_scaling_factor: 9.266968325791856
+    path: Llama3_1-8B-Base-L9R-8x
+  - id: L10R_8x
+    l0: 50.0
+    norm_scaling_factor: 8.827586206896552
+    path: Llama3_1-8B-Base-L10R-8x
+  - id: L11R_8x
+    l0: 50.0
+    norm_scaling_factor: 8.462809917355372
+    path: Llama3_1-8B-Base-L11R-8x
+  - id: L12R_8x
+    l0: 50.0
+    norm_scaling_factor: 7.937984496124031
+    path: Llama3_1-8B-Base-L12R-8x
+  - id: L13R_8x
+    l0: 50.0
+    norm_scaling_factor: 7.26241134751773
+    path: Llama3_1-8B-Base-L13R-8x
+  - id: L14R_8x
+    l0: 50.0
+    norm_scaling_factor: 6.69281045751634
+    path: Llama3_1-8B-Base-L14R-8x
+  - id: L15R_8x
+    l0: 50.0
+    norm_scaling_factor: 5.91907514450867
+    path: Llama3_1-8B-Base-L15R-8x
+  - id: L16R_8x
+    l0: 50.0
+    norm_scaling_factor: 5.278350515463917
+    path: Llama3_1-8B-Base-L16R-8x
+  - id: L17R_8x
+    l0: 50.0
+    norm_scaling_factor: 4.633484162895928
+    path: Llama3_1-8B-Base-L17R-8x
+  - id: L18R_8x
+    l0: 50.0
+    norm_scaling_factor: 4.129032258064516
+    path: Llama3_1-8B-Base-L18R-8x
+  - id: L19R_8x
+    l0: 50.0
+    norm_scaling_factor: 3.7372262773722627
+    path: Llama3_1-8B-Base-L19R-8x
+  - id: L20R_8x
+    l0: 50.0
+    norm_scaling_factor: 3.4133333333333336
+    path: Llama3_1-8B-Base-L20R-8x
+  - id: L21R_8x
+    l0: 50.0
+    norm_scaling_factor: 2.9767441860465116
+    path: Llama3_1-8B-Base-L21R-8x
+  - id: L22R_8x
+    l0: 50.0
+    norm_scaling_factor: 2.680628272251309
+    path: Llama3_1-8B-Base-L22R-8x
+  - id: L23R_8x
+    l0: 50.0
+    norm_scaling_factor: 2.4150943396226414
+    path: Llama3_1-8B-Base-L23R-8x
+  - id: L24R_8x
+    l0: 50.0
+    norm_scaling_factor: 2.1880341880341883
+    path: Llama3_1-8B-Base-L24R-8x
+  - id: L25R_8x
+    l0: 50.0
+    norm_scaling_factor: 2.0237154150197627
+    path: Llama3_1-8B-Base-L25R-8x
+  - id: L26R_8x
+    l0: 50.0
+    norm_scaling_factor: 1.8156028368794326
+    path: Llama3_1-8B-Base-L26R-8x
+  - id: L27R_8x
+    l0: 50.0
+    norm_scaling_factor: 1.673202614379085
+    path: Llama3_1-8B-Base-L27R-8x
+  - id: L28R_8x
+    l0: 50.0
+    norm_scaling_factor: 1.5058823529411764
+    path: Llama3_1-8B-Base-L28R-8x
+  - id: L29R_8x
+    l0: 50.0
+    norm_scaling_factor: 1.3763440860215055
+    path: Llama3_1-8B-Base-L29R-8x
+  - id: L30R_8x
+    l0: 50.0
+    norm_scaling_factor: 1.2018779342723005
+    path: Llama3_1-8B-Base-L30R-8x
+  - id: L31R_8x
+    l0: 50.0
+    norm_scaling_factor: 0.8590604026845637
+    path: Llama3_1-8B-Base-L31R-8x

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -405,6 +405,112 @@ def gemma_2_sae_loader(
     return cfg_dict, state_dict, log_sparsity
 
 
+def get_llama_scope_config(
+    repo_id: str,
+    folder_name: str,
+    options: SAEConfigLoadOptions,
+) -> Dict[str, Any]:
+    # Llama Scope SAEs
+    # repo_id: fnlp/Llama3_1-8B-Base-LX{sublayer}-{exp_factor}x
+    # folder_name: Llama3_1-8B-Base-L{layer}{sublayer}-{exp_factor}x
+    config_path = folder_name + "/hyperparams.json"
+    config_path = hf_hub_download(repo_id, config_path)
+    
+    old_cfg_dict = json.load(open(config_path, "r"))
+
+    # Model specific parameters
+    model_name, d_in = "meta-llama/Llama-3.1-8B", old_cfg_dict["d_model"]
+    
+    hook_suffix = {
+        "M": "hook_mlp_out",
+        "A": "hook_attn_out",
+        "R": "hook_resid_post",
+        "TC": "ln2.hook_normalized",
+    }
+
+    return {
+        "architecture": "jumprelu",
+        "jump_relu_threshold": old_cfg_dict["jump_relu_threshold"],
+        # We use a scalar jump_relu_threshold for all features
+        # This is different from Gemma Scope JumpReLU SAEs.
+        "d_in": d_in,
+        "d_sae": old_cfg_dict["d_sae"],
+        "dtype": "bfloat16",
+        "model_name": model_name,
+        "hook_name": old_cfg_dict["hook_point_in"],
+        "hook_layer": int(old_cfg_dict["hook_point_in"].split(".")[1]),
+        "hook_head_index": None,
+        "activation_fn_str": "relu",
+        "finetuning_scaling_factor": False,
+        "sae_lens_training_version": None,
+        "prepend_bos": True,
+        "dataset_path": "cerebras/SlimPajama-627B",
+        "context_size": 1024,
+        "dataset_trust_remote_code": True,
+        "apply_b_dec_to_input": False,
+        "normalize_activations": 'expected_average_only_in',
+    }
+
+
+def llama_scope_sae_loader(
+    release: str,
+    sae_id: str,
+    device: str = "cpu",
+    force_download: bool = False,
+    cfg_overrides: Optional[Dict[str, Any]] = None,
+    d_sae_override: Optional[int] = None,
+    layer_override: Optional[int] = None,
+) -> Tuple[Dict[str, Any], Dict[str, torch.Tensor], Optional[torch.Tensor]]:
+    """
+    Custom loader for Llama Scope SAEs.
+    """
+    options = SAEConfigLoadOptions(
+        device=device,
+        d_sae_override=d_sae_override,
+        layer_override=layer_override,
+    )
+    cfg_dict = get_sae_config(
+        release,
+        sae_id=sae_id,
+        options=options,
+    )
+    cfg_dict["device"] = device
+
+
+    # Apply overrides if provided
+    if cfg_overrides is not None:
+        cfg_dict.update(cfg_overrides)
+
+    repo_id, folder_name = get_repo_id_and_folder_name(release, sae_id=sae_id)
+
+    # Download the SAE weights
+    sae_path = hf_hub_download(
+        repo_id=repo_id,
+        filename="final.safetensors",
+        subfolder=folder_name+"/checkpoints",
+        force_download=force_download,
+    )
+
+    # Load and convert the weights
+    with safe_open(sae_path, framework="pt", device=device) as f:
+        state_dict = {
+            'W_enc': f.get_tensor('encoder.weight').to(dtype=DTYPE_MAP[cfg_dict["dtype"]]).T,
+            'W_dec': f.get_tensor('decoder.weight').to(dtype=DTYPE_MAP[cfg_dict["dtype"]]).T,
+            'b_enc': f.get_tensor('encoder.bias').to(dtype=DTYPE_MAP[cfg_dict["dtype"]]),
+            'b_dec': f.get_tensor('decoder.bias').to(dtype=DTYPE_MAP[cfg_dict["dtype"]]),
+            'threshold': torch.ones(
+                cfg_dict['d_sae'], 
+                dtype=DTYPE_MAP[cfg_dict["dtype"]], 
+                device=cfg_dict["device"]
+            ) * cfg_dict["jump_relu_threshold"]
+        }
+
+    # No sparsity tensor for Llama Scope SAEs
+    log_sparsity = None
+
+    return cfg_dict, state_dict, log_sparsity
+
+
 def get_dictionary_learning_config_1(
     repo_id: str, folder_name: str, options: SAEConfigLoadOptions
 ) -> dict[str, Any]:
@@ -526,6 +632,7 @@ NAMED_PRETRAINED_SAE_LOADERS: dict[str, PretrainedSaeLoader] = {
     "sae_lens": sae_lens_loader,  # type: ignore
     "connor_rob_hook_z": connor_rob_hook_z_loader,  # type: ignore
     "gemma_2": gemma_2_sae_loader,
+    "llama_scope": llama_scope_sae_loader,
     "dictionary_learning_1": dictionary_learning_sae_loader_1,
 }
 
@@ -533,5 +640,6 @@ NAMED_PRETRAINED_SAE_CONFIG_GETTERS = {
     "sae_lens": get_sae_config_from_hf,
     "connor_rob_hook_z": get_connor_rob_hook_z_config,
     "gemma_2": get_gemma_2_config,
+    "llama_scope": get_llama_scope_config,
     "dictionary_learning_1": get_dictionary_learning_config_1,
 }


### PR DESCRIPTION
# Description

This pull request includes the following updates:

- add entries to Llama Scope SAEs in pretrained_saes.yaml
- implement Llama Scope loaders in pretrained_sae_loaders.py
- implement an option to not replacing bos activations when computing ce_loss_score in eval.py. This is necessary for SAEs trained with context starting with bos but is not trained with bos activations.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 