### PR TITLE
Replace assert statements with exception code

### DIFF
--- a/sae_lens/analysis/hooked_sae_transformer.py
+++ b/sae_lens/analysis/hooked_sae_transformer.py
@@ -141,9 +141,8 @@ class HookedSAETransformer(HookedTransformer):
             act_names = list(self.acts_to_saes.keys())
 
         if prev_saes:
-            assert len(act_names) == len(
-                prev_saes
-            ), "act_names and prev_saes must have the same length"
+            if len(act_names) != len(prev_saes):
+                raise ValueError("act_names and prev_saes must have the same length")
         else:
             prev_saes = [None] * len(act_names)  # type: ignore
 

--- a/sae_lens/analysis/neuronpedia_integration.py
+++ b/sae_lens/analysis/neuronpedia_integration.py
@@ -365,7 +365,10 @@ async def autointerp_neuronpedia_features(  # noqa: C901
                 f"ERROR: Failed to explain feature {feature.modelId}@{feature.layer}-{feature.dataset}:{feature.feature}"
             )
 
-        assert len(explanations) == 1
+        if len(explanations) != 1:
+            raise ValueError(
+                f"Expected exactly one explanation but got {len(explanations)}. This may indicate an issue with the explainer's response."
+            )
         explanation = explanations[0].rstrip(".")
         logger.info(
             f"===== {autointerp_explainer_model_name}'s explanation: {explanation}"

--- a/sae_lens/cache_activations_runner.py
+++ b/sae_lens/cache_activations_runner.py
@@ -159,12 +159,22 @@ class CacheActivationsRunner:
         """
         first_shard_dir_name = "shard_00000"  # shard_{i:05d}
 
-        assert source_dir.exists() and source_dir.is_dir()
-        assert (
-            output_dir.exists()
-            and output_dir.is_dir()
-            and not any(p for p in output_dir.iterdir() if p.name != ".tmp_shards")
-        )
+        if not source_dir.exists() or not source_dir.is_dir():
+            raise NotADirectoryError(
+                f"source_dir is not an existing directory: {source_dir}"
+            )
+
+        if not output_dir.exists() or not output_dir.is_dir():
+            raise NotADirectoryError(
+                f"output_dir is not an existing directory: {output_dir}"
+            )
+
+        other_items = [p for p in output_dir.iterdir() if p.name != ".tmp_shards"]
+        if other_items:
+            raise FileExistsError(
+                f"output_dir must be empty (besides .tmp_shards). Found: {other_items}"
+            )
+
         if not (source_dir / first_shard_dir_name).exists():
             raise Exception(f"No shards in {source_dir} exist!")
 

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -566,7 +566,9 @@ class CacheActivationsRunnerConfig:
                 )
             token_length = len(toks)
             self.context_size = token_length
-        assert self.context_size != -1
+
+        if self.context_size == -1:
+            raise ValueError("context_size is still -1 after dataset inspection.")
 
         if self.seqpos_slice is not None:
             _validate_seqpos(
@@ -704,11 +706,15 @@ def _validate_seqpos(seqpos: tuple[int | None, ...], context_size: int) -> None:
     # Ensure that the step-size is larger or equal to 1
     if len(seqpos) == 3:
         step_size = seqpos[2] or 1
-        assert (
-            step_size > 1
-        ), f"Ensure the step_size {seqpos[2]=} for sequence slicing is positive."
+        if step_size <= 1:
+            raise ValueError(
+                f"Ensure the step_size={seqpos[2]} for sequence slicing is at least 1."
+            )
     # Ensure that the choice of seqpos doesn't end up with an empty list
-    assert len(list(range(context_size))[slice(*seqpos)]) > 0
+    if len(list(range(context_size))[slice(*seqpos)]) == 0:
+        raise ValueError(
+            f"The slice {seqpos} results in an empty range. Please adjust your seqpos or context_size."
+        )
 
 
 @dataclass

--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -130,7 +130,11 @@ def run_evals(
     }
 
     if eval_config.compute_kl or eval_config.compute_ce_loss:
-        assert eval_config.n_eval_reconstruction_batches > 0
+        if eval_config.n_eval_reconstruction_batches <= 0:
+            raise ValueError(
+                "eval_config.n_eval_reconstruction_batches must be > 0 when "
+                "compute_kl or compute_ce_loss is True."
+            )
         reconstruction_metrics = get_downstream_reconstruction_metrics(
             sae,
             model,
@@ -175,7 +179,11 @@ def run_evals(
         or eval_config.compute_sparsity_metrics
         or eval_config.compute_variance_metrics
     ):
-        assert eval_config.n_eval_sparsity_variance_batches > 0
+        if eval_config.n_eval_sparsity_variance_batches <= 0:
+            raise ValueError(
+                "eval_config.n_eval_sparsity_variance_batches must be > 0 when "
+                "compute_l2_norms, compute_sparsity_metrics, or compute_variance_metrics is True."
+            )
         sparsity_variance_metrics, feature_metrics = get_sparsity_and_variance_metrics(
             sae,
             model,
@@ -743,7 +751,8 @@ def multiple_evals(
 
     filtered_saes = get_saes_from_regex(sae_regex_pattern, sae_block_pattern)
 
-    assert len(filtered_saes) > 0, "No SAEs matched the given regex patterns"
+    if len(filtered_saes) == 0:
+        raise ValueError("No SAEs matched the given regex patterns")
 
     eval_results = []
     output_path = Path(output_dir)

--- a/sae_lens/load_model.py
+++ b/sae_lens/load_model.py
@@ -130,18 +130,25 @@ class HookedProxyLM(HookedRootModule):
         # Assumes that prepend_bos is always False, move_to_device is always False, and truncate is always False
         # copied from HookedTransformer.to_tokens
 
-        assert (
-            prepend_bos is False
-        ), "Only works with prepend_bos=False, to match ActivationsStore usage"
-        assert (
-            padding_side is None
-        ), "Only works with padding_side=None, to match ActivationsStore usage"
-        assert (
-            truncate is False
-        ), "Only works with truncate=False, to match ActivationsStore usage"
-        assert (
-            move_to_device is False
-        ), "Only works with move_to_device=False, to match ActivationsStore usage"
+        if prepend_bos is not False:
+            raise ValueError(
+                "Only works with prepend_bos=False, to match ActivationsStore usage"
+            )
+
+        if padding_side is not None:
+            raise ValueError(
+                "Only works with padding_side=None, to match ActivationsStore usage"
+            )
+
+        if truncate is not False:
+            raise ValueError(
+                "Only works with truncate=False, to match ActivationsStore usage"
+            )
+
+        if move_to_device is not False:
+            raise ValueError(
+                "Only works with move_to_device=False, to match ActivationsStore usage"
+            )
 
         tokens = self.tokenizer(
             input,

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -648,9 +648,8 @@ class SAE(HookedRootModule):
         return cls(SAEConfig.from_dict(config_dict))
 
     def turn_on_forward_pass_hook_z_reshaping(self):
-        assert self.cfg.hook_name.endswith(
-            "_z"
-        ), "This method should only be called for hook_z SAEs."
+        if not self.cfg.hook_name.endswith("_z"):
+            raise ValueError("This method should only be called for hook_z SAEs.")
 
         def reshape_fn_in(x: torch.Tensor):
             self.d_head = x.shape[-1]  # type: ignore
@@ -703,7 +702,8 @@ def get_activation_fn(
 
         return tanh_relu
     if activation_fn == "topk":
-        assert "k" in kwargs, "TopK activation function requires a k value."
+        if "k" not in kwargs:
+            raise ValueError("TopK activation function requires a k value.")
         k = kwargs.get("k", 1)  # Default k to 1 if not provided
         postact_fn = kwargs.get(
             "postact_fn", nn.ReLU()

--- a/sae_lens/tokenization_and_batching.py
+++ b/sae_lens/tokenization_and_batching.py
@@ -79,9 +79,8 @@ def concat_and_batch_sequences(
     """
     batch: torch.Tensor | None = None
     for tokens in tokens_iterator:
-        assert (
-            len(tokens.shape) == 1
-        ), f"tokens.shape should be 1D but was {tokens.shape}"
+        if len(tokens.shape) != 1:
+            raise ValueError(f"tokens.shape should be 1D but was {tokens.shape}")
         offset = 0
         total_toks = tokens.shape[0]
         is_start_of_sequence = True

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -233,9 +233,10 @@ def read_sae_from_disk(
             del state_dict["scaling_factor"]
             cfg_dict["finetuning_scaling_factor"] = False
         else:
-            assert cfg_dict[
-                "finetuning_scaling_factor"
-            ], "Scaling factor is present but finetuning_scaling_factor is False."
+            if not cfg_dict["finetuning_scaling_factor"]:
+                raise ValueError(
+                    "Scaling factor is present but finetuning_scaling_factor is False."
+                )
             state_dict["finetuning_scaling_factor"] = state_dict["scaling_factor"]
             del state_dict["scaling_factor"]
     else:
@@ -391,9 +392,10 @@ def gemma_2_sae_loader(
             del state_dict["scaling_factor"]
             cfg_dict["finetuning_scaling_factor"] = False
         else:
-            assert cfg_dict[
-                "finetuning_scaling_factor"
-            ], "Scaling factor is present but finetuning_scaling_factor is False."
+            if not cfg_dict["finetuning_scaling_factor"]:
+                raise ValueError(
+                    "Scaling factor is present but finetuning_scaling_factor is False."
+                )
             state_dict["finetuning_scaling_factor"] = state_dict.pop("scaling_factor")
     else:
         cfg_dict["finetuning_scaling_factor"] = False

--- a/sae_lens/toolkit/pretrained_saes.py
+++ b/sae_lens/toolkit/pretrained_saes.py
@@ -66,10 +66,11 @@ def get_gpt2_res_jb_saes(
     ] + ["blocks.11.hook_resid_post"]
 
     if hook_point is not None:
-        assert hook_point in GPT2_SMALL_RESIDUAL_SAES_HOOK_POINTS, (
-            f"hook_point must be one of {GPT2_SMALL_RESIDUAL_SAES_HOOK_POINTS}"
-            f"but got {hook_point}"
-        )
+        if hook_point not in GPT2_SMALL_RESIDUAL_SAES_HOOK_POINTS:
+            raise ValueError(
+                f"hook_point must be one of {GPT2_SMALL_RESIDUAL_SAES_HOOK_POINTS} "
+                f"but got {hook_point}"
+            )
         GPT2_SMALL_RESIDUAL_SAES_HOOK_POINTS = [hook_point]
 
     saes = {}

--- a/sae_lens/toolkit/pretrained_saes_directory.py
+++ b/sae_lens/toolkit/pretrained_saes_directory.py
@@ -33,7 +33,8 @@ def get_pretrained_saes_directory() -> dict[str, PretrainedSAELookup]:
             l0_map: dict[str, float] = {}
             neuronpedia_id_map: dict[str, str] = {}
 
-            assert "saes" in value, f"Missing 'saes' key in {release}"
+            if "saes" not in value:
+                raise KeyError(f"Missing 'saes' key in {release}")
             for hook_info in value["saes"]:
                 saes_map[hook_info["id"]] = hook_info["path"]
                 var_explained_map[hook_info["id"]] = hook_info.get(

--- a/sae_lens/training/optim.py
+++ b/sae_lens/training/optim.py
@@ -119,7 +119,10 @@ class L1Scheduler:
 
         self.current_step = 0
         self.total_steps = total_steps
-        assert isinstance(self.final_l1_coefficient, float | int)
+        if not isinstance(self.final_l1_coefficient, (float, int)):
+            raise TypeError(
+                f"final_l1_coefficient must be float or int, got {type(self.final_l1_coefficient)}."
+            )
 
     def __repr__(self) -> str:
         return (

--- a/tests/unit/training/test_config.py
+++ b/tests/unit/training/test_config.py
@@ -1,5 +1,5 @@
 from dataclasses import fields
-from typing import Optional, Type
+from typing import Type
 
 import pytest
 
@@ -140,16 +140,10 @@ test_cases_for_seqpos = [
 
 @pytest.mark.parametrize("seqpos_slice, expected_error", test_cases_for_seqpos)
 def test_sae_training_runner_config_seqpos(
-    seqpos_slice: tuple[int, int], expected_error: Optional[Type[BaseException]]
+    seqpos_slice: tuple[int, int], expected_error: Type[BaseException]
 ):
     context_size = 10
-    if expected_error is not None:
-        with pytest.raises(expected_error):
-            LanguageModelSAERunnerConfig(
-                seqpos_slice=seqpos_slice,
-                context_size=context_size,
-            )
-    else:
+    with pytest.raises(expected_error):
         LanguageModelSAERunnerConfig(
             seqpos_slice=seqpos_slice,
             context_size=context_size,
@@ -159,22 +153,9 @@ def test_sae_training_runner_config_seqpos(
 @pytest.mark.parametrize("seqpos_slice, expected_error", test_cases_for_seqpos)
 def test_cache_activations_runner_config_seqpos(
     seqpos_slice: tuple[int, int],
-    expected_error: Optional[Type[BaseException]],
+    expected_error: Type[BaseException],
 ):
-    if expected_error is ValueError:
-        with pytest.raises(expected_error):
-            CacheActivationsRunnerConfig(
-                dataset_path="",
-                model_name="",
-                model_batch_size=1,
-                hook_name="",
-                hook_layer=0,
-                d_in=1,
-                training_tokens=100,
-                context_size=10,
-                seqpos_slice=seqpos_slice,
-            )
-    else:
+    with pytest.raises(expected_error):
         CacheActivationsRunnerConfig(
             dataset_path="",
             model_name="",

--- a/tests/unit/training/test_config.py
+++ b/tests/unit/training/test_config.py
@@ -1,5 +1,5 @@
 from dataclasses import fields
-from typing import Optional
+from typing import Optional, Type
 
 import pytest
 
@@ -131,19 +131,19 @@ def test_sae_training_runner_config_expansion_factor():
 
 
 test_cases_for_seqpos = [
-    ((None, 10, -1), AssertionError),
-    ((None, 10, 0), AssertionError),
-    ((5, 5, None), AssertionError),
-    ((6, 3, None), AssertionError),
+    ((None, 10, -1), ValueError),
+    ((None, 10, 0), ValueError),
+    ((5, 5, None), ValueError),
+    ((6, 3, None), ValueError),
 ]
 
 
 @pytest.mark.parametrize("seqpos_slice, expected_error", test_cases_for_seqpos)
 def test_sae_training_runner_config_seqpos(
-    seqpos_slice: tuple[int, int], expected_error: Optional[AssertionError]
+    seqpos_slice: tuple[int, int], expected_error: Optional[Type[BaseException]]
 ):
     context_size = 10
-    if expected_error is AssertionError:
+    if expected_error is not None:
         with pytest.raises(expected_error):
             LanguageModelSAERunnerConfig(
                 seqpos_slice=seqpos_slice,
@@ -158,9 +158,10 @@ def test_sae_training_runner_config_seqpos(
 
 @pytest.mark.parametrize("seqpos_slice, expected_error", test_cases_for_seqpos)
 def test_cache_activations_runner_config_seqpos(
-    seqpos_slice: tuple[int, int], expected_error: Optional[AssertionError]
+    seqpos_slice: tuple[int, int],
+    expected_error: Optional[Type[BaseException]],
 ):
-    if expected_error is AssertionError:
+    if expected_error is ValueError:
         with pytest.raises(expected_error):
             CacheActivationsRunnerConfig(
                 dataset_path="",


### PR DESCRIPTION
# Description

Replaces `assert` statements with code to raise exceptions when I'd expect that a user could see an `AssertionError` and excluding `assert` statements for `pyright` and in notebooks/the `tutorials` directory. I'd made a comment in https://github.com/jbloomAus/SAELens/pull/226#discussion_r1835621811 about `assert` statements in production code and we want to change them to code to throw exceptions when we'd expect users could see them fail.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.




# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 