### PR TITLE
fix: remove restrictive typeguard dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "5.3.3"
 description = "Training and Analyzing Sparse Autoencoders (SAEs)"
 authors = ["Joseph Bloom"]
 readme = "README.md"
-packages = [{include = "sae_lens"}]
+packages = [{ include = "sae_lens" }]
 include = ["pretrained_saes.yaml"]
 repository = "https://github.com/jbloomAus/SAELens"
 homepage = "https://jbloomaus.github.io/SAELens"
@@ -19,7 +19,6 @@ classifiers = ["Topic :: Scientific/Engineering :: Artificial Intelligence"]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-typeguard = "<3.0.0"
 transformer-lens = "^2.0.0"
 transformers = "^4.38.1"
 plotly = "^5.19.0"
@@ -86,20 +85,14 @@ reportUnknownLambdaType = "none"
 reportPrivateUsage = "none"
 reportDeprecated = "none"
 reportPrivateImportUsage = "none"
-ignore = [
-    "**/wandb/**"
-]
+ignore = ["**/wandb/**"]
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.semantic_release]
-version_variables = [
-    "sae_lens/__init__.py:__version__",
-]
-version_toml = [
-    "pyproject.toml:tool.poetry.version",
-]
+version_variables = ["sae_lens/__init__.py:__version__"]
+version_toml = ["pyproject.toml:tool.poetry.version"]
 branch = "main"
 build_command = "pip install poetry && poetry build"


### PR DESCRIPTION
# Description

In https://github.com/jbloomAus/SAELens/pull/412/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R22, a dependency on typeguard < 3.0.0 was added. This means SAELens cannot be installed in any project uses any recent version of typeguard (typeguard is currently on v4.4.1, the most recent v2 release is from 2021). This includes all modern versions of Transformerlens, which SAELens depends on. SAELens does not use typeguard, so this restriction seems unnecessary.

This PR removes this dependency, so current SAELens versions can be installed without forcing very outdated dependencies in existing projects.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### You have tested formatting, typing and unit tests (acceptance tests not currently in use)

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
