### PR TITLE
feat: ignore special tokens in SAE training

### DIFF
--- a/sae_lens/cache_activations_runner.py
+++ b/sae_lens/cache_activations_runner.py
@@ -6,10 +6,10 @@ from pathlib import Path
 
 import einops
 import torch
-from datasets import Array2D, Dataset, Features
+from datasets import Array2D, Dataset, Features, Sequence, Value
 from datasets.fingerprint import generate_fingerprint
 from huggingface_hub import HfApi
-from jaxtyping import Float
+from jaxtyping import Float, Int
 from tqdm import tqdm
 from transformer_lens.HookedTransformer import HookedRootModule
 
@@ -70,14 +70,16 @@ class CacheActivationsRunner:
         self.context_size = self._get_sliced_context_size(
             self.cfg.context_size, self.cfg.seqpos_slice
         )
-        self.features = Features(
-            {
-                hook_name: Array2D(
-                    shape=(self.context_size, self.cfg.d_in), dtype=self.cfg.dtype
-                )
-                for hook_name in [self.cfg.hook_name]
-            }
+        features_dict: dict[str, Array2D | Sequence] = {
+            hook_name: Array2D(
+                shape=(self.context_size, self.cfg.d_in), dtype=self.cfg.dtype
+            )
+            for hook_name in [self.cfg.hook_name]
+        }
+        features_dict["token_ids"] = Sequence(
+            Value(dtype="int32"), length=self.context_size
         )
+        self.features = Features(features_dict)
 
     def __str__(self):
         """
@@ -264,7 +266,6 @@ class CacheActivationsRunner:
                     f"{tmp_cached_activation_path}/shard_{i:05d}", num_shards=1
                 )
                 del buffer, shard
-
             except StopIteration:
                 logger.warning(
                     f"Warning: Ran out of samples while filling the buffer at batch {i} before reaching {self.cfg.n_buffers} batches."
@@ -310,20 +311,33 @@ class CacheActivationsRunner:
 
     def _create_shard(
         self,
-        buffer: Float[torch.Tensor, "(bs context_size) num_layers d_in"],
+        buffer: tuple[
+            Float[torch.Tensor, "(bs context_size) num_layers d_in"],
+            Int[torch.Tensor, "(bs context_size)"] | None,
+        ],
     ) -> Dataset:
         hook_names = [self.cfg.hook_name]
-
-        buffer = einops.rearrange(
-            buffer,
+        acts, token_ids = buffer
+        acts = einops.rearrange(
+            acts,
             "(bs context_size) num_layers d_in -> num_layers bs context_size d_in",
             bs=self.cfg.n_seq_in_buffer,
             context_size=self.context_size,
             d_in=self.cfg.d_in,
             num_layers=len(hook_names),
         )
+        shard_dict = {hook_name: act for hook_name, act in zip(hook_names, acts)}
+
+        if token_ids is not None:
+            token_ids = einops.rearrange(
+                token_ids,
+                "(bs context_size) -> bs context_size",
+                bs=self.cfg.n_seq_in_buffer,
+                context_size=self.context_size,
+            )
+            shard_dict["token_ids"] = token_ids.to(torch.int32)
         return Dataset.from_dict(
-            {hook_name: act for hook_name, act in zip(hook_names, buffer)},
+            shard_dict,
             features=self.features,
         )
 

--- a/sae_lens/cache_activations_runner.py
+++ b/sae_lens/cache_activations_runner.py
@@ -22,6 +22,7 @@ from sae_lens.training.activations_store import ActivationsStore
 def _mk_activations_store(
     model: HookedRootModule,
     cfg: CacheActivationsRunnerConfig,
+    override_dataset: Dataset | None = None,
 ) -> ActivationsStore:
     """
     Internal method used in CacheActivationsRunner. Used to create a cached dataset
@@ -29,7 +30,7 @@ def _mk_activations_store(
     """
     return ActivationsStore(
         model=model,
-        dataset=cfg.dataset_path,
+        dataset=override_dataset or cfg.dataset_path,
         streaming=cfg.streaming,
         hook_name=cfg.hook_name,
         hook_layer=cfg.hook_layer,
@@ -53,7 +54,11 @@ def _mk_activations_store(
 
 
 class CacheActivationsRunner:
-    def __init__(self, cfg: CacheActivationsRunnerConfig):
+    def __init__(
+        self,
+        cfg: CacheActivationsRunnerConfig,
+        override_dataset: Dataset | None = None,
+    ):
         self.cfg = cfg
         self.model: HookedRootModule = load_model(
             model_class_name=self.cfg.model_class_name,
@@ -66,6 +71,7 @@ class CacheActivationsRunner:
         self.activations_store = _mk_activations_store(
             self.model,
             self.cfg,
+            override_dataset=override_dataset,
         )
         self.context_size = self._get_sliced_context_size(
             self.cfg.context_size, self.cfg.seqpos_slice

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -398,12 +398,10 @@ class LanguageModelSAERunnerConfig:
 
         _validate_seqpos(seqpos=self.seqpos_slice, context_size=self.context_size)
 
-        if isinstance(self.exclude_special_tokens, list):
-            # Validate that all elements are integers
-            if not all(isinstance(x, int) for x in self.exclude_special_tokens):
-                raise ValueError(
-                    "exclude_special_tokens list must contain only integers"
-                )
+        if isinstance(self.exclude_special_tokens, list) and not all(
+            isinstance(x, int) for x in self.exclude_special_tokens
+        ):
+            raise ValueError("exclude_special_tokens list must contain only integers")
 
     @property
     def total_training_tokens(self) -> int:

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -4,7 +4,7 @@ import contextlib
 import json
 import os
 import warnings
-from collections.abc import Generator, Iterator
+from collections.abc import Generator, Iterator, Sequence
 from typing import Any, Literal, cast
 
 import datasets
@@ -13,10 +13,11 @@ import torch
 from datasets import Dataset, DatasetDict, IterableDataset, load_dataset
 from huggingface_hub import hf_hub_download
 from huggingface_hub.utils import HfHubHTTPError
-from jaxtyping import Float
+from jaxtyping import Float, Int
 from requests import HTTPError
 from safetensors.torch import save_file
 from torch.utils.data import DataLoader
+from torch.utils.data import Dataset as TorchDataset
 from tqdm import tqdm
 from transformer_lens.hook_points import HookedRootModule
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
@@ -48,7 +49,8 @@ class ActivationsStore:
     hook_layer: int
     hook_head_index: int | None
     _dataloader: Iterator[Any] | None = None
-    _storage_buffer: torch.Tensor | None = None
+    _storage_buffer: tuple[torch.Tensor, torch.Tensor | None] | None = None
+    exclude_special_tokens: torch.Tensor | None = None
     device: torch.device
 
     @classmethod
@@ -83,6 +85,7 @@ class ActivationsStore:
             model_kwargs=None,
             autocast_lm=False,
             dataset_trust_remote_code=None,
+            exclude_special_tokens=None,
         )
 
     @classmethod
@@ -108,6 +111,16 @@ class ActivationsStore:
                 "You must either pass in a dataset or specify a dataset_path in your configutation."
             )
 
+        device = torch.device(cfg.act_store_device)
+        exclude_special_tokens = cfg.exclude_special_tokens
+        if exclude_special_tokens is False:
+            exclude_special_tokens = None
+        if exclude_special_tokens is True:
+            exclude_special_tokens = _get_special_token_ids(model.tokenizer)  # type: ignore
+        if exclude_special_tokens is not None:
+            exclude_special_tokens = torch.tensor(
+                exclude_special_tokens, dtype=torch.long, device=device
+            )
         return cls(
             model=model,
             dataset=override_dataset or cfg.dataset_path,
@@ -123,13 +136,14 @@ class ActivationsStore:
             train_batch_size_tokens=cfg.train_batch_size_tokens,
             prepend_bos=cfg.prepend_bos,
             normalize_activations=cfg.normalize_activations,
-            device=torch.device(cfg.act_store_device),
+            device=device,
             dtype=cfg.dtype,
             cached_activations_path=cached_activations_path,
             model_kwargs=cfg.model_kwargs,
             autocast_lm=cfg.autocast_lm,
             dataset_trust_remote_code=cfg.dataset_trust_remote_code,
             seqpos_slice=cfg.seqpos_slice,
+            exclude_special_tokens=exclude_special_tokens,
         )
 
     @classmethod
@@ -190,6 +204,7 @@ class ActivationsStore:
         autocast_lm: bool = False,
         dataset_trust_remote_code: bool | None = None,
         seqpos_slice: tuple[int | None, ...] = (None,),
+        exclude_special_tokens: torch.Tensor | None = None,
     ):
         self.model = model
         if model_kwargs is None:
@@ -232,6 +247,7 @@ class ActivationsStore:
         self.cached_activations_path = cached_activations_path
         self.autocast_lm = autocast_lm
         self.seqpos_slice = seqpos_slice
+        self.exclude_special_tokens = exclude_special_tokens
 
         self.n_dataset_processed = 0
 
@@ -374,8 +390,11 @@ class ActivationsStore:
         # ---
         # Actual code
         activations_dataset = datasets.load_from_disk(self.cached_activations_path)
+        columns = [self.hook_name]
+        if "token_ids" in activations_dataset.column_names:
+            columns.append("token_ids")
         activations_dataset.set_format(
-            type="torch", columns=[self.hook_name], device=self.device, dtype=self.dtype
+            type="torch", columns=columns, device=self.device, dtype=self.dtype
         )
         self.current_row_idx = 0  # idx to load next batch from
         # ---
@@ -427,7 +446,7 @@ class ActivationsStore:
         ):
             # temporalily set estimated_norm_scaling_factor to 1.0 so the dataloader works
             self.estimated_norm_scaling_factor = 1.0
-            acts = self.next_batch()
+            acts = self.next_batch()[0]
             self.estimated_norm_scaling_factor = None
             norms_per_batch.append(acts.norm(dim=-1).mean().item())
         mean_norm = np.mean(norms_per_batch)
@@ -454,7 +473,7 @@ class ActivationsStore:
         self.iterable_dataset = iter(self.dataset)
 
     @property
-    def storage_buffer(self) -> torch.Tensor:
+    def storage_buffer(self) -> tuple[torch.Tensor, torch.Tensor | None]:
         if self._storage_buffer is None:
             self._storage_buffer = self.get_buffer(self.half_buffer_size)
 
@@ -553,7 +572,10 @@ class ActivationsStore:
         num_layers: int,
         d_in: int,
         raise_on_epoch_end: bool,
-    ) -> Float[torch.Tensor, "(total_size context_size) num_layers d_in"]:
+    ) -> tuple[
+        Float[torch.Tensor, "(total_size context_size) num_layers d_in"],
+        Int[torch.Tensor, "(total_size context_size)"] | None,
+    ]:
         """
         Loads `total_size` activations from `cached_activation_dataset`
 
@@ -577,12 +599,13 @@ class ActivationsStore:
                 raise StopIteration
 
         new_buffer = []
+        ds_slice = self.cached_activation_dataset[
+            self.current_row_idx : self.current_row_idx + total_size
+        ]
         for hook_name in hook_names:
             # Load activations for each hook.
             # Usually faster to first slice dataset then pick column
-            _hook_buffer = self.cached_activation_dataset[
-                self.current_row_idx : self.current_row_idx + total_size
-            ][hook_name]
+            _hook_buffer = ds_slice[hook_name]
             if _hook_buffer.shape != (total_size, context_size, d_in):
                 raise ValueError(
                     f"_hook_buffer has shape {_hook_buffer.shape}, "
@@ -600,7 +623,19 @@ class ActivationsStore:
             )
 
         self.current_row_idx += total_size
-        return new_buffer.reshape(total_size * context_size, num_layers, d_in)
+        acts_buffer = new_buffer.reshape(total_size * context_size, num_layers, d_in)
+
+        if "token_ids" not in self.cached_activation_dataset.column_names:
+            return acts_buffer, None
+
+        token_ids_buffer = ds_slice["token_ids"]
+        if token_ids_buffer.shape != (total_size, context_size):
+            raise ValueError(
+                f"token_ids_buffer has shape {token_ids_buffer.shape}, "
+                f"but expected ({total_size}, {context_size})."
+            )
+        token_ids_buffer = token_ids_buffer.reshape(total_size * context_size)
+        return acts_buffer, token_ids_buffer
 
     @torch.no_grad()
     def get_buffer(
@@ -608,9 +643,9 @@ class ActivationsStore:
         n_batches_in_buffer: int,
         raise_on_epoch_end: bool = False,
         shuffle: bool = True,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """
-        Loads the next n_batches_in_buffer batches of activations into a tensor and returns half of it.
+        Loads the next n_batches_in_buffer batches of activations into a tensor and returns it.
 
         The primary purpose here is maintaining a shuffling buffer.
 
@@ -630,9 +665,14 @@ class ActivationsStore:
 
         refill_iterator = range(0, total_size, batch_size)
         # Initialize empty tensor buffer of the maximum required size with an additional dimension for layers
-        new_buffer = torch.zeros(
+        new_buffer_activations = torch.zeros(
             (total_size, training_context_size, num_layers, d_in),
             dtype=self.dtype,  # type: ignore
+            device=self.device,
+        )
+        new_buffer_token_ids = torch.zeros(
+            (total_size, training_context_size),
+            dtype=torch.long,
             device=self.device,
         )
 
@@ -646,19 +686,33 @@ class ActivationsStore:
             refill_activations = self.get_activations(refill_batch_tokens)
             # move acts back to cpu
             refill_activations.to(self.device)
-            new_buffer[
+            new_buffer_activations[
                 refill_batch_idx_start : refill_batch_idx_start + batch_size, ...
             ] = refill_activations
 
-        new_buffer = new_buffer.reshape(-1, num_layers, d_in)
+            # handle seqpos_slice, this is done for activations in get_activations
+            refill_batch_tokens = refill_batch_tokens[:, slice(*self.seqpos_slice)]
+            new_buffer_token_ids[
+                refill_batch_idx_start : refill_batch_idx_start + batch_size, ...
+            ] = refill_batch_tokens
+
+        new_buffer_activations = new_buffer_activations.reshape(-1, num_layers, d_in)
+        new_buffer_token_ids = new_buffer_token_ids.reshape(-1)
         if shuffle:
-            new_buffer = new_buffer[torch.randperm(new_buffer.shape[0])]
+            new_buffer_activations, new_buffer_token_ids = permute_together(
+                [new_buffer_activations, new_buffer_token_ids]
+            )
 
         # every buffer should be normalized:
         if self.normalize_activations == "expected_average_only_in":
-            new_buffer = self.apply_norm_scaling_factor(new_buffer)
+            new_buffer_activations = self.apply_norm_scaling_factor(
+                new_buffer_activations
+            )
 
-        return new_buffer
+        return (
+            new_buffer_activations,
+            new_buffer_token_ids,
+        )
 
     def get_data_loader(
         self,
@@ -674,7 +728,7 @@ class ActivationsStore:
         batch_size = self.train_batch_size_tokens
 
         try:
-            new_samples = self.get_buffer(
+            new_sample_acts, new_sample_toks = self.get_buffer(
                 self.half_buffer_size, raise_on_epoch_end=True
             )
         except StopIteration:
@@ -685,34 +739,52 @@ class ActivationsStore:
                 None  # dump the current buffer so samples do not leak between epochs
             )
             try:
-                new_samples = self.get_buffer(self.half_buffer_size)
+                new_sample_acts, new_sample_toks = self.get_buffer(
+                    self.half_buffer_size
+                )
             except StopIteration:
                 raise ValueError(
                     "We were unable to fill up the buffer directly after starting a new epoch. This could indicate that there are less samples in the dataset than are required to fill up the buffer. Consider reducing batch_size or n_batches_in_buffer. "
                 )
 
         # 1. # create new buffer by mixing stored and new buffer
-        mixing_buffer = torch.cat(
-            [new_samples, self.storage_buffer],
+        existing_buffer_acts, existing_buffer_toks = self.storage_buffer
+        mixing_buffer_acts = torch.cat(
+            [new_sample_acts, existing_buffer_acts],
             dim=0,
         )
 
-        mixing_buffer = mixing_buffer[torch.randperm(mixing_buffer.shape[0])]
+        permutation = torch.randperm(mixing_buffer_acts.shape[0])
+        mixing_buffer_acts = mixing_buffer_acts[permutation]
+
+        mixing_buffer_toks = None
+        if existing_buffer_toks is not None and new_sample_toks is not None:
+            mixing_buffer_toks = torch.cat(
+                [new_sample_toks, existing_buffer_toks],
+                dim=0,
+            )
+            mixing_buffer_toks = mixing_buffer_toks[permutation]
 
         # 2.  put 50 % in storage
-        self._storage_buffer = mixing_buffer[: mixing_buffer.shape[0] // 2]
+        half_buffer_acts = mixing_buffer_acts[: mixing_buffer_acts.shape[0] // 2]
+        half_buffer_toks = (
+            None
+            if mixing_buffer_toks is None
+            else mixing_buffer_toks[: mixing_buffer_toks.shape[0] // 2]
+        )
+        self._storage_buffer = (half_buffer_acts, half_buffer_toks)
 
         # 3. put other 50 % in a dataloader
-        return iter(
-            DataLoader(
-                # TODO: seems like a typing bug?
-                cast(Any, mixing_buffer[mixing_buffer.shape[0] // 2 :]),
-                batch_size=batch_size,
-                shuffle=True,
-            )
+        toks_dataset = ActivationsTokensDataset(
+            activations=mixing_buffer_acts[mixing_buffer_acts.shape[0] // 2 :],
+            tokens=mixing_buffer_toks[mixing_buffer_toks.shape[0] // 2 :]
+            if mixing_buffer_toks is not None
+            else None,
+            mask_tokens=self.exclude_special_tokens,
         )
+        return iter(DataLoader(toks_dataset, batch_size=batch_size, shuffle=True))
 
-    def next_batch(self):
+    def next_batch(self) -> tuple[torch.Tensor, torch.Tensor | None]:
         """
         Get the next batch from the current DataLoader.
         If the DataLoader is exhausted, refill the buffer and create a new DataLoader.
@@ -730,7 +802,9 @@ class ActivationsStore:
             "n_dataset_processed": torch.tensor(self.n_dataset_processed),
         }
         if self._storage_buffer is not None:  # first time might be None
-            result["storage_buffer"] = self._storage_buffer
+            result["storage_buffer_activations"] = self._storage_buffer[0]
+            if self._storage_buffer[1] is not None:
+                result["storage_buffer_tokens"] = self._storage_buffer[1]
         if self.estimated_norm_scaling_factor is not None:
             result["estimated_norm_scaling_factor"] = torch.tensor(
                 self.estimated_norm_scaling_factor
@@ -776,3 +850,61 @@ def _get_model_device(model: HookedRootModule) -> torch.device:
     if hasattr(model, "cfg") and hasattr(model.cfg, "device"):
         return model.cfg.device  # type: ignore
     return next(model.parameters()).device  # type: ignore
+
+
+def _get_special_token_ids(tokenizer: PreTrainedTokenizerBase) -> list[int]:
+    """Get all special token IDs from a tokenizer."""
+    special_tokens = set()
+
+    # Get special tokens from tokenizer attributes
+    for attr in dir(tokenizer):
+        if attr.endswith("_token_id"):
+            token_id = getattr(tokenizer, attr)
+            if token_id is not None:
+                special_tokens.add(token_id)
+
+    # Get any additional special tokens from the tokenizer's special tokens map
+    if hasattr(tokenizer, "special_tokens_map"):
+        for token in tokenizer.special_tokens_map.values():
+            if isinstance(token, str):
+                token_id = tokenizer.convert_tokens_to_ids(token)  # type: ignore
+                special_tokens.add(token_id)
+            elif isinstance(token, list):
+                for t in token:
+                    token_id = tokenizer.convert_tokens_to_ids(t)  # type: ignore
+                    special_tokens.add(token_id)
+
+    return list(special_tokens)
+
+
+class ActivationsTokensDataset(TorchDataset[tuple[torch.Tensor, torch.Tensor]]):
+    """
+    Dataset of activations and tokens. Handles masking special tokens.
+    """
+
+    def __init__(
+        self,
+        activations: torch.Tensor,
+        tokens: torch.Tensor | None,
+        mask_tokens: torch.Tensor | None,
+    ) -> None:
+        self.activations = activations
+        self.tokens = tokens
+        self.mask_tokens = mask_tokens
+
+    def __len__(self) -> int:
+        return len(self.activations)
+
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
+        act = self.activations[idx]
+        if self.mask_tokens is None or self.tokens is None:
+            return act, torch.ones_like(act, dtype=torch.bool)
+        tok = self.tokens[idx]
+        mask = torch.isin(tok, self.mask_tokens)
+        return act, mask
+
+
+def permute_together(tensors: Sequence[torch.Tensor]) -> tuple[torch.Tensor, ...]:
+    """Permute tensors together."""
+    permutation = torch.randperm(tensors[0].shape[0])
+    return tuple(t[permutation] for t in tensors)

--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -332,11 +332,17 @@ class SAETrainer:
             self.cfg.wandb_log_frequency * self.cfg.eval_every_n_wandb_logs
         ) == 0:
             self.sae.eval()
+            ignore_tokens = set()
+            if self.activations_store.exclude_special_tokens is not None:
+                ignore_tokens = set(
+                    self.activations_store.exclude_special_tokens.tolist()
+                )
             eval_metrics, _ = run_evals(
                 sae=self.sae,
                 activation_store=self.activations_store,
                 model=self.model,
                 eval_config=self.trainer_eval_config,
+                ignore_tokens=ignore_tokens,
                 model_kwargs=self.cfg.model_kwargs,
             )  # not calculating featurwise metrics here.
 

--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -218,9 +218,9 @@ class SAETrainer:
         self,
         sae: TrainingSAE,
         sae_in: torch.Tensor,
-        token_mask: torch.Tensor | None = None,
     ) -> TrainStepOutput:
         sae.train()
+        # Make sure the W_dec is still zero-norm
         if self.cfg.normalize_sae_decoder:
             sae.set_decoder_norm_to_unit_norm()
 
@@ -231,34 +231,23 @@ class SAETrainer:
                 wandb.log(sparsity_log_dict, step=self.n_training_steps)
             self._reset_running_sparsity_stats()
 
+        # for documentation on autocasting see:
+        # https://pytorch.org/tutorials/recipes/recipes/amp_recipe.html
         with self.autocast_if_enabled:
             train_step_output = self.sae.training_forward_pass(
                 sae_in=sae_in,
                 dead_neuron_mask=self.dead_neurons,
                 current_l1_coefficient=self.current_l1_coefficient,
-                token_mask=token_mask,
             )
 
             with torch.no_grad():
-                did_fire = (train_step_output.feature_acts > 0).float()
-                if token_mask is not None:
-                    did_fire = did_fire * token_mask.unsqueeze(-1)
-                did_fire = did_fire.sum(-2) > 0
-
+                did_fire = (train_step_output.feature_acts > 0).float().sum(-2) > 0
                 self.n_forward_passes_since_fired += 1
                 self.n_forward_passes_since_fired[did_fire] = 0
-
-                act_freq = (train_step_output.feature_acts.abs() > 0).float()
-                if token_mask is not None:
-                    act_freq = act_freq * token_mask.unsqueeze(-1)
-                self.act_freq_scores += act_freq.sum(0)
-
-                n_valid_tokens = (
-                    token_mask.sum()
-                    if token_mask is not None
-                    else self.cfg.train_batch_size_tokens
+                self.act_freq_scores += (
+                    (train_step_output.feature_acts.abs() > 0).float().sum(0)
                 )
-                self.n_frac_active_tokens += n_valid_tokens
+                self.n_frac_active_tokens += self.cfg.train_batch_size_tokens
 
         # Scaler will rescale gradients if autocast is enabled
         self.scaler.scale(

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -5,7 +5,7 @@ https://github.com/ArthurConmy/sae/blob/main/sae/model.py
 import json
 import os
 from dataclasses import dataclass, fields
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 import einops
 import numpy as np
@@ -371,85 +371,56 @@ class TrainingSAE(SAE):
         sae_in: torch.Tensor,
         current_l1_coefficient: float,
         dead_neuron_mask: Optional[torch.Tensor] = None,
+        token_mask: Optional[torch.Tensor] = None,
     ) -> TrainStepOutput:
-        # do a forward pass to get SAE out, but we also need the
-        # hidden pre.
         feature_acts, hidden_pre = self.encode_with_hidden_pre_fn(sae_in)
         sae_out = self.decode(feature_acts)
 
-        # MSE LOSS
+        # Apply mask to all losses
         per_item_mse_loss = self.mse_loss_fn(sae_out, sae_in)
-        mse_loss = per_item_mse_loss.sum(dim=-1).mean()
+        mse_loss = _apply_mask_to_loss(per_item_mse_loss, token_mask)
 
         losses: dict[str, float | torch.Tensor] = {}
 
         if self.cfg.architecture == "gated":
             # Gated SAE Loss Calculation
-
-            # Shared variables
             sae_in_centered = (
                 self.reshape_fn_in(sae_in) - self.b_dec * self.cfg.apply_b_dec_to_input
             )
             pi_gate = sae_in_centered @ self.W_enc + self.b_gate
             pi_gate_act = torch.relu(pi_gate)
 
-            # SFN sparsity loss - summed over the feature dimension and averaged over the batch
-            l1_loss = (
-                current_l1_coefficient
-                * torch.sum(pi_gate_act * self.W_dec.norm(dim=1), dim=-1).mean()
+            # Apply mask to sparsity loss
+            sparsity_loss = pi_gate_act * self.W_dec.norm(dim=1)
+            l1_loss = current_l1_coefficient * _apply_mask_to_loss(
+                sparsity_loss, token_mask
             )
 
-            # Auxiliary reconstruction loss - summed over the feature dimension and averaged over the batch
+            # Apply mask to auxiliary reconstruction loss
             via_gate_reconstruction = pi_gate_act @ self.W_dec + self.b_dec
-            aux_reconstruction_loss = torch.sum(
-                (via_gate_reconstruction - sae_in) ** 2, dim=-1
-            ).mean()
+            per_item_aux_loss = (via_gate_reconstruction - sae_in) ** 2
+            aux_reconstruction_loss = _apply_mask_to_loss(per_item_aux_loss, token_mask)
+
             loss = mse_loss + l1_loss + aux_reconstruction_loss
             losses["auxiliary_reconstruction_loss"] = aux_reconstruction_loss
             losses["l1_loss"] = l1_loss
+
         elif self.cfg.architecture == "jumprelu":
             threshold = torch.exp(self.log_threshold)
-            l0 = torch.sum(Step.apply(hidden_pre, threshold, self.bandwidth), dim=-1)  # type: ignore
-            l0_loss = (current_l1_coefficient * l0).mean()
+            l0 = torch.sum(Step.apply(hidden_pre, threshold, self.bandwidth), dim=-1)
+            l0_loss = current_l1_coefficient * _apply_mask_to_loss(l0, token_mask)
             loss = mse_loss + l0_loss
             losses["l0_loss"] = l0_loss
-        elif self.cfg.architecture == "topk":
-            topk_loss = self.calculate_topk_aux_loss(
-                sae_in=sae_in,
-                sae_out=sae_out,
-                hidden_pre=hidden_pre,
-                dead_neuron_mask=dead_neuron_mask,
-            )
-            losses["auxiliary_reconstruction_loss"] = topk_loss
-            loss = mse_loss + topk_loss
-        else:
-            # default SAE sparsity loss
-            weighted_feature_acts = feature_acts
-            if self.cfg.scale_sparsity_penalty_by_decoder_norm:
-                weighted_feature_acts = feature_acts * self.W_dec.norm(dim=1)
-            sparsity = weighted_feature_acts.norm(
-                p=self.cfg.lp_norm, dim=-1
-            )  # sum over the feature dimension
 
-            l1_loss = (current_l1_coefficient * sparsity).mean()
+        else:  # standard architecture
+            l1_loss = current_l1_coefficient * _apply_mask_to_loss(
+                feature_acts.abs(), token_mask
+            )
             loss = mse_loss + l1_loss
-            if (
-                self.cfg.use_ghost_grads
-                and self.training
-                and dead_neuron_mask is not None
-            ):
-                ghost_grad_loss = self.calculate_ghost_grad_loss(
-                    x=sae_in,
-                    sae_out=sae_out,
-                    per_item_mse_loss=per_item_mse_loss,
-                    hidden_pre=hidden_pre,
-                    dead_neuron_mask=dead_neuron_mask,
-                )
-                losses["ghost_grad_loss"] = ghost_grad_loss
-                loss = loss + ghost_grad_loss
             losses["l1_loss"] = l1_loss
 
         losses["mse_loss"] = mse_loss
+        losses["loss"] = loss
 
         return TrainStepOutput(
             sae_in=sae_in,
@@ -712,3 +683,31 @@ def _calculate_topk_aux_acts(
     auxk_acts.scatter_(-1, auxk_topk.indices, auxk_topk.values)
     # Set activations to zero for all but top k_aux dead latents
     return auxk_acts
+
+
+def _apply_mask_to_loss(
+    loss: torch.Tensor,
+    token_mask: torch.Tensor | None,
+    reduction: Literal["mean", "sum"] = "mean",
+) -> torch.Tensor:
+    """
+    Apply token mask to a loss tensor and handle reduction appropriately.
+
+    Args:
+        loss: Loss tensor of shape (batch_size, seq_len, ...) or (batch_size * seq_len, ...)
+        token_mask: Boolean mask of shape (batch_size, seq_len) or (batch_size * seq_len)
+        reduction: Whether to return mean or sum of masked loss
+    """
+    if token_mask is None:
+        if reduction == "mean":
+            return loss.mean()
+        return loss.sum()
+
+    # Ensure mask matches loss dimensions
+    while token_mask.ndim < loss.ndim:
+        token_mask = token_mask.unsqueeze(-1)
+
+    masked_loss = loss * token_mask
+    if reduction == "mean":
+        return masked_loss.sum() / token_mask.sum()
+    return masked_loss.sum()

--- a/tests/benchmark/test_cache_activations_runner.py
+++ b/tests/benchmark/test_cache_activations_runner.py
@@ -140,7 +140,7 @@ def test_hf_dataset_save_vs_safetensors(tmp_path: Path):
 
     start_time = time.perf_counter()
     for i in trange(niters, leave=False):
-        buffer = store.get_buffer(cfg.n_batches_in_buffer)
+        buffer = store.get_buffer(cfg.n_batches_in_buffer)[0]
         save_file({"activations": buffer}, safetensors_path / f"{i}.safetensors")
     end_time = time.perf_counter()
 


### PR DESCRIPTION
# Description

This PR adds an option `exclude_special_tokens` to the config, which can be set to `True` to ignore all special tokens in the tokenizer, or set to a list of ints corresponding to token IDs to explicitly ignore.

This works by keeping track of the token ids that correspond to each activation in the activation store, and filtering out the excluded tokens when generating training batches. This PR also updates the cache activations runner to add the token_ids that correspond to each activation to the generated dataset as well.

This PR doesn't make ignoring special tokens the default, but am happy to make that change if that makes more sense (or make the change with the next major version release).

Closes #333

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)