### PR TITLE
fix: remove typeguard dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ pytest-profiling = "^1.7.0"
 zstandard = "^0.22.0"
 typing-extensions = "^4.10.0"
 simple-parsing = "^0.1.6"
-typeguard = "2.13.3" # remove this after the following issue is fixed: https://github.com/TransformerLensOrg/TransformerLens/issues/785
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
# Description

This is a follow-up from #370, which added `typeguard` as a dependency to fix an import bug in transformer-lens (https://github.com/TransformerLensOrg/TransformerLens/issues/785). However, Bryce fixed that issue super-fast (https://github.com/TransformerLensOrg/TransformerLens/pull/787), so we no longer need to include `typeguard` explicitly in pyproject.toml. This PR removes this now unnecessary dependency..

## Type of change

Please delete options that are not relevant.

- [x] dependency issue