### PR TITLE
chore: adding test that all config params pass to sae

### DIFF
--- a/tests/unit/training/test_config.py
+++ b/tests/unit/training/test_config.py
@@ -1,9 +1,12 @@
+from dataclasses import fields
 from typing import Optional
 
 import pytest
 
 from sae_lens import __version__
 from sae_lens.config import CacheActivationsRunnerConfig, LanguageModelSAERunnerConfig
+from sae_lens.sae import SAEConfig
+from sae_lens.training.training_sae import TrainingSAEConfig
 
 TINYSTORIES_MODEL = "tiny-stories-1M"
 TINYSTORIES_DATASET = "roneneldan/TinyStories"
@@ -18,6 +21,26 @@ def test_get_training_sae_cfg_dict_passes_scale_sparsity_penalty_by_decoder_norm
         scale_sparsity_penalty_by_decoder_norm=False, normalize_sae_decoder=False
     )
     assert not cfg.get_training_sae_cfg_dict()["scale_sparsity_penalty_by_decoder_norm"]
+
+
+def test_get_training_sae_cfg_dict_has_all_relevant_options():
+    cfg = LanguageModelSAERunnerConfig()
+    cfg_dict = cfg.get_training_sae_cfg_dict()
+    training_sae_opts = fields(TrainingSAEConfig)
+    allowed_missing_fields = {"neuronpedia_id"}
+    training_sae_field_names = {opt.name for opt in training_sae_opts}
+    missing_fields = training_sae_field_names - allowed_missing_fields - cfg_dict.keys()
+    assert missing_fields == set()
+
+
+def test_get_base_sae_cfg_dict_has_all_relevant_options():
+    cfg = LanguageModelSAERunnerConfig()
+    cfg_dict = cfg.get_base_sae_cfg_dict()
+    sae_opts = fields(SAEConfig)
+    allowed_missing_fields = {"neuronpedia_id"}
+    sae_field_names = {opt.name for opt in sae_opts}
+    missing_fields = sae_field_names - allowed_missing_fields - cfg_dict.keys()
+    assert missing_fields == set()
 
 
 def test_sae_training_runner_config_runs_with_defaults():


### PR DESCRIPTION
# Description

Following #377, this PR adds tests which iterate over all the properties of `cfg.get_training_sae_cfg_dict()` and `cfg.get_base_sae_cfg_dict()` and ensure that there are no properties missing. This should help ensure that more bugs like #377 can't happen in the future.

## Type of change

Please delete options that are not relevant.

-[x] chore: tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
