### PR TITLE
fix: fixing jumprelu encode and save/load

### DIFF
--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -314,27 +314,7 @@ class SAE(HookedRootModule):
         self.threshold = nn.Parameter(
             torch.zeros(self.cfg.d_sae, dtype=self.dtype, device=self.device)
         )
-        self.b_enc = nn.Parameter(
-            torch.zeros(self.cfg.d_sae, dtype=self.dtype, device=self.device)
-        )
-
-        self.W_dec = nn.Parameter(
-            torch.nn.init.kaiming_uniform_(
-                torch.empty(
-                    self.cfg.d_sae, self.cfg.d_in, dtype=self.dtype, device=self.device
-                )
-            )
-        )
-        self.W_enc = nn.Parameter(
-            torch.nn.init.kaiming_uniform_(
-                torch.empty(
-                    self.cfg.d_in, self.cfg.d_sae, dtype=self.dtype, device=self.device
-                )
-            )
-        )
-        self.b_dec = nn.Parameter(
-            torch.zeros(self.cfg.d_in, dtype=self.dtype, device=self.device)
-        )
+        self.initialize_weights_basic()
 
     @overload
     def to(

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -266,29 +266,9 @@ class TrainingSAE(SAE):
     def initialize_weights_jumprelu(self):
         # same as the superclass, except we use a log_threshold parameter instead of threshold
         self.log_threshold = nn.Parameter(
-            torch.ones(self.cfg.d_sae, dtype=self.dtype, device=self.device)
+            torch.empty(self.cfg.d_sae, dtype=self.dtype, device=self.device)
         )
-        self.b_enc = nn.Parameter(
-            torch.zeros(self.cfg.d_sae, dtype=self.dtype, device=self.device)
-        )
-
-        self.W_dec = nn.Parameter(
-            torch.nn.init.kaiming_uniform_(
-                torch.empty(
-                    self.cfg.d_sae, self.cfg.d_in, dtype=self.dtype, device=self.device
-                )
-            )
-        )
-        self.W_enc = nn.Parameter(
-            torch.nn.init.kaiming_uniform_(
-                torch.empty(
-                    self.cfg.d_in, self.cfg.d_sae, dtype=self.dtype, device=self.device
-                )
-            )
-        )
-        self.b_dec = nn.Parameter(
-            torch.zeros(self.cfg.d_in, dtype=self.dtype, device=self.device)
-        )
+        self.initialize_weights_basic()
 
     @property
     def threshold(self) -> torch.Tensor:

--- a/tests/unit/training/test_jumprelu_sae.py
+++ b/tests/unit/training/test_jumprelu_sae.py
@@ -1,0 +1,65 @@
+import pytest
+import torch
+
+from sae_lens.training.training_sae import JumpReLU, TrainingSAE
+from tests.unit.helpers import build_sae_cfg
+
+
+def test_jumprelu_sae_encoding():
+    cfg = build_sae_cfg(architecture="jumprelu")
+    sae = TrainingSAE.from_dict(cfg.get_training_sae_cfg_dict())
+
+    batch_size = 32
+    d_in = sae.cfg.d_in
+    d_sae = sae.cfg.d_sae
+
+    x = torch.randn(batch_size, d_in)
+    feature_acts, hidden_pre = sae.encode_with_hidden_pre_jumprelu(x)
+
+    assert feature_acts.shape == (batch_size, d_sae)
+    assert hidden_pre.shape == (batch_size, d_sae)
+
+    # Check the JumpReLU thresholding
+    sae_in = sae.process_sae_in(x)
+    expected_hidden_pre = sae_in @ sae.W_enc + sae.b_enc
+    threshold = torch.exp(sae.log_threshold)
+    expected_feature_acts = JumpReLU.apply(
+        expected_hidden_pre, threshold, sae.bandwidth
+    )
+
+    assert torch.allclose(feature_acts, expected_feature_acts, atol=1e-6)  # type: ignore
+
+
+def test_jumprelu_sae_training_forward_pass():
+    cfg = build_sae_cfg(architecture="jumprelu")
+    sae = TrainingSAE.from_dict(cfg.get_training_sae_cfg_dict())
+
+    batch_size = 32
+    d_in = sae.cfg.d_in
+
+    x = torch.randn(batch_size, d_in)
+    train_step_output = sae.training_forward_pass(
+        sae_in=x,
+        current_l1_coefficient=sae.cfg.l1_coefficient,
+    )
+
+    assert train_step_output.sae_out.shape == (batch_size, d_in)
+    assert train_step_output.feature_acts.shape == (batch_size, sae.cfg.d_sae)
+    assert (
+        pytest.approx(train_step_output.loss.detach(), rel=1e-3)
+        == (
+            train_step_output.losses["mse_loss"] + train_step_output.losses["l0_loss"]
+        ).item()  # type: ignore
+    )
+
+    expected_mse_loss = (
+        (torch.pow((train_step_output.sae_out - x.float()), 2))
+        .sum(dim=-1)
+        .mean()
+        .detach()
+        .float()
+    )
+
+    assert (
+        pytest.approx(train_step_output.losses["mse_loss"].item()) == expected_mse_loss  # type: ignore
+    )

--- a/tests/unit/training/test_sae_basic.py
+++ b/tests/unit/training/test_sae_basic.py
@@ -9,7 +9,6 @@ from transformer_lens.hook_points import HookPoint
 
 from sae_lens.config import LanguageModelSAERunnerConfig
 from sae_lens.sae import SAE, _disable_hooks
-from sae_lens.training.training_sae import TrainingSAE
 from tests.unit.helpers import build_sae_cfg
 
 
@@ -181,32 +180,6 @@ def test_sae_save_and_load_from_pretrained_gated(tmp_path: Path) -> None:
     cfg = build_sae_cfg(architecture="gated")
     model_path = str(tmp_path)
     sae = SAE.from_dict(cfg.get_base_sae_cfg_dict())
-    sae_state_dict = sae.state_dict()
-    sae.save_model(model_path)
-
-    assert os.path.exists(model_path)
-
-    sae_loaded = SAE.load_from_pretrained(model_path, device="cpu")
-
-    sae_loaded_state_dict = sae_loaded.state_dict()
-
-    # check state_dict matches the original
-    for key in sae.state_dict().keys():
-        assert torch.allclose(
-            sae_state_dict[key],
-            sae_loaded_state_dict[key],
-        )
-
-    sae_in = torch.randn(10, cfg.d_in, device=cfg.device)
-    sae_out_1 = sae(sae_in)
-    sae_out_2 = sae_loaded(sae_in)
-    assert torch.allclose(sae_out_1, sae_out_2)
-
-
-def test_sae_save_and_load_from_pretrained_jumprelu(tmp_path: Path) -> None:
-    cfg = build_sae_cfg(architecture="gated")
-    model_path = str(tmp_path)
-    sae = TrainingSAE.from_dict(cfg.get_training_sae_cfg_dict())
     sae_state_dict = sae.state_dict()
     sae.save_model(model_path)
 

--- a/tests/unit/training/test_training_sae.py
+++ b/tests/unit/training/test_training_sae.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 
 from sae_lens.sae import SAE
-from sae_lens.training.training_sae import JumpReLU, TrainingSAE, TrainingSAEConfig
+from sae_lens.training.training_sae import TrainingSAE, TrainingSAEConfig
 from tests.unit.helpers import build_sae_cfg
 
 
@@ -63,66 +63,6 @@ def test_TrainingSAE_initializes_only_with_log_threshold_if_jumprelu():
     assert torch.allclose(
         sae.threshold,
         torch.ones_like(sae.log_threshold.data) * cfg.jumprelu_init_threshold,
-    )
-
-
-def test_TrainingSAE_jumprelu_sae_encoding():
-    cfg = build_sae_cfg(architecture="jumprelu")
-    sae = TrainingSAE.from_dict(cfg.get_training_sae_cfg_dict())
-
-    batch_size = 32
-    d_in = sae.cfg.d_in
-    d_sae = sae.cfg.d_sae
-
-    x = torch.randn(batch_size, d_in)
-    feature_acts, hidden_pre = sae.encode_with_hidden_pre_jumprelu(x)
-
-    assert feature_acts.shape == (batch_size, d_sae)
-    assert hidden_pre.shape == (batch_size, d_sae)
-
-    # Check the JumpReLU thresholding
-    sae_in = sae.process_sae_in(x)
-    expected_hidden_pre = sae_in @ sae.W_enc + sae.b_enc
-    threshold = torch.exp(sae.log_threshold)
-    expected_feature_acts = JumpReLU.apply(
-        expected_hidden_pre, threshold, sae.bandwidth
-    )
-
-    assert torch.allclose(feature_acts, expected_feature_acts, atol=1e-6)  # type: ignore
-
-
-def test_TrainingSAE_jumprelu_sae_training_forward_pass():
-    cfg = build_sae_cfg(architecture="jumprelu")
-    sae = TrainingSAE.from_dict(cfg.get_training_sae_cfg_dict())
-
-    batch_size = 32
-    d_in = sae.cfg.d_in
-
-    x = torch.randn(batch_size, d_in)
-    train_step_output = sae.training_forward_pass(
-        sae_in=x,
-        current_l1_coefficient=sae.cfg.l1_coefficient,
-    )
-
-    assert train_step_output.sae_out.shape == (batch_size, d_in)
-    assert train_step_output.feature_acts.shape == (batch_size, sae.cfg.d_sae)
-    assert (
-        pytest.approx(train_step_output.loss.detach(), rel=1e-3)
-        == (
-            train_step_output.losses["mse_loss"] + train_step_output.losses["l0_loss"]
-        ).item()  # type: ignore
-    )
-
-    expected_mse_loss = (
-        (torch.pow((train_step_output.sae_out - x.float()), 2))
-        .sum(dim=-1)
-        .mean()
-        .detach()
-        .float()
-    )
-
-    assert (
-        pytest.approx(train_step_output.losses["mse_loss"].item()) == expected_mse_loss  # type: ignore
     )
 
 


### PR DESCRIPTION
# Description

This PR fixes some minor issues related to jumprelu SAEs:
- fixes a bug where we were accidentally creating a `threshold` param and a `log_threshold` param on `TrainingSAE`, and calling `encode()` incorrectly used the `threshold` while `encode_with_hidden_pre` correctly used the `log_threshold`
- enables loading saved jumprelu SAEs for further training
- fixes a bug where jumprelu bandwidth and init threshold weren't being saved along with the rest of the config

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)