### PR TITLE
fix: Added hf_revision to runner config

### DIFF
--- a/sae_lens/cache_activations_runner.py
+++ b/sae_lens/cache_activations_runner.py
@@ -11,11 +11,10 @@ from datasets import Array2D, Dataset, Features
 from datasets.fingerprint import generate_fingerprint
 from huggingface_hub import HfApi
 from jaxtyping import Float
-from tqdm import tqdm
-
 from sae_lens.config import DTYPE_MAP, CacheActivationsRunnerConfig
 from sae_lens.load_model import load_model
 from sae_lens.training.activations_store import ActivationsStore
+from tqdm import tqdm
 
 
 class CacheActivationsRunner:
@@ -273,10 +272,20 @@ class CacheActivationsRunner:
             meta_io.seek(0)
 
             api = HfApi()
+
+            # Tacks on username to the repo id
+            user_repo_id = api.create_repo(
+                self.cfg.hf_repo_id,
+                private=self.cfg.hf_is_private_repo,
+                repo_type="dataset",
+                exist_ok=True,  # should exist already
+            ).repo_id
+
             api.upload_file(
                 path_or_fileobj=meta_io,
                 path_in_repo="cache_activations_runner_cfg.json",
-                repo_id=self.cfg.hf_repo_id,
+                repo_id=user_repo_id,
+                revision=self.cfg.hf_revision,
                 repo_type="dataset",
                 commit_message="Add cache_activations_runner metadata",
             )


### PR DESCRIPTION
Also now allows the user to not specify the username in the hf_repo_id

Small fix that when specifying push to branch, the runner cfg was pushed to main still.

Also allows the user not to specify their username in `hf_repo_id`, e.g:

```python
hf_repo_id = "layer-4-resid_post"
```

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (barely)

# Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility


### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [X] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)