### PR TITLE
fix: properly parse CLI dict options as json

### DIFF
--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -164,7 +164,7 @@ class LanguageModelSAERunnerConfig:
         None  # defaults to 4 if d_sae and expansion_factor is None
     )
     activation_fn: str = None  # relu, tanh-relu, topk. Default is relu. # type: ignore
-    activation_fn_kwargs: dict[str, Any] = dict_field(default=None)  # for topk
+    activation_fn_kwargs: dict[str, int] = dict_field(default=None)  # for topk
     normalize_sae_decoder: bool = True
     noise_scale: float = 0.0
     from_pretrained_path: Optional[str] = None

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -4,6 +4,7 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, Literal, Optional, cast
 
+import simple_parsing
 import torch
 import wandb
 from datasets import (
@@ -28,6 +29,23 @@ DTYPE_MAP = {
 }
 
 HfDataset = DatasetDict | Dataset | IterableDatasetDict | IterableDataset
+
+
+# calling this "json_dict" so error messages will reference "json_dict" being invalid
+def json_dict(s: str) -> Any:
+    res = json.loads(s)
+    if res is not None and not isinstance(res, dict):
+        raise ValueError(f"Expected a dictionary, got {type(res)}")
+    return res
+
+
+def dict_field(default: dict[str, Any] | None, **kwargs: Any) -> Any:  # type: ignore
+    """
+    Helper to wrap simple_parsing.helpers.dict_field so we can load JSON fields from the command line.
+    """
+    if default is None:
+        return simple_parsing.helpers.field(default=None, type=json_dict, **kwargs)
+    return simple_parsing.helpers.dict_field(default, type=json_dict, **kwargs)
 
 
 @dataclass
@@ -146,7 +164,7 @@ class LanguageModelSAERunnerConfig:
         None  # defaults to 4 if d_sae and expansion_factor is None
     )
     activation_fn: str = None  # relu, tanh-relu, topk. Default is relu. # type: ignore
-    activation_fn_kwargs: dict[str, Any] = None  # for topk # type: ignore
+    activation_fn_kwargs: dict[str, Any] = dict_field(default=None)  # for topk
     normalize_sae_decoder: bool = True
     noise_scale: float = 0.0
     from_pretrained_path: Optional[str] = None
@@ -238,8 +256,8 @@ class LanguageModelSAERunnerConfig:
     n_checkpoints: int = 0
     checkpoint_path: str = "checkpoints"
     verbose: bool = True
-    model_kwargs: dict[str, Any] = field(default_factory=dict)
-    model_from_pretrained_kwargs: dict[str, Any] | None = None
+    model_kwargs: dict[str, Any] = dict_field(default={})
+    model_from_pretrained_kwargs: dict[str, Any] | None = dict_field(default=None)
     sae_lens_version: str = field(default_factory=lambda: __version__)
     sae_lens_training_version: str = field(default_factory=lambda: __version__)
     exclude_special_tokens: bool | list[int] = False

--- a/sae_lens/sae_training_runner.py
+++ b/sae_lens/sae_training_runner.py
@@ -234,7 +234,7 @@ class SAETrainingRunner:
 def _parse_cfg_args(args: Sequence[str]) -> LanguageModelSAERunnerConfig:
     if len(args) == 0:
         args = ["--help"]
-    parser = ArgumentParser()
+    parser = ArgumentParser(exit_on_error=False)
     parser.add_arguments(LanguageModelSAERunnerConfig, dest="cfg")
     return parser.parse_args(args).cfg
 


### PR DESCRIPTION
# Description

This PR allows passing dict options to the CLI runner encoded as JSON, based on https://github.com/lebrice/SimpleParsing/issues/335.

Fixes #422 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)