### PR TITLE
fix: ensure flattened_mask is on correct device in evals

### DIFF
--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -5,11 +5,12 @@ import math
 import re
 import subprocess
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from functools import partial
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Union
+from typing import Any, Dict, List, Union
 
 import einops
 import pandas as pd
@@ -460,9 +461,15 @@ def get_sparsity_and_variance_metrics(
         # TODO: Clean this up.
         # apply mask
         masked_sae_feature_activations = sae_feature_activations * mask.unsqueeze(-1)
-        flattened_sae_input = flattened_sae_input[flattened_mask]
-        flattened_sae_feature_acts = flattened_sae_feature_acts[flattened_mask]
-        flattened_sae_out = flattened_sae_out[flattened_mask]
+        flattened_sae_input = flattened_sae_input[
+            flattened_mask.to(flattened_sae_input.device)
+        ]
+        flattened_sae_feature_acts = flattened_sae_feature_acts[
+            flattened_mask.to(flattened_sae_feature_acts.device)
+        ]
+        flattened_sae_out = flattened_sae_out[
+            flattened_mask.to(flattened_sae_out.device)
+        ]
 
         if compute_l2_norms:
             l2_norm_in = torch.norm(flattened_sae_input, dim=-1)


### PR DESCRIPTION
# Description

It looks like if there's multiple GPUs, where model and SAE are on different GPUs, then during evals the flattened mask can end up on the incorrect GPU and break the eval. This PR explicitly moves the mask to the same device as the tensor being masked.

I wish we could test this explicitly in CI, but as far as I know there's no way in torch to set a testing device 😢: https://github.com/pytorch/pytorch/issues/61654

Fixes #337

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)