### PR TITLE
Update logits_lens_with_features.ipynb

### DIFF
--- a/tutorials/logits_lens_with_features.ipynb
+++ b/tutorials/logits_lens_with_features.ipynb
@@ -130,7 +130,7 @@
     "for layer in range(12):\n",
     "    sae, original_cfg_dict, sparsity = SAE.from_pretrained(\n",
     "        release=\"gpt2-small-res-jb\",\n",
-    "        sae_id=\"blocks.0.hook_resid_pre\",\n",
+    "        sae_id=f\"blocks.{layer}.hook_resid_pre\",\n",
     "        device=\"cpu\",\n",
     "    )\n",
     "    gpt2_small_sparse_autoencoders[f\"blocks.{layer}.hook_resid_pre\"] = sae\n",


### PR DESCRIPTION
# Description

when load `sae` through `SAE.from_pretrained`, `sae_id` should change with `layer` not always `blocks.0.hook_resid_pre`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)