### PR TITLE
chore: fix tokenizer typing for bos_token_id

### DIFF
--- a/sae_lens/pretokenize_runner.py
+++ b/sae_lens/pretokenize_runner.py
@@ -60,11 +60,11 @@ def get_special_token_from_cfg(
     if isinstance(cfg_token, int):
         return cfg_token
     if cfg_token == "bos":
-        return tokenizer.bos_token_id
+        return tokenizer.bos_token_id  # type: ignore
     if cfg_token == "eos":
-        return tokenizer.eos_token_id
+        return tokenizer.eos_token_id  # type: ignore
     if cfg_token == "sep":
-        return tokenizer.sep_token_id
+        return tokenizer.sep_token_id  # type: ignore
     raise ValueError(f"Invalid token type: {cfg_token}")
 
 

--- a/tests/unit/training/test_activations_store.py
+++ b/tests/unit/training/test_activations_store.py
@@ -24,7 +24,7 @@ from tests.unit.helpers import build_sae_cfg, load_model_cached
 def tokenize_with_bos(model: HookedTransformer, text: str) -> list[int]:
     assert model.tokenizer is not None
     assert model.tokenizer.bos_token_id is not None
-    return [model.tokenizer.bos_token_id] + model.tokenizer.encode(text)
+    return [model.tokenizer.bos_token_id] + model.tokenizer.encode(text)  # type: ignore
 
 
 # Define a new fixture for different configurations


### PR DESCRIPTION
# Description

It looks like `PreTrainedTokenizerBase` typing no longer has `bos_token_id` or other token IDs defined in the most recent version of transformers. I'm not sure if that was intentional by `transformers`, or an oversight, but this PR just ignore the typing for these token IDs so CI can pass.

## Type of change

Please delete options that are not relevant.

- [x] CI chore
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update