### PR TITLE
Replace print with logging

### DIFF
--- a/sae_lens/__init__.py
+++ b/sae_lens/__init__.py
@@ -1,5 +1,8 @@
 __version__ = "4.4.5"
 
+import logging
+
+logger = logging.getLogger(__name__)
 
 from .analysis.hooked_sae_transformer import HookedSAETransformer
 from .cache_activations_runner import CacheActivationsRunner

--- a/sae_lens/analysis/tsea.py
+++ b/sae_lens/analysis/tsea.py
@@ -11,6 +11,8 @@ import torch
 from babe import UsNames
 from transformer_lens import HookedTransformer
 
+from sae_lens import logger
+
 
 def get_enrichment_df(
     projections: torch.Tensor,
@@ -180,10 +182,10 @@ def plot_top_k_feature_projections_by_token_and_category(
 
     # scores = enrichment_scores[category][features]
     scores = enrichment_scores[category].loc[features]
-    print(scores)
+    logger.debug(scores)
     tokens_list = [model.to_single_str_token(i) for i in list(range(model.cfg.d_vocab))]
 
-    print(features)
+    logger.debug(features)
     feature_logit_scores = pd.DataFrame(
         dec_projection_onto_W_U[features].numpy(), index=features  # type: ignore
     ).T
@@ -193,9 +195,9 @@ def plot_top_k_feature_projections_by_token_and_category(
     ]
 
     # display(feature_)
-    print(category)
+    logger.debug(category)
     for feature, score in zip(features, scores):  # type: ignore
-        print(feature)
+        logger.debug(feature)
         score = -1 * np.log(1 - score)  # convert to enrichment score
         fig = px.histogram(
             feature_logit_scores,

--- a/sae_lens/cache_activations_runner.py
+++ b/sae_lens/cache_activations_runner.py
@@ -13,6 +13,7 @@ from huggingface_hub import HfApi
 from jaxtyping import Float
 from tqdm import tqdm
 
+from sae_lens import logger
 from sae_lens.config import DTYPE_MAP, CacheActivationsRunnerConfig
 from sae_lens.load_model import load_model
 from sae_lens.training.activations_store import ActivationsStore
@@ -226,7 +227,7 @@ class CacheActivationsRunner:
 
         ### Create temporary sharded datasets
 
-        print(f"Started caching {self.cfg.training_tokens} activations")
+        logger.info(f"Started caching {self.cfg.training_tokens} activations")
 
         for i in tqdm(range(self.n_buffers), desc="Caching activations"):
             try:
@@ -241,7 +242,7 @@ class CacheActivationsRunner:
                 del buffer, shard
 
             except StopIteration:
-                print(
+                logger.warning(
                     f"Warning: Ran out of samples while filling the buffer at batch {i} before reaching {self.n_buffers} batches. No more caching will occur."
                 )
                 break
@@ -253,11 +254,11 @@ class CacheActivationsRunner:
         )
 
         if self.cfg.shuffle:
-            print("Shuffling...")
+            logger.info("Shuffling...")
             dataset = dataset.shuffle(seed=self.cfg.seed)
 
         if self.cfg.hf_repo_id:
-            print("Pushing to hub...")
+            logger.info("Pushing to hub...")
             dataset.push_to_hub(
                 repo_id=self.cfg.hf_repo_id,
                 num_shards=self.cfg.hf_num_shards or self.n_buffers,

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -7,7 +7,7 @@ import torch
 import wandb
 from datasets import Dataset, DatasetDict, IterableDataset, IterableDatasetDict
 
-from sae_lens import __version__
+from sae_lens import __version__, logger
 
 DTYPE_MAP = {
     "float32": torch.float32,
@@ -335,7 +335,7 @@ class LanguageModelSAERunnerConfig:
         self.checkpoint_path = f"{self.checkpoint_path}/{unique_id}"
 
         if self.verbose:
-            print(
+            logger.info(
                 f"Run name: {self.d_sae}-L1-{self.l1_coefficient}-LR-{self.lr}-Tokens-{self.training_tokens:3.3e}"
             )
             # Print out some useful info:
@@ -344,43 +344,45 @@ class LanguageModelSAERunnerConfig:
                 * self.context_size
                 * self.n_batches_in_buffer
             )
-            print(f"n_tokens_per_buffer (millions): {n_tokens_per_buffer / 10 ** 6}")
+            logger.info(
+                f"n_tokens_per_buffer (millions): {n_tokens_per_buffer / 10 ** 6}"
+            )
             n_contexts_per_buffer = (
                 self.store_batch_size_prompts * self.n_batches_in_buffer
             )
-            print(
+            logger.info(
                 f"Lower bound: n_contexts_per_buffer (millions): {n_contexts_per_buffer / 10 ** 6}"
             )
 
             total_training_steps = (
                 self.training_tokens + self.finetuning_tokens
             ) // self.train_batch_size_tokens
-            print(f"Total training steps: {total_training_steps}")
+            logger.info(f"Total training steps: {total_training_steps}")
 
             total_wandb_updates = total_training_steps // self.wandb_log_frequency
-            print(f"Total wandb updates: {total_wandb_updates}")
+            logger.info(f"Total wandb updates: {total_wandb_updates}")
 
             # how many times will we sample dead neurons?
             # assert self.dead_feature_window <= self.feature_sampling_window, "dead_feature_window must be smaller than feature_sampling_window"
             n_feature_window_samples = (
                 total_training_steps // self.feature_sampling_window
             )
-            print(
+            logger.info(
                 f"n_tokens_per_feature_sampling_window (millions): {(self.feature_sampling_window * self.context_size * self.train_batch_size_tokens) / 10 ** 6}"
             )
-            print(
+            logger.info(
                 f"n_tokens_per_dead_feature_window (millions): {(self.dead_feature_window * self.context_size * self.train_batch_size_tokens) / 10 ** 6}"
             )
-            print(
+            logger.info(
                 f"We will reset the sparsity calculation {n_feature_window_samples} times."
             )
-            # print("Number tokens in dead feature calculation window: ", self.dead_feature_window * self.train_batch_size_tokens)
-            print(
+            # logger.info("Number tokens in dead feature calculation window: ", self.dead_feature_window * self.train_batch_size_tokens)
+            logger.info(
                 f"Number tokens in sparsity calculation window: {self.feature_sampling_window * self.train_batch_size_tokens:.2e}"
             )
 
         if self.use_ghost_grads:
-            print("Using Ghost Grads.")
+            logger.info("Using Ghost Grads.")
 
         if self.context_size < 0:
             raise ValueError(

--- a/sae_lens/load_model.py
+++ b/sae_lens/load_model.py
@@ -11,6 +11,8 @@ from transformer_lens.utils import (
 )
 from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedTokenizerBase
 
+from sae_lens import logger
+
 
 def load_model(
     model_class_name: str,
@@ -23,11 +25,11 @@ def load_model(
     if "n_devices" in model_from_pretrained_kwargs:
         n_devices = model_from_pretrained_kwargs["n_devices"]
         if n_devices > 1:
-            print("MODEL LOADING:")
-            print("Setting model device to cuda for d_devices")
-            print(f"Will use cuda:0 to cuda:{n_devices-1}")
+            logger.info("MODEL LOADING:")
+            logger.info("Setting model device to cuda for d_devices")
+            logger.info(f"Will use cuda:0 to cuda:{n_devices-1}")
             device = "cuda"
-            print("-------------")
+            logger.info("-------------")
 
     if model_class_name == "HookedTransformer":
         return HookedTransformer.from_pretrained_no_processing(

--- a/sae_lens/sae_training_runner.py
+++ b/sae_lens/sae_training_runner.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 import signal
 import sys
@@ -11,6 +10,7 @@ from safetensors.torch import save_file
 from simple_parsing import ArgumentParser
 from transformer_lens.hook_points import HookedRootModule
 
+from sae_lens import logger
 from sae_lens.config import HfDataset, LanguageModelSAERunnerConfig
 from sae_lens.load_model import load_model
 from sae_lens.sae import SAE_CFG_PATH, SAE_WEIGHTS_PATH, SPARSITY_PATH
@@ -46,11 +46,11 @@ class SAETrainingRunner:
         override_sae: TrainingSAE | None = None,
     ):
         if override_dataset is not None:
-            logging.warning(
+            logger.warning(
                 f"You just passed in a dataset which will override the one specified in your configuration: {cfg.dataset_path}. As a consequence this run will not be reproducible via configuration alone."
             )
         if override_model is not None:
-            logging.warning(
+            logger.warning(
                 f"You just passed in a model which will override the one specified in your configuration: {cfg.model_name}. As a consequence this run will not be reproducible via configuration alone."
             )
 
@@ -156,10 +156,10 @@ class SAETrainingRunner:
             sae = trainer.fit()
 
         except (KeyboardInterrupt, InterruptedException):
-            print("interrupted, saving progress")
+            logger.warning("interrupted, saving progress")
             checkpoint_name = trainer.n_training_tokens
             self.save_checkpoint(trainer, checkpoint_name=checkpoint_name)
-            print("done saving")
+            logger.info("done saving")
             raise
 
         return sae

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -10,6 +10,7 @@ from huggingface_hub.utils import EntryNotFoundError
 from safetensors import safe_open
 from safetensors.torch import load_file
 
+from sae_lens import logger
 from sae_lens.config import DTYPE_MAP
 from sae_lens.toolkit.pretrained_saes_directory import (
     PretrainedSAELookup,
@@ -401,7 +402,7 @@ def gemma_2_sae_loader(
 
     # if it is an embedding SAE, then we need to adjust for the scale of d_model because of how they trained it
     if "embedding" in folder_name:
-        print("Adjusting for d_model in embedding SAE")
+        logger.debug("Adjusting for d_model in embedding SAE")
         state_dict["W_enc"].data = state_dict["W_enc"].data / np.sqrt(cfg_dict["d_in"])
         state_dict["W_dec"].data = state_dict["W_dec"].data * np.sqrt(cfg_dict["d_in"])
 

--- a/sae_lens/toolkit/pretrained_saes.py
+++ b/sae_lens/toolkit/pretrained_saes.py
@@ -7,7 +7,7 @@ from huggingface_hub import hf_hub_download, list_repo_tree
 from safetensors import safe_open
 from tqdm import tqdm
 
-from sae_lens.sae import SAE
+from sae_lens.sae import SAE, logger
 
 
 def load_sparsity(path: str) -> torch.Tensor:
@@ -144,7 +144,7 @@ def get_gpt2_small_ckrk_attn_out_saes() -> dict[str, SAE]:
 
     saes = {}
     for name, config in sae_configs.items():
-        print(f"Loading {name}")
+        logger.debug(f"Loading {name}")
         saes[name] = convert_connor_rob_sae_to_our_saelens_format(
             saes_weights[name], config
         )

--- a/sae_lens/toolkit/pretrained_saes.py
+++ b/sae_lens/toolkit/pretrained_saes.py
@@ -7,7 +7,8 @@ from huggingface_hub import hf_hub_download, list_repo_tree
 from safetensors import safe_open
 from tqdm import tqdm
 
-from sae_lens.sae import SAE, logger
+from sae_lens import logger
+from sae_lens.sae import SAE
 
 
 def load_sparsity(path: str) -> torch.Tensor:

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -20,6 +20,7 @@ from tqdm import tqdm
 from transformer_lens.hook_points import HookedRootModule
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
+from sae_lens import logger
 from sae_lens.config import (
     DTYPE_MAP,
     CacheActivationsRunnerConfig,
@@ -483,8 +484,8 @@ class ActivationsStore:
                     n_batches, n_context, -1
                 )
             except RuntimeError as e:
-                print(f"Error during view operation: {e}")
-                print("Attempting to use reshape instead...")
+                logger.error(f"Error during view operation: {e}")
+                logger.info("Attempting to use reshape instead...")
                 stacked_activations[:, :, 0] = layerwise_activations.reshape(
                     n_batches, n_context, -1
                 )

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -13,6 +13,7 @@ import torch
 from jaxtyping import Float
 from torch import nn
 
+from sae_lens import logger
 from sae_lens.config import LanguageModelSAERunnerConfig
 from sae_lens.sae import SAE, SAEConfig
 from sae_lens.toolkit.pretrained_sae_loaders import (
@@ -647,11 +648,11 @@ class TrainingSAE(SAE):
         previous_distances = torch.norm(all_activations - previous_b_dec, dim=-1)
         distances = torch.norm(all_activations - out, dim=-1)
 
-        print("Reinitializing b_dec with mean of activations")
-        print(
+        logger.info("Reinitializing b_dec with mean of activations")
+        logger.debug(
             f"Previous distances: {previous_distances.median(0).values.mean().item()}"
         )
-        print(f"New distances: {distances.median(0).values.mean().item()}")
+        logger.debug(f"New distances: {distances.median(0).values.mean().item()}")
 
         self.b_dec.data = out.to(self.dtype).to(self.device)
 

--- a/sae_lens/training/upload_saes_to_huggingface.py
+++ b/sae_lens/training/upload_saes_to_huggingface.py
@@ -8,6 +8,7 @@ from huggingface_hub import HfApi, create_repo, get_hf_file_metadata, hf_hub_url
 from huggingface_hub.utils import EntryNotFoundError, RepositoryNotFoundError
 from tqdm.autonotebook import tqdm
 
+from sae_lens import logger
 from sae_lens.sae import SAE, SAE_CFG_PATH, SAE_WEIGHTS_PATH, SPARSITY_PATH
 
 
@@ -45,7 +46,7 @@ def upload_saes_to_huggingface(
             )
         if add_default_readme:
             if _repo_file_exists(hf_repo_id, "README.md", hf_revision):
-                print("README.md already exists in the repo, skipping upload")
+                logger.info("README.md already exists in the repo, skipping upload")
             else:
                 readme = _create_default_readme(hf_repo_id, saes_dict)
                 readme_io = io.BytesIO()


### PR DESCRIPTION
# Description

Replaces `print()` with logging methods called on a logger, where we don't display console output for a command line script, and excluding notebooks and the `benchmark/tests` directory. This allows us to track the severity of events and makes it possible to configure the logging verbosity. Currently, we're just using `print()`.

Fixes #43

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 