### PR TITLE
Supports llama scope r1 distill SAEs

### DIFF
--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -10730,6 +10730,198 @@ llama_scope_r1_distill:
   - id: l31r_800m_slimpajama
     norm_scaling_factor: 1.0963025732622191
     path: 800M-Slimpajama-0-OpenR1-Math-220k/L31R
+  - id: l0r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 53.97673033497749
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L0R
+  - id: l1r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 36.76995792628666
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L1R
+  - id: l2r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 26.86329549484781
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L2R
+  - id: l3r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 20.473522361966317
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L3R
+  - id: l4r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 16.491433880849524
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L4R
+  - id: l5r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 13.902529211394633
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L5R
+  - id: l6r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 11.959185891949216
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L6R
+  - id: l7r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 10.454685082137889
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L7R
+  - id: l8r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 9.625849752730096
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L8R
+  - id: l9r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 8.705443147441324
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L9R
+  - id: l10r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 8.0884989084078
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L10R
+  - id: l11r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 7.449578399564585
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L11R
+  - id: l12r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 6.80144905444981
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L12R
+  - id: l13r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 6.331711239265464
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L13R
+  - id: l14r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 5.70284230018703
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L14R
+  - id: l15r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 5.318041374444156
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L15R
+  - id: l16r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 4.79639347416429
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L16R
+  - id: l17r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 4.333554093692626
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L17R
+  - id: l18r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 3.9386839067851334
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L18R
+  - id: l19r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 3.584045063066589
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L19R
+  - id: l20r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 3.4122850442674064
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L20R
+  - id: l21r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 2.9930188471058385
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L21R
+  - id: l22r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 2.7548717844301582
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L22R
+  - id: l23r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 2.5281942698718076
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L23R
+  - id: l24r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 2.326851186904894
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L24R
+  - id: l25r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 2.101068654605767
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L25R
+  - id: l26r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 1.9361189375890395
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L26R
+  - id: l27r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 1.7784660082777055
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L27R
+  - id: l28r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 1.6635049539624462
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L28R
+  - id: l29r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 1.448853212514504
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L29R
+  - id: l30r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 1.157008764313032
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L30R
+  - id: l31r_400m_slimpajama_400m_openr1_math
+    norm_scaling_factor: 1.041977999933546
+    path: 400M-Slimpajama-400M-OpenR1-Math-220k/L31R
+  - id: l0r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 54.308791085956486
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L0R
+  - id: l1r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 36.49473030775242
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L1R
+  - id: l2r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 26.96126387031055
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L2R
+  - id: l3r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 20.52210199911164
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L3R
+  - id: l4r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 16.67733543806145
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L4R
+  - id: l5r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 14.067505043509176
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L5R
+  - id: l6r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 12.034338704494331
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L6R
+  - id: l7r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 10.495662821867164
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L7R
+  - id: l8r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 9.683004157081735
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L8R
+  - id: l9r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 8.679730500864236
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L9R
+  - id: l10r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 7.988383971728427
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L10R
+  - id: l11r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 7.237531143695951
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L11R
+  - id: l12r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 6.69444885029299
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L12R
+  - id: l13r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 6.0489858065009265
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L13R
+  - id: l14r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 5.4935929917888595
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L14R
+  - id: l15r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 4.970860531188141
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L15R
+  - id: l16r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 4.541887865516153
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L16R
+  - id: l17r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 4.111292885351861
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L17R
+  - id: l18r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 3.7319009471881754
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L18R
+  - id: l19r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 3.4464218438335172
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L19R
+  - id: l20r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 3.1614163309538377
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L20R
+  - id: l21r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 2.8600260547627334
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L21R
+  - id: l22r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 2.636157171207381
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L22R
+  - id: l23r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 2.4287397996449367
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L23R
+  - id: l24r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 2.2405978768214556
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L24R
+  - id: l25r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 2.034659098936678
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L25R
+  - id: l26r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 1.8430054630341937
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L26R
+  - id: l27r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 1.6554423260870552
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L27R
+  - id: l28r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 1.477070442772071
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L28R
+  - id: l29r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 1.3361543238773446
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L29R
+  - id: l30r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 1.1387454210154435
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L30R
+  - id: l31r_0_slimpajama_800m_openr1_math
+    norm_scaling_factor: 0.926395749048437
+    path: 0-Slimpajama-800M-OpenR1-Math-220k/L31R
 mistral-7b-res-wg:
   config_overrides:
     normalize_activations: constant_norm_rescale

--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -1,734 +1,2028 @@
-gpt2-small-res-jb:
-  repo_id: jbloom/GPT2-Small-SAEs-Reformatted
-  model: gpt2-small
-  conversion_func: null
-  links:
-    model: https://huggingface.co/gpt2
-    dashboards: https://www.neuronpedia.org/gpt2sm-res-jb
-    publication: https://www.lesswrong.com/posts/f9EgfLSurAiqRJySD/open-source-sparse-autoencoders-for-all-residual-stream
-  config_overrides:
-    model_from_pretrained_kwargs:
-      center_writing_weights: true
+deepseek-r1-distill-llama-8b-qresearch:
+  conversion_func: deepseek_r1
+  model: deepseek-ai/DeepSeek-R1-Distill-Llama-8B
+  repo_id: qresearch/DeepSeek-R1-Distill-Llama-8B-SAE-l19
   saes:
-  - id: blocks.0.hook_resid_pre
-    path: blocks.0.hook_resid_pre
-    neuronpedia: gpt2-small/0-res-jb
-    variance_explained: 0.999
-    l0: 10.0
-  - id: blocks.1.hook_resid_pre
-    path: blocks.1.hook_resid_pre
-    neuronpedia: gpt2-small/1-res-jb
-    variance_explained: 0.999
-    l0: 10.0
-  - id: blocks.2.hook_resid_pre
-    path: blocks.2.hook_resid_pre
-    neuronpedia: gpt2-small/2-res-jb
-    variance_explained: 0.999
-    l0: 18.0
-  - id: blocks.3.hook_resid_pre
-    path: blocks.3.hook_resid_pre
-    neuronpedia: gpt2-small/3-res-jb
-    variance_explained: 0.999
-    l0: 23.0
-  - id: blocks.4.hook_resid_pre
-    path: blocks.4.hook_resid_pre
-    neuronpedia: gpt2-small/4-res-jb
-    variance_explained: 0.9
-    l0: 31.0
-  - id: blocks.5.hook_resid_pre
-    path: blocks.5.hook_resid_pre
-    neuronpedia: gpt2-small/5-res-jb
-    variance_explained: 0.9
-    l0: 41.0
-  - id: blocks.6.hook_resid_pre
-    path: blocks.6.hook_resid_pre
-    neuronpedia: gpt2-small/6-res-jb
-    variance_explained: 0.9
-    l0: 51.0
-  - id: blocks.7.hook_resid_pre
-    path: blocks.7.hook_resid_pre
-    neuronpedia: gpt2-small/7-res-jb
-    variance_explained: 0.9
-    l0: 54.0
-  - id: blocks.8.hook_resid_pre
-    path: blocks.8.hook_resid_pre
-    neuronpedia: gpt2-small/8-res-jb
-    variance_explained: 0.9
-    l0: 60.0
-  - id: blocks.9.hook_resid_pre
-    path: blocks.9.hook_resid_pre
-    neuronpedia: gpt2-small/9-res-jb
-    variance_explained: 0.77
-    l0: 70.0
-  - id: blocks.10.hook_resid_pre
-    path: blocks.10.hook_resid_pre
-    neuronpedia: gpt2-small/10-res-jb
-    variance_explained: 0.77
-    l0: 52.0
-  - id: blocks.11.hook_resid_pre
-    path: blocks.11.hook_resid_pre
-    neuronpedia: gpt2-small/11-res-jb
-    variance_explained: 0.77
-    l0: 56.0
-  - id: blocks.11.hook_resid_post
-    path: blocks.11.hook_resid_post
-    neuronpedia: gpt2-small/12-res-jb
-    variance_explained: 0.77
-    l0: 70.0
-gpt2-small-hook-z-kk:
-  repo_id: ckkissane/attn-saes-gpt2-small-all-layers
-  model: gpt2-small
-  conversion_func: connor_rob_hook_z
-  links:
-    model: https://huggingface.co/gpt2
-    dashboards: https://www.neuronpedia.org/gpt2sm-kk
-    publication: https://www.lesswrong.com/posts/FSTRedtjuHa4Gfdbr/attention-saes-scale-to-gpt-2-small
-  saes:
-  - id: blocks.0.hook_z
-    path: gpt2-small_L0_Hcat_z_lr1.20e-03_l11.80e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
-    neuronpedia: gpt2-small/0-att-kk
-    variance_explained: 0.13
-    l0: 3.0
-  - id: blocks.1.hook_z
-    path: gpt2-small_L1_Hcat_z_lr1.20e-03_l18.00e-01_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v5.pt
-    neuronpedia: gpt2-small/1-att-kk
-    variance_explained: 0.42
-    l0: 23.0
-  - id: blocks.2.hook_z
-    path: gpt2-small_L2_Hcat_z_lr1.20e-03_l11.00e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v4.pt
-    neuronpedia: gpt2-small/2-att-kk
-    variance_explained: 0.4
-    l0: 16.0
-  - id: blocks.3.hook_z
-    path: gpt2-small_L3_Hcat_z_lr1.20e-03_l19.00e-01_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
-    neuronpedia: gpt2-small/3-att-kk
-    variance_explained: 0.43
-    l0: 15.0
-  - id: blocks.4.hook_z
-    path: gpt2-small_L4_Hcat_z_lr1.20e-03_l11.10e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v7.pt
-    neuronpedia: gpt2-small/4-att-kk
-    variance_explained: 0.27
-    l0: 14.0
-  - id: blocks.5.hook_z
-    path: gpt2-small_L5_Hcat_z_lr1.20e-03_l11.00e+00_ds49152_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
-    neuronpedia: gpt2-small/5-att-kk
-    variance_explained: 0.13
-    l0: 17.0
-  - id: blocks.6.hook_z
-    path: gpt2-small_L6_Hcat_z_lr1.20e-03_l11.10e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
-    neuronpedia: gpt2-small/6-att-kk
-    variance_explained: 0.0
-    l0: 17.0
-  - id: blocks.7.hook_z
-    path: gpt2-small_L7_Hcat_z_lr1.20e-03_l11.10e+00_ds49152_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
-    neuronpedia: gpt2-small/7-att-kk
-    variance_explained: -7.55
-    l0: 19.0
-  - id: blocks.8.hook_z
-    path: gpt2-small_L8_Hcat_z_lr1.20e-03_l11.30e+00_ds24576_bs4096_dc1.00e-05_rsanthropic_rie25000_nr4_v6.pt
-    neuronpedia: gpt2-small/8-att-kk
-    variance_explained: -0.22
-    l0: 23.0
-  - id: blocks.9.hook_z
-    path: gpt2-small_L9_Hcat_z_lr1.20e-03_l11.20e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
-    neuronpedia: gpt2-small/9-att-kk
-    variance_explained: -0.54
-    l0: 23.0
-  - id: blocks.10.hook_z
-    path: gpt2-small_L10_Hcat_z_lr1.20e-03_l11.30e+00_ds24576_bs4096_dc1.00e-05_rsanthropic_rie25000_nr4_v9.pt
-    neuronpedia: gpt2-small/10-att-kk
-    variance_explained: -0.27
-    l0: 14.0
-  - id: blocks.11.hook_z
-    path: gpt2-small_L11_Hcat_z_lr1.20e-03_l13.00e+00_ds24576_bs4096_dc3.16e-06_rsanthropic_rie25000_nr4_v9.pt
-    neuronpedia: gpt2-small/11-att-kk
-    variance_explained: -0.7
-    l0: 9.4
-gpt2-small-mlp-tm:
-  repo_id: tommmcgrath/gpt2-small-mlp-out-saes
-  model: gpt2-small
-  links:
-    model: https://huggingface.co/gpt2
-  conversion_func: null
+  - id: blocks.19.hook_resid_post
+    neuronpedia: deepseek-r1-distill-llama-8b/19-qresearch-res-65k
+    path: DeepSeek-R1-Distill-Llama-8B-SAE-l19.pt
+gemma-2b-it-res-jb:
   config_overrides:
     dataset_path: Skylion007/openwebtext
-    model_from_pretrained_kwargs:
-      center_writing_weights: true
-  saes:
-  - id: blocks.0.hook_mlp_out
-    path: sae_group_gpt2_blocks.0.hook_mlp_out_24576:v1
-    variance_explained: 0.999
-    l0: 15.0
-    norm_scaling_factor: 1.049317316132615
-  - id: blocks.1.hook_mlp_out
-    path: sae_group_gpt2_blocks.1.hook_mlp_out_24576:v0
-    variance_explained: 0.57
-    l0: 21.0
-    norm_scaling_factor: 2.3693984005104283
-  - id: blocks.2.hook_mlp_out
-    path: sae_group_gpt2_blocks.2.hook_mlp_out_24576:v0
-    variance_explained: 0.55
-    l0: 137.0
-    norm_scaling_factor: 1.6411934982190302
-  - id: blocks.3.hook_mlp_out
-    path: sae_group_gpt2_blocks.3.hook_mlp_out_24576:v0
-    variance_explained: 0.57
-    l0: 54.0
-    norm_scaling_factor: 1.8958522157897557
-  - id: blocks.4.hook_mlp_out
-    path: sae_group_gpt2_blocks.4.hook_mlp_out_24576:v0
-    variance_explained: 0.44
-    l0: 74.0
-    norm_scaling_factor: 1.81673478700627
-  - id: blocks.5.hook_mlp_out
-    path: sae_group_gpt2_blocks.5.hook_mlp_out_24576:v0
-    variance_explained: 0.52
-    l0: 76.0
-    norm_scaling_factor: 1.550234472245924
-  - id: blocks.6.hook_mlp_out
-    path: sae_group_gpt2_blocks.6.hook_mlp_out_24576:v0
-    variance_explained: 0.508
-    l0: 40.0
-    norm_scaling_factor: 1.3237742807210804
-  - id: blocks.7.hook_mlp_out
-    path: sae_group_gpt2_blocks.7.hook_mlp_out_24576:v0
-    variance_explained: 0.53
-    l0: 52.0
-    norm_scaling_factor: 1.1042905114723296
-  - id: blocks.8.hook_mlp_out
-    path: sae_group_gpt2_blocks.8.hook_mlp_out_24576:v1
-    variance_explained: 0.46
-    l0: 36.0
-    norm_scaling_factor: 0.9123762783479742
-  - id: blocks.9.hook_mlp_out
-    path: sae_group_gpt2_blocks.9.hook_mlp_out_24576:v0
-    variance_explained: 0.49
-    l0: 49.0
-    norm_scaling_factor: 0.6955335635232373
-  - id: blocks.10.hook_mlp_out
-    path: sae_group_gpt2_blocks.10.hook_mlp_out_24576:v0
-    variance_explained: 0.22
-    l0: 167.0
-    norm_scaling_factor: 0.3619728926727644
-  - id: blocks.11.hook_mlp_out
-    path: sae_group_gpt2_blocks.11.hook_mlp_out_24576:v2
-    variance_explained: 0.59
-    l0: 170.0
-    norm_scaling_factor: 0.2851548652550073
-gpt2-small-res-jb-feature-splitting:
-  repo_id: jbloom/GPT2-Small-Feature-Splitting-Experiment-Layer-8
-  model: gpt2-small
-  links:
-    model: https://huggingface.co/gpt2
-    dashboards: https://www.neuronpedia.org/gpt2sm-rfs-jb
-  conversion_func: null
-  config_overrides:
-    model_from_pretrained_kwargs:
-      center_writing_weights: true
-  saes:
-  - id: blocks.8.hook_resid_pre_768
-    path: blocks.8.hook_resid_pre_768
-    neuronpedia: gpt2-small/8-res_fs768-jb
-    variance_explained: 0.61
-    l0: 36.0
-  - id: blocks.8.hook_resid_pre_1536
-    path: blocks.8.hook_resid_pre_1536
-    neuronpedia: gpt2-small/8-res_fs1536-jb
-    variance_explained: 0.67
-    l0: 39.0
-  - id: blocks.8.hook_resid_pre_3072
-    path: blocks.8.hook_resid_pre_3072
-    neuronpedia: gpt2-small/8-res_fs3072-jb
-    variance_explained: 0.72
-    l0: 41.0
-  - id: blocks.8.hook_resid_pre_6144
-    path: blocks.8.hook_resid_pre_6144
-    neuronpedia: gpt2-small/8-res_fs6144-jb
-    variance_explained: 0.76
-    l0: 43.0
-  - id: blocks.8.hook_resid_pre_12288
-    path: blocks.8.hook_resid_pre_12288
-    neuronpedia: gpt2-small/8-res_fs12288-jb
-    variance_explained: 0.77
-    l0: 43.0
-  - id: blocks.8.hook_resid_pre_24576
-    path: blocks.8.hook_resid_pre_24576
-    neuronpedia: gpt2-small/8-res_fs24576-jb
-    variance_explained: 0.79
-    l0: 40.0
-  - id: blocks.8.hook_resid_pre_49152
-    path: blocks.8.hook_resid_pre_49152
-    neuronpedia: gpt2-small/8-res_fs49152-jb
-    variance_explained: 0.81
-    l0: 40.0
-  - id: blocks.8.hook_resid_pre_98304
-    path: blocks.8.hook_resid_pre_98304
-    neuronpedia: gpt2-small/8-res_fs98304-jb
-    variance_explained: 0.82
-    l0: 43.0
-gpt2-small-resid-post-v5-32k:
-  repo_id: jbloom/GPT2-Small-OAI-v5-32k-resid-post-SAEs
-  model: gpt2-small
-  conversion_func: null
-  config_overrides:
-    dataset_path: Skylion007/openwebtext
-  saes:
-  - id: blocks.0.hook_resid_post
-    path: v5_32k_layer_0.pt
-    neuronpedia: gpt2-small/0-res_post_32k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.1.hook_resid_post
-    path: v5_32k_layer_1.pt
-    neuronpedia: gpt2-small/1-res_post_32k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.2.hook_resid_post
-    path: v5_32k_layer_2.pt
-    neuronpedia: gpt2-small/2-res_post_32k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.3.hook_resid_post
-    path: v5_32k_layer_3.pt
-    neuronpedia: gpt2-small/3-res_post_32k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.4.hook_resid_post
-    path: v5_32k_layer_4.pt
-    neuronpedia: gpt2-small/4-res_post_32k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.5.hook_resid_post
-    path: v5_32k_layer_5.pt
-    neuronpedia: gpt2-small/5-res_post_32k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.6.hook_resid_post
-    path: v5_32k_layer_6.pt
-    neuronpedia: gpt2-small/6-res_post_32k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.7.hook_resid_post
-    path: v5_32k_layer_7.pt
-    neuronpedia: gpt2-small/7-res_post_32k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.8.hook_resid_post
-    path: v5_32k_layer_8.pt
-    neuronpedia: gpt2-small/8-res_post_32k-oai
-    variance_explained: 0.74
-    l0: 32.0
-  - id: blocks.9.hook_resid_post
-    path: v5_32k_layer_9.pt
-    neuronpedia: gpt2-small/9-res_post_32k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.10.hook_resid_post
-    path: v5_32k_layer_10.pt
-    neuronpedia: gpt2-small/10-res_post_32k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.11.hook_resid_post
-    path: v5_32k_layer_11.pt
-    neuronpedia: gpt2-small/11-res_post_32k-oai
-    variance_explained: 0.9
-    l0: 32.0
-gpt2-small-resid-post-v5-128k:
-  repo_id: jbloom/GPT2-Small-OAI-v5-128k-resid-post-SAEs
-  model: gpt2-small
-  conversion_func: null
-  config_overrides:
-    dataset_path: Skylion007/openwebtext
-  saes:
-  - id: blocks.0.hook_resid_post
-    path: v5_128k_layer_0
-    neuronpedia: gpt2-small/0-res_post_128k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.1.hook_resid_post
-    path: v5_128k_layer_1
-    neuronpedia: gpt2-small/1-res_post_128k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.2.hook_resid_post
-    path: v5_128k_layer_2
-    neuronpedia: gpt2-small/2-res_post_128k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.3.hook_resid_post
-    path: v5_128k_layer_3
-    neuronpedia: gpt2-small/3-res_post_128k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.4.hook_resid_post
-    path: v5_128k_layer_4
-    neuronpedia: gpt2-small/4-res_post_128k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.5.hook_resid_post
-    path: v5_128k_layer_5
-    neuronpedia: gpt2-small/5-res_post_128k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.6.hook_resid_post
-    path: v5_128k_layer_6
-    neuronpedia: gpt2-small/6-res_post_128k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.7.hook_resid_post
-    path: v5_128k_layer_7
-    neuronpedia: gpt2-small/7-res_post_128k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.8.hook_resid_post
-    path: v5_128k_layer_8
-    neuronpedia: gpt2-small/8-res_post_128k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.9.hook_resid_post
-    path: v5_128k_layer_9
-    neuronpedia: gpt2-small/9-res_post_128k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.10.hook_resid_post
-    path: v5_128k_layer_10
-    neuronpedia: gpt2-small/10-res_post_128k-oai
-    variance_explained: 0.9
-    l0: 32.0
-  - id: blocks.11.hook_resid_post
-    path: v5_128k_layer_11
-    neuronpedia: gpt2-small/11-res_post_128k-oai
-    variance_explained: 0.9
-    l0: 32.0
-gemma-2b-res-jb:
-  repo_id: jbloom/Gemma-2b-Residual-Stream-SAEs
-  model: gemma-2b
   conversion_func: null
   links:
-    model: https://huggingface.co/google/gemma-2b
-    dashboards: https://www.neuronpedia.org/gemma2b-res-jb
+    dashboards: https://www.neuronpedia.org/gemma2bit-res-jb
+    model: https://huggingface.co/google/gemma-2b-it
+  model: gemma-2b-it
+  repo_id: jbloom/Gemma-2b-IT-Residual-Stream-SAEs
   saes:
-  - id: blocks.0.hook_resid_post
-    path: gemma_2b_blocks.0.hook_resid_post_16384_anthropic
-    neuronpedia: gemma-2b/0-res-jb
-    variance_explained: 0.999
-    l0: 47.0
-  - id: blocks.6.hook_resid_post
-    path: gemma_2b_blocks.6.hook_resid_post_16384_anthropic_fast_lr
-    neuronpedia: gemma-2b/6-res-jb
-    variance_explained: 0.71
-    l0: 56.0
-  - id: blocks.10.hook_resid_post
-    path: gemma_2b_blocks.10.hook_resid_post_16384
-    neuronpedia: gemma-2b/10-res-jb
-    variance_explained: -0.2
-    l0: 62.0
   - id: blocks.12.hook_resid_post
-    path: gemma_2b_blocks.12.hook_resid_post_16384
-    neuronpedia: gemma-2b/12-res-jb
-    variance_explained: -0.65
+    l0: 61.0
+    neuronpedia: gemma-2b-it/12-res-jb
+    path: gemma_2b_it_blocks.12.hook_resid_post_16384
+    variance_explained: 0.57
+gemma-2b-res-jb:
+  conversion_func: null
+  links:
+    dashboards: https://www.neuronpedia.org/gemma2b-res-jb
+    model: https://huggingface.co/google/gemma-2b
+  model: gemma-2b
+  repo_id: jbloom/Gemma-2b-Residual-Stream-SAEs
+  saes:
+  - id: blocks.0.hook_resid_post
+    l0: 47.0
+    neuronpedia: gemma-2b/0-res-jb
+    path: gemma_2b_blocks.0.hook_resid_post_16384_anthropic
+    variance_explained: 0.999
+  - id: blocks.6.hook_resid_post
+    l0: 56.0
+    neuronpedia: gemma-2b/6-res-jb
+    path: gemma_2b_blocks.6.hook_resid_post_16384_anthropic_fast_lr
+    variance_explained: 0.71
+  - id: blocks.10.hook_resid_post
     l0: 62.0
+    neuronpedia: gemma-2b/10-res-jb
+    path: gemma_2b_blocks.10.hook_resid_post_16384
+    variance_explained: -0.2
+  - id: blocks.12.hook_resid_post
+    l0: 62.0
+    neuronpedia: gemma-2b/12-res-jb
     norm_scaling_factor: 0.21381938399317255
+    path: gemma_2b_blocks.12.hook_resid_post_16384
+    variance_explained: -0.65
   - id: blocks.17.hook_resid_post
+    l0: 54.0
     path: gemma_2b_blocks.17.hook_resid_post_16384
     variance_explained: -0.85
-    l0: 54.0
-gemma-2b-it-res-jb:
-  repo_id: jbloom/Gemma-2b-IT-Residual-Stream-SAEs
-  model: gemma-2b-it
-  conversion_func: null
-  config_overrides:
-    dataset_path: Skylion007/openwebtext
-  links:
-    model: https://huggingface.co/google/gemma-2b-it
-    dashboards: https://www.neuronpedia.org/gemma2bit-res-jb
-  saes:
-  - id: blocks.12.hook_resid_post
-    path: gemma_2b_it_blocks.12.hook_resid_post_16384
-    neuronpedia: gemma-2b-it/12-res-jb
-    variance_explained: 0.57
-    l0: 61.0
-mistral-7b-res-wg:
-  repo_id: JoshEngels/Mistral-7B-Residual-Stream-SAEs
-  model: mistral-7b
-  conversion_func: null
-  config_overrides:
-    normalize_activations: constant_norm_rescale
-  saes:
-  - id: blocks.8.hook_resid_pre
-    path: mistral_7b_layer_8
-    variance_explained: 0.94
-    l0: 92
-  - id: blocks.16.hook_resid_pre
-    path: mistral_7b_layer_16
-    variance_explained: 0.85
-    l0: 74
-  - id: blocks.24.hook_resid_pre
-    path: mistral_7b_layer_24
-    variance_explained: 0.72
-    l0: 75
-gpt2-small-resid-mid-v5-32k:
-  repo_id: jbloom/GPT2-Small-OAI-v5-32k-resid-mid-SAEs
-  model: gpt2-small
-  conversion_func: null
-  config_overrides:
-    dataset_path: Skylion007/openwebtext
-  saes:
-  - id: blocks.0.hook_resid_mid
-    path: v5_32k_layer_0
-    neuronpedia: gpt2-small/0-res_mid_32k-oai
-  - id: blocks.1.hook_resid_mid
-    path: v5_32k_layer_1
-    neuronpedia: gpt2-small/1-res_mid_32k-oai
-  - id: blocks.2.hook_resid_mid
-    path: v5_32k_layer_2
-    neuronpedia: gpt2-small/2-res_mid_32k-oai
-  - id: blocks.3.hook_resid_mid
-    path: v5_32k_layer_3
-    neuronpedia: gpt2-small/3-res_mid_32k-oai
-  - id: blocks.4.hook_resid_mid
-    path: v5_32k_layer_4
-    neuronpedia: gpt2-small/4-res_mid_32k-oai
-  - id: blocks.5.hook_resid_mid
-    path: v5_32k_layer_5
-    neuronpedia: gpt2-small/5-res_mid_32k-oai
-  - id: blocks.6.hook_resid_mid
-    path: v5_32k_layer_6
-    neuronpedia: gpt2-small/6-res_mid_32k-oai
-  - id: blocks.7.hook_resid_mid
-    path: v5_32k_layer_7
-    neuronpedia: gpt2-small/7-res_mid_32k-oai
-  - id: blocks.8.hook_resid_mid
-    path: v5_32k_layer_8
-    neuronpedia: gpt2-small/8-res_mid_32k-oai
-  - id: blocks.9.hook_resid_mid
-    path: v5_32k_layer_9
-    neuronpedia: gpt2-small/9-res_mid_32k-oai
-  - id: blocks.10.hook_resid_mid
-    path: v5_32k_layer_10
-    neuronpedia: gpt2-small/10-res_mid_32k-oai
-  - id: blocks.11.hook_resid_mid
-    path: v5_32k_layer_11
-    neuronpedia: gpt2-small/11-res_mid_32k-oai
-gpt2-small-resid-mid-v5-128k:
-  repo_id: jbloom/GPT2-Small-OAI-v5-128k-resid-mid-SAEs
-  model: gpt2-small
-  conversion_func: null
-  config_overrides:
-    dataset_path: Skylion007/openwebtext
-  saes:
-  - id: blocks.0.hook_resid_mid
-    path: v5_128k_layer_0
-    neuronpedia: gpt2-small/0-res_mid_128k-oai
-  - id: blocks.1.hook_resid_mid
-    path: v5_128k_layer_1
-    neuronpedia: gpt2-small/1-res_mid_128k-oai
-  - id: blocks.2.hook_resid_mid
-    path: v5_128k_layer_2
-    neuronpedia: gpt2-small/2-res_mid_128k-oai
-  - id: blocks.3.hook_resid_mid
-    path: v5_128k_layer_3
-    neuronpedia: gpt2-small/3-res_mid_128k-oai
-  - id: blocks.4.hook_resid_mid
-    path: v5_128k_layer_4
-    neuronpedia: gpt2-small/4-res_mid_128k-oai
-  - id: blocks.5.hook_resid_mid
-    path: v5_128k_layer_5
-    neuronpedia: gpt2-small/5-res_mid_128k-oai
-  - id: blocks.6.hook_resid_mid
-    path: v5_128k_layer_6
-    neuronpedia: gpt2-small/6-res_mid_128k-oai
-  - id: blocks.7.hook_resid_mid
-    path: v5_128k_layer_7
-    neuronpedia: gpt2-small/7-res_mid_128k-oai
-  - id: blocks.8.hook_resid_mid
-    path: v5_128k_layer_8
-    neuronpedia: gpt2-small/8-res_mid_128k-oai
-  - id: blocks.9.hook_resid_mid
-    path: v5_128k_layer_9
-    neuronpedia: gpt2-small/9-res_mid_128k-oai
-  - id: blocks.10.hook_resid_mid
-    path: v5_128k_layer_10
-    neuronpedia: gpt2-small/10-res_mid_128k-oai
-  - id: blocks.11.hook_resid_mid
-    path: v5_128k_layer_11
-    neuronpedia: gpt2-small/11-res_mid_128k-oai
-gpt2-small-mlp-out-v5-32k:
-  repo_id: jbloom/GPT2-Small-OAI-v5-32k-mlp-out-SAEs
-  model: gpt2-small
-  conversion_func: null
-  config_overrides:
-    dataset_path: Skylion007/openwebtext
-  saes:
-  - id: blocks.0.hook_mlp_out
-    path: v5_32k_layer_0
-    neuronpedia: gpt2-small/0-mlp_32k-oai
-  - id: blocks.1.hook_mlp_out
-    path: v5_32k_layer_1
-    neuronpedia: gpt2-small/1-mlp_32k-oai
-  - id: blocks.2.hook_mlp_out
-    path: v5_32k_layer_2
-    neuronpedia: gpt2-small/2-mlp_32k-oai
-  - id: blocks.3.hook_mlp_out
-    path: v5_32k_layer_3
-    neuronpedia: gpt2-small/3-mlp_32k-oai
-  - id: blocks.4.hook_mlp_out
-    path: v5_32k_layer_4
-    neuronpedia: gpt2-small/4-mlp_32k-oai
-  - id: blocks.5.hook_mlp_out
-    path: v5_32k_layer_5
-    neuronpedia: gpt2-small/5-mlp_32k-oai
-  - id: blocks.6.hook_mlp_out
-    path: v5_32k_layer_6
-    neuronpedia: gpt2-small/6-mlp_32k-oai
-  - id: blocks.7.hook_mlp_out
-    path: v5_32k_layer_7
-    neuronpedia: gpt2-small/7-mlp_32k-oai
-  - id: blocks.8.hook_mlp_out
-    path: v5_32k_layer_8
-    neuronpedia: gpt2-small/8-mlp_32k-oai
-  - id: blocks.9.hook_mlp_out
-    path: v5_32k_layer_9
-    neuronpedia: gpt2-small/9-mlp_32k-oai
-  - id: blocks.10.hook_mlp_out
-    path: v5_32k_layer_10
-    neuronpedia: gpt2-small/10-mlp_32k-oai
-  - id: blocks.11.hook_mlp_out
-    path: v5_32k_layer_11
-    neuronpedia: gpt2-small/11-mlp_32k-oai
-gpt2-small-mlp-out-v5-128k:
-  repo_id: jbloom/GPT2-Small-OAI-v5-128k-mlp-out-SAEs
-  model: gpt2-small
-  conversion_func: null
-  config_overrides:
-    dataset_path: Skylion007/openwebtext
-  saes:
-  - id: blocks.0.hook_mlp_out
-    path: v5_128k_layer_0
-    neuronpedia: gpt2-small/0-mlp_128k-oai
-  - id: blocks.1.hook_mlp_out
-    path: v5_128k_layer_1
-    neuronpedia: gpt2-small/1-mlp_128k-oai
-  - id: blocks.2.hook_mlp_out
-    path: v5_128k_layer_2
-    neuronpedia: gpt2-small/2-mlp_128k-oai
-  - id: blocks.3.hook_mlp_out
-    path: v5_128k_layer_3
-    neuronpedia: gpt2-small/3-mlp_128k-oai
-  - id: blocks.4.hook_mlp_out
-    path: v5_128k_layer_4
-    neuronpedia: gpt2-small/4-mlp_128k-oai
-  - id: blocks.5.hook_mlp_out
-    path: v5_128k_layer_5
-    neuronpedia: gpt2-small/5-mlp_128k-oai
-  - id: blocks.6.hook_mlp_out
-    path: v5_128k_layer_6
-    neuronpedia: gpt2-small/6-mlp_128k-oai
-  - id: blocks.7.hook_mlp_out
-    path: v5_128k_layer_7
-    neuronpedia: gpt2-small/7-mlp_128k-oai
-  - id: blocks.8.hook_mlp_out
-    path: v5_128k_layer_8
-    neuronpedia: gpt2-small/8-mlp_128k-oai
-  - id: blocks.9.hook_mlp_out
-    path: v5_128k_layer_9
-    neuronpedia: gpt2-small/9-mlp_128k-oai
-  - id: blocks.10.hook_mlp_out
-    path: v5_128k_layer_10
-    neuronpedia: gpt2-small/10-mlp_128k-oai
-  - id: blocks.11.hook_mlp_out
-    path: v5_128k_layer_11
-    neuronpedia: gpt2-small/11-mlp_128k-oai
-gpt2-small-attn-out-v5-32k:
-  repo_id: jbloom/GPT2-Small-OAI-v5-32k-attn-out-SAEs
-  model: gpt2-small
-  conversion_func: null
-  config_overrides:
-    dataset_path: Skylion007/openwebtext
-  saes:
-  - id: blocks.0.hook_attn_out
-    path: v5_32k_layer_0
-    neuronpedia: gpt2-small/0-att_32k-oai
-  - id: blocks.1.hook_attn_out
-    path: v5_32k_layer_1
-    neuronpedia: gpt2-small/1-att_32k-oai
-  - id: blocks.2.hook_attn_out
-    path: v5_32k_layer_2
-    neuronpedia: gpt2-small/2-att_32k-oai
-  - id: blocks.3.hook_attn_out
-    path: v5_32k_layer_3
-    neuronpedia: gpt2-small/3-att_32k-oai
-  - id: blocks.4.hook_attn_out
-    path: v5_32k_layer_4
-    neuronpedia: gpt2-small/4-att_32k-oai
-  - id: blocks.5.hook_attn_out
-    path: v5_32k_layer_5
-    neuronpedia: gpt2-small/5-att_32k-oai
-  - id: blocks.6.hook_attn_out
-    path: v5_32k_layer_6
-    neuronpedia: gpt2-small/6-att_32k-oai
-  - id: blocks.7.hook_attn_out
-    path: v5_32k_layer_7
-    neuronpedia: gpt2-small/7-att_32k-oai
-  - id: blocks.8.hook_attn_out
-    path: v5_32k_layer_8
-    neuronpedia: gpt2-small/8-att_32k-oai
-  - id: blocks.9.hook_attn_out
-    path: v5_32k_layer_9
-    neuronpedia: gpt2-small/9-att_32k-oai
-  - id: blocks.10.hook_attn_out
-    path: v5_32k_layer_10
-    neuronpedia: gpt2-small/10-att_32k-oai
-  - id: blocks.11.hook_attn_out
-    path: v5_32k_layer_11
-    neuronpedia: gpt2-small/11-att_32k-oai
-gpt2-small-attn-out-v5-128k:
-  repo_id: jbloom/GPT2-Small-OAI-v5-128k-attn-out-SAEs
-  model: gpt2-small
-  conversion_func: null
-  config_overrides:
-    dataset_path: Skylion007/openwebtext
-  saes:
-  - id: blocks.0.hook_attn_out
-    path: v5_128k_layer_0
-    neuronpedia: gpt2-small/0-att_128k-oai
-  - id: blocks.1.hook_attn_out
-    path: v5_128k_layer_1
-    neuronpedia: gpt2-small/1-att_128k-oai
-  - id: blocks.2.hook_attn_out
-    path: v5_128k_layer_2
-    neuronpedia: gpt2-small/2-att_128k-oai
-  - id: blocks.3.hook_attn_out
-    path: v5_128k_layer_3
-    neuronpedia: gpt2-small/3-att_128k-oai
-  - id: blocks.4.hook_attn_out
-    path: v5_128k_layer_4
-    neuronpedia: gpt2-small/4-att_128k-oai
-  - id: blocks.5.hook_attn_out
-    path: v5_128k_layer_5
-    neuronpedia: gpt2-small/5-att_128k-oai
-  - id: blocks.6.hook_attn_out
-    path: v5_128k_layer_6
-    neuronpedia: gpt2-small/6-att_128k-oai
-  - id: blocks.7.hook_attn_out
-    path: v5_128k_layer_7
-    neuronpedia: gpt2-small/7-att_128k-oai
-  - id: blocks.8.hook_attn_out
-    path: v5_128k_layer_8
-    neuronpedia: gpt2-small/8-att_128k-oai
-  - id: blocks.9.hook_attn_out
-    path: v5_128k_layer_9
-    neuronpedia: gpt2-small/9-att_128k-oai
-  - id: blocks.10.hook_attn_out
-    path: v5_128k_layer_10
-    neuronpedia: gpt2-small/10-att_128k-oai
-  - id: blocks.11.hook_attn_out
-    path: v5_128k_layer_11
-    neuronpedia: gpt2-small/11-att_128k-oai
-gemma-scope-2b-pt-res:
-  repo_id: google/gemma-scope-2b-pt-res
-  model: gemma-2-2b
+gemma-scope-27b-pt-res:
   conversion_func: gemma_2
+  model: gemma-2-27b
+  repo_id: google/gemma-scope-27b-pt-res
+  saes:
+  - id: layer_10/width_131k/average_l0_106
+    l0: 106
+    path: layer_10/width_131k/average_l0_106
+  - id: layer_10/width_131k/average_l0_15
+    l0: 15
+    path: layer_10/width_131k/average_l0_15
+  - id: layer_10/width_131k/average_l0_200
+    l0: 200
+    path: layer_10/width_131k/average_l0_200
+  - id: layer_10/width_131k/average_l0_24
+    l0: 24
+    path: layer_10/width_131k/average_l0_24
+  - id: layer_10/width_131k/average_l0_37
+    l0: 37
+    path: layer_10/width_131k/average_l0_37
+  - id: layer_10/width_131k/average_l0_64
+    l0: 64
+    path: layer_10/width_131k/average_l0_64
+  - id: layer_22/width_131k/average_l0_150
+    l0: 150
+    path: layer_22/width_131k/average_l0_150
+  - id: layer_22/width_131k/average_l0_20
+    l0: 20
+    path: layer_22/width_131k/average_l0_20
+  - id: layer_22/width_131k/average_l0_290
+    l0: 290
+    path: layer_22/width_131k/average_l0_290
+  - id: layer_22/width_131k/average_l0_31
+    l0: 31
+    path: layer_22/width_131k/average_l0_31
+  - id: layer_22/width_131k/average_l0_48
+    l0: 48
+    path: layer_22/width_131k/average_l0_48
+  - id: layer_22/width_131k/average_l0_82
+    l0: 82
+    path: layer_22/width_131k/average_l0_82
+  - id: layer_34/width_131k/average_l0_155
+    l0: 155
+    path: layer_34/width_131k/average_l0_155
+  - id: layer_34/width_131k/average_l0_21
+    l0: 21
+    path: layer_34/width_131k/average_l0_21
+  - id: layer_34/width_131k/average_l0_333
+    l0: 333
+    path: layer_34/width_131k/average_l0_333
+  - id: layer_34/width_131k/average_l0_38
+    l0: 38
+    path: layer_34/width_131k/average_l0_38
+  - id: layer_34/width_131k/average_l0_72
+    l0: 72
+    path: layer_34/width_131k/average_l0_72
+  - id: layer_34/width_131k/average_l0_785
+    l0: 785
+    path: layer_34/width_131k/average_l0_785
+gemma-scope-27b-pt-res-canonical:
+  conversion_func: gemma_2
+  model: gemma-2-27b
+  repo_id: google/gemma-scope-27b-pt-res
+  saes:
+  - id: layer_10/width_131k/canonical
+    neuronpedia: gemma-2-27b/10-gemmascope-res-131k
+    path: layer_10/width_131k/average_l0_106
+  - id: layer_22/width_131k/canonical
+    neuronpedia: gemma-2-27b/22-gemmascope-res-131k
+    path: layer_22/width_131k/average_l0_82
+  - id: layer_34/width_131k/canonical
+    neuronpedia: gemma-2-27b/34-gemmascope-res-131k
+    path: layer_34/width_131k/average_l0_72
+gemma-scope-2b-pt-att:
+  conversion_func: gemma_2
+  model: gemma-2-2b
+  repo_id: google/gemma-scope-2b-pt-att
+  saes:
+  - id: layer_0/width_16k/average_l0_104
+    l0: 104
+    path: layer_0/width_16k/average_l0_104
+  - id: layer_0/width_16k/average_l0_12
+    l0: 12
+    path: layer_0/width_16k/average_l0_12
+  - id: layer_0/width_16k/average_l0_18
+    l0: 18
+    path: layer_0/width_16k/average_l0_18
+  - id: layer_0/width_16k/average_l0_30
+    l0: 30
+    path: layer_0/width_16k/average_l0_30
+  - id: layer_0/width_16k/average_l0_57
+    l0: 57
+    path: layer_0/width_16k/average_l0_57
+  - id: layer_1/width_16k/average_l0_146
+    l0: 146
+    path: layer_1/width_16k/average_l0_146
+  - id: layer_1/width_16k/average_l0_20
+    l0: 20
+    path: layer_1/width_16k/average_l0_20
+  - id: layer_1/width_16k/average_l0_251
+    l0: 251
+    path: layer_1/width_16k/average_l0_251
+  - id: layer_1/width_16k/average_l0_40
+    l0: 40
+    path: layer_1/width_16k/average_l0_40
+  - id: layer_1/width_16k/average_l0_79
+    l0: 79
+    path: layer_1/width_16k/average_l0_79
+  - id: layer_2/width_16k/average_l0_174
+    l0: 174
+    path: layer_2/width_16k/average_l0_174
+  - id: layer_2/width_16k/average_l0_19
+    l0: 19
+    path: layer_2/width_16k/average_l0_19
+  - id: layer_2/width_16k/average_l0_297
+    l0: 297
+    path: layer_2/width_16k/average_l0_297
+  - id: layer_2/width_16k/average_l0_43
+    l0: 43
+    path: layer_2/width_16k/average_l0_43
+  - id: layer_2/width_16k/average_l0_93
+    l0: 93
+    path: layer_2/width_16k/average_l0_93
+  - id: layer_3/width_16k/average_l0_117
+    l0: 117
+    path: layer_3/width_16k/average_l0_117
+  - id: layer_3/width_16k/average_l0_219
+    l0: 219
+    path: layer_3/width_16k/average_l0_219
+  - id: layer_3/width_16k/average_l0_24
+    l0: 24
+    path: layer_3/width_16k/average_l0_24
+  - id: layer_3/width_16k/average_l0_386
+    l0: 386
+    path: layer_3/width_16k/average_l0_386
+  - id: layer_3/width_16k/average_l0_55
+    l0: 55
+    path: layer_3/width_16k/average_l0_55
+  - id: layer_4/width_16k/average_l0_116
+    l0: 116
+    path: layer_4/width_16k/average_l0_116
+  - id: layer_4/width_16k/average_l0_249
+    l0: 249
+    path: layer_4/width_16k/average_l0_249
+  - id: layer_4/width_16k/average_l0_26
+    l0: 26
+    path: layer_4/width_16k/average_l0_26
+  - id: layer_4/width_16k/average_l0_454
+    l0: 454
+    path: layer_4/width_16k/average_l0_454
+  - id: layer_4/width_16k/average_l0_53
+    l0: 53
+    path: layer_4/width_16k/average_l0_53
+  - id: layer_5/width_16k/average_l0_135
+    l0: 135
+    path: layer_5/width_16k/average_l0_135
+  - id: layer_5/width_16k/average_l0_268
+    l0: 268
+    path: layer_5/width_16k/average_l0_268
+  - id: layer_5/width_16k/average_l0_30
+    l0: 30
+    path: layer_5/width_16k/average_l0_30
+  - id: layer_5/width_16k/average_l0_449
+    l0: 449
+    path: layer_5/width_16k/average_l0_449
+  - id: layer_5/width_16k/average_l0_59
+    l0: 59
+    path: layer_5/width_16k/average_l0_59
+  - id: layer_6/width_16k/average_l0_143
+    l0: 143
+    path: layer_6/width_16k/average_l0_143
+  - id: layer_6/width_16k/average_l0_292
+    l0: 292
+    path: layer_6/width_16k/average_l0_292
+  - id: layer_6/width_16k/average_l0_30
+    l0: 30
+    path: layer_6/width_16k/average_l0_30
+  - id: layer_6/width_16k/average_l0_479
+    l0: 479
+    path: layer_6/width_16k/average_l0_479
+  - id: layer_6/width_16k/average_l0_61
+    l0: 61
+    path: layer_6/width_16k/average_l0_61
+  - id: layer_7/width_16k/average_l0_184
+    l0: 184
+    path: layer_7/width_16k/average_l0_184
+  - id: layer_7/width_16k/average_l0_331
+    l0: 331
+    path: layer_7/width_16k/average_l0_331
+  - id: layer_7/width_16k/average_l0_46
+    l0: 46
+    path: layer_7/width_16k/average_l0_46
+  - id: layer_7/width_16k/average_l0_537
+    l0: 537
+    path: layer_7/width_16k/average_l0_537
+  - id: layer_7/width_16k/average_l0_99
+    l0: 99
+    path: layer_7/width_16k/average_l0_99
+  - id: layer_8/width_16k/average_l0_129
+    l0: 129
+    path: layer_8/width_16k/average_l0_129
+  - id: layer_8/width_16k/average_l0_282
+    l0: 282
+    path: layer_8/width_16k/average_l0_282
+  - id: layer_8/width_16k/average_l0_32
+    l0: 32
+    path: layer_8/width_16k/average_l0_32
+  - id: layer_8/width_16k/average_l0_482
+    l0: 482
+    path: layer_8/width_16k/average_l0_482
+  - id: layer_8/width_16k/average_l0_64
+    l0: 64
+    path: layer_8/width_16k/average_l0_64
+  - id: layer_9/width_16k/average_l0_127
+    l0: 127
+    path: layer_9/width_16k/average_l0_127
+  - id: layer_9/width_16k/average_l0_270
+    l0: 270
+    path: layer_9/width_16k/average_l0_270
+  - id: layer_9/width_16k/average_l0_34
+    l0: 34
+    path: layer_9/width_16k/average_l0_34
+  - id: layer_9/width_16k/average_l0_499
+    l0: 499
+    path: layer_9/width_16k/average_l0_499
+  - id: layer_9/width_16k/average_l0_64
+    l0: 64
+    path: layer_9/width_16k/average_l0_64
+  - id: layer_10/width_16k/average_l0_148
+    l0: 148
+    path: layer_10/width_16k/average_l0_148
+  - id: layer_10/width_16k/average_l0_307
+    l0: 307
+    path: layer_10/width_16k/average_l0_307
+  - id: layer_10/width_16k/average_l0_36
+    l0: 36
+    path: layer_10/width_16k/average_l0_36
+  - id: layer_10/width_16k/average_l0_541
+    l0: 541
+    path: layer_10/width_16k/average_l0_541
+  - id: layer_10/width_16k/average_l0_70
+    l0: 70
+    path: layer_10/width_16k/average_l0_70
+  - id: layer_11/width_16k/average_l0_170
+    l0: 170
+    path: layer_11/width_16k/average_l0_170
+  - id: layer_11/width_16k/average_l0_350
+    l0: 350
+    path: layer_11/width_16k/average_l0_350
+  - id: layer_11/width_16k/average_l0_41
+    l0: 41
+    path: layer_11/width_16k/average_l0_41
+  - id: layer_11/width_16k/average_l0_593
+    l0: 593
+    path: layer_11/width_16k/average_l0_593
+  - id: layer_11/width_16k/average_l0_80
+    l0: 80
+    path: layer_11/width_16k/average_l0_80
+  - id: layer_12/width_16k/average_l0_184
+    l0: 184
+    path: layer_12/width_16k/average_l0_184
+  - id: layer_12/width_16k/average_l0_328
+    l0: 328
+    path: layer_12/width_16k/average_l0_328
+  - id: layer_12/width_16k/average_l0_41
+    l0: 41
+    path: layer_12/width_16k/average_l0_41
+  - id: layer_12/width_16k/average_l0_514
+    l0: 514
+    path: layer_12/width_16k/average_l0_514
+  - id: layer_12/width_16k/average_l0_85
+    l0: 85
+    path: layer_12/width_16k/average_l0_85
+  - id: layer_13/width_16k/average_l0_203
+    l0: 203
+    path: layer_13/width_16k/average_l0_203
+  - id: layer_13/width_16k/average_l0_372
+    l0: 372
+    path: layer_13/width_16k/average_l0_372
+  - id: layer_13/width_16k/average_l0_43
+    l0: 43
+    path: layer_13/width_16k/average_l0_43
+  - id: layer_13/width_16k/average_l0_570
+    l0: 570
+    path: layer_13/width_16k/average_l0_570
+  - id: layer_13/width_16k/average_l0_92
+    l0: 92
+    path: layer_13/width_16k/average_l0_92
+  - id: layer_14/width_16k/average_l0_161
+    l0: 161
+    path: layer_14/width_16k/average_l0_161
+  - id: layer_14/width_16k/average_l0_298
+    l0: 298
+    path: layer_14/width_16k/average_l0_298
+  - id: layer_14/width_16k/average_l0_37
+    l0: 37
+    path: layer_14/width_16k/average_l0_37
+  - id: layer_14/width_16k/average_l0_468
+    l0: 468
+    path: layer_14/width_16k/average_l0_468
+  - id: layer_14/width_16k/average_l0_71
+    l0: 71
+    path: layer_14/width_16k/average_l0_71
+  - id: layer_15/width_16k/average_l0_195
+    l0: 195
+    path: layer_15/width_16k/average_l0_195
+  - id: layer_15/width_16k/average_l0_342
+    l0: 342
+    path: layer_15/width_16k/average_l0_342
+  - id: layer_15/width_16k/average_l0_44
+    l0: 44
+    path: layer_15/width_16k/average_l0_44
+  - id: layer_15/width_16k/average_l0_535
+    l0: 535
+    path: layer_15/width_16k/average_l0_535
+  - id: layer_15/width_16k/average_l0_98
+    l0: 98
+    path: layer_15/width_16k/average_l0_98
+  - id: layer_16/width_16k/average_l0_144
+    l0: 144
+    path: layer_16/width_16k/average_l0_144
+  - id: layer_16/width_16k/average_l0_293
+    l0: 293
+    path: layer_16/width_16k/average_l0_293
+  - id: layer_16/width_16k/average_l0_37
+    l0: 37
+    path: layer_16/width_16k/average_l0_37
+  - id: layer_16/width_16k/average_l0_527
+    l0: 527
+    path: layer_16/width_16k/average_l0_527
+  - id: layer_16/width_16k/average_l0_71
+    l0: 71
+    path: layer_16/width_16k/average_l0_71
+  - id: layer_17/width_16k/average_l0_176
+    l0: 176
+    path: layer_17/width_16k/average_l0_176
+  - id: layer_17/width_16k/average_l0_316
+    l0: 316
+    path: layer_17/width_16k/average_l0_316
+  - id: layer_17/width_16k/average_l0_38
+    l0: 38
+    path: layer_17/width_16k/average_l0_38
+  - id: layer_17/width_16k/average_l0_509
+    l0: 509
+    path: layer_17/width_16k/average_l0_509
+  - id: layer_17/width_16k/average_l0_79
+    l0: 79
+    path: layer_17/width_16k/average_l0_79
+  - id: layer_18/width_16k/average_l0_144
+    l0: 144
+    path: layer_18/width_16k/average_l0_144
+  - id: layer_18/width_16k/average_l0_292
+    l0: 292
+    path: layer_18/width_16k/average_l0_292
+  - id: layer_18/width_16k/average_l0_34
+    l0: 34
+    path: layer_18/width_16k/average_l0_34
+  - id: layer_18/width_16k/average_l0_491
+    l0: 491
+    path: layer_18/width_16k/average_l0_491
+  - id: layer_18/width_16k/average_l0_72
+    l0: 72
+    path: layer_18/width_16k/average_l0_72
+  - id: layer_19/width_16k/average_l0_122
+    l0: 122
+    path: layer_19/width_16k/average_l0_122
+  - id: layer_19/width_16k/average_l0_249
+    l0: 249
+    path: layer_19/width_16k/average_l0_249
+  - id: layer_19/width_16k/average_l0_28
+    l0: 28
+    path: layer_19/width_16k/average_l0_28
+  - id: layer_19/width_16k/average_l0_423
+    l0: 423
+    path: layer_19/width_16k/average_l0_423
+  - id: layer_19/width_16k/average_l0_56
+    l0: 56
+    path: layer_19/width_16k/average_l0_56
+  - id: layer_20/width_16k/average_l0_141
+    l0: 141
+    path: layer_20/width_16k/average_l0_141
+  - id: layer_20/width_16k/average_l0_274
+    l0: 274
+    path: layer_20/width_16k/average_l0_274
+  - id: layer_20/width_16k/average_l0_31
+    l0: 31
+    path: layer_20/width_16k/average_l0_31
+  - id: layer_20/width_16k/average_l0_446
+    l0: 446
+    path: layer_20/width_16k/average_l0_446
+  - id: layer_20/width_16k/average_l0_62
+    l0: 62
+    path: layer_20/width_16k/average_l0_62
+  - id: layer_21/width_16k/average_l0_142
+    l0: 142
+    path: layer_21/width_16k/average_l0_142
+  - id: layer_21/width_16k/average_l0_301
+    l0: 301
+    path: layer_21/width_16k/average_l0_301
+  - id: layer_21/width_16k/average_l0_32
+    l0: 32
+    path: layer_21/width_16k/average_l0_32
+  - id: layer_21/width_16k/average_l0_505
+    l0: 505
+    path: layer_21/width_16k/average_l0_505
+  - id: layer_21/width_16k/average_l0_65
+    l0: 65
+    path: layer_21/width_16k/average_l0_65
+  - id: layer_22/width_16k/average_l0_106
+    l0: 106
+    path: layer_22/width_16k/average_l0_106
+  - id: layer_22/width_16k/average_l0_215
+    l0: 215
+    path: layer_22/width_16k/average_l0_215
+  - id: layer_22/width_16k/average_l0_22
+    l0: 22
+    path: layer_22/width_16k/average_l0_22
+  - id: layer_22/width_16k/average_l0_373
+    l0: 373
+    path: layer_22/width_16k/average_l0_373
+  - id: layer_22/width_16k/average_l0_47
+    l0: 47
+    path: layer_22/width_16k/average_l0_47
+  - id: layer_23/width_16k/average_l0_161
+    l0: 161
+    path: layer_23/width_16k/average_l0_161
+  - id: layer_23/width_16k/average_l0_30
+    l0: 30
+    path: layer_23/width_16k/average_l0_30
+  - id: layer_23/width_16k/average_l0_300
+    l0: 300
+    path: layer_23/width_16k/average_l0_300
+  - id: layer_23/width_16k/average_l0_474
+    l0: 474
+    path: layer_23/width_16k/average_l0_474
+  - id: layer_23/width_16k/average_l0_73
+    l0: 73
+    path: layer_23/width_16k/average_l0_73
+  - id: layer_24/width_16k/average_l0_212
+    l0: 212
+    path: layer_24/width_16k/average_l0_212
+  - id: layer_24/width_16k/average_l0_372
+    l0: 372
+    path: layer_24/width_16k/average_l0_372
+  - id: layer_24/width_16k/average_l0_39
+    l0: 39
+    path: layer_24/width_16k/average_l0_39
+  - id: layer_24/width_16k/average_l0_558
+    l0: 558
+    path: layer_24/width_16k/average_l0_558
+  - id: layer_24/width_16k/average_l0_96
+    l0: 96
+    path: layer_24/width_16k/average_l0_96
+  - id: layer_25/width_16k/average_l0_177
+    l0: 177
+    path: layer_25/width_16k/average_l0_177
+  - id: layer_25/width_16k/average_l0_313
+    l0: 313
+    path: layer_25/width_16k/average_l0_313
+  - id: layer_25/width_16k/average_l0_35
+    l0: 35
+    path: layer_25/width_16k/average_l0_35
+  - id: layer_25/width_16k/average_l0_492
+    l0: 492
+    path: layer_25/width_16k/average_l0_492
+  - id: layer_25/width_16k/average_l0_77
+    l0: 77
+    path: layer_25/width_16k/average_l0_77
+  - id: layer_0/width_65k/average_l0_10
+    l0: 10
+    path: layer_0/width_65k/average_l0_10
+  - id: layer_0/width_65k/average_l0_16
+    l0: 16
+    path: layer_0/width_65k/average_l0_16
+  - id: layer_0/width_65k/average_l0_24
+    l0: 24
+    path: layer_0/width_65k/average_l0_24
+  - id: layer_0/width_65k/average_l0_43
+    l0: 43
+    path: layer_0/width_65k/average_l0_43
+  - id: layer_0/width_65k/average_l0_75
+    l0: 75
+    path: layer_0/width_65k/average_l0_75
+  - id: layer_1/width_65k/average_l0_15
+    l0: 15
+    path: layer_1/width_65k/average_l0_15
+  - id: layer_1/width_65k/average_l0_181
+    l0: 181
+    path: layer_1/width_65k/average_l0_181
+  - id: layer_1/width_65k/average_l0_28
+    l0: 28
+    path: layer_1/width_65k/average_l0_28
+  - id: layer_1/width_65k/average_l0_55
+    l0: 55
+    path: layer_1/width_65k/average_l0_55
+  - id: layer_1/width_65k/average_l0_98
+    l0: 98
+    path: layer_1/width_65k/average_l0_98
+  - id: layer_2/width_65k/average_l0_125
+    l0: 125
+    path: layer_2/width_65k/average_l0_125
+  - id: layer_2/width_65k/average_l0_14
+    l0: 14
+    path: layer_2/width_65k/average_l0_14
+  - id: layer_2/width_65k/average_l0_228
+    l0: 228
+    path: layer_2/width_65k/average_l0_228
+  - id: layer_2/width_65k/average_l0_28
+    l0: 28
+    path: layer_2/width_65k/average_l0_28
+  - id: layer_2/width_65k/average_l0_59
+    l0: 59
+    path: layer_2/width_65k/average_l0_59
+  - id: layer_3/width_65k/average_l0_174
+    l0: 174
+    path: layer_3/width_65k/average_l0_174
+  - id: layer_3/width_65k/average_l0_19
+    l0: 19
+    path: layer_3/width_65k/average_l0_19
+  - id: layer_3/width_65k/average_l0_320
+    l0: 320
+    path: layer_3/width_65k/average_l0_320
+  - id: layer_3/width_65k/average_l0_39
+    l0: 39
+    path: layer_3/width_65k/average_l0_39
+  - id: layer_3/width_65k/average_l0_83
+    l0: 83
+    path: layer_3/width_65k/average_l0_83
+  - id: layer_4/width_65k/average_l0_188
+    l0: 188
+    path: layer_4/width_65k/average_l0_188
+  - id: layer_4/width_65k/average_l0_22
+    l0: 22
+    path: layer_4/width_65k/average_l0_22
+  - id: layer_4/width_65k/average_l0_382
+    l0: 382
+    path: layer_4/width_65k/average_l0_382
+  - id: layer_4/width_65k/average_l0_43
+    l0: 43
+    path: layer_4/width_65k/average_l0_43
+  - id: layer_4/width_65k/average_l0_87
+    l0: 87
+    path: layer_4/width_65k/average_l0_87
+  - id: layer_5/width_65k/average_l0_227
+    l0: 227
+    path: layer_5/width_65k/average_l0_227
+  - id: layer_5/width_65k/average_l0_28
+    l0: 28
+    path: layer_5/width_65k/average_l0_28
+  - id: layer_5/width_65k/average_l0_400
+    l0: 400
+    path: layer_5/width_65k/average_l0_400
+  - id: layer_5/width_65k/average_l0_51
+    l0: 51
+    path: layer_5/width_65k/average_l0_51
+  - id: layer_5/width_65k/average_l0_99
+    l0: 99
+    path: layer_5/width_65k/average_l0_99
+  - id: layer_6/width_65k/average_l0_112
+    l0: 112
+    path: layer_6/width_65k/average_l0_112
+  - id: layer_6/width_65k/average_l0_261
+    l0: 261
+    path: layer_6/width_65k/average_l0_261
+  - id: layer_6/width_65k/average_l0_30
+    l0: 30
+    path: layer_6/width_65k/average_l0_30
+  - id: layer_6/width_65k/average_l0_449
+    l0: 449
+    path: layer_6/width_65k/average_l0_449
+  - id: layer_6/width_65k/average_l0_55
+    l0: 55
+    path: layer_6/width_65k/average_l0_55
+  - id: layer_7/width_65k/average_l0_176
+    l0: 176
+    path: layer_7/width_65k/average_l0_176
+  - id: layer_7/width_65k/average_l0_311
+    l0: 311
+    path: layer_7/width_65k/average_l0_311
+  - id: layer_7/width_65k/average_l0_519
+    l0: 519
+    path: layer_7/width_65k/average_l0_519
+  - id: layer_7/width_65k/average_l0_52
+    l0: 52
+    path: layer_7/width_65k/average_l0_52
+  - id: layer_7/width_65k/average_l0_96
+    l0: 96
+    path: layer_7/width_65k/average_l0_96
+  - id: layer_8/width_65k/average_l0_112
+    l0: 112
+    path: layer_8/width_65k/average_l0_112
+  - id: layer_8/width_65k/average_l0_246
+    l0: 246
+    path: layer_8/width_65k/average_l0_246
+  - id: layer_8/width_65k/average_l0_35
+    l0: 35
+    path: layer_8/width_65k/average_l0_35
+  - id: layer_8/width_65k/average_l0_454
+    l0: 454
+    path: layer_8/width_65k/average_l0_454
+  - id: layer_8/width_65k/average_l0_56
+    l0: 56
+    path: layer_8/width_65k/average_l0_56
+  - id: layer_9/width_65k/average_l0_107
+    l0: 107
+    path: layer_9/width_65k/average_l0_107
+  - id: layer_9/width_65k/average_l0_231
+    l0: 231
+    path: layer_9/width_65k/average_l0_231
+  - id: layer_9/width_65k/average_l0_31
+    l0: 31
+    path: layer_9/width_65k/average_l0_31
+  - id: layer_9/width_65k/average_l0_454
+    l0: 454
+    path: layer_9/width_65k/average_l0_454
+  - id: layer_9/width_65k/average_l0_57
+    l0: 57
+    path: layer_9/width_65k/average_l0_57
+  - id: layer_10/width_65k/average_l0_134
+    l0: 134
+    path: layer_10/width_65k/average_l0_134
+  - id: layer_10/width_65k/average_l0_292
+    l0: 292
+    path: layer_10/width_65k/average_l0_292
+  - id: layer_10/width_65k/average_l0_35
+    l0: 35
+    path: layer_10/width_65k/average_l0_35
+  - id: layer_10/width_65k/average_l0_521
+    l0: 521
+    path: layer_10/width_65k/average_l0_521
+  - id: layer_10/width_65k/average_l0_67
+    l0: 67
+    path: layer_10/width_65k/average_l0_67
+  - id: layer_11/width_65k/average_l0_154
+    l0: 154
+    path: layer_11/width_65k/average_l0_154
+  - id: layer_11/width_65k/average_l0_330
+    l0: 330
+    path: layer_11/width_65k/average_l0_330
+  - id: layer_11/width_65k/average_l0_41
+    l0: 41
+    path: layer_11/width_65k/average_l0_41
+  - id: layer_11/width_65k/average_l0_576
+    l0: 576
+    path: layer_11/width_65k/average_l0_576
+  - id: layer_11/width_65k/average_l0_75
+    l0: 75
+    path: layer_11/width_65k/average_l0_75
+  - id: layer_12/width_65k/average_l0_172
+    l0: 172
+    path: layer_12/width_65k/average_l0_172
+  - id: layer_12/width_65k/average_l0_320
+    l0: 320
+    path: layer_12/width_65k/average_l0_320
+  - id: layer_12/width_65k/average_l0_39
+    l0: 39
+    path: layer_12/width_65k/average_l0_39
+  - id: layer_12/width_65k/average_l0_503
+    l0: 503
+    path: layer_12/width_65k/average_l0_503
+  - id: layer_12/width_65k/average_l0_79
+    l0: 79
+    path: layer_12/width_65k/average_l0_79
+  - id: layer_13/width_65k/average_l0_191
+    l0: 191
+    path: layer_13/width_65k/average_l0_191
+  - id: layer_13/width_65k/average_l0_363
+    l0: 363
+    path: layer_13/width_65k/average_l0_363
+  - id: layer_13/width_65k/average_l0_41
+    l0: 41
+    path: layer_13/width_65k/average_l0_41
+  - id: layer_13/width_65k/average_l0_556
+    l0: 556
+    path: layer_13/width_65k/average_l0_556
+  - id: layer_13/width_65k/average_l0_87
+    l0: 87
+    path: layer_13/width_65k/average_l0_87
+  - id: layer_14/width_65k/average_l0_138
+    l0: 138
+    path: layer_14/width_65k/average_l0_138
+  - id: layer_14/width_65k/average_l0_283
+    l0: 283
+    path: layer_14/width_65k/average_l0_283
+  - id: layer_14/width_65k/average_l0_37
+    l0: 37
+    path: layer_14/width_65k/average_l0_37
+  - id: layer_14/width_65k/average_l0_453
+    l0: 453
+    path: layer_14/width_65k/average_l0_453
+  - id: layer_14/width_65k/average_l0_66
+    l0: 66
+    path: layer_14/width_65k/average_l0_66
+  - id: layer_15/width_65k/average_l0_182
+    l0: 182
+    path: layer_15/width_65k/average_l0_182
+  - id: layer_15/width_65k/average_l0_327
+    l0: 327
+    path: layer_15/width_65k/average_l0_327
+  - id: layer_15/width_65k/average_l0_42
+    l0: 42
+    path: layer_15/width_65k/average_l0_42
+  - id: layer_15/width_65k/average_l0_517
+    l0: 517
+    path: layer_15/width_65k/average_l0_517
+  - id: layer_15/width_65k/average_l0_90
+    l0: 90
+    path: layer_15/width_65k/average_l0_90
+  - id: layer_16/width_65k/average_l0_129
+    l0: 129
+    path: layer_16/width_65k/average_l0_129
+  - id: layer_16/width_65k/average_l0_260
+    l0: 260
+    path: layer_16/width_65k/average_l0_260
+  - id: layer_16/width_65k/average_l0_35
+    l0: 35
+    path: layer_16/width_65k/average_l0_35
+  - id: layer_16/width_65k/average_l0_502
+    l0: 502
+    path: layer_16/width_65k/average_l0_502
+  - id: layer_16/width_65k/average_l0_64
+    l0: 64
+    path: layer_16/width_65k/average_l0_64
+  - id: layer_17/width_65k/average_l0_157
+    l0: 157
+    path: layer_17/width_65k/average_l0_157
+  - id: layer_17/width_65k/average_l0_293
+    l0: 293
+    path: layer_17/width_65k/average_l0_293
+  - id: layer_17/width_65k/average_l0_35
+    l0: 35
+    path: layer_17/width_65k/average_l0_35
+  - id: layer_17/width_65k/average_l0_489
+    l0: 489
+    path: layer_17/width_65k/average_l0_489
+  - id: layer_17/width_65k/average_l0_70
+    l0: 70
+    path: layer_17/width_65k/average_l0_70
+  - id: layer_18/width_65k/average_l0_123
+    l0: 123
+    path: layer_18/width_65k/average_l0_123
+  - id: layer_18/width_65k/average_l0_255
+    l0: 255
+    path: layer_18/width_65k/average_l0_255
+  - id: layer_18/width_65k/average_l0_29
+    l0: 29
+    path: layer_18/width_65k/average_l0_29
+  - id: layer_18/width_65k/average_l0_466
+    l0: 466
+    path: layer_18/width_65k/average_l0_466
+  - id: layer_18/width_65k/average_l0_58
+    l0: 58
+    path: layer_18/width_65k/average_l0_58
+  - id: layer_19/width_65k/average_l0_106
+    l0: 106
+    path: layer_19/width_65k/average_l0_106
+  - id: layer_19/width_65k/average_l0_220
+    l0: 220
+    path: layer_19/width_65k/average_l0_220
+  - id: layer_19/width_65k/average_l0_26
+    l0: 26
+    path: layer_19/width_65k/average_l0_26
+  - id: layer_19/width_65k/average_l0_411
+    l0: 411
+    path: layer_19/width_65k/average_l0_411
+  - id: layer_19/width_65k/average_l0_49
+    l0: 49
+    path: layer_19/width_65k/average_l0_49
+  - id: layer_20/width_65k/average_l0_102
+    l0: 102
+    path: layer_20/width_65k/average_l0_102
+  - id: layer_20/width_65k/average_l0_242
+    l0: 242
+    path: layer_20/width_65k/average_l0_242
+  - id: layer_20/width_65k/average_l0_26
+    l0: 26
+    path: layer_20/width_65k/average_l0_26
+  - id: layer_20/width_65k/average_l0_419
+    l0: 419
+    path: layer_20/width_65k/average_l0_419
+  - id: layer_20/width_65k/average_l0_49
+    l0: 49
+    path: layer_20/width_65k/average_l0_49
+  - id: layer_21/width_65k/average_l0_118
+    l0: 118
+    path: layer_21/width_65k/average_l0_118
+  - id: layer_21/width_65k/average_l0_266
+    l0: 266
+    path: layer_21/width_65k/average_l0_266
+  - id: layer_21/width_65k/average_l0_29
+    l0: 29
+    path: layer_21/width_65k/average_l0_29
+  - id: layer_21/width_65k/average_l0_474
+    l0: 474
+    path: layer_21/width_65k/average_l0_474
+  - id: layer_21/width_65k/average_l0_56
+    l0: 56
+    path: layer_21/width_65k/average_l0_56
+  - id: layer_22/width_65k/average_l0_112
+    l0: 112
+    path: layer_22/width_65k/average_l0_112
+  - id: layer_22/width_65k/average_l0_196
+    l0: 196
+    path: layer_22/width_65k/average_l0_196
+  - id: layer_22/width_65k/average_l0_20
+    l0: 20
+    path: layer_22/width_65k/average_l0_20
+  - id: layer_22/width_65k/average_l0_361
+    l0: 361
+    path: layer_22/width_65k/average_l0_361
+  - id: layer_22/width_65k/average_l0_37
+    l0: 37
+    path: layer_22/width_65k/average_l0_37
+  - id: layer_23/width_65k/average_l0_140
+    l0: 140
+    path: layer_23/width_65k/average_l0_140
+  - id: layer_23/width_65k/average_l0_27
+    l0: 27
+    path: layer_23/width_65k/average_l0_27
+  - id: layer_23/width_65k/average_l0_276
+    l0: 276
+    path: layer_23/width_65k/average_l0_276
+  - id: layer_23/width_65k/average_l0_457
+    l0: 457
+    path: layer_23/width_65k/average_l0_457
+  - id: layer_23/width_65k/average_l0_56
+    l0: 56
+    path: layer_23/width_65k/average_l0_56
+  - id: layer_24/width_65k/average_l0_186
+    l0: 186
+    path: layer_24/width_65k/average_l0_186
+  - id: layer_24/width_65k/average_l0_32
+    l0: 32
+    path: layer_24/width_65k/average_l0_32
+  - id: layer_24/width_65k/average_l0_347
+    l0: 347
+    path: layer_24/width_65k/average_l0_347
+  - id: layer_24/width_65k/average_l0_537
+    l0: 537
+    path: layer_24/width_65k/average_l0_537
+  - id: layer_24/width_65k/average_l0_77
+    l0: 77
+    path: layer_24/width_65k/average_l0_77
+  - id: layer_25/width_65k/average_l0_153
+    l0: 153
+    path: layer_25/width_65k/average_l0_153
+  - id: layer_25/width_65k/average_l0_290
+    l0: 290
+    path: layer_25/width_65k/average_l0_290
+  - id: layer_25/width_65k/average_l0_30
+    l0: 30
+    path: layer_25/width_65k/average_l0_30
+  - id: layer_25/width_65k/average_l0_465
+    l0: 465
+    path: layer_25/width_65k/average_l0_465
+  - id: layer_25/width_65k/average_l0_63
+    l0: 63
+    path: layer_25/width_65k/average_l0_63
+gemma-scope-2b-pt-att-canonical:
+  conversion_func: gemma_2
+  model: gemma-2-2b
+  repo_id: google/gemma-scope-2b-pt-att
+  saes:
+  - id: layer_0/width_16k/canonical
+    neuronpedia: gemma-2-2b/0-gemmascope-att-16k
+    path: layer_0/width_16k/average_l0_104
+  - id: layer_1/width_16k/canonical
+    neuronpedia: gemma-2-2b/1-gemmascope-att-16k
+    path: layer_1/width_16k/average_l0_79
+  - id: layer_2/width_16k/canonical
+    neuronpedia: gemma-2-2b/2-gemmascope-att-16k
+    path: layer_2/width_16k/average_l0_93
+  - id: layer_3/width_16k/canonical
+    neuronpedia: gemma-2-2b/3-gemmascope-att-16k
+    path: layer_3/width_16k/average_l0_117
+  - id: layer_4/width_16k/canonical
+    neuronpedia: gemma-2-2b/4-gemmascope-att-16k
+    path: layer_4/width_16k/average_l0_116
+  - id: layer_5/width_16k/canonical
+    neuronpedia: gemma-2-2b/5-gemmascope-att-16k
+    path: layer_5/width_16k/average_l0_135
+  - id: layer_6/width_16k/canonical
+    neuronpedia: gemma-2-2b/6-gemmascope-att-16k
+    path: layer_6/width_16k/average_l0_61
+  - id: layer_7/width_16k/canonical
+    neuronpedia: gemma-2-2b/7-gemmascope-att-16k
+    path: layer_7/width_16k/average_l0_99
+  - id: layer_8/width_16k/canonical
+    neuronpedia: gemma-2-2b/8-gemmascope-att-16k
+    path: layer_8/width_16k/average_l0_129
+  - id: layer_9/width_16k/canonical
+    neuronpedia: gemma-2-2b/9-gemmascope-att-16k
+    path: layer_9/width_16k/average_l0_127
+  - id: layer_10/width_16k/canonical
+    neuronpedia: gemma-2-2b/10-gemmascope-att-16k
+    path: layer_10/width_16k/average_l0_70
+  - id: layer_11/width_16k/canonical
+    neuronpedia: gemma-2-2b/11-gemmascope-att-16k
+    path: layer_11/width_16k/average_l0_80
+  - id: layer_12/width_16k/canonical
+    neuronpedia: gemma-2-2b/12-gemmascope-att-16k
+    path: layer_12/width_16k/average_l0_85
+  - id: layer_13/width_16k/canonical
+    neuronpedia: gemma-2-2b/13-gemmascope-att-16k
+    path: layer_13/width_16k/average_l0_92
+  - id: layer_14/width_16k/canonical
+    neuronpedia: gemma-2-2b/14-gemmascope-att-16k
+    path: layer_14/width_16k/average_l0_71
+  - id: layer_15/width_16k/canonical
+    neuronpedia: gemma-2-2b/15-gemmascope-att-16k
+    path: layer_15/width_16k/average_l0_98
+  - id: layer_16/width_16k/canonical
+    neuronpedia: gemma-2-2b/16-gemmascope-att-16k
+    path: layer_16/width_16k/average_l0_71
+  - id: layer_17/width_16k/canonical
+    neuronpedia: gemma-2-2b/17-gemmascope-att-16k
+    path: layer_17/width_16k/average_l0_79
+  - id: layer_18/width_16k/canonical
+    neuronpedia: gemma-2-2b/18-gemmascope-att-16k
+    path: layer_18/width_16k/average_l0_72
+  - id: layer_19/width_16k/canonical
+    neuronpedia: gemma-2-2b/19-gemmascope-att-16k
+    path: layer_19/width_16k/average_l0_122
+  - id: layer_20/width_16k/canonical
+    neuronpedia: gemma-2-2b/20-gemmascope-att-16k
+    path: layer_20/width_16k/average_l0_62
+  - id: layer_21/width_16k/canonical
+    neuronpedia: gemma-2-2b/21-gemmascope-att-16k
+    path: layer_21/width_16k/average_l0_65
+  - id: layer_22/width_16k/canonical
+    neuronpedia: gemma-2-2b/22-gemmascope-att-16k
+    path: layer_22/width_16k/average_l0_106
+  - id: layer_23/width_16k/canonical
+    neuronpedia: gemma-2-2b/23-gemmascope-att-16k
+    path: layer_23/width_16k/average_l0_73
+  - id: layer_24/width_16k/canonical
+    neuronpedia: gemma-2-2b/24-gemmascope-att-16k
+    path: layer_24/width_16k/average_l0_96
+  - id: layer_25/width_16k/canonical
+    neuronpedia: gemma-2-2b/25-gemmascope-att-16k
+    path: layer_25/width_16k/average_l0_77
+  - id: layer_0/width_65k/canonical
+    neuronpedia: gemma-2-2b/0-gemmascope-att-65k
+    path: layer_0/width_65k/average_l0_75
+  - id: layer_1/width_65k/canonical
+    neuronpedia: gemma-2-2b/1-gemmascope-att-65k
+    path: layer_1/width_65k/average_l0_98
+  - id: layer_2/width_65k/canonical
+    neuronpedia: gemma-2-2b/2-gemmascope-att-65k
+    path: layer_2/width_65k/average_l0_125
+  - id: layer_3/width_65k/canonical
+    neuronpedia: gemma-2-2b/3-gemmascope-att-65k
+    path: layer_3/width_65k/average_l0_83
+  - id: layer_4/width_65k/canonical
+    neuronpedia: gemma-2-2b/4-gemmascope-att-65k
+    path: layer_4/width_65k/average_l0_87
+  - id: layer_5/width_65k/canonical
+    neuronpedia: gemma-2-2b/5-gemmascope-att-65k
+    path: layer_5/width_65k/average_l0_99
+  - id: layer_6/width_65k/canonical
+    neuronpedia: gemma-2-2b/6-gemmascope-att-65k
+    path: layer_6/width_65k/average_l0_112
+  - id: layer_7/width_65k/canonical
+    neuronpedia: gemma-2-2b/7-gemmascope-att-65k
+    path: layer_7/width_65k/average_l0_96
+  - id: layer_8/width_65k/canonical
+    neuronpedia: gemma-2-2b/8-gemmascope-att-65k
+    path: layer_8/width_65k/average_l0_112
+  - id: layer_9/width_65k/canonical
+    neuronpedia: gemma-2-2b/9-gemmascope-att-65k
+    path: layer_9/width_65k/average_l0_107
+  - id: layer_10/width_65k/canonical
+    neuronpedia: gemma-2-2b/10-gemmascope-att-65k
+    path: layer_10/width_65k/average_l0_67
+  - id: layer_11/width_65k/canonical
+    neuronpedia: gemma-2-2b/11-gemmascope-att-65k
+    path: layer_11/width_65k/average_l0_75
+  - id: layer_12/width_65k/canonical
+    neuronpedia: gemma-2-2b/12-gemmascope-att-65k
+    path: layer_12/width_65k/average_l0_79
+  - id: layer_13/width_65k/canonical
+    neuronpedia: gemma-2-2b/13-gemmascope-att-65k
+    path: layer_13/width_65k/average_l0_87
+  - id: layer_14/width_65k/canonical
+    neuronpedia: gemma-2-2b/14-gemmascope-att-65k
+    path: layer_14/width_65k/average_l0_66
+  - id: layer_15/width_65k/canonical
+    neuronpedia: gemma-2-2b/15-gemmascope-att-65k
+    path: layer_15/width_65k/average_l0_90
+  - id: layer_16/width_65k/canonical
+    neuronpedia: gemma-2-2b/16-gemmascope-att-65k
+    path: layer_16/width_65k/average_l0_129
+  - id: layer_17/width_65k/canonical
+    neuronpedia: gemma-2-2b/17-gemmascope-att-65k
+    path: layer_17/width_65k/average_l0_70
+  - id: layer_18/width_65k/canonical
+    neuronpedia: gemma-2-2b/18-gemmascope-att-65k
+    path: layer_18/width_65k/average_l0_123
+  - id: layer_19/width_65k/canonical
+    neuronpedia: gemma-2-2b/19-gemmascope-att-65k
+    path: layer_19/width_65k/average_l0_106
+  - id: layer_20/width_65k/canonical
+    neuronpedia: gemma-2-2b/20-gemmascope-att-65k
+    path: layer_20/width_65k/average_l0_102
+  - id: layer_21/width_65k/canonical
+    neuronpedia: gemma-2-2b/21-gemmascope-att-65k
+    path: layer_21/width_65k/average_l0_118
+  - id: layer_22/width_65k/canonical
+    neuronpedia: gemma-2-2b/22-gemmascope-att-65k
+    path: layer_22/width_65k/average_l0_112
+  - id: layer_23/width_65k/canonical
+    neuronpedia: gemma-2-2b/23-gemmascope-att-65k
+    path: layer_23/width_65k/average_l0_140
+  - id: layer_24/width_65k/canonical
+    neuronpedia: gemma-2-2b/24-gemmascope-att-65k
+    path: layer_24/width_65k/average_l0_77
+  - id: layer_25/width_65k/canonical
+    neuronpedia: gemma-2-2b/25-gemmascope-att-65k
+    path: layer_25/width_65k/average_l0_63
+gemma-scope-2b-pt-mlp:
+  conversion_func: gemma_2
+  model: gemma-2-2b
+  repo_id: google/gemma-scope-2b-pt-mlp
+  saes:
+  - id: layer_0/width_16k/average_l0_119
+    l0: 119
+    path: layer_0/width_16k/average_l0_119
+  - id: layer_0/width_16k/average_l0_16
+    l0: 16
+    path: layer_0/width_16k/average_l0_16
+  - id: layer_0/width_16k/average_l0_30
+    l0: 30
+    path: layer_0/width_16k/average_l0_30
+  - id: layer_0/width_16k/average_l0_60
+    l0: 60
+    path: layer_0/width_16k/average_l0_60
+  - id: layer_0/width_16k/average_l0_9
+    l0: 9
+    path: layer_0/width_16k/average_l0_9
+  - id: layer_1/width_16k/average_l0_105
+    l0: 105
+    path: layer_1/width_16k/average_l0_105
+  - id: layer_1/width_16k/average_l0_12
+    l0: 12
+    path: layer_1/width_16k/average_l0_12
+  - id: layer_1/width_16k/average_l0_239
+    l0: 239
+    path: layer_1/width_16k/average_l0_239
+  - id: layer_1/width_16k/average_l0_24
+    l0: 24
+    path: layer_1/width_16k/average_l0_24
+  - id: layer_1/width_16k/average_l0_50
+    l0: 50
+    path: layer_1/width_16k/average_l0_50
+  - id: layer_2/width_16k/average_l0_19
+    l0: 19
+    path: layer_2/width_16k/average_l0_19
+  - id: layer_2/width_16k/average_l0_213
+    l0: 213
+    path: layer_2/width_16k/average_l0_213
+  - id: layer_2/width_16k/average_l0_41
+    l0: 41
+    path: layer_2/width_16k/average_l0_41
+  - id: layer_2/width_16k/average_l0_434
+    l0: 434
+    path: layer_2/width_16k/average_l0_434
+  - id: layer_2/width_16k/average_l0_95
+    l0: 95
+    path: layer_2/width_16k/average_l0_95
+  - id: layer_3/width_16k/average_l0_195
+    l0: 195
+    path: layer_3/width_16k/average_l0_195
+  - id: layer_3/width_16k/average_l0_21
+    l0: 21
+    path: layer_3/width_16k/average_l0_21
+  - id: layer_3/width_16k/average_l0_377
+    l0: 377
+    path: layer_3/width_16k/average_l0_377
+  - id: layer_3/width_16k/average_l0_44
+    l0: 44
+    path: layer_3/width_16k/average_l0_44
+  - id: layer_3/width_16k/average_l0_95
+    l0: 95
+    path: layer_3/width_16k/average_l0_95
+  - id: layer_4/width_16k/average_l0_18
+    l0: 18
+    path: layer_4/width_16k/average_l0_18
+  - id: layer_4/width_16k/average_l0_198
+    l0: 198
+    path: layer_4/width_16k/average_l0_198
+  - id: layer_4/width_16k/average_l0_38
+    l0: 38
+    path: layer_4/width_16k/average_l0_38
+  - id: layer_4/width_16k/average_l0_433
+    l0: 433
+    path: layer_4/width_16k/average_l0_433
+  - id: layer_4/width_16k/average_l0_85
+    l0: 85
+    path: layer_4/width_16k/average_l0_85
+  - id: layer_5/width_16k/average_l0_114
+    l0: 114
+    path: layer_5/width_16k/average_l0_114
+  - id: layer_5/width_16k/average_l0_23
+    l0: 23
+    path: layer_5/width_16k/average_l0_23
+  - id: layer_5/width_16k/average_l0_269
+    l0: 269
+    path: layer_5/width_16k/average_l0_269
+  - id: layer_5/width_16k/average_l0_48
+    l0: 48
+    path: layer_5/width_16k/average_l0_48
+  - id: layer_5/width_16k/average_l0_575
+    l0: 575
+    path: layer_5/width_16k/average_l0_575
+  - id: layer_6/width_16k/average_l0_133
+    l0: 133
+    path: layer_6/width_16k/average_l0_133
+  - id: layer_6/width_16k/average_l0_25
+    l0: 25
+    path: layer_6/width_16k/average_l0_25
+  - id: layer_6/width_16k/average_l0_328
+    l0: 328
+    path: layer_6/width_16k/average_l0_328
+  - id: layer_6/width_16k/average_l0_55
+    l0: 55
+    path: layer_6/width_16k/average_l0_55
+  - id: layer_6/width_16k/average_l0_699
+    l0: 699
+    path: layer_6/width_16k/average_l0_699
+  - id: layer_7/width_16k/average_l0_146
+    l0: 146
+    path: layer_7/width_16k/average_l0_146
+  - id: layer_7/width_16k/average_l0_28
+    l0: 28
+    path: layer_7/width_16k/average_l0_28
+  - id: layer_7/width_16k/average_l0_355
+    l0: 355
+    path: layer_7/width_16k/average_l0_355
+  - id: layer_7/width_16k/average_l0_60
+    l0: 60
+    path: layer_7/width_16k/average_l0_60
+  - id: layer_7/width_16k/average_l0_731
+    l0: 731
+    path: layer_7/width_16k/average_l0_731
+  - id: layer_8/width_16k/average_l0_136
+    l0: 136
+    path: layer_8/width_16k/average_l0_136
+  - id: layer_8/width_16k/average_l0_27
+    l0: 27
+    path: layer_8/width_16k/average_l0_27
+  - id: layer_8/width_16k/average_l0_351
+    l0: 351
+    path: layer_8/width_16k/average_l0_351
+  - id: layer_8/width_16k/average_l0_56
+    l0: 56
+    path: layer_8/width_16k/average_l0_56
+  - id: layer_8/width_16k/average_l0_739
+    l0: 739
+    path: layer_8/width_16k/average_l0_739
+  - id: layer_9/width_16k/average_l0_216
+    l0: 216
+    path: layer_9/width_16k/average_l0_216
+  - id: layer_9/width_16k/average_l0_38
+    l0: 38
+    path: layer_9/width_16k/average_l0_38
+  - id: layer_9/width_16k/average_l0_482
+    l0: 482
+    path: layer_9/width_16k/average_l0_482
+  - id: layer_9/width_16k/average_l0_861
+    l0: 861
+    path: layer_9/width_16k/average_l0_861
+  - id: layer_9/width_16k/average_l0_88
+    l0: 88
+    path: layer_9/width_16k/average_l0_88
+  - id: layer_10/width_16k/average_l0_110
+    l0: 110
+    path: layer_10/width_16k/average_l0_110
+  - id: layer_10/width_16k/average_l0_266
+    l0: 266
+    path: layer_10/width_16k/average_l0_266
+  - id: layer_10/width_16k/average_l0_45
+    l0: 45
+    path: layer_10/width_16k/average_l0_45
+  - id: layer_10/width_16k/average_l0_568
+    l0: 568
+    path: layer_10/width_16k/average_l0_568
+  - id: layer_10/width_16k/average_l0_908
+    l0: 908
+    path: layer_10/width_16k/average_l0_908
+  - id: layer_11/width_16k/average_l0_234
+    l0: 234
+    path: layer_11/width_16k/average_l0_234
+  - id: layer_11/width_16k/average_l0_42
+    l0: 42
+    path: layer_11/width_16k/average_l0_42
+  - id: layer_11/width_16k/average_l0_499
+    l0: 499
+    path: layer_11/width_16k/average_l0_499
+  - id: layer_11/width_16k/average_l0_847
+    l0: 847
+    path: layer_11/width_16k/average_l0_847
+  - id: layer_11/width_16k/average_l0_98
+    l0: 98
+    path: layer_11/width_16k/average_l0_98
+  - id: layer_12/width_16k/average_l0_108
+    l0: 108
+    path: layer_12/width_16k/average_l0_108
+  - id: layer_12/width_16k/average_l0_262
+    l0: 262
+    path: layer_12/width_16k/average_l0_262
+  - id: layer_12/width_16k/average_l0_44
+    l0: 44
+    path: layer_12/width_16k/average_l0_44
+  - id: layer_12/width_16k/average_l0_548
+    l0: 548
+    path: layer_12/width_16k/average_l0_548
+  - id: layer_12/width_16k/average_l0_879
+    l0: 879
+    path: layer_12/width_16k/average_l0_879
+  - id: layer_13/width_16k/average_l0_112
+    l0: 112
+    path: layer_13/width_16k/average_l0_112
+  - id: layer_13/width_16k/average_l0_267
+    l0: 267
+    path: layer_13/width_16k/average_l0_267
+  - id: layer_13/width_16k/average_l0_47
+    l0: 47
+    path: layer_13/width_16k/average_l0_47
+  - id: layer_13/width_16k/average_l0_553
+    l0: 553
+    path: layer_13/width_16k/average_l0_553
+  - id: layer_13/width_16k/average_l0_892
+    l0: 892
+    path: layer_13/width_16k/average_l0_892
+  - id: layer_14/width_16k/average_l0_246
+    l0: 246
+    path: layer_14/width_16k/average_l0_246
+  - id: layer_14/width_16k/average_l0_41
+    l0: 41
+    path: layer_14/width_16k/average_l0_41
+  - id: layer_14/width_16k/average_l0_536
+    l0: 536
+    path: layer_14/width_16k/average_l0_536
+  - id: layer_14/width_16k/average_l0_894
+    l0: 894
+    path: layer_14/width_16k/average_l0_894
+  - id: layer_14/width_16k/average_l0_97
+    l0: 97
+    path: layer_14/width_16k/average_l0_97
+  - id: layer_15/width_16k/average_l0_207
+    l0: 207
+    path: layer_15/width_16k/average_l0_207
+  - id: layer_15/width_16k/average_l0_35
+    l0: 35
+    path: layer_15/width_16k/average_l0_35
+  - id: layer_15/width_16k/average_l0_492
+    l0: 492
+    path: layer_15/width_16k/average_l0_492
+  - id: layer_15/width_16k/average_l0_80
+    l0: 80
+    path: layer_15/width_16k/average_l0_80
+  - id: layer_15/width_16k/average_l0_879
+    l0: 879
+    path: layer_15/width_16k/average_l0_879
+  - id: layer_16/width_16k/average_l0_185
+    l0: 185
+    path: layer_16/width_16k/average_l0_185
+  - id: layer_16/width_16k/average_l0_33
+    l0: 33
+    path: layer_16/width_16k/average_l0_33
+  - id: layer_16/width_16k/average_l0_452
+    l0: 452
+    path: layer_16/width_16k/average_l0_452
+  - id: layer_16/width_16k/average_l0_72
+    l0: 72
+    path: layer_16/width_16k/average_l0_72
+  - id: layer_16/width_16k/average_l0_847
+    l0: 847
+    path: layer_16/width_16k/average_l0_847
+  - id: layer_17/width_16k/average_l0_179
+    l0: 179
+    path: layer_17/width_16k/average_l0_179
+  - id: layer_17/width_16k/average_l0_31
+    l0: 31
+    path: layer_17/width_16k/average_l0_31
+  - id: layer_17/width_16k/average_l0_453
+    l0: 453
+    path: layer_17/width_16k/average_l0_453
+  - id: layer_17/width_16k/average_l0_68
+    l0: 68
+    path: layer_17/width_16k/average_l0_68
+  - id: layer_17/width_16k/average_l0_853
+    l0: 853
+    path: layer_17/width_16k/average_l0_853
+  - id: layer_18/width_16k/average_l0_106
+    l0: 106
+    path: layer_18/width_16k/average_l0_106
+  - id: layer_18/width_16k/average_l0_24
+    l0: 24
+    path: layer_18/width_16k/average_l0_24
+  - id: layer_18/width_16k/average_l0_292
+    l0: 292
+    path: layer_18/width_16k/average_l0_292
+  - id: layer_18/width_16k/average_l0_47
+    l0: 47
+    path: layer_18/width_16k/average_l0_47
+  - id: layer_18/width_16k/average_l0_672
+    l0: 672
+    path: layer_18/width_16k/average_l0_672
+  - id: layer_19/width_16k/average_l0_109
+    l0: 109
+    path: layer_19/width_16k/average_l0_109
+  - id: layer_19/width_16k/average_l0_25
+    l0: 25
+    path: layer_19/width_16k/average_l0_25
+  - id: layer_19/width_16k/average_l0_295
+    l0: 295
+    path: layer_19/width_16k/average_l0_295
+  - id: layer_19/width_16k/average_l0_50
+    l0: 50
+    path: layer_19/width_16k/average_l0_50
+  - id: layer_19/width_16k/average_l0_673
+    l0: 673
+    path: layer_19/width_16k/average_l0_673
+  - id: layer_20/width_16k/average_l0_109
+    l0: 109
+    path: layer_20/width_16k/average_l0_109
+  - id: layer_20/width_16k/average_l0_24
+    l0: 24
+    path: layer_20/width_16k/average_l0_24
+  - id: layer_20/width_16k/average_l0_289
+    l0: 289
+    path: layer_20/width_16k/average_l0_289
+  - id: layer_20/width_16k/average_l0_49
+    l0: 49
+    path: layer_20/width_16k/average_l0_49
+  - id: layer_20/width_16k/average_l0_658
+    l0: 658
+    path: layer_20/width_16k/average_l0_658
+  - id: layer_21/width_16k/average_l0_113
+    l0: 113
+    path: layer_21/width_16k/average_l0_113
+  - id: layer_21/width_16k/average_l0_23
+    l0: 23
+    path: layer_21/width_16k/average_l0_23
+  - id: layer_21/width_16k/average_l0_279
+    l0: 279
+    path: layer_21/width_16k/average_l0_279
+  - id: layer_21/width_16k/average_l0_48
+    l0: 48
+    path: layer_21/width_16k/average_l0_48
+  - id: layer_21/width_16k/average_l0_633
+    l0: 633
+    path: layer_21/width_16k/average_l0_633
+  - id: layer_22/width_16k/average_l0_121
+    l0: 121
+    path: layer_22/width_16k/average_l0_121
+  - id: layer_22/width_16k/average_l0_24
+    l0: 24
+    path: layer_22/width_16k/average_l0_24
+  - id: layer_22/width_16k/average_l0_290
+    l0: 290
+    path: layer_22/width_16k/average_l0_290
+  - id: layer_22/width_16k/average_l0_51
+    l0: 51
+    path: layer_22/width_16k/average_l0_51
+  - id: layer_22/width_16k/average_l0_624
+    l0: 624
+    path: layer_22/width_16k/average_l0_624
+  - id: layer_23/width_16k/average_l0_128
+    l0: 128
+    path: layer_23/width_16k/average_l0_128
+  - id: layer_23/width_16k/average_l0_27
+    l0: 27
+    path: layer_23/width_16k/average_l0_27
+  - id: layer_23/width_16k/average_l0_287
+    l0: 287
+    path: layer_23/width_16k/average_l0_287
+  - id: layer_23/width_16k/average_l0_57
+    l0: 57
+    path: layer_23/width_16k/average_l0_57
+  - id: layer_23/width_16k/average_l0_627
+    l0: 627
+    path: layer_23/width_16k/average_l0_627
+  - id: layer_24/width_16k/average_l0_158
+    l0: 158
+    path: layer_24/width_16k/average_l0_158
+  - id: layer_24/width_16k/average_l0_19
+    l0: 19
+    path: layer_24/width_16k/average_l0_19
+  - id: layer_24/width_16k/average_l0_35
+    l0: 35
+    path: layer_24/width_16k/average_l0_35
+  - id: layer_24/width_16k/average_l0_357
+    l0: 357
+    path: layer_24/width_16k/average_l0_357
+  - id: layer_24/width_16k/average_l0_73
+    l0: 73
+    path: layer_24/width_16k/average_l0_73
+  - id: layer_25/width_16k/average_l0_126
+    l0: 126
+    path: layer_25/width_16k/average_l0_126
+  - id: layer_25/width_16k/average_l0_15
+    l0: 15
+    path: layer_25/width_16k/average_l0_15
+  - id: layer_25/width_16k/average_l0_277
+    l0: 277
+    path: layer_25/width_16k/average_l0_277
+  - id: layer_25/width_16k/average_l0_29
+    l0: 29
+    path: layer_25/width_16k/average_l0_29
+  - id: layer_25/width_16k/average_l0_59
+    l0: 59
+    path: layer_25/width_16k/average_l0_59
+  - id: layer_0/width_65k/average_l0_12
+    l0: 12
+    path: layer_0/width_65k/average_l0_12
+  - id: layer_0/width_65k/average_l0_21
+    l0: 21
+    path: layer_0/width_65k/average_l0_21
+  - id: layer_0/width_65k/average_l0_39
+    l0: 39
+    path: layer_0/width_65k/average_l0_39
+  - id: layer_0/width_65k/average_l0_7
+    l0: 7
+    path: layer_0/width_65k/average_l0_7
+  - id: layer_0/width_65k/average_l0_72
+    l0: 72
+    path: layer_0/width_65k/average_l0_72
+  - id: layer_1/width_65k/average_l0_11
+    l0: 11
+    path: layer_1/width_65k/average_l0_11
+  - id: layer_1/width_65k/average_l0_127
+    l0: 127
+    path: layer_1/width_65k/average_l0_127
+  - id: layer_1/width_65k/average_l0_20
+    l0: 20
+    path: layer_1/width_65k/average_l0_20
+  - id: layer_1/width_65k/average_l0_37
+    l0: 37
+    path: layer_1/width_65k/average_l0_37
+  - id: layer_1/width_65k/average_l0_67
+    l0: 67
+    path: layer_1/width_65k/average_l0_67
+  - id: layer_2/width_65k/average_l0_134
+    l0: 134
+    path: layer_2/width_65k/average_l0_134
+  - id: layer_2/width_65k/average_l0_16
+    l0: 16
+    path: layer_2/width_65k/average_l0_16
+  - id: layer_2/width_65k/average_l0_265
+    l0: 265
+    path: layer_2/width_65k/average_l0_265
+  - id: layer_2/width_65k/average_l0_31
+    l0: 31
+    path: layer_2/width_65k/average_l0_31
+  - id: layer_2/width_65k/average_l0_60
+    l0: 60
+    path: layer_2/width_65k/average_l0_60
+  - id: layer_3/width_65k/average_l0_144
+    l0: 144
+    path: layer_3/width_65k/average_l0_144
+  - id: layer_3/width_65k/average_l0_18
+    l0: 18
+    path: layer_3/width_65k/average_l0_18
+  - id: layer_3/width_65k/average_l0_279
+    l0: 279
+    path: layer_3/width_65k/average_l0_279
+  - id: layer_3/width_65k/average_l0_33
+    l0: 33
+    path: layer_3/width_65k/average_l0_33
+  - id: layer_3/width_65k/average_l0_68
+    l0: 68
+    path: layer_3/width_65k/average_l0_68
+  - id: layer_4/width_65k/average_l0_138
+    l0: 138
+    path: layer_4/width_65k/average_l0_138
+  - id: layer_4/width_65k/average_l0_17
+    l0: 17
+    path: layer_4/width_65k/average_l0_17
+  - id: layer_4/width_65k/average_l0_299
+    l0: 299
+    path: layer_4/width_65k/average_l0_299
+  - id: layer_4/width_65k/average_l0_32
+    l0: 32
+    path: layer_4/width_65k/average_l0_32
+  - id: layer_4/width_65k/average_l0_66
+    l0: 66
+    path: layer_4/width_65k/average_l0_66
+  - id: layer_5/width_65k/average_l0_186
+    l0: 186
+    path: layer_5/width_65k/average_l0_186
+  - id: layer_5/width_65k/average_l0_22
+    l0: 22
+    path: layer_5/width_65k/average_l0_22
+  - id: layer_5/width_65k/average_l0_407
+    l0: 407
+    path: layer_5/width_65k/average_l0_407
+  - id: layer_5/width_65k/average_l0_43
+    l0: 43
+    path: layer_5/width_65k/average_l0_43
+  - id: layer_5/width_65k/average_l0_86
+    l0: 86
+    path: layer_5/width_65k/average_l0_86
+  - id: layer_6/width_65k/average_l0_101
+    l0: 101
+    path: layer_6/width_65k/average_l0_101
+  - id: layer_6/width_65k/average_l0_224
+    l0: 224
+    path: layer_6/width_65k/average_l0_224
+  - id: layer_6/width_65k/average_l0_24
+    l0: 24
+    path: layer_6/width_65k/average_l0_24
+  - id: layer_6/width_65k/average_l0_47
+    l0: 47
+    path: layer_6/width_65k/average_l0_47
+  - id: layer_6/width_65k/average_l0_515
+    l0: 515
+    path: layer_6/width_65k/average_l0_515
+  - id: layer_7/width_65k/average_l0_115
+    l0: 115
+    path: layer_7/width_65k/average_l0_115
+  - id: layer_7/width_65k/average_l0_266
+    l0: 266
+    path: layer_7/width_65k/average_l0_266
+  - id: layer_7/width_65k/average_l0_28
+    l0: 28
+    path: layer_7/width_65k/average_l0_28
+  - id: layer_7/width_65k/average_l0_56
+    l0: 56
+    path: layer_7/width_65k/average_l0_56
+  - id: layer_7/width_65k/average_l0_571
+    l0: 571
+    path: layer_7/width_65k/average_l0_571
+  - id: layer_8/width_65k/average_l0_110
+    l0: 110
+    path: layer_8/width_65k/average_l0_110
+  - id: layer_8/width_65k/average_l0_256
+    l0: 256
+    path: layer_8/width_65k/average_l0_256
+  - id: layer_8/width_65k/average_l0_31
+    l0: 31
+    path: layer_8/width_65k/average_l0_31
+  - id: layer_8/width_65k/average_l0_547
+    l0: 547
+    path: layer_8/width_65k/average_l0_547
+  - id: layer_8/width_65k/average_l0_55
+    l0: 55
+    path: layer_8/width_65k/average_l0_55
+  - id: layer_9/width_65k/average_l0_168
+    l0: 168
+    path: layer_9/width_65k/average_l0_168
+  - id: layer_9/width_65k/average_l0_38
+    l0: 38
+    path: layer_9/width_65k/average_l0_38
+  - id: layer_9/width_65k/average_l0_387
+    l0: 387
+    path: layer_9/width_65k/average_l0_387
+  - id: layer_9/width_65k/average_l0_745
+    l0: 745
+    path: layer_9/width_65k/average_l0_745
+  - id: layer_9/width_65k/average_l0_77
+    l0: 77
+    path: layer_9/width_65k/average_l0_77
+  - id: layer_10/width_65k/average_l0_218
+    l0: 218
+    path: layer_10/width_65k/average_l0_218
+  - id: layer_10/width_65k/average_l0_43
+    l0: 43
+    path: layer_10/width_65k/average_l0_43
+  - id: layer_10/width_65k/average_l0_474
+    l0: 474
+    path: layer_10/width_65k/average_l0_474
+  - id: layer_10/width_65k/average_l0_851
+    l0: 851
+    path: layer_10/width_65k/average_l0_851
+  - id: layer_10/width_65k/average_l0_95
+    l0: 95
+    path: layer_10/width_65k/average_l0_95
+  - id: layer_11/width_65k/average_l0_200
+    l0: 200
+    path: layer_11/width_65k/average_l0_200
+  - id: layer_11/width_65k/average_l0_41
+    l0: 41
+    path: layer_11/width_65k/average_l0_41
+  - id: layer_11/width_65k/average_l0_436
+    l0: 436
+    path: layer_11/width_65k/average_l0_436
+  - id: layer_11/width_65k/average_l0_771
+    l0: 771
+    path: layer_11/width_65k/average_l0_771
+  - id: layer_11/width_65k/average_l0_88
+    l0: 88
+    path: layer_11/width_65k/average_l0_88
+  - id: layer_12/width_65k/average_l0_222
+    l0: 222
+    path: layer_12/width_65k/average_l0_222
+  - id: layer_12/width_65k/average_l0_44
+    l0: 44
+    path: layer_12/width_65k/average_l0_44
+  - id: layer_12/width_65k/average_l0_482
+    l0: 482
+    path: layer_12/width_65k/average_l0_482
+  - id: layer_12/width_65k/average_l0_848
+    l0: 848
+    path: layer_12/width_65k/average_l0_848
+  - id: layer_12/width_65k/average_l0_96
+    l0: 96
+    path: layer_12/width_65k/average_l0_96
+  - id: layer_13/width_65k/average_l0_228
+    l0: 228
+    path: layer_13/width_65k/average_l0_228
+  - id: layer_13/width_65k/average_l0_44
+    l0: 44
+    path: layer_13/width_65k/average_l0_44
+  - id: layer_13/width_65k/average_l0_480
+    l0: 480
+    path: layer_13/width_65k/average_l0_480
+  - id: layer_13/width_65k/average_l0_841
+    l0: 841
+    path: layer_13/width_65k/average_l0_841
+  - id: layer_13/width_65k/average_l0_98
+    l0: 98
+    path: layer_13/width_65k/average_l0_98
+  - id: layer_14/width_65k/average_l0_204
+    l0: 204
+    path: layer_14/width_65k/average_l0_204
+  - id: layer_14/width_65k/average_l0_39
+    l0: 39
+    path: layer_14/width_65k/average_l0_39
+  - id: layer_14/width_65k/average_l0_463
+    l0: 463
+    path: layer_14/width_65k/average_l0_463
+  - id: layer_14/width_65k/average_l0_816
+    l0: 816
+    path: layer_14/width_65k/average_l0_816
+  - id: layer_14/width_65k/average_l0_89
+    l0: 89
+    path: layer_14/width_65k/average_l0_89
+  - id: layer_15/width_65k/average_l0_164
+    l0: 164
+    path: layer_15/width_65k/average_l0_164
+  - id: layer_15/width_65k/average_l0_35
+    l0: 35
+    path: layer_15/width_65k/average_l0_35
+  - id: layer_15/width_65k/average_l0_405
+    l0: 405
+    path: layer_15/width_65k/average_l0_405
+  - id: layer_15/width_65k/average_l0_72
+    l0: 72
+    path: layer_15/width_65k/average_l0_72
+  - id: layer_15/width_65k/average_l0_754
+    l0: 754
+    path: layer_15/width_65k/average_l0_754
+  - id: layer_16/width_65k/average_l0_142
+    l0: 142
+    path: layer_16/width_65k/average_l0_142
+  - id: layer_16/width_65k/average_l0_32
+    l0: 32
+    path: layer_16/width_65k/average_l0_32
+  - id: layer_16/width_65k/average_l0_348
+    l0: 348
+    path: layer_16/width_65k/average_l0_348
+  - id: layer_16/width_65k/average_l0_66
+    l0: 66
+    path: layer_16/width_65k/average_l0_66
+  - id: layer_16/width_65k/average_l0_695
+    l0: 695
+    path: layer_16/width_65k/average_l0_695
+  - id: layer_17/width_65k/average_l0_136
+    l0: 136
+    path: layer_17/width_65k/average_l0_136
+  - id: layer_17/width_65k/average_l0_30
+    l0: 30
+    path: layer_17/width_65k/average_l0_30
+  - id: layer_17/width_65k/average_l0_342
+    l0: 342
+    path: layer_17/width_65k/average_l0_342
+  - id: layer_17/width_65k/average_l0_61
+    l0: 61
+    path: layer_17/width_65k/average_l0_61
+  - id: layer_17/width_65k/average_l0_666
+    l0: 666
+    path: layer_17/width_65k/average_l0_666
+  - id: layer_18/width_65k/average_l0_191
+    l0: 191
+    path: layer_18/width_65k/average_l0_191
+  - id: layer_18/width_65k/average_l0_24
+    l0: 24
+    path: layer_18/width_65k/average_l0_24
+  - id: layer_18/width_65k/average_l0_44
+    l0: 44
+    path: layer_18/width_65k/average_l0_44
+  - id: layer_18/width_65k/average_l0_491
+    l0: 491
+    path: layer_18/width_65k/average_l0_491
+  - id: layer_18/width_65k/average_l0_88
+    l0: 88
+    path: layer_18/width_65k/average_l0_88
+  - id: layer_19/width_65k/average_l0_192
+    l0: 192
+    path: layer_19/width_65k/average_l0_192
+  - id: layer_19/width_65k/average_l0_25
+    l0: 25
+    path: layer_19/width_65k/average_l0_25
+  - id: layer_19/width_65k/average_l0_45
+    l0: 45
+    path: layer_19/width_65k/average_l0_45
+  - id: layer_19/width_65k/average_l0_470
+    l0: 470
+    path: layer_19/width_65k/average_l0_470
+  - id: layer_19/width_65k/average_l0_88
+    l0: 88
+    path: layer_19/width_65k/average_l0_88
+  - id: layer_20/width_65k/average_l0_189
+    l0: 189
+    path: layer_20/width_65k/average_l0_189
+  - id: layer_20/width_65k/average_l0_23
+    l0: 23
+    path: layer_20/width_65k/average_l0_23
+  - id: layer_20/width_65k/average_l0_44
+    l0: 44
+    path: layer_20/width_65k/average_l0_44
+  - id: layer_20/width_65k/average_l0_446
+    l0: 446
+    path: layer_20/width_65k/average_l0_446
+  - id: layer_20/width_65k/average_l0_88
+    l0: 88
+    path: layer_20/width_65k/average_l0_88
+  - id: layer_21/width_65k/average_l0_192
+    l0: 192
+    path: layer_21/width_65k/average_l0_192
+  - id: layer_21/width_65k/average_l0_23
+    l0: 23
+    path: layer_21/width_65k/average_l0_23
+  - id: layer_21/width_65k/average_l0_42
+    l0: 42
+    path: layer_21/width_65k/average_l0_42
+  - id: layer_21/width_65k/average_l0_472
+    l0: 472
+    path: layer_21/width_65k/average_l0_472
+  - id: layer_21/width_65k/average_l0_86
+    l0: 86
+    path: layer_21/width_65k/average_l0_86
+  - id: layer_22/width_65k/average_l0_203
+    l0: 203
+    path: layer_22/width_65k/average_l0_203
+  - id: layer_22/width_65k/average_l0_23
+    l0: 23
+    path: layer_22/width_65k/average_l0_23
+  - id: layer_22/width_65k/average_l0_46
+    l0: 46
+    path: layer_22/width_65k/average_l0_46
+  - id: layer_22/width_65k/average_l0_487
+    l0: 487
+    path: layer_22/width_65k/average_l0_487
+  - id: layer_22/width_65k/average_l0_92
+    l0: 92
+    path: layer_22/width_65k/average_l0_92
+  - id: layer_23/width_65k/average_l0_102
+    l0: 102
+    path: layer_23/width_65k/average_l0_102
+  - id: layer_23/width_65k/average_l0_218
+    l0: 218
+    path: layer_23/width_65k/average_l0_218
+  - id: layer_23/width_65k/average_l0_25
+    l0: 25
+    path: layer_23/width_65k/average_l0_25
+  - id: layer_23/width_65k/average_l0_49
+    l0: 49
+    path: layer_23/width_65k/average_l0_49
+  - id: layer_23/width_65k/average_l0_497
+    l0: 497
+    path: layer_23/width_65k/average_l0_497
+  - id: layer_24/width_65k/average_l0_128
+    l0: 128
+    path: layer_24/width_65k/average_l0_128
+  - id: layer_24/width_65k/average_l0_18
+    l0: 18
+    path: layer_24/width_65k/average_l0_18
+  - id: layer_24/width_65k/average_l0_268
+    l0: 268
+    path: layer_24/width_65k/average_l0_268
+  - id: layer_24/width_65k/average_l0_32
+    l0: 32
+    path: layer_24/width_65k/average_l0_32
+  - id: layer_24/width_65k/average_l0_62
+    l0: 62
+    path: layer_24/width_65k/average_l0_62
+  - id: layer_25/width_65k/average_l0_107
+    l0: 107
+    path: layer_25/width_65k/average_l0_107
+  - id: layer_25/width_65k/average_l0_14
+    l0: 14
+    path: layer_25/width_65k/average_l0_14
+  - id: layer_25/width_65k/average_l0_215
+    l0: 215
+    path: layer_25/width_65k/average_l0_215
+  - id: layer_25/width_65k/average_l0_26
+    l0: 26
+    path: layer_25/width_65k/average_l0_26
+  - id: layer_25/width_65k/average_l0_52
+    l0: 52
+    path: layer_25/width_65k/average_l0_52
+gemma-scope-2b-pt-mlp-canonical:
+  conversion_func: gemma_2
+  model: gemma-2-2b
+  repo_id: google/gemma-scope-2b-pt-mlp
+  saes:
+  - id: layer_0/width_16k/canonical
+    neuronpedia: gemma-2-2b/0-gemmascope-mlp-16k
+    path: layer_0/width_16k/average_l0_119
+  - id: layer_1/width_16k/canonical
+    neuronpedia: gemma-2-2b/1-gemmascope-mlp-16k
+    path: layer_1/width_16k/average_l0_105
+  - id: layer_2/width_16k/canonical
+    neuronpedia: gemma-2-2b/2-gemmascope-mlp-16k
+    path: layer_2/width_16k/average_l0_95
+  - id: layer_3/width_16k/canonical
+    neuronpedia: gemma-2-2b/3-gemmascope-mlp-16k
+    path: layer_3/width_16k/average_l0_95
+  - id: layer_4/width_16k/canonical
+    neuronpedia: gemma-2-2b/4-gemmascope-mlp-16k
+    path: layer_4/width_16k/average_l0_85
+  - id: layer_5/width_16k/canonical
+    neuronpedia: gemma-2-2b/5-gemmascope-mlp-16k
+    path: layer_5/width_16k/average_l0_114
+  - id: layer_6/width_16k/canonical
+    neuronpedia: gemma-2-2b/6-gemmascope-mlp-16k
+    path: layer_6/width_16k/average_l0_133
+  - id: layer_7/width_16k/canonical
+    neuronpedia: gemma-2-2b/7-gemmascope-mlp-16k
+    path: layer_7/width_16k/average_l0_60
+  - id: layer_8/width_16k/canonical
+    neuronpedia: gemma-2-2b/8-gemmascope-mlp-16k
+    path: layer_8/width_16k/average_l0_136
+  - id: layer_9/width_16k/canonical
+    neuronpedia: gemma-2-2b/9-gemmascope-mlp-16k
+    path: layer_9/width_16k/average_l0_88
+  - id: layer_10/width_16k/canonical
+    neuronpedia: gemma-2-2b/10-gemmascope-mlp-16k
+    path: layer_10/width_16k/average_l0_110
+  - id: layer_11/width_16k/canonical
+    neuronpedia: gemma-2-2b/11-gemmascope-mlp-16k
+    path: layer_11/width_16k/average_l0_98
+  - id: layer_12/width_16k/canonical
+    neuronpedia: gemma-2-2b/12-gemmascope-mlp-16k
+    path: layer_12/width_16k/average_l0_108
+  - id: layer_13/width_16k/canonical
+    neuronpedia: gemma-2-2b/13-gemmascope-mlp-16k
+    path: layer_13/width_16k/average_l0_112
+  - id: layer_14/width_16k/canonical
+    neuronpedia: gemma-2-2b/14-gemmascope-mlp-16k
+    path: layer_14/width_16k/average_l0_97
+  - id: layer_15/width_16k/canonical
+    neuronpedia: gemma-2-2b/15-gemmascope-mlp-16k
+    path: layer_15/width_16k/average_l0_80
+  - id: layer_16/width_16k/canonical
+    neuronpedia: gemma-2-2b/16-gemmascope-mlp-16k
+    path: layer_16/width_16k/average_l0_72
+  - id: layer_17/width_16k/canonical
+    neuronpedia: gemma-2-2b/17-gemmascope-mlp-16k
+    path: layer_17/width_16k/average_l0_68
+  - id: layer_18/width_16k/canonical
+    neuronpedia: gemma-2-2b/18-gemmascope-mlp-16k
+    path: layer_18/width_16k/average_l0_106
+  - id: layer_19/width_16k/canonical
+    neuronpedia: gemma-2-2b/19-gemmascope-mlp-16k
+    path: layer_19/width_16k/average_l0_109
+  - id: layer_20/width_16k/canonical
+    neuronpedia: gemma-2-2b/20-gemmascope-mlp-16k
+    path: layer_20/width_16k/average_l0_109
+  - id: layer_21/width_16k/canonical
+    neuronpedia: gemma-2-2b/21-gemmascope-mlp-16k
+    path: layer_21/width_16k/average_l0_113
+  - id: layer_22/width_16k/canonical
+    neuronpedia: gemma-2-2b/22-gemmascope-mlp-16k
+    path: layer_22/width_16k/average_l0_121
+  - id: layer_23/width_16k/canonical
+    neuronpedia: gemma-2-2b/23-gemmascope-mlp-16k
+    path: layer_23/width_16k/average_l0_128
+  - id: layer_24/width_16k/canonical
+    neuronpedia: gemma-2-2b/24-gemmascope-mlp-16k
+    path: layer_24/width_16k/average_l0_73
+  - id: layer_25/width_16k/canonical
+    neuronpedia: gemma-2-2b/25-gemmascope-mlp-16k
+    path: layer_25/width_16k/average_l0_126
+  - id: layer_0/width_65k/canonical
+    neuronpedia: gemma-2-2b/0-gemmascope-mlp-65k
+    path: layer_0/width_65k/average_l0_72
+  - id: layer_1/width_65k/canonical
+    neuronpedia: gemma-2-2b/1-gemmascope-mlp-65k
+    path: layer_1/width_65k/average_l0_127
+  - id: layer_2/width_65k/canonical
+    neuronpedia: gemma-2-2b/2-gemmascope-mlp-65k
+    path: layer_2/width_65k/average_l0_134
+  - id: layer_3/width_65k/canonical
+    neuronpedia: gemma-2-2b/3-gemmascope-mlp-65k
+    path: layer_3/width_65k/average_l0_68
+  - id: layer_4/width_65k/canonical
+    neuronpedia: gemma-2-2b/4-gemmascope-mlp-65k
+    path: layer_4/width_65k/average_l0_66
+  - id: layer_5/width_65k/canonical
+    neuronpedia: gemma-2-2b/5-gemmascope-mlp-65k
+    path: layer_5/width_65k/average_l0_86
+  - id: layer_6/width_65k/canonical
+    neuronpedia: gemma-2-2b/6-gemmascope-mlp-65k
+    path: layer_6/width_65k/average_l0_101
+  - id: layer_7/width_65k/canonical
+    neuronpedia: gemma-2-2b/7-gemmascope-mlp-65k
+    path: layer_7/width_65k/average_l0_115
+  - id: layer_8/width_65k/canonical
+    neuronpedia: gemma-2-2b/8-gemmascope-mlp-65k
+    path: layer_8/width_65k/average_l0_110
+  - id: layer_9/width_65k/canonical
+    neuronpedia: gemma-2-2b/9-gemmascope-mlp-65k
+    path: layer_9/width_65k/average_l0_77
+  - id: layer_10/width_65k/canonical
+    neuronpedia: gemma-2-2b/10-gemmascope-mlp-65k
+    path: layer_10/width_65k/average_l0_95
+  - id: layer_11/width_65k/canonical
+    neuronpedia: gemma-2-2b/11-gemmascope-mlp-65k
+    path: layer_11/width_65k/average_l0_88
+  - id: layer_12/width_65k/canonical
+    neuronpedia: gemma-2-2b/12-gemmascope-mlp-65k
+    path: layer_12/width_65k/average_l0_96
+  - id: layer_13/width_65k/canonical
+    neuronpedia: gemma-2-2b/13-gemmascope-mlp-65k
+    path: layer_13/width_65k/average_l0_98
+  - id: layer_14/width_65k/canonical
+    neuronpedia: gemma-2-2b/14-gemmascope-mlp-65k
+    path: layer_14/width_65k/average_l0_89
+  - id: layer_15/width_65k/canonical
+    neuronpedia: gemma-2-2b/15-gemmascope-mlp-65k
+    path: layer_15/width_65k/average_l0_72
+  - id: layer_16/width_65k/canonical
+    neuronpedia: gemma-2-2b/16-gemmascope-mlp-65k
+    path: layer_16/width_65k/average_l0_66
+  - id: layer_17/width_65k/canonical
+    neuronpedia: gemma-2-2b/17-gemmascope-mlp-65k
+    path: layer_17/width_65k/average_l0_136
+  - id: layer_18/width_65k/canonical
+    neuronpedia: gemma-2-2b/18-gemmascope-mlp-65k
+    path: layer_18/width_65k/average_l0_88
+  - id: layer_19/width_65k/canonical
+    neuronpedia: gemma-2-2b/19-gemmascope-mlp-65k
+    path: layer_19/width_65k/average_l0_88
+  - id: layer_20/width_65k/canonical
+    neuronpedia: gemma-2-2b/20-gemmascope-mlp-65k
+    path: layer_20/width_65k/average_l0_88
+  - id: layer_21/width_65k/canonical
+    neuronpedia: gemma-2-2b/21-gemmascope-mlp-65k
+    path: layer_21/width_65k/average_l0_86
+  - id: layer_22/width_65k/canonical
+    neuronpedia: gemma-2-2b/22-gemmascope-mlp-65k
+    path: layer_22/width_65k/average_l0_92
+  - id: layer_23/width_65k/canonical
+    neuronpedia: gemma-2-2b/23-gemmascope-mlp-65k
+    path: layer_23/width_65k/average_l0_102
+  - id: layer_24/width_65k/canonical
+    neuronpedia: gemma-2-2b/24-gemmascope-mlp-65k
+    path: layer_24/width_65k/average_l0_128
+  - id: layer_25/width_65k/canonical
+    neuronpedia: gemma-2-2b/25-gemmascope-mlp-65k
+    path: layer_25/width_65k/average_l0_107
+gemma-scope-2b-pt-res:
+  conversion_func: gemma_2
+  model: gemma-2-2b
+  repo_id: google/gemma-scope-2b-pt-res
   saes:
   - id: embedding/width_4k/average_l0_6
     path: embedding/width_4k/average_l0_6
@@ -739,3060 +2033,4804 @@ gemma-scope-2b-pt-res:
   - id: embedding/width_4k/average_l0_111
     path: embedding/width_4k/average_l0_111
   - id: layer_0/width_16k/average_l0_105
-    path: layer_0/width_16k/average_l0_105
     l0: 105
+    path: layer_0/width_16k/average_l0_105
   - id: layer_0/width_16k/average_l0_13
+    l0: 13
     path: layer_0/width_16k/average_l0_13
-    l0: 13
   - id: layer_0/width_16k/average_l0_226
-    path: layer_0/width_16k/average_l0_226
     l0: 226
+    path: layer_0/width_16k/average_l0_226
   - id: layer_0/width_16k/average_l0_25
-    path: layer_0/width_16k/average_l0_25
     l0: 25
+    path: layer_0/width_16k/average_l0_25
   - id: layer_0/width_16k/average_l0_46
-    path: layer_0/width_16k/average_l0_46
     l0: 46
+    path: layer_0/width_16k/average_l0_46
   - id: layer_1/width_16k/average_l0_10
-    path: layer_1/width_16k/average_l0_10
     l0: 10
+    path: layer_1/width_16k/average_l0_10
   - id: layer_1/width_16k/average_l0_102
-    path: layer_1/width_16k/average_l0_102
     l0: 102
+    path: layer_1/width_16k/average_l0_102
   - id: layer_1/width_16k/average_l0_20
-    path: layer_1/width_16k/average_l0_20
     l0: 20
+    path: layer_1/width_16k/average_l0_20
   - id: layer_1/width_16k/average_l0_250
-    path: layer_1/width_16k/average_l0_250
     l0: 250
+    path: layer_1/width_16k/average_l0_250
   - id: layer_1/width_16k/average_l0_40
-    path: layer_1/width_16k/average_l0_40
     l0: 40
+    path: layer_1/width_16k/average_l0_40
   - id: layer_2/width_16k/average_l0_13
-    path: layer_2/width_16k/average_l0_13
     l0: 13
+    path: layer_2/width_16k/average_l0_13
   - id: layer_2/width_16k/average_l0_141
-    path: layer_2/width_16k/average_l0_141
     l0: 141
+    path: layer_2/width_16k/average_l0_141
   - id: layer_2/width_16k/average_l0_142
+    l0: 142
     path: layer_2/width_16k/average_l0_142
-    l0: 142
   - id: layer_2/width_16k/average_l0_24
-    path: layer_2/width_16k/average_l0_24
     l0: 24
+    path: layer_2/width_16k/average_l0_24
   - id: layer_2/width_16k/average_l0_304
-    path: layer_2/width_16k/average_l0_304
     l0: 304
+    path: layer_2/width_16k/average_l0_304
   - id: layer_2/width_16k/average_l0_53
-    path: layer_2/width_16k/average_l0_53
     l0: 53
+    path: layer_2/width_16k/average_l0_53
   - id: layer_3/width_16k/average_l0_14
-    path: layer_3/width_16k/average_l0_14
     l0: 14
+    path: layer_3/width_16k/average_l0_14
   - id: layer_3/width_16k/average_l0_142
-    path: layer_3/width_16k/average_l0_142
     l0: 142
+    path: layer_3/width_16k/average_l0_142
   - id: layer_3/width_16k/average_l0_28
-    path: layer_3/width_16k/average_l0_28
     l0: 28
+    path: layer_3/width_16k/average_l0_28
   - id: layer_3/width_16k/average_l0_315
-    path: layer_3/width_16k/average_l0_315
     l0: 315
+    path: layer_3/width_16k/average_l0_315
   - id: layer_3/width_16k/average_l0_59
-    path: layer_3/width_16k/average_l0_59
     l0: 59
+    path: layer_3/width_16k/average_l0_59
   - id: layer_4/width_16k/average_l0_124
-    path: layer_4/width_16k/average_l0_124
     l0: 124
+    path: layer_4/width_16k/average_l0_124
   - id: layer_4/width_16k/average_l0_125
-    path: layer_4/width_16k/average_l0_125
     l0: 125
+    path: layer_4/width_16k/average_l0_125
   - id: layer_4/width_16k/average_l0_17
-    path: layer_4/width_16k/average_l0_17
     l0: 17
+    path: layer_4/width_16k/average_l0_17
   - id: layer_4/width_16k/average_l0_281
-    path: layer_4/width_16k/average_l0_281
     l0: 281
+    path: layer_4/width_16k/average_l0_281
   - id: layer_4/width_16k/average_l0_31
-    path: layer_4/width_16k/average_l0_31
     l0: 31
+    path: layer_4/width_16k/average_l0_31
   - id: layer_4/width_16k/average_l0_60
-    path: layer_4/width_16k/average_l0_60
     l0: 60
+    path: layer_4/width_16k/average_l0_60
   - id: layer_5/width_16k/average_l0_143
-    path: layer_5/width_16k/average_l0_143
     l0: 143
     neuronpedia: gemma-2-2b/5-gemmascope-res-16k__l0-143
+    path: layer_5/width_16k/average_l0_143
   - id: layer_5/width_16k/average_l0_18
-    path: layer_5/width_16k/average_l0_18
     l0: 18
     neuronpedia: gemma-2-2b/5-gemmascope-res-16k__l0-18
+    path: layer_5/width_16k/average_l0_18
   - id: layer_5/width_16k/average_l0_309
-    path: layer_5/width_16k/average_l0_309
     l0: 309
     neuronpedia: gemma-2-2b/5-gemmascope-res-16k__l0-309
+    path: layer_5/width_16k/average_l0_309
   - id: layer_5/width_16k/average_l0_34
-    path: layer_5/width_16k/average_l0_34
     l0: 34
     neuronpedia: gemma-2-2b/5-gemmascope-res-16k__l0-34
+    path: layer_5/width_16k/average_l0_34
   - id: layer_5/width_16k/average_l0_68
-    path: layer_5/width_16k/average_l0_68
     l0: 68
+    path: layer_5/width_16k/average_l0_68
   - id: layer_6/width_16k/average_l0_144
-    path: layer_6/width_16k/average_l0_144
     l0: 144
+    path: layer_6/width_16k/average_l0_144
   - id: layer_6/width_16k/average_l0_19
-    path: layer_6/width_16k/average_l0_19
     l0: 19
+    path: layer_6/width_16k/average_l0_19
   - id: layer_6/width_16k/average_l0_301
+    l0: 301
     path: layer_6/width_16k/average_l0_301
-    l0: 301
   - id: layer_6/width_16k/average_l0_36
+    l0: 36
     path: layer_6/width_16k/average_l0_36
-    l0: 36
   - id: layer_6/width_16k/average_l0_70
-    path: layer_6/width_16k/average_l0_70
     l0: 70
+    path: layer_6/width_16k/average_l0_70
   - id: layer_7/width_16k/average_l0_137
-    path: layer_7/width_16k/average_l0_137
     l0: 137
+    path: layer_7/width_16k/average_l0_137
   - id: layer_7/width_16k/average_l0_20
+    l0: 20
     path: layer_7/width_16k/average_l0_20
-    l0: 20
   - id: layer_7/width_16k/average_l0_285
-    path: layer_7/width_16k/average_l0_285
     l0: 285
+    path: layer_7/width_16k/average_l0_285
   - id: layer_7/width_16k/average_l0_36
-    path: layer_7/width_16k/average_l0_36
     l0: 36
+    path: layer_7/width_16k/average_l0_36
   - id: layer_7/width_16k/average_l0_69
-    path: layer_7/width_16k/average_l0_69
     l0: 69
+    path: layer_7/width_16k/average_l0_69
   - id: layer_8/width_16k/average_l0_142
-    path: layer_8/width_16k/average_l0_142
     l0: 142
+    path: layer_8/width_16k/average_l0_142
   - id: layer_8/width_16k/average_l0_20
-    path: layer_8/width_16k/average_l0_20
     l0: 20
+    path: layer_8/width_16k/average_l0_20
   - id: layer_8/width_16k/average_l0_301
-    path: layer_8/width_16k/average_l0_301
     l0: 301
+    path: layer_8/width_16k/average_l0_301
   - id: layer_8/width_16k/average_l0_37
+    l0: 37
     path: layer_8/width_16k/average_l0_37
-    l0: 37
   - id: layer_8/width_16k/average_l0_71
-    path: layer_8/width_16k/average_l0_71
     l0: 71
+    path: layer_8/width_16k/average_l0_71
   - id: layer_9/width_16k/average_l0_151
-    path: layer_9/width_16k/average_l0_151
     l0: 151
+    path: layer_9/width_16k/average_l0_151
   - id: layer_9/width_16k/average_l0_21
+    l0: 21
     path: layer_9/width_16k/average_l0_21
-    l0: 21
   - id: layer_9/width_16k/average_l0_340
-    path: layer_9/width_16k/average_l0_340
     l0: 340
+    path: layer_9/width_16k/average_l0_340
   - id: layer_9/width_16k/average_l0_37
-    path: layer_9/width_16k/average_l0_37
     l0: 37
+    path: layer_9/width_16k/average_l0_37
   - id: layer_9/width_16k/average_l0_73
-    path: layer_9/width_16k/average_l0_73
     l0: 73
+    path: layer_9/width_16k/average_l0_73
   - id: layer_10/width_16k/average_l0_166
-    path: layer_10/width_16k/average_l0_166
     l0: 166
+    path: layer_10/width_16k/average_l0_166
   - id: layer_10/width_16k/average_l0_21
-    path: layer_10/width_16k/average_l0_21
     l0: 21
+    path: layer_10/width_16k/average_l0_21
   - id: layer_10/width_16k/average_l0_39
-    path: layer_10/width_16k/average_l0_39
     l0: 39
+    path: layer_10/width_16k/average_l0_39
   - id: layer_10/width_16k/average_l0_395
-    path: layer_10/width_16k/average_l0_395
     l0: 395
+    path: layer_10/width_16k/average_l0_395
   - id: layer_10/width_16k/average_l0_77
+    l0: 77
     path: layer_10/width_16k/average_l0_77
-    l0: 77
   - id: layer_11/width_16k/average_l0_168
-    path: layer_11/width_16k/average_l0_168
     l0: 168
+    path: layer_11/width_16k/average_l0_168
   - id: layer_11/width_16k/average_l0_22
+    l0: 22
     path: layer_11/width_16k/average_l0_22
-    l0: 22
   - id: layer_11/width_16k/average_l0_393
-    path: layer_11/width_16k/average_l0_393
     l0: 393
+    path: layer_11/width_16k/average_l0_393
   - id: layer_11/width_16k/average_l0_41
+    l0: 41
     path: layer_11/width_16k/average_l0_41
-    l0: 41
   - id: layer_11/width_16k/average_l0_80
-    path: layer_11/width_16k/average_l0_80
     l0: 80
+    path: layer_11/width_16k/average_l0_80
   - id: layer_12/width_16k/average_l0_176
-    path: layer_12/width_16k/average_l0_176
-    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-176
     l0: 176
+    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-176
+    path: layer_12/width_16k/average_l0_176
   - id: layer_12/width_16k/average_l0_22
-    path: layer_12/width_16k/average_l0_22
-    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-22
     l0: 22
+    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-22
+    path: layer_12/width_16k/average_l0_22
   - id: layer_12/width_16k/average_l0_41
-    path: layer_12/width_16k/average_l0_41
+    l0: 41
     neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-41
-    l0: 41
+    path: layer_12/width_16k/average_l0_41
   - id: layer_12/width_16k/average_l0_445
-    path: layer_12/width_16k/average_l0_445
-    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-445
     l0: 445
+    neuronpedia: gemma-2-2b/12-gemmascope-res-16k__l0-445
+    path: layer_12/width_16k/average_l0_445
   - id: layer_12/width_16k/average_l0_82
-    path: layer_12/width_16k/average_l0_82
     l0: 82
+    path: layer_12/width_16k/average_l0_82
   - id: layer_13/width_16k/average_l0_173
+    l0: 173
     path: layer_13/width_16k/average_l0_173
-    l0: 173
   - id: layer_13/width_16k/average_l0_23
+    l0: 23
     path: layer_13/width_16k/average_l0_23
-    l0: 23
   - id: layer_13/width_16k/average_l0_403
-    path: layer_13/width_16k/average_l0_403
     l0: 403
+    path: layer_13/width_16k/average_l0_403
   - id: layer_13/width_16k/average_l0_43
+    l0: 43
     path: layer_13/width_16k/average_l0_43
-    l0: 43
   - id: layer_13/width_16k/average_l0_83
+    l0: 83
     path: layer_13/width_16k/average_l0_83
-    l0: 83
   - id: layer_13/width_16k/average_l0_84
+    l0: 84
     path: layer_13/width_16k/average_l0_84
-    l0: 84
   - id: layer_14/width_16k/average_l0_173
-    path: layer_14/width_16k/average_l0_173
     l0: 173
+    path: layer_14/width_16k/average_l0_173
   - id: layer_14/width_16k/average_l0_23
+    l0: 23
     path: layer_14/width_16k/average_l0_23
-    l0: 23
   - id: layer_14/width_16k/average_l0_388
-    path: layer_14/width_16k/average_l0_388
     l0: 388
+    path: layer_14/width_16k/average_l0_388
   - id: layer_14/width_16k/average_l0_43
-    path: layer_14/width_16k/average_l0_43
     l0: 43
+    path: layer_14/width_16k/average_l0_43
   - id: layer_14/width_16k/average_l0_83
-    path: layer_14/width_16k/average_l0_83
     l0: 83
+    path: layer_14/width_16k/average_l0_83
   - id: layer_14/width_16k/average_l0_84
-    path: layer_14/width_16k/average_l0_84
     l0: 84
+    path: layer_14/width_16k/average_l0_84
   - id: layer_15/width_16k/average_l0_150
+    l0: 150
     path: layer_15/width_16k/average_l0_150
-    l0: 150
   - id: layer_15/width_16k/average_l0_23
+    l0: 23
     path: layer_15/width_16k/average_l0_23
-    l0: 23
   - id: layer_15/width_16k/average_l0_308
-    path: layer_15/width_16k/average_l0_308
     l0: 308
+    path: layer_15/width_16k/average_l0_308
   - id: layer_15/width_16k/average_l0_41
-    path: layer_15/width_16k/average_l0_41
     l0: 41
+    path: layer_15/width_16k/average_l0_41
   - id: layer_15/width_16k/average_l0_78
+    l0: 78
     path: layer_15/width_16k/average_l0_78
-    l0: 78
   - id: layer_16/width_16k/average_l0_154
-    path: layer_16/width_16k/average_l0_154
     l0: 154
+    path: layer_16/width_16k/average_l0_154
   - id: layer_16/width_16k/average_l0_23
+    l0: 23
     path: layer_16/width_16k/average_l0_23
-    l0: 23
   - id: layer_16/width_16k/average_l0_335
-    path: layer_16/width_16k/average_l0_335
     l0: 335
+    path: layer_16/width_16k/average_l0_335
   - id: layer_16/width_16k/average_l0_42
+    l0: 42
     path: layer_16/width_16k/average_l0_42
-    l0: 42
   - id: layer_16/width_16k/average_l0_78
-    path: layer_16/width_16k/average_l0_78
     l0: 78
+    path: layer_16/width_16k/average_l0_78
   - id: layer_17/width_16k/average_l0_150
-    path: layer_17/width_16k/average_l0_150
     l0: 150
+    path: layer_17/width_16k/average_l0_150
   - id: layer_17/width_16k/average_l0_23
+    l0: 23
     path: layer_17/width_16k/average_l0_23
-    l0: 23
   - id: layer_17/width_16k/average_l0_304
-    path: layer_17/width_16k/average_l0_304
     l0: 304
+    path: layer_17/width_16k/average_l0_304
   - id: layer_17/width_16k/average_l0_42
-    path: layer_17/width_16k/average_l0_42
     l0: 42
+    path: layer_17/width_16k/average_l0_42
   - id: layer_17/width_16k/average_l0_77
-    path: layer_17/width_16k/average_l0_77
     l0: 77
+    path: layer_17/width_16k/average_l0_77
   - id: layer_18/width_16k/average_l0_138
-    path: layer_18/width_16k/average_l0_138
     l0: 138
+    path: layer_18/width_16k/average_l0_138
   - id: layer_18/width_16k/average_l0_23
-    path: layer_18/width_16k/average_l0_23
     l0: 23
+    path: layer_18/width_16k/average_l0_23
   - id: layer_18/width_16k/average_l0_280
-    path: layer_18/width_16k/average_l0_280
     l0: 280
+    path: layer_18/width_16k/average_l0_280
   - id: layer_18/width_16k/average_l0_40
-    path: layer_18/width_16k/average_l0_40
     l0: 40
+    path: layer_18/width_16k/average_l0_40
   - id: layer_18/width_16k/average_l0_74
-    path: layer_18/width_16k/average_l0_74
     l0: 74
+    path: layer_18/width_16k/average_l0_74
   - id: layer_19/width_16k/average_l0_137
-    path: layer_19/width_16k/average_l0_137
     l0: 137
     neuronpedia: gemma-2-2b/19-gemmascope-res-16k__l0-137
+    path: layer_19/width_16k/average_l0_137
   - id: layer_19/width_16k/average_l0_23
-    path: layer_19/width_16k/average_l0_23
     l0: 23
     neuronpedia: gemma-2-2b/19-gemmascope-res-16k__l0-23
+    path: layer_19/width_16k/average_l0_23
   - id: layer_19/width_16k/average_l0_279
-    path: layer_19/width_16k/average_l0_279
     l0: 279
     neuronpedia: gemma-2-2b/19-gemmascope-res-16k__l0-279
+    path: layer_19/width_16k/average_l0_279
   - id: layer_19/width_16k/average_l0_40
-    path: layer_19/width_16k/average_l0_40
     l0: 40
     neuronpedia: gemma-2-2b/19-gemmascope-res-16k__l0-40
+    path: layer_19/width_16k/average_l0_40
   - id: layer_19/width_16k/average_l0_73
+    l0: 73
     path: layer_19/width_16k/average_l0_73
-    l0: 73
   - id: layer_20/width_16k/average_l0_139
+    l0: 139
     path: layer_20/width_16k/average_l0_139
-    l0: 139
   - id: layer_20/width_16k/average_l0_22
+    l0: 22
     path: layer_20/width_16k/average_l0_22
-    l0: 22
   - id: layer_20/width_16k/average_l0_294
-    path: layer_20/width_16k/average_l0_294
     l0: 294
+    path: layer_20/width_16k/average_l0_294
   - id: layer_20/width_16k/average_l0_38
+    l0: 38
     path: layer_20/width_16k/average_l0_38
-    l0: 38
   - id: layer_20/width_16k/average_l0_71
-    path: layer_20/width_16k/average_l0_71
     l0: 71
+    path: layer_20/width_16k/average_l0_71
   - id: layer_21/width_16k/average_l0_139
-    path: layer_21/width_16k/average_l0_139
     l0: 139
+    path: layer_21/width_16k/average_l0_139
   - id: layer_21/width_16k/average_l0_22
-    path: layer_21/width_16k/average_l0_22
     l0: 22
+    path: layer_21/width_16k/average_l0_22
   - id: layer_21/width_16k/average_l0_301
-    path: layer_21/width_16k/average_l0_301
     l0: 301
+    path: layer_21/width_16k/average_l0_301
   - id: layer_21/width_16k/average_l0_38
+    l0: 38
     path: layer_21/width_16k/average_l0_38
-    l0: 38
   - id: layer_21/width_16k/average_l0_70
-    path: layer_21/width_16k/average_l0_70
     l0: 70
+    path: layer_21/width_16k/average_l0_70
   - id: layer_22/width_16k/average_l0_147
-    path: layer_22/width_16k/average_l0_147
     l0: 147
+    path: layer_22/width_16k/average_l0_147
   - id: layer_22/width_16k/average_l0_21
+    l0: 21
     path: layer_22/width_16k/average_l0_21
-    l0: 21
   - id: layer_22/width_16k/average_l0_349
-    path: layer_22/width_16k/average_l0_349
     l0: 349
+    path: layer_22/width_16k/average_l0_349
   - id: layer_22/width_16k/average_l0_38
+    l0: 38
     path: layer_22/width_16k/average_l0_38
-    l0: 38
   - id: layer_22/width_16k/average_l0_72
-    path: layer_22/width_16k/average_l0_72
     l0: 72
+    path: layer_22/width_16k/average_l0_72
   - id: layer_23/width_16k/average_l0_157
-    path: layer_23/width_16k/average_l0_157
     l0: 157
+    path: layer_23/width_16k/average_l0_157
   - id: layer_23/width_16k/average_l0_21
-    path: layer_23/width_16k/average_l0_21
     l0: 21
+    path: layer_23/width_16k/average_l0_21
   - id: layer_23/width_16k/average_l0_38
+    l0: 38
     path: layer_23/width_16k/average_l0_38
-    l0: 38
   - id: layer_23/width_16k/average_l0_404
-    path: layer_23/width_16k/average_l0_404
     l0: 404
+    path: layer_23/width_16k/average_l0_404
   - id: layer_23/width_16k/average_l0_74
-    path: layer_23/width_16k/average_l0_74
     l0: 74
+    path: layer_23/width_16k/average_l0_74
   - id: layer_23/width_16k/average_l0_75
-    path: layer_23/width_16k/average_l0_75
     l0: 75
+    path: layer_23/width_16k/average_l0_75
   - id: layer_24/width_16k/average_l0_158
-    path: layer_24/width_16k/average_l0_158
     l0: 158
+    path: layer_24/width_16k/average_l0_158
   - id: layer_24/width_16k/average_l0_20
-    path: layer_24/width_16k/average_l0_20
     l0: 20
+    path: layer_24/width_16k/average_l0_20
   - id: layer_24/width_16k/average_l0_38
-    path: layer_24/width_16k/average_l0_38
     l0: 38
+    path: layer_24/width_16k/average_l0_38
   - id: layer_24/width_16k/average_l0_457
-    path: layer_24/width_16k/average_l0_457
     l0: 457
+    path: layer_24/width_16k/average_l0_457
   - id: layer_24/width_16k/average_l0_73
-    path: layer_24/width_16k/average_l0_73
     l0: 73
+    path: layer_24/width_16k/average_l0_73
   - id: layer_25/width_16k/average_l0_116
-    path: layer_25/width_16k/average_l0_116
     l0: 116
+    path: layer_25/width_16k/average_l0_116
   - id: layer_25/width_16k/average_l0_16
-    path: layer_25/width_16k/average_l0_16
     l0: 16
+    path: layer_25/width_16k/average_l0_16
   - id: layer_25/width_16k/average_l0_28
-    path: layer_25/width_16k/average_l0_28
     l0: 28
+    path: layer_25/width_16k/average_l0_28
   - id: layer_25/width_16k/average_l0_285
-    path: layer_25/width_16k/average_l0_285
     l0: 285
+    path: layer_25/width_16k/average_l0_285
   - id: layer_25/width_16k/average_l0_55
-    path: layer_25/width_16k/average_l0_55
     l0: 55
+    path: layer_25/width_16k/average_l0_55
   - id: layer_5/width_1m/average_l0_114
-    path: layer_5/width_1m/average_l0_114
     l0: 114
     neuronpedia: gemma-2-2b/5-gemmascope-res-1m__l0-114
+    path: layer_5/width_1m/average_l0_114
   - id: layer_5/width_1m/average_l0_13
-    path: layer_5/width_1m/average_l0_13
     l0: 13
     neuronpedia: gemma-2-2b/5-gemmascope-res-1m__l0-13
+    path: layer_5/width_1m/average_l0_13
   - id: layer_5/width_1m/average_l0_21
-    path: layer_5/width_1m/average_l0_21
     l0: 21
     neuronpedia: gemma-2-2b/5-gemmascope-res-1m__l0-21
+    path: layer_5/width_1m/average_l0_21
   - id: layer_5/width_1m/average_l0_36
-    path: layer_5/width_1m/average_l0_36
     l0: 36
     neuronpedia: gemma-2-2b/5-gemmascope-res-1m__l0-36
+    path: layer_5/width_1m/average_l0_36
   - id: layer_5/width_1m/average_l0_63
-    path: layer_5/width_1m/average_l0_63
     l0: 63
     neuronpedia: gemma-2-2b/5-gemmascope-res-1m__l0-63
+    path: layer_5/width_1m/average_l0_63
   - id: layer_5/width_1m/average_l0_9
-    path: layer_5/width_1m/average_l0_9
     l0: 9
     neuronpedia: gemma-2-2b/5-gemmascope-res-1m__l0-9
+    path: layer_5/width_1m/average_l0_9
   - id: layer_12/width_1m/average_l0_107
-    path: layer_12/width_1m/average_l0_107
     l0: 107
+    path: layer_12/width_1m/average_l0_107
   - id: layer_12/width_1m/average_l0_19
-    path: layer_12/width_1m/average_l0_19
     l0: 19
     neuronpedia: gemma-2-2b/12-gemmascope-res-1m__l0-19
+    path: layer_12/width_1m/average_l0_19
   - id: layer_12/width_1m/average_l0_207
-    path: layer_12/width_1m/average_l0_207
     l0: 207
     neuronpedia: gemma-2-2b/12-gemmascope-res-1m__l0-207
+    path: layer_12/width_1m/average_l0_207
   - id: layer_12/width_1m/average_l0_26
-    path: layer_12/width_1m/average_l0_26
     l0: 26
     neuronpedia: gemma-2-2b/12-gemmascope-res-1m__l0-26
+    path: layer_12/width_1m/average_l0_26
   - id: layer_12/width_1m/average_l0_58
-    path: layer_12/width_1m/average_l0_58
     l0: 58
     neuronpedia: gemma-2-2b/12-gemmascope-res-1m__l0-58
+    path: layer_12/width_1m/average_l0_58
   - id: layer_12/width_1m/average_l0_73
-    path: layer_12/width_1m/average_l0_73
     l0: 73
     neuronpedia: gemma-2-2b/12-gemmascope-res-1m__l0-73
+    path: layer_12/width_1m/average_l0_73
   - id: layer_19/width_1m/average_l0_157
-    path: layer_19/width_1m/average_l0_157
     l0: 157
     neuronpedia: gemma-2-2b/19-gemmascope-res-1m__l0-157
+    path: layer_19/width_1m/average_l0_157
   - id: layer_19/width_1m/average_l0_16
-    path: layer_19/width_1m/average_l0_16
     l0: 16
     neuronpedia: gemma-2-2b/19-gemmascope-res-1m__l0-16
+    path: layer_19/width_1m/average_l0_16
   - id: layer_19/width_1m/average_l0_18
-    path: layer_19/width_1m/average_l0_18
     l0: 18
     neuronpedia: gemma-2-2b/19-gemmascope-res-1m__l0-18
+    path: layer_19/width_1m/average_l0_18
   - id: layer_19/width_1m/average_l0_29
-    path: layer_19/width_1m/average_l0_29
     l0: 29
     neuronpedia: gemma-2-2b/19-gemmascope-res-1m__l0-29
+    path: layer_19/width_1m/average_l0_29
   - id: layer_19/width_1m/average_l0_50
-    path: layer_19/width_1m/average_l0_50
     l0: 50
     neuronpedia: gemma-2-2b/19-gemmascope-res-1m__l0-50
+    path: layer_19/width_1m/average_l0_50
   - id: layer_19/width_1m/average_l0_88
-    path: layer_19/width_1m/average_l0_88
     l0: 88
+    path: layer_19/width_1m/average_l0_88
   - id: layer_12/width_262k/average_l0_11
+    l0: 11
     path: layer_12/width_262k/average_l0_11
-    l0: 11
   - id: layer_12/width_262k/average_l0_121
+    l0: 121
     path: layer_12/width_262k/average_l0_121
-    l0: 121
   - id: layer_12/width_262k/average_l0_21
-    path: layer_12/width_262k/average_l0_21
     l0: 21
+    path: layer_12/width_262k/average_l0_21
   - id: layer_12/width_262k/average_l0_243
-    path: layer_12/width_262k/average_l0_243
     l0: 243
+    path: layer_12/width_262k/average_l0_243
   - id: layer_12/width_262k/average_l0_36
+    l0: 36
     path: layer_12/width_262k/average_l0_36
-    l0: 36
   - id: layer_12/width_262k/average_l0_67
+    l0: 67
     path: layer_12/width_262k/average_l0_67
-    l0: 67
   - id: layer_12/width_32k/average_l0_12
+    l0: 12
     path: layer_12/width_32k/average_l0_12
-    l0: 12
   - id: layer_12/width_32k/average_l0_155
-    path: layer_12/width_32k/average_l0_155
     l0: 155
+    path: layer_12/width_32k/average_l0_155
   - id: layer_12/width_32k/average_l0_22
+    l0: 22
     path: layer_12/width_32k/average_l0_22
-    l0: 22
   - id: layer_12/width_32k/average_l0_360
-    path: layer_12/width_32k/average_l0_360
     l0: 360
+    path: layer_12/width_32k/average_l0_360
   - id: layer_12/width_32k/average_l0_40
-    path: layer_12/width_32k/average_l0_40
     l0: 40
+    path: layer_12/width_32k/average_l0_40
   - id: layer_12/width_32k/average_l0_76
-    path: layer_12/width_32k/average_l0_76
     l0: 76
+    path: layer_12/width_32k/average_l0_76
   - id: layer_12/width_524k/average_l0_115
-    path: layer_12/width_524k/average_l0_115
     l0: 115
+    path: layer_12/width_524k/average_l0_115
   - id: layer_12/width_524k/average_l0_22
-    path: layer_12/width_524k/average_l0_22
     l0: 22
+    path: layer_12/width_524k/average_l0_22
   - id: layer_12/width_524k/average_l0_227
-    path: layer_12/width_524k/average_l0_227
     l0: 227
+    path: layer_12/width_524k/average_l0_227
   - id: layer_12/width_524k/average_l0_29
-    path: layer_12/width_524k/average_l0_29
     l0: 29
+    path: layer_12/width_524k/average_l0_29
   - id: layer_12/width_524k/average_l0_46
+    l0: 46
     path: layer_12/width_524k/average_l0_46
-    l0: 46
   - id: layer_12/width_524k/average_l0_65
-    path: layer_12/width_524k/average_l0_65
     l0: 65
+    path: layer_12/width_524k/average_l0_65
   - id: layer_12/width_131k/average_l0_12
-    path: layer_12/width_131k/average_l0_12
     l0: 12
+    path: layer_12/width_131k/average_l0_12
   - id: layer_12/width_131k/average_l0_129
-    path: layer_12/width_131k/average_l0_129
     l0: 129
+    path: layer_12/width_131k/average_l0_129
   - id: layer_12/width_131k/average_l0_20
+    l0: 20
     path: layer_12/width_131k/average_l0_20
-    l0: 20
   - id: layer_12/width_131k/average_l0_264
-    path: layer_12/width_131k/average_l0_264
     l0: 264
+    path: layer_12/width_131k/average_l0_264
   - id: layer_12/width_131k/average_l0_36
-    path: layer_12/width_131k/average_l0_36
     l0: 36
+    path: layer_12/width_131k/average_l0_36
   - id: layer_12/width_131k/average_l0_67
-    path: layer_12/width_131k/average_l0_67
     l0: 67
+    path: layer_12/width_131k/average_l0_67
   - id: layer_0/width_65k/average_l0_11
+    l0: 11
     path: layer_0/width_65k/average_l0_11
-    l0: 11
   - id: layer_0/width_65k/average_l0_17
-    path: layer_0/width_65k/average_l0_17
     l0: 17
+    path: layer_0/width_65k/average_l0_17
   - id: layer_0/width_65k/average_l0_27
-    path: layer_0/width_65k/average_l0_27
     l0: 27
+    path: layer_0/width_65k/average_l0_27
   - id: layer_0/width_65k/average_l0_43
-    path: layer_0/width_65k/average_l0_43
     l0: 43
+    path: layer_0/width_65k/average_l0_43
   - id: layer_0/width_65k/average_l0_73
-    path: layer_0/width_65k/average_l0_73
     l0: 73
+    path: layer_0/width_65k/average_l0_73
   - id: layer_1/width_65k/average_l0_121
-    path: layer_1/width_65k/average_l0_121
     l0: 121
+    path: layer_1/width_65k/average_l0_121
   - id: layer_1/width_65k/average_l0_16
-    path: layer_1/width_65k/average_l0_16
     l0: 16
+    path: layer_1/width_65k/average_l0_16
   - id: layer_1/width_65k/average_l0_30
-    path: layer_1/width_65k/average_l0_30
     l0: 30
+    path: layer_1/width_65k/average_l0_30
   - id: layer_1/width_65k/average_l0_54
-    path: layer_1/width_65k/average_l0_54
     l0: 54
+    path: layer_1/width_65k/average_l0_54
   - id: layer_1/width_65k/average_l0_9
-    path: layer_1/width_65k/average_l0_9
     l0: 9
+    path: layer_1/width_65k/average_l0_9
   - id: layer_2/width_65k/average_l0_11
-    path: layer_2/width_65k/average_l0_11
     l0: 11
+    path: layer_2/width_65k/average_l0_11
   - id: layer_2/width_65k/average_l0_169
-    path: layer_2/width_65k/average_l0_169
     l0: 169
+    path: layer_2/width_65k/average_l0_169
   - id: layer_2/width_65k/average_l0_20
-    path: layer_2/width_65k/average_l0_20
     l0: 20
+    path: layer_2/width_65k/average_l0_20
   - id: layer_2/width_65k/average_l0_37
-    path: layer_2/width_65k/average_l0_37
     l0: 37
+    path: layer_2/width_65k/average_l0_37
   - id: layer_2/width_65k/average_l0_77
-    path: layer_2/width_65k/average_l0_77
     l0: 77
+    path: layer_2/width_65k/average_l0_77
   - id: layer_3/width_65k/average_l0_13
-    path: layer_3/width_65k/average_l0_13
     l0: 13
+    path: layer_3/width_65k/average_l0_13
   - id: layer_3/width_65k/average_l0_193
-    path: layer_3/width_65k/average_l0_193
     l0: 193
+    path: layer_3/width_65k/average_l0_193
   - id: layer_3/width_65k/average_l0_23
-    path: layer_3/width_65k/average_l0_23
     l0: 23
+    path: layer_3/width_65k/average_l0_23
   - id: layer_3/width_65k/average_l0_42
-    path: layer_3/width_65k/average_l0_42
     l0: 42
+    path: layer_3/width_65k/average_l0_42
   - id: layer_3/width_65k/average_l0_89
+    l0: 89
     path: layer_3/width_65k/average_l0_89
-    l0: 89
   - id: layer_4/width_65k/average_l0_14
-    path: layer_4/width_65k/average_l0_14
     l0: 14
+    path: layer_4/width_65k/average_l0_14
   - id: layer_4/width_65k/average_l0_177
-    path: layer_4/width_65k/average_l0_177
     l0: 177
+    path: layer_4/width_65k/average_l0_177
   - id: layer_4/width_65k/average_l0_25
-    path: layer_4/width_65k/average_l0_25
     l0: 25
+    path: layer_4/width_65k/average_l0_25
   - id: layer_4/width_65k/average_l0_46
-    path: layer_4/width_65k/average_l0_46
     l0: 46
+    path: layer_4/width_65k/average_l0_46
   - id: layer_4/width_65k/average_l0_89
-    path: layer_4/width_65k/average_l0_89
     l0: 89
+    path: layer_4/width_65k/average_l0_89
   - id: layer_5/width_65k/average_l0_105
-    path: layer_5/width_65k/average_l0_105
     l0: 105
+    path: layer_5/width_65k/average_l0_105
   - id: layer_5/width_65k/average_l0_17
-    path: layer_5/width_65k/average_l0_17
     l0: 17
     neuronpedia: gemma-2-2b/5-gemmascope-res-65k__l0-17
+    path: layer_5/width_65k/average_l0_17
   - id: layer_5/width_65k/average_l0_211
-    path: layer_5/width_65k/average_l0_211
     l0: 211
     neuronpedia: gemma-2-2b/5-gemmascope-res-65k__l0-211
+    path: layer_5/width_65k/average_l0_211
   - id: layer_5/width_65k/average_l0_29
-    path: layer_5/width_65k/average_l0_29
     l0: 29
     neuronpedia: gemma-2-2b/5-gemmascope-res-65k__l0-29
+    path: layer_5/width_65k/average_l0_29
   - id: layer_5/width_65k/average_l0_53
-    path: layer_5/width_65k/average_l0_53
     l0: 53
     neuronpedia: gemma-2-2b/5-gemmascope-res-65k__l0-53
+    path: layer_5/width_65k/average_l0_53
   - id: layer_6/width_65k/average_l0_107
+    l0: 107
     path: layer_6/width_65k/average_l0_107
-    l0: 107
   - id: layer_6/width_65k/average_l0_17
-    path: layer_6/width_65k/average_l0_17
     l0: 17
+    path: layer_6/width_65k/average_l0_17
   - id: layer_6/width_65k/average_l0_208
-    path: layer_6/width_65k/average_l0_208
     l0: 208
+    path: layer_6/width_65k/average_l0_208
   - id: layer_6/width_65k/average_l0_30
-    path: layer_6/width_65k/average_l0_30
     l0: 30
+    path: layer_6/width_65k/average_l0_30
   - id: layer_6/width_65k/average_l0_56
-    path: layer_6/width_65k/average_l0_56
     l0: 56
+    path: layer_6/width_65k/average_l0_56
   - id: layer_7/width_65k/average_l0_107
-    path: layer_7/width_65k/average_l0_107
     l0: 107
+    path: layer_7/width_65k/average_l0_107
   - id: layer_7/width_65k/average_l0_18
-    path: layer_7/width_65k/average_l0_18
     l0: 18
+    path: layer_7/width_65k/average_l0_18
   - id: layer_7/width_65k/average_l0_203
-    path: layer_7/width_65k/average_l0_203
     l0: 203
+    path: layer_7/width_65k/average_l0_203
   - id: layer_7/width_65k/average_l0_31
-    path: layer_7/width_65k/average_l0_31
     l0: 31
+    path: layer_7/width_65k/average_l0_31
   - id: layer_7/width_65k/average_l0_57
-    path: layer_7/width_65k/average_l0_57
     l0: 57
+    path: layer_7/width_65k/average_l0_57
   - id: layer_8/width_65k/average_l0_111
-    path: layer_8/width_65k/average_l0_111
     l0: 111
+    path: layer_8/width_65k/average_l0_111
   - id: layer_8/width_65k/average_l0_19
+    l0: 19
     path: layer_8/width_65k/average_l0_19
-    l0: 19
   - id: layer_8/width_65k/average_l0_213
-    path: layer_8/width_65k/average_l0_213
     l0: 213
+    path: layer_8/width_65k/average_l0_213
   - id: layer_8/width_65k/average_l0_33
-    path: layer_8/width_65k/average_l0_33
     l0: 33
+    path: layer_8/width_65k/average_l0_33
   - id: layer_8/width_65k/average_l0_59
-    path: layer_8/width_65k/average_l0_59
     l0: 59
+    path: layer_8/width_65k/average_l0_59
   - id: layer_9/width_65k/average_l0_118
-    path: layer_9/width_65k/average_l0_118
     l0: 118
+    path: layer_9/width_65k/average_l0_118
   - id: layer_9/width_65k/average_l0_19
-    path: layer_9/width_65k/average_l0_19
     l0: 19
+    path: layer_9/width_65k/average_l0_19
   - id: layer_9/width_65k/average_l0_240
+    l0: 240
     path: layer_9/width_65k/average_l0_240
-    l0: 240
   - id: layer_9/width_65k/average_l0_34
-    path: layer_9/width_65k/average_l0_34
     l0: 34
+    path: layer_9/width_65k/average_l0_34
   - id: layer_9/width_65k/average_l0_61
-    path: layer_9/width_65k/average_l0_61
     l0: 61
+    path: layer_9/width_65k/average_l0_61
   - id: layer_10/width_65k/average_l0_128
+    l0: 128
     path: layer_10/width_65k/average_l0_128
-    l0: 128
   - id: layer_10/width_65k/average_l0_20
-    path: layer_10/width_65k/average_l0_20
     l0: 20
+    path: layer_10/width_65k/average_l0_20
   - id: layer_10/width_65k/average_l0_265
-    path: layer_10/width_65k/average_l0_265
     l0: 265
+    path: layer_10/width_65k/average_l0_265
   - id: layer_10/width_65k/average_l0_36
+    l0: 36
     path: layer_10/width_65k/average_l0_36
-    l0: 36
   - id: layer_10/width_65k/average_l0_66
-    path: layer_10/width_65k/average_l0_66
     l0: 66
+    path: layer_10/width_65k/average_l0_66
   - id: layer_11/width_65k/average_l0_134
-    path: layer_11/width_65k/average_l0_134
     l0: 134
+    path: layer_11/width_65k/average_l0_134
   - id: layer_11/width_65k/average_l0_21
+    l0: 21
     path: layer_11/width_65k/average_l0_21
-    l0: 21
   - id: layer_11/width_65k/average_l0_273
-    path: layer_11/width_65k/average_l0_273
     l0: 273
+    path: layer_11/width_65k/average_l0_273
   - id: layer_11/width_65k/average_l0_37
-    path: layer_11/width_65k/average_l0_37
     l0: 37
+    path: layer_11/width_65k/average_l0_37
   - id: layer_11/width_65k/average_l0_70
-    path: layer_11/width_65k/average_l0_70
     l0: 70
+    path: layer_11/width_65k/average_l0_70
   - id: layer_12/width_65k/average_l0_141
-    path: layer_12/width_65k/average_l0_141
-    neuronpedia: gemma-2-2b/12-gemmascope-res-65k__l0-141
     l0: 141
+    neuronpedia: gemma-2-2b/12-gemmascope-res-65k__l0-141
+    path: layer_12/width_65k/average_l0_141
   - id: layer_12/width_65k/average_l0_21
-    path: layer_12/width_65k/average_l0_21
+    l0: 21
     neuronpedia: gemma-2-2b/12-gemmascope-res-65k__l0-21
-    l0: 21
+    path: layer_12/width_65k/average_l0_21
   - id: layer_12/width_65k/average_l0_297
-    path: layer_12/width_65k/average_l0_297
-    neuronpedia: gemma-2-2b/12-gemmascope-res-65k__l0-297
     l0: 297
+    neuronpedia: gemma-2-2b/12-gemmascope-res-65k__l0-297
+    path: layer_12/width_65k/average_l0_297
   - id: layer_12/width_65k/average_l0_38
-    path: layer_12/width_65k/average_l0_38
+    l0: 38
     neuronpedia: gemma-2-2b/12-gemmascope-res-65k__l0-38
-    l0: 38
+    path: layer_12/width_65k/average_l0_38
   - id: layer_12/width_65k/average_l0_72
-    path: layer_12/width_65k/average_l0_72
     l0: 72
+    path: layer_12/width_65k/average_l0_72
   - id: layer_13/width_65k/average_l0_142
-    path: layer_13/width_65k/average_l0_142
     l0: 142
+    path: layer_13/width_65k/average_l0_142
   - id: layer_13/width_65k/average_l0_22
-    path: layer_13/width_65k/average_l0_22
     l0: 22
+    path: layer_13/width_65k/average_l0_22
   - id: layer_13/width_65k/average_l0_288
-    path: layer_13/width_65k/average_l0_288
     l0: 288
+    path: layer_13/width_65k/average_l0_288
   - id: layer_13/width_65k/average_l0_40
+    l0: 40
     path: layer_13/width_65k/average_l0_40
-    l0: 40
   - id: layer_13/width_65k/average_l0_74
-    path: layer_13/width_65k/average_l0_74
     l0: 74
+    path: layer_13/width_65k/average_l0_74
   - id: layer_13/width_65k/average_l0_75
-    path: layer_13/width_65k/average_l0_75
     l0: 75
+    path: layer_13/width_65k/average_l0_75
   - id: layer_14/width_65k/average_l0_144
-    path: layer_14/width_65k/average_l0_144
     l0: 144
+    path: layer_14/width_65k/average_l0_144
   - id: layer_14/width_65k/average_l0_21
+    l0: 21
     path: layer_14/width_65k/average_l0_21
-    l0: 21
   - id: layer_14/width_65k/average_l0_284
-    path: layer_14/width_65k/average_l0_284
     l0: 284
+    path: layer_14/width_65k/average_l0_284
   - id: layer_14/width_65k/average_l0_40
-    path: layer_14/width_65k/average_l0_40
     l0: 40
+    path: layer_14/width_65k/average_l0_40
   - id: layer_14/width_65k/average_l0_73
-    path: layer_14/width_65k/average_l0_73
     l0: 73
+    path: layer_14/width_65k/average_l0_73
   - id: layer_15/width_65k/average_l0_127
-    path: layer_15/width_65k/average_l0_127
     l0: 127
+    path: layer_15/width_65k/average_l0_127
   - id: layer_15/width_65k/average_l0_21
+    l0: 21
     path: layer_15/width_65k/average_l0_21
-    l0: 21
   - id: layer_15/width_65k/average_l0_240
-    path: layer_15/width_65k/average_l0_240
     l0: 240
+    path: layer_15/width_65k/average_l0_240
   - id: layer_15/width_65k/average_l0_38
+    l0: 38
     path: layer_15/width_65k/average_l0_38
-    l0: 38
   - id: layer_15/width_65k/average_l0_68
+    l0: 68
     path: layer_15/width_65k/average_l0_68
-    l0: 68
   - id: layer_16/width_65k/average_l0_128
-    path: layer_16/width_65k/average_l0_128
     l0: 128
+    path: layer_16/width_65k/average_l0_128
   - id: layer_16/width_65k/average_l0_21
+    l0: 21
     path: layer_16/width_65k/average_l0_21
-    l0: 21
   - id: layer_16/width_65k/average_l0_244
-    path: layer_16/width_65k/average_l0_244
     l0: 244
+    path: layer_16/width_65k/average_l0_244
   - id: layer_16/width_65k/average_l0_38
+    l0: 38
     path: layer_16/width_65k/average_l0_38
-    l0: 38
   - id: layer_16/width_65k/average_l0_69
-    path: layer_16/width_65k/average_l0_69
     l0: 69
+    path: layer_16/width_65k/average_l0_69
   - id: layer_17/width_65k/average_l0_125
-    path: layer_17/width_65k/average_l0_125
     l0: 125
+    path: layer_17/width_65k/average_l0_125
   - id: layer_17/width_65k/average_l0_21
+    l0: 21
     path: layer_17/width_65k/average_l0_21
-    l0: 21
   - id: layer_17/width_65k/average_l0_233
-    path: layer_17/width_65k/average_l0_233
     l0: 233
+    path: layer_17/width_65k/average_l0_233
   - id: layer_17/width_65k/average_l0_38
-    path: layer_17/width_65k/average_l0_38
     l0: 38
+    path: layer_17/width_65k/average_l0_38
   - id: layer_17/width_65k/average_l0_68
-    path: layer_17/width_65k/average_l0_68
     l0: 68
+    path: layer_17/width_65k/average_l0_68
   - id: layer_18/width_65k/average_l0_116
-    path: layer_18/width_65k/average_l0_116
     l0: 116
+    path: layer_18/width_65k/average_l0_116
   - id: layer_18/width_65k/average_l0_117
-    path: layer_18/width_65k/average_l0_117
     l0: 117
+    path: layer_18/width_65k/average_l0_117
   - id: layer_18/width_65k/average_l0_21
-    path: layer_18/width_65k/average_l0_21
     l0: 21
+    path: layer_18/width_65k/average_l0_21
   - id: layer_18/width_65k/average_l0_216
-    path: layer_18/width_65k/average_l0_216
     l0: 216
+    path: layer_18/width_65k/average_l0_216
   - id: layer_18/width_65k/average_l0_36
-    path: layer_18/width_65k/average_l0_36
     l0: 36
+    path: layer_18/width_65k/average_l0_36
   - id: layer_18/width_65k/average_l0_64
-    path: layer_18/width_65k/average_l0_64
     l0: 64
+    path: layer_18/width_65k/average_l0_64
   - id: layer_19/width_65k/average_l0_115
-    path: layer_19/width_65k/average_l0_115
     l0: 115
+    path: layer_19/width_65k/average_l0_115
   - id: layer_19/width_65k/average_l0_21
-    path: layer_19/width_65k/average_l0_21
     l0: 21
     neuronpedia: gemma-2-2b/19-gemmascope-res-65k__l0-21
+    path: layer_19/width_65k/average_l0_21
   - id: layer_19/width_65k/average_l0_216
-    path: layer_19/width_65k/average_l0_216
     l0: 216
     neuronpedia: gemma-2-2b/19-gemmascope-res-65k__l0-216
+    path: layer_19/width_65k/average_l0_216
   - id: layer_19/width_65k/average_l0_35
-    path: layer_19/width_65k/average_l0_35
     l0: 35
     neuronpedia: gemma-2-2b/19-gemmascope-res-65k__l0-35
+    path: layer_19/width_65k/average_l0_35
   - id: layer_19/width_65k/average_l0_63
-    path: layer_19/width_65k/average_l0_63
     l0: 63
     neuronpedia: gemma-2-2b/19-gemmascope-res-65k__l0-63
+    path: layer_19/width_65k/average_l0_63
   - id: layer_20/width_65k/average_l0_114
-    path: layer_20/width_65k/average_l0_114
     l0: 114
+    path: layer_20/width_65k/average_l0_114
   - id: layer_20/width_65k/average_l0_20
+    l0: 20
     path: layer_20/width_65k/average_l0_20
-    l0: 20
   - id: layer_20/width_65k/average_l0_221
-    path: layer_20/width_65k/average_l0_221
     l0: 221
+    path: layer_20/width_65k/average_l0_221
   - id: layer_20/width_65k/average_l0_34
+    l0: 34
     path: layer_20/width_65k/average_l0_34
-    l0: 34
   - id: layer_20/width_65k/average_l0_61
+    l0: 61
     path: layer_20/width_65k/average_l0_61
-    l0: 61
   - id: layer_21/width_65k/average_l0_111
-    path: layer_21/width_65k/average_l0_111
     l0: 111
+    path: layer_21/width_65k/average_l0_111
   - id: layer_21/width_65k/average_l0_112
-    path: layer_21/width_65k/average_l0_112
     l0: 112
+    path: layer_21/width_65k/average_l0_112
   - id: layer_21/width_65k/average_l0_20
+    l0: 20
     path: layer_21/width_65k/average_l0_20
-    l0: 20
   - id: layer_21/width_65k/average_l0_225
-    path: layer_21/width_65k/average_l0_225
     l0: 225
+    path: layer_21/width_65k/average_l0_225
   - id: layer_21/width_65k/average_l0_33
+    l0: 33
     path: layer_21/width_65k/average_l0_33
-    l0: 33
   - id: layer_21/width_65k/average_l0_61
-    path: layer_21/width_65k/average_l0_61
     l0: 61
+    path: layer_21/width_65k/average_l0_61
   - id: layer_22/width_65k/average_l0_116
-    path: layer_22/width_65k/average_l0_116
     l0: 116
+    path: layer_22/width_65k/average_l0_116
   - id: layer_22/width_65k/average_l0_117
-    path: layer_22/width_65k/average_l0_117
     l0: 117
+    path: layer_22/width_65k/average_l0_117
   - id: layer_22/width_65k/average_l0_20
+    l0: 20
     path: layer_22/width_65k/average_l0_20
-    l0: 20
   - id: layer_22/width_65k/average_l0_248
-    path: layer_22/width_65k/average_l0_248
     l0: 248
+    path: layer_22/width_65k/average_l0_248
   - id: layer_22/width_65k/average_l0_33
-    path: layer_22/width_65k/average_l0_33
     l0: 33
+    path: layer_22/width_65k/average_l0_33
   - id: layer_22/width_65k/average_l0_62
-    path: layer_22/width_65k/average_l0_62
     l0: 62
+    path: layer_22/width_65k/average_l0_62
   - id: layer_23/width_65k/average_l0_123
-    path: layer_23/width_65k/average_l0_123
     l0: 123
+    path: layer_23/width_65k/average_l0_123
   - id: layer_23/width_65k/average_l0_124
+    l0: 124
     path: layer_23/width_65k/average_l0_124
-    l0: 124
   - id: layer_23/width_65k/average_l0_20
-    path: layer_23/width_65k/average_l0_20
     l0: 20
+    path: layer_23/width_65k/average_l0_20
   - id: layer_23/width_65k/average_l0_272
-    path: layer_23/width_65k/average_l0_272
     l0: 272
+    path: layer_23/width_65k/average_l0_272
   - id: layer_23/width_65k/average_l0_35
-    path: layer_23/width_65k/average_l0_35
     l0: 35
+    path: layer_23/width_65k/average_l0_35
   - id: layer_23/width_65k/average_l0_64
-    path: layer_23/width_65k/average_l0_64
     l0: 64
+    path: layer_23/width_65k/average_l0_64
   - id: layer_24/width_65k/average_l0_124
-    path: layer_24/width_65k/average_l0_124
     l0: 124
+    path: layer_24/width_65k/average_l0_124
   - id: layer_24/width_65k/average_l0_19
-    path: layer_24/width_65k/average_l0_19
     l0: 19
+    path: layer_24/width_65k/average_l0_19
   - id: layer_24/width_65k/average_l0_273
-    path: layer_24/width_65k/average_l0_273
     l0: 273
+    path: layer_24/width_65k/average_l0_273
   - id: layer_24/width_65k/average_l0_34
-    path: layer_24/width_65k/average_l0_34
     l0: 34
+    path: layer_24/width_65k/average_l0_34
   - id: layer_24/width_65k/average_l0_63
-    path: layer_24/width_65k/average_l0_63
     l0: 63
+    path: layer_24/width_65k/average_l0_63
   - id: layer_25/width_65k/average_l0_15
-    path: layer_25/width_65k/average_l0_15
     l0: 15
+    path: layer_25/width_65k/average_l0_15
   - id: layer_25/width_65k/average_l0_197
-    path: layer_25/width_65k/average_l0_197
     l0: 197
+    path: layer_25/width_65k/average_l0_197
   - id: layer_25/width_65k/average_l0_26
-    path: layer_25/width_65k/average_l0_26
     l0: 26
+    path: layer_25/width_65k/average_l0_26
   - id: layer_25/width_65k/average_l0_48
-    path: layer_25/width_65k/average_l0_48
     l0: 48
+    path: layer_25/width_65k/average_l0_48
   - id: layer_25/width_65k/average_l0_93
-    path: layer_25/width_65k/average_l0_93
     l0: 93
+    path: layer_25/width_65k/average_l0_93
 gemma-scope-2b-pt-res-canonical:
-  repo_id: google/gemma-scope-2b-pt-res
-  model: gemma-2-2b
   conversion_func: gemma_2
   links:
-    model: https://huggingface.co/google/gemma-2-2b
     dashboards: https://www.neuronpedia.org/gemma-2-2b/gemmascope-res-16k
+    model: https://huggingface.co/google/gemma-2-2b
     publication: https://huggingface.co/google/gemma-scope
+  model: gemma-2-2b
+  repo_id: google/gemma-scope-2b-pt-res
   saes:
   - id: layer_0/width_16k/canonical
-    path: layer_0/width_16k/average_l0_105
     neuronpedia: gemma-2-2b/0-gemmascope-res-16k
+    path: layer_0/width_16k/average_l0_105
   - id: layer_1/width_16k/canonical
-    path: layer_1/width_16k/average_l0_102
     neuronpedia: gemma-2-2b/1-gemmascope-res-16k
+    path: layer_1/width_16k/average_l0_102
   - id: layer_2/width_16k/canonical
-    path: layer_2/width_16k/average_l0_141
     neuronpedia: gemma-2-2b/2-gemmascope-res-16k
+    path: layer_2/width_16k/average_l0_141
   - id: layer_3/width_16k/canonical
-    path: layer_3/width_16k/average_l0_59
     neuronpedia: gemma-2-2b/3-gemmascope-res-16k
+    path: layer_3/width_16k/average_l0_59
   - id: layer_4/width_16k/canonical
-    path: layer_4/width_16k/average_l0_124
     neuronpedia: gemma-2-2b/4-gemmascope-res-16k
+    path: layer_4/width_16k/average_l0_124
   - id: layer_5/width_16k/canonical
-    path: layer_5/width_16k/average_l0_68
     neuronpedia: gemma-2-2b/5-gemmascope-res-16k
+    path: layer_5/width_16k/average_l0_68
   - id: layer_6/width_16k/canonical
-    path: layer_6/width_16k/average_l0_70
     neuronpedia: gemma-2-2b/6-gemmascope-res-16k
+    path: layer_6/width_16k/average_l0_70
   - id: layer_7/width_16k/canonical
-    path: layer_7/width_16k/average_l0_69
     neuronpedia: gemma-2-2b/7-gemmascope-res-16k
+    path: layer_7/width_16k/average_l0_69
   - id: layer_8/width_16k/canonical
-    path: layer_8/width_16k/average_l0_71
     neuronpedia: gemma-2-2b/8-gemmascope-res-16k
+    path: layer_8/width_16k/average_l0_71
   - id: layer_9/width_16k/canonical
-    path: layer_9/width_16k/average_l0_73
     neuronpedia: gemma-2-2b/9-gemmascope-res-16k
+    path: layer_9/width_16k/average_l0_73
   - id: layer_10/width_16k/canonical
-    path: layer_10/width_16k/average_l0_77
     neuronpedia: gemma-2-2b/10-gemmascope-res-16k
+    path: layer_10/width_16k/average_l0_77
   - id: layer_11/width_16k/canonical
-    path: layer_11/width_16k/average_l0_80
     neuronpedia: gemma-2-2b/11-gemmascope-res-16k
+    path: layer_11/width_16k/average_l0_80
   - id: layer_12/width_16k/canonical
-    path: layer_12/width_16k/average_l0_82
     neuronpedia: gemma-2-2b/12-gemmascope-res-16k
+    path: layer_12/width_16k/average_l0_82
   - id: layer_13/width_16k/canonical
-    path: layer_13/width_16k/average_l0_84
     neuronpedia: gemma-2-2b/13-gemmascope-res-16k
+    path: layer_13/width_16k/average_l0_84
   - id: layer_14/width_16k/canonical
-    path: layer_14/width_16k/average_l0_84
     neuronpedia: gemma-2-2b/14-gemmascope-res-16k
+    path: layer_14/width_16k/average_l0_84
   - id: layer_15/width_16k/canonical
-    path: layer_15/width_16k/average_l0_78
     neuronpedia: gemma-2-2b/15-gemmascope-res-16k
+    path: layer_15/width_16k/average_l0_78
   - id: layer_16/width_16k/canonical
-    path: layer_16/width_16k/average_l0_78
     neuronpedia: gemma-2-2b/16-gemmascope-res-16k
+    path: layer_16/width_16k/average_l0_78
   - id: layer_17/width_16k/canonical
-    path: layer_17/width_16k/average_l0_77
     neuronpedia: gemma-2-2b/17-gemmascope-res-16k
+    path: layer_17/width_16k/average_l0_77
   - id: layer_18/width_16k/canonical
-    path: layer_18/width_16k/average_l0_74
     neuronpedia: gemma-2-2b/18-gemmascope-res-16k
+    path: layer_18/width_16k/average_l0_74
   - id: layer_19/width_16k/canonical
-    path: layer_19/width_16k/average_l0_73
     neuronpedia: gemma-2-2b/19-gemmascope-res-16k
+    path: layer_19/width_16k/average_l0_73
   - id: layer_20/width_16k/canonical
-    path: layer_20/width_16k/average_l0_71
     neuronpedia: gemma-2-2b/20-gemmascope-res-16k
+    path: layer_20/width_16k/average_l0_71
   - id: layer_21/width_16k/canonical
-    path: layer_21/width_16k/average_l0_70
     neuronpedia: gemma-2-2b/21-gemmascope-res-16k
+    path: layer_21/width_16k/average_l0_70
   - id: layer_22/width_16k/canonical
-    path: layer_22/width_16k/average_l0_72
     neuronpedia: gemma-2-2b/22-gemmascope-res-16k
+    path: layer_22/width_16k/average_l0_72
   - id: layer_23/width_16k/canonical
-    path: layer_23/width_16k/average_l0_75
     neuronpedia: gemma-2-2b/23-gemmascope-res-16k
+    path: layer_23/width_16k/average_l0_75
   - id: layer_24/width_16k/canonical
-    path: layer_24/width_16k/average_l0_73
     neuronpedia: gemma-2-2b/24-gemmascope-res-16k
+    path: layer_24/width_16k/average_l0_73
   - id: layer_25/width_16k/canonical
-    path: layer_25/width_16k/average_l0_116
     neuronpedia: gemma-2-2b/25-gemmascope-res-16k
+    path: layer_25/width_16k/average_l0_116
   - id: layer_5/width_1m/canonical
-    path: layer_5/width_1m/average_l0_114
     neuronpedia: gemma-2-2b/5-gemmascope-res-1m
+    path: layer_5/width_1m/average_l0_114
   - id: layer_12/width_1m/canonical
-    path: layer_12/width_1m/average_l0_107
     neuronpedia: gemma-2-2b/12-gemmascope-res-1m
+    path: layer_12/width_1m/average_l0_107
   - id: layer_19/width_1m/canonical
-    path: layer_19/width_1m/average_l0_88
     neuronpedia: gemma-2-2b/19-gemmascope-res-1m
+    path: layer_19/width_1m/average_l0_88
   - id: layer_12/width_262k/canonical
-    path: layer_12/width_262k/average_l0_121
     neuronpedia: gemma-2-2b/12-gemmascope-res-262k
+    path: layer_12/width_262k/average_l0_121
   - id: layer_12/width_32k/canonical
-    path: layer_12/width_32k/average_l0_76
     neuronpedia: gemma-2-2b/12-gemmascope-res-32k
+    path: layer_12/width_32k/average_l0_76
   - id: layer_12/width_524k/canonical
-    path: layer_12/width_524k/average_l0_115
     neuronpedia: gemma-2-2b/12-gemmascope-res-524k
+    path: layer_12/width_524k/average_l0_115
   - id: layer_0/width_65k/canonical
-    path: layer_0/width_65k/average_l0_73
     neuronpedia: gemma-2-2b/0-gemmascope-res-65k
+    path: layer_0/width_65k/average_l0_73
   - id: layer_1/width_65k/canonical
-    path: layer_1/width_65k/average_l0_121
     neuronpedia: gemma-2-2b/1-gemmascope-res-65k
+    path: layer_1/width_65k/average_l0_121
   - id: layer_2/width_65k/canonical
-    path: layer_2/width_65k/average_l0_77
     neuronpedia: gemma-2-2b/2-gemmascope-res-65k
+    path: layer_2/width_65k/average_l0_77
   - id: layer_3/width_65k/canonical
-    path: layer_3/width_65k/average_l0_89
     neuronpedia: gemma-2-2b/3-gemmascope-res-65k
+    path: layer_3/width_65k/average_l0_89
   - id: layer_4/width_65k/canonical
-    path: layer_4/width_65k/average_l0_89
     neuronpedia: gemma-2-2b/4-gemmascope-res-65k
+    path: layer_4/width_65k/average_l0_89
   - id: layer_5/width_65k/canonical
-    path: layer_5/width_65k/average_l0_105
     neuronpedia: gemma-2-2b/5-gemmascope-res-65k
+    path: layer_5/width_65k/average_l0_105
   - id: layer_6/width_65k/canonical
-    path: layer_6/width_65k/average_l0_107
     neuronpedia: gemma-2-2b/6-gemmascope-res-65k
+    path: layer_6/width_65k/average_l0_107
   - id: layer_7/width_65k/canonical
-    path: layer_7/width_65k/average_l0_107
     neuronpedia: gemma-2-2b/7-gemmascope-res-65k
+    path: layer_7/width_65k/average_l0_107
   - id: layer_8/width_65k/canonical
-    path: layer_8/width_65k/average_l0_111
     neuronpedia: gemma-2-2b/8-gemmascope-res-65k
+    path: layer_8/width_65k/average_l0_111
   - id: layer_9/width_65k/canonical
-    path: layer_9/width_65k/average_l0_118
     neuronpedia: gemma-2-2b/9-gemmascope-res-65k
+    path: layer_9/width_65k/average_l0_118
   - id: layer_10/width_65k/canonical
-    path: layer_10/width_65k/average_l0_128
     neuronpedia: gemma-2-2b/10-gemmascope-res-65k
+    path: layer_10/width_65k/average_l0_128
   - id: layer_11/width_65k/canonical
-    path: layer_11/width_65k/average_l0_70
     neuronpedia: gemma-2-2b/11-gemmascope-res-65k
+    path: layer_11/width_65k/average_l0_70
   - id: layer_12/width_65k/canonical
-    path: layer_12/width_65k/average_l0_72
     neuronpedia: gemma-2-2b/12-gemmascope-res-65k
+    path: layer_12/width_65k/average_l0_72
   - id: layer_13/width_65k/canonical
-    path: layer_13/width_65k/average_l0_75
     neuronpedia: gemma-2-2b/13-gemmascope-res-65k
+    path: layer_13/width_65k/average_l0_75
   - id: layer_14/width_65k/canonical
-    path: layer_14/width_65k/average_l0_73
     neuronpedia: gemma-2-2b/14-gemmascope-res-65k
+    path: layer_14/width_65k/average_l0_73
   - id: layer_15/width_65k/canonical
-    path: layer_15/width_65k/average_l0_127
     neuronpedia: gemma-2-2b/15-gemmascope-res-65k
+    path: layer_15/width_65k/average_l0_127
   - id: layer_16/width_65k/canonical
-    path: layer_16/width_65k/average_l0_128
     neuronpedia: gemma-2-2b/16-gemmascope-res-65k
+    path: layer_16/width_65k/average_l0_128
   - id: layer_17/width_65k/canonical
-    path: layer_17/width_65k/average_l0_125
     neuronpedia: gemma-2-2b/17-gemmascope-res-65k
+    path: layer_17/width_65k/average_l0_125
   - id: layer_18/width_65k/canonical
-    path: layer_18/width_65k/average_l0_116
     neuronpedia: gemma-2-2b/18-gemmascope-res-65k
+    path: layer_18/width_65k/average_l0_116
   - id: layer_19/width_65k/canonical
-    path: layer_19/width_65k/average_l0_115
     neuronpedia: gemma-2-2b/19-gemmascope-res-65k
+    path: layer_19/width_65k/average_l0_115
   - id: layer_20/width_65k/canonical
-    path: layer_20/width_65k/average_l0_114
     neuronpedia: gemma-2-2b/20-gemmascope-res-65k
+    path: layer_20/width_65k/average_l0_114
   - id: layer_21/width_65k/canonical
-    path: layer_21/width_65k/average_l0_111
     neuronpedia: gemma-2-2b/21-gemmascope-res-65k
+    path: layer_21/width_65k/average_l0_111
   - id: layer_22/width_65k/canonical
-    path: layer_22/width_65k/average_l0_116
     neuronpedia: gemma-2-2b/22-gemmascope-res-65k
+    path: layer_22/width_65k/average_l0_116
   - id: layer_23/width_65k/canonical
-    path: layer_23/width_65k/average_l0_123
     neuronpedia: gemma-2-2b/23-gemmascope-res-65k
+    path: layer_23/width_65k/average_l0_123
   - id: layer_24/width_65k/canonical
-    path: layer_24/width_65k/average_l0_124
     neuronpedia: gemma-2-2b/24-gemmascope-res-65k
+    path: layer_24/width_65k/average_l0_124
   - id: layer_25/width_65k/canonical
-    path: layer_25/width_65k/average_l0_93
     neuronpedia: gemma-2-2b/25-gemmascope-res-65k
-gemma-scope-2b-pt-mlp:
-  repo_id: google/gemma-scope-2b-pt-mlp
-  model: gemma-2-2b
+    path: layer_25/width_65k/average_l0_93
+gemma-scope-9b-it-res:
   conversion_func: gemma_2
-  saes:
-  - id: layer_0/width_16k/average_l0_119
-    path: layer_0/width_16k/average_l0_119
-    l0: 119
-  - id: layer_0/width_16k/average_l0_16
-    path: layer_0/width_16k/average_l0_16
-    l0: 16
-  - id: layer_0/width_16k/average_l0_30
-    path: layer_0/width_16k/average_l0_30
-    l0: 30
-  - id: layer_0/width_16k/average_l0_60
-    path: layer_0/width_16k/average_l0_60
-    l0: 60
-  - id: layer_0/width_16k/average_l0_9
-    path: layer_0/width_16k/average_l0_9
-    l0: 9
-  - id: layer_1/width_16k/average_l0_105
-    path: layer_1/width_16k/average_l0_105
-    l0: 105
-  - id: layer_1/width_16k/average_l0_12
-    path: layer_1/width_16k/average_l0_12
-    l0: 12
-  - id: layer_1/width_16k/average_l0_239
-    path: layer_1/width_16k/average_l0_239
-    l0: 239
-  - id: layer_1/width_16k/average_l0_24
-    path: layer_1/width_16k/average_l0_24
-    l0: 24
-  - id: layer_1/width_16k/average_l0_50
-    path: layer_1/width_16k/average_l0_50
-    l0: 50
-  - id: layer_2/width_16k/average_l0_19
-    path: layer_2/width_16k/average_l0_19
-    l0: 19
-  - id: layer_2/width_16k/average_l0_213
-    path: layer_2/width_16k/average_l0_213
-    l0: 213
-  - id: layer_2/width_16k/average_l0_41
-    path: layer_2/width_16k/average_l0_41
-    l0: 41
-  - id: layer_2/width_16k/average_l0_434
-    path: layer_2/width_16k/average_l0_434
-    l0: 434
-  - id: layer_2/width_16k/average_l0_95
-    path: layer_2/width_16k/average_l0_95
-    l0: 95
-  - id: layer_3/width_16k/average_l0_195
-    path: layer_3/width_16k/average_l0_195
-    l0: 195
-  - id: layer_3/width_16k/average_l0_21
-    path: layer_3/width_16k/average_l0_21
-    l0: 21
-  - id: layer_3/width_16k/average_l0_377
-    path: layer_3/width_16k/average_l0_377
-    l0: 377
-  - id: layer_3/width_16k/average_l0_44
-    path: layer_3/width_16k/average_l0_44
-    l0: 44
-  - id: layer_3/width_16k/average_l0_95
-    path: layer_3/width_16k/average_l0_95
-    l0: 95
-  - id: layer_4/width_16k/average_l0_18
-    path: layer_4/width_16k/average_l0_18
-    l0: 18
-  - id: layer_4/width_16k/average_l0_198
-    path: layer_4/width_16k/average_l0_198
-    l0: 198
-  - id: layer_4/width_16k/average_l0_38
-    path: layer_4/width_16k/average_l0_38
-    l0: 38
-  - id: layer_4/width_16k/average_l0_433
-    path: layer_4/width_16k/average_l0_433
-    l0: 433
-  - id: layer_4/width_16k/average_l0_85
-    path: layer_4/width_16k/average_l0_85
-    l0: 85
-  - id: layer_5/width_16k/average_l0_114
-    path: layer_5/width_16k/average_l0_114
-    l0: 114
-  - id: layer_5/width_16k/average_l0_23
-    path: layer_5/width_16k/average_l0_23
-    l0: 23
-  - id: layer_5/width_16k/average_l0_269
-    path: layer_5/width_16k/average_l0_269
-    l0: 269
-  - id: layer_5/width_16k/average_l0_48
-    path: layer_5/width_16k/average_l0_48
-    l0: 48
-  - id: layer_5/width_16k/average_l0_575
-    path: layer_5/width_16k/average_l0_575
-    l0: 575
-  - id: layer_6/width_16k/average_l0_133
-    path: layer_6/width_16k/average_l0_133
-    l0: 133
-  - id: layer_6/width_16k/average_l0_25
-    path: layer_6/width_16k/average_l0_25
-    l0: 25
-  - id: layer_6/width_16k/average_l0_328
-    path: layer_6/width_16k/average_l0_328
-    l0: 328
-  - id: layer_6/width_16k/average_l0_55
-    path: layer_6/width_16k/average_l0_55
-    l0: 55
-  - id: layer_6/width_16k/average_l0_699
-    path: layer_6/width_16k/average_l0_699
-    l0: 699
-  - id: layer_7/width_16k/average_l0_146
-    path: layer_7/width_16k/average_l0_146
-    l0: 146
-  - id: layer_7/width_16k/average_l0_28
-    path: layer_7/width_16k/average_l0_28
-    l0: 28
-  - id: layer_7/width_16k/average_l0_355
-    path: layer_7/width_16k/average_l0_355
-    l0: 355
-  - id: layer_7/width_16k/average_l0_60
-    path: layer_7/width_16k/average_l0_60
-    l0: 60
-  - id: layer_7/width_16k/average_l0_731
-    path: layer_7/width_16k/average_l0_731
-    l0: 731
-  - id: layer_8/width_16k/average_l0_136
-    path: layer_8/width_16k/average_l0_136
-    l0: 136
-  - id: layer_8/width_16k/average_l0_27
-    path: layer_8/width_16k/average_l0_27
-    l0: 27
-  - id: layer_8/width_16k/average_l0_351
-    path: layer_8/width_16k/average_l0_351
-    l0: 351
-  - id: layer_8/width_16k/average_l0_56
-    path: layer_8/width_16k/average_l0_56
-    l0: 56
-  - id: layer_8/width_16k/average_l0_739
-    path: layer_8/width_16k/average_l0_739
-    l0: 739
-  - id: layer_9/width_16k/average_l0_216
-    path: layer_9/width_16k/average_l0_216
-    l0: 216
-  - id: layer_9/width_16k/average_l0_38
-    path: layer_9/width_16k/average_l0_38
-    l0: 38
-  - id: layer_9/width_16k/average_l0_482
-    path: layer_9/width_16k/average_l0_482
-    l0: 482
-  - id: layer_9/width_16k/average_l0_861
-    path: layer_9/width_16k/average_l0_861
-    l0: 861
-  - id: layer_9/width_16k/average_l0_88
-    path: layer_9/width_16k/average_l0_88
-    l0: 88
-  - id: layer_10/width_16k/average_l0_110
-    path: layer_10/width_16k/average_l0_110
-    l0: 110
-  - id: layer_10/width_16k/average_l0_266
-    path: layer_10/width_16k/average_l0_266
-    l0: 266
-  - id: layer_10/width_16k/average_l0_45
-    path: layer_10/width_16k/average_l0_45
-    l0: 45
-  - id: layer_10/width_16k/average_l0_568
-    path: layer_10/width_16k/average_l0_568
-    l0: 568
-  - id: layer_10/width_16k/average_l0_908
-    path: layer_10/width_16k/average_l0_908
-    l0: 908
-  - id: layer_11/width_16k/average_l0_234
-    path: layer_11/width_16k/average_l0_234
-    l0: 234
-  - id: layer_11/width_16k/average_l0_42
-    path: layer_11/width_16k/average_l0_42
-    l0: 42
-  - id: layer_11/width_16k/average_l0_499
-    path: layer_11/width_16k/average_l0_499
-    l0: 499
-  - id: layer_11/width_16k/average_l0_847
-    path: layer_11/width_16k/average_l0_847
-    l0: 847
-  - id: layer_11/width_16k/average_l0_98
-    path: layer_11/width_16k/average_l0_98
-    l0: 98
-  - id: layer_12/width_16k/average_l0_108
-    path: layer_12/width_16k/average_l0_108
-    l0: 108
-  - id: layer_12/width_16k/average_l0_262
-    path: layer_12/width_16k/average_l0_262
-    l0: 262
-  - id: layer_12/width_16k/average_l0_44
-    path: layer_12/width_16k/average_l0_44
-    l0: 44
-  - id: layer_12/width_16k/average_l0_548
-    path: layer_12/width_16k/average_l0_548
-    l0: 548
-  - id: layer_12/width_16k/average_l0_879
-    path: layer_12/width_16k/average_l0_879
-    l0: 879
-  - id: layer_13/width_16k/average_l0_112
-    path: layer_13/width_16k/average_l0_112
-    l0: 112
-  - id: layer_13/width_16k/average_l0_267
-    path: layer_13/width_16k/average_l0_267
-    l0: 267
-  - id: layer_13/width_16k/average_l0_47
-    path: layer_13/width_16k/average_l0_47
-    l0: 47
-  - id: layer_13/width_16k/average_l0_553
-    path: layer_13/width_16k/average_l0_553
-    l0: 553
-  - id: layer_13/width_16k/average_l0_892
-    path: layer_13/width_16k/average_l0_892
-    l0: 892
-  - id: layer_14/width_16k/average_l0_246
-    path: layer_14/width_16k/average_l0_246
-    l0: 246
-  - id: layer_14/width_16k/average_l0_41
-    path: layer_14/width_16k/average_l0_41
-    l0: 41
-  - id: layer_14/width_16k/average_l0_536
-    path: layer_14/width_16k/average_l0_536
-    l0: 536
-  - id: layer_14/width_16k/average_l0_894
-    path: layer_14/width_16k/average_l0_894
-    l0: 894
-  - id: layer_14/width_16k/average_l0_97
-    path: layer_14/width_16k/average_l0_97
-    l0: 97
-  - id: layer_15/width_16k/average_l0_207
-    path: layer_15/width_16k/average_l0_207
-    l0: 207
-  - id: layer_15/width_16k/average_l0_35
-    path: layer_15/width_16k/average_l0_35
-    l0: 35
-  - id: layer_15/width_16k/average_l0_492
-    path: layer_15/width_16k/average_l0_492
-    l0: 492
-  - id: layer_15/width_16k/average_l0_80
-    path: layer_15/width_16k/average_l0_80
-    l0: 80
-  - id: layer_15/width_16k/average_l0_879
-    path: layer_15/width_16k/average_l0_879
-    l0: 879
-  - id: layer_16/width_16k/average_l0_185
-    path: layer_16/width_16k/average_l0_185
-    l0: 185
-  - id: layer_16/width_16k/average_l0_33
-    path: layer_16/width_16k/average_l0_33
-    l0: 33
-  - id: layer_16/width_16k/average_l0_452
-    path: layer_16/width_16k/average_l0_452
-    l0: 452
-  - id: layer_16/width_16k/average_l0_72
-    path: layer_16/width_16k/average_l0_72
-    l0: 72
-  - id: layer_16/width_16k/average_l0_847
-    path: layer_16/width_16k/average_l0_847
-    l0: 847
-  - id: layer_17/width_16k/average_l0_179
-    path: layer_17/width_16k/average_l0_179
-    l0: 179
-  - id: layer_17/width_16k/average_l0_31
-    path: layer_17/width_16k/average_l0_31
-    l0: 31
-  - id: layer_17/width_16k/average_l0_453
-    path: layer_17/width_16k/average_l0_453
-    l0: 453
-  - id: layer_17/width_16k/average_l0_68
-    path: layer_17/width_16k/average_l0_68
-    l0: 68
-  - id: layer_17/width_16k/average_l0_853
-    path: layer_17/width_16k/average_l0_853
-    l0: 853
-  - id: layer_18/width_16k/average_l0_106
-    path: layer_18/width_16k/average_l0_106
-    l0: 106
-  - id: layer_18/width_16k/average_l0_24
-    path: layer_18/width_16k/average_l0_24
-    l0: 24
-  - id: layer_18/width_16k/average_l0_292
-    path: layer_18/width_16k/average_l0_292
-    l0: 292
-  - id: layer_18/width_16k/average_l0_47
-    path: layer_18/width_16k/average_l0_47
-    l0: 47
-  - id: layer_18/width_16k/average_l0_672
-    path: layer_18/width_16k/average_l0_672
-    l0: 672
-  - id: layer_19/width_16k/average_l0_109
-    path: layer_19/width_16k/average_l0_109
-    l0: 109
-  - id: layer_19/width_16k/average_l0_25
-    path: layer_19/width_16k/average_l0_25
-    l0: 25
-  - id: layer_19/width_16k/average_l0_295
-    path: layer_19/width_16k/average_l0_295
-    l0: 295
-  - id: layer_19/width_16k/average_l0_50
-    path: layer_19/width_16k/average_l0_50
-    l0: 50
-  - id: layer_19/width_16k/average_l0_673
-    path: layer_19/width_16k/average_l0_673
-    l0: 673
-  - id: layer_20/width_16k/average_l0_109
-    path: layer_20/width_16k/average_l0_109
-    l0: 109
-  - id: layer_20/width_16k/average_l0_24
-    path: layer_20/width_16k/average_l0_24
-    l0: 24
-  - id: layer_20/width_16k/average_l0_289
-    path: layer_20/width_16k/average_l0_289
-    l0: 289
-  - id: layer_20/width_16k/average_l0_49
-    path: layer_20/width_16k/average_l0_49
-    l0: 49
-  - id: layer_20/width_16k/average_l0_658
-    path: layer_20/width_16k/average_l0_658
-    l0: 658
-  - id: layer_21/width_16k/average_l0_113
-    path: layer_21/width_16k/average_l0_113
-    l0: 113
-  - id: layer_21/width_16k/average_l0_23
-    path: layer_21/width_16k/average_l0_23
-    l0: 23
-  - id: layer_21/width_16k/average_l0_279
-    path: layer_21/width_16k/average_l0_279
-    l0: 279
-  - id: layer_21/width_16k/average_l0_48
-    path: layer_21/width_16k/average_l0_48
-    l0: 48
-  - id: layer_21/width_16k/average_l0_633
-    path: layer_21/width_16k/average_l0_633
-    l0: 633
-  - id: layer_22/width_16k/average_l0_121
-    path: layer_22/width_16k/average_l0_121
-    l0: 121
-  - id: layer_22/width_16k/average_l0_24
-    path: layer_22/width_16k/average_l0_24
-    l0: 24
-  - id: layer_22/width_16k/average_l0_290
-    path: layer_22/width_16k/average_l0_290
-    l0: 290
-  - id: layer_22/width_16k/average_l0_51
-    path: layer_22/width_16k/average_l0_51
-    l0: 51
-  - id: layer_22/width_16k/average_l0_624
-    path: layer_22/width_16k/average_l0_624
-    l0: 624
-  - id: layer_23/width_16k/average_l0_128
-    path: layer_23/width_16k/average_l0_128
-    l0: 128
-  - id: layer_23/width_16k/average_l0_27
-    path: layer_23/width_16k/average_l0_27
-    l0: 27
-  - id: layer_23/width_16k/average_l0_287
-    path: layer_23/width_16k/average_l0_287
-    l0: 287
-  - id: layer_23/width_16k/average_l0_57
-    path: layer_23/width_16k/average_l0_57
-    l0: 57
-  - id: layer_23/width_16k/average_l0_627
-    path: layer_23/width_16k/average_l0_627
-    l0: 627
-  - id: layer_24/width_16k/average_l0_158
-    path: layer_24/width_16k/average_l0_158
-    l0: 158
-  - id: layer_24/width_16k/average_l0_19
-    path: layer_24/width_16k/average_l0_19
-    l0: 19
-  - id: layer_24/width_16k/average_l0_35
-    path: layer_24/width_16k/average_l0_35
-    l0: 35
-  - id: layer_24/width_16k/average_l0_357
-    path: layer_24/width_16k/average_l0_357
-    l0: 357
-  - id: layer_24/width_16k/average_l0_73
-    path: layer_24/width_16k/average_l0_73
-    l0: 73
-  - id: layer_25/width_16k/average_l0_126
-    path: layer_25/width_16k/average_l0_126
-    l0: 126
-  - id: layer_25/width_16k/average_l0_15
-    path: layer_25/width_16k/average_l0_15
-    l0: 15
-  - id: layer_25/width_16k/average_l0_277
-    path: layer_25/width_16k/average_l0_277
-    l0: 277
-  - id: layer_25/width_16k/average_l0_29
-    path: layer_25/width_16k/average_l0_29
-    l0: 29
-  - id: layer_25/width_16k/average_l0_59
-    path: layer_25/width_16k/average_l0_59
-    l0: 59
-  - id: layer_0/width_65k/average_l0_12
-    path: layer_0/width_65k/average_l0_12
-    l0: 12
-  - id: layer_0/width_65k/average_l0_21
-    path: layer_0/width_65k/average_l0_21
-    l0: 21
-  - id: layer_0/width_65k/average_l0_39
-    path: layer_0/width_65k/average_l0_39
-    l0: 39
-  - id: layer_0/width_65k/average_l0_7
-    path: layer_0/width_65k/average_l0_7
-    l0: 7
-  - id: layer_0/width_65k/average_l0_72
-    path: layer_0/width_65k/average_l0_72
-    l0: 72
-  - id: layer_1/width_65k/average_l0_11
-    path: layer_1/width_65k/average_l0_11
-    l0: 11
-  - id: layer_1/width_65k/average_l0_127
-    path: layer_1/width_65k/average_l0_127
-    l0: 127
-  - id: layer_1/width_65k/average_l0_20
-    path: layer_1/width_65k/average_l0_20
-    l0: 20
-  - id: layer_1/width_65k/average_l0_37
-    path: layer_1/width_65k/average_l0_37
-    l0: 37
-  - id: layer_1/width_65k/average_l0_67
-    path: layer_1/width_65k/average_l0_67
-    l0: 67
-  - id: layer_2/width_65k/average_l0_134
-    path: layer_2/width_65k/average_l0_134
-    l0: 134
-  - id: layer_2/width_65k/average_l0_16
-    path: layer_2/width_65k/average_l0_16
-    l0: 16
-  - id: layer_2/width_65k/average_l0_265
-    path: layer_2/width_65k/average_l0_265
-    l0: 265
-  - id: layer_2/width_65k/average_l0_31
-    path: layer_2/width_65k/average_l0_31
-    l0: 31
-  - id: layer_2/width_65k/average_l0_60
-    path: layer_2/width_65k/average_l0_60
-    l0: 60
-  - id: layer_3/width_65k/average_l0_144
-    path: layer_3/width_65k/average_l0_144
-    l0: 144
-  - id: layer_3/width_65k/average_l0_18
-    path: layer_3/width_65k/average_l0_18
-    l0: 18
-  - id: layer_3/width_65k/average_l0_279
-    path: layer_3/width_65k/average_l0_279
-    l0: 279
-  - id: layer_3/width_65k/average_l0_33
-    path: layer_3/width_65k/average_l0_33
-    l0: 33
-  - id: layer_3/width_65k/average_l0_68
-    path: layer_3/width_65k/average_l0_68
-    l0: 68
-  - id: layer_4/width_65k/average_l0_138
-    path: layer_4/width_65k/average_l0_138
-    l0: 138
-  - id: layer_4/width_65k/average_l0_17
-    path: layer_4/width_65k/average_l0_17
-    l0: 17
-  - id: layer_4/width_65k/average_l0_299
-    path: layer_4/width_65k/average_l0_299
-    l0: 299
-  - id: layer_4/width_65k/average_l0_32
-    path: layer_4/width_65k/average_l0_32
-    l0: 32
-  - id: layer_4/width_65k/average_l0_66
-    path: layer_4/width_65k/average_l0_66
-    l0: 66
-  - id: layer_5/width_65k/average_l0_186
-    path: layer_5/width_65k/average_l0_186
-    l0: 186
-  - id: layer_5/width_65k/average_l0_22
-    path: layer_5/width_65k/average_l0_22
-    l0: 22
-  - id: layer_5/width_65k/average_l0_407
-    path: layer_5/width_65k/average_l0_407
-    l0: 407
-  - id: layer_5/width_65k/average_l0_43
-    path: layer_5/width_65k/average_l0_43
-    l0: 43
-  - id: layer_5/width_65k/average_l0_86
-    path: layer_5/width_65k/average_l0_86
-    l0: 86
-  - id: layer_6/width_65k/average_l0_101
-    path: layer_6/width_65k/average_l0_101
-    l0: 101
-  - id: layer_6/width_65k/average_l0_224
-    path: layer_6/width_65k/average_l0_224
-    l0: 224
-  - id: layer_6/width_65k/average_l0_24
-    path: layer_6/width_65k/average_l0_24
-    l0: 24
-  - id: layer_6/width_65k/average_l0_47
-    path: layer_6/width_65k/average_l0_47
-    l0: 47
-  - id: layer_6/width_65k/average_l0_515
-    path: layer_6/width_65k/average_l0_515
-    l0: 515
-  - id: layer_7/width_65k/average_l0_115
-    path: layer_7/width_65k/average_l0_115
-    l0: 115
-  - id: layer_7/width_65k/average_l0_266
-    path: layer_7/width_65k/average_l0_266
-    l0: 266
-  - id: layer_7/width_65k/average_l0_28
-    path: layer_7/width_65k/average_l0_28
-    l0: 28
-  - id: layer_7/width_65k/average_l0_56
-    path: layer_7/width_65k/average_l0_56
-    l0: 56
-  - id: layer_7/width_65k/average_l0_571
-    path: layer_7/width_65k/average_l0_571
-    l0: 571
-  - id: layer_8/width_65k/average_l0_110
-    path: layer_8/width_65k/average_l0_110
-    l0: 110
-  - id: layer_8/width_65k/average_l0_256
-    path: layer_8/width_65k/average_l0_256
-    l0: 256
-  - id: layer_8/width_65k/average_l0_31
-    path: layer_8/width_65k/average_l0_31
-    l0: 31
-  - id: layer_8/width_65k/average_l0_547
-    path: layer_8/width_65k/average_l0_547
-    l0: 547
-  - id: layer_8/width_65k/average_l0_55
-    path: layer_8/width_65k/average_l0_55
-    l0: 55
-  - id: layer_9/width_65k/average_l0_168
-    path: layer_9/width_65k/average_l0_168
-    l0: 168
-  - id: layer_9/width_65k/average_l0_38
-    path: layer_9/width_65k/average_l0_38
-    l0: 38
-  - id: layer_9/width_65k/average_l0_387
-    path: layer_9/width_65k/average_l0_387
-    l0: 387
-  - id: layer_9/width_65k/average_l0_745
-    path: layer_9/width_65k/average_l0_745
-    l0: 745
-  - id: layer_9/width_65k/average_l0_77
-    path: layer_9/width_65k/average_l0_77
-    l0: 77
-  - id: layer_10/width_65k/average_l0_218
-    path: layer_10/width_65k/average_l0_218
-    l0: 218
-  - id: layer_10/width_65k/average_l0_43
-    path: layer_10/width_65k/average_l0_43
-    l0: 43
-  - id: layer_10/width_65k/average_l0_474
-    path: layer_10/width_65k/average_l0_474
-    l0: 474
-  - id: layer_10/width_65k/average_l0_851
-    path: layer_10/width_65k/average_l0_851
-    l0: 851
-  - id: layer_10/width_65k/average_l0_95
-    path: layer_10/width_65k/average_l0_95
-    l0: 95
-  - id: layer_11/width_65k/average_l0_200
-    path: layer_11/width_65k/average_l0_200
-    l0: 200
-  - id: layer_11/width_65k/average_l0_41
-    path: layer_11/width_65k/average_l0_41
-    l0: 41
-  - id: layer_11/width_65k/average_l0_436
-    path: layer_11/width_65k/average_l0_436
-    l0: 436
-  - id: layer_11/width_65k/average_l0_771
-    path: layer_11/width_65k/average_l0_771
-    l0: 771
-  - id: layer_11/width_65k/average_l0_88
-    path: layer_11/width_65k/average_l0_88
-    l0: 88
-  - id: layer_12/width_65k/average_l0_222
-    path: layer_12/width_65k/average_l0_222
-    l0: 222
-  - id: layer_12/width_65k/average_l0_44
-    path: layer_12/width_65k/average_l0_44
-    l0: 44
-  - id: layer_12/width_65k/average_l0_482
-    path: layer_12/width_65k/average_l0_482
-    l0: 482
-  - id: layer_12/width_65k/average_l0_848
-    path: layer_12/width_65k/average_l0_848
-    l0: 848
-  - id: layer_12/width_65k/average_l0_96
-    path: layer_12/width_65k/average_l0_96
-    l0: 96
-  - id: layer_13/width_65k/average_l0_228
-    path: layer_13/width_65k/average_l0_228
-    l0: 228
-  - id: layer_13/width_65k/average_l0_44
-    path: layer_13/width_65k/average_l0_44
-    l0: 44
-  - id: layer_13/width_65k/average_l0_480
-    path: layer_13/width_65k/average_l0_480
-    l0: 480
-  - id: layer_13/width_65k/average_l0_841
-    path: layer_13/width_65k/average_l0_841
-    l0: 841
-  - id: layer_13/width_65k/average_l0_98
-    path: layer_13/width_65k/average_l0_98
-    l0: 98
-  - id: layer_14/width_65k/average_l0_204
-    path: layer_14/width_65k/average_l0_204
-    l0: 204
-  - id: layer_14/width_65k/average_l0_39
-    path: layer_14/width_65k/average_l0_39
-    l0: 39
-  - id: layer_14/width_65k/average_l0_463
-    path: layer_14/width_65k/average_l0_463
-    l0: 463
-  - id: layer_14/width_65k/average_l0_816
-    path: layer_14/width_65k/average_l0_816
-    l0: 816
-  - id: layer_14/width_65k/average_l0_89
-    path: layer_14/width_65k/average_l0_89
-    l0: 89
-  - id: layer_15/width_65k/average_l0_164
-    path: layer_15/width_65k/average_l0_164
-    l0: 164
-  - id: layer_15/width_65k/average_l0_35
-    path: layer_15/width_65k/average_l0_35
-    l0: 35
-  - id: layer_15/width_65k/average_l0_405
-    path: layer_15/width_65k/average_l0_405
-    l0: 405
-  - id: layer_15/width_65k/average_l0_72
-    path: layer_15/width_65k/average_l0_72
-    l0: 72
-  - id: layer_15/width_65k/average_l0_754
-    path: layer_15/width_65k/average_l0_754
-    l0: 754
-  - id: layer_16/width_65k/average_l0_142
-    path: layer_16/width_65k/average_l0_142
-    l0: 142
-  - id: layer_16/width_65k/average_l0_32
-    path: layer_16/width_65k/average_l0_32
-    l0: 32
-  - id: layer_16/width_65k/average_l0_348
-    path: layer_16/width_65k/average_l0_348
-    l0: 348
-  - id: layer_16/width_65k/average_l0_66
-    path: layer_16/width_65k/average_l0_66
-    l0: 66
-  - id: layer_16/width_65k/average_l0_695
-    path: layer_16/width_65k/average_l0_695
-    l0: 695
-  - id: layer_17/width_65k/average_l0_136
-    path: layer_17/width_65k/average_l0_136
-    l0: 136
-  - id: layer_17/width_65k/average_l0_30
-    path: layer_17/width_65k/average_l0_30
-    l0: 30
-  - id: layer_17/width_65k/average_l0_342
-    path: layer_17/width_65k/average_l0_342
-    l0: 342
-  - id: layer_17/width_65k/average_l0_61
-    path: layer_17/width_65k/average_l0_61
-    l0: 61
-  - id: layer_17/width_65k/average_l0_666
-    path: layer_17/width_65k/average_l0_666
-    l0: 666
-  - id: layer_18/width_65k/average_l0_191
-    path: layer_18/width_65k/average_l0_191
-    l0: 191
-  - id: layer_18/width_65k/average_l0_24
-    path: layer_18/width_65k/average_l0_24
-    l0: 24
-  - id: layer_18/width_65k/average_l0_44
-    path: layer_18/width_65k/average_l0_44
-    l0: 44
-  - id: layer_18/width_65k/average_l0_491
-    path: layer_18/width_65k/average_l0_491
-    l0: 491
-  - id: layer_18/width_65k/average_l0_88
-    path: layer_18/width_65k/average_l0_88
-    l0: 88
-  - id: layer_19/width_65k/average_l0_192
-    path: layer_19/width_65k/average_l0_192
-    l0: 192
-  - id: layer_19/width_65k/average_l0_25
-    path: layer_19/width_65k/average_l0_25
-    l0: 25
-  - id: layer_19/width_65k/average_l0_45
-    path: layer_19/width_65k/average_l0_45
-    l0: 45
-  - id: layer_19/width_65k/average_l0_470
-    path: layer_19/width_65k/average_l0_470
-    l0: 470
-  - id: layer_19/width_65k/average_l0_88
-    path: layer_19/width_65k/average_l0_88
-    l0: 88
-  - id: layer_20/width_65k/average_l0_189
-    path: layer_20/width_65k/average_l0_189
-    l0: 189
-  - id: layer_20/width_65k/average_l0_23
-    path: layer_20/width_65k/average_l0_23
-    l0: 23
-  - id: layer_20/width_65k/average_l0_44
-    path: layer_20/width_65k/average_l0_44
-    l0: 44
-  - id: layer_20/width_65k/average_l0_446
-    path: layer_20/width_65k/average_l0_446
-    l0: 446
-  - id: layer_20/width_65k/average_l0_88
-    path: layer_20/width_65k/average_l0_88
-    l0: 88
-  - id: layer_21/width_65k/average_l0_192
-    path: layer_21/width_65k/average_l0_192
-    l0: 192
-  - id: layer_21/width_65k/average_l0_23
-    path: layer_21/width_65k/average_l0_23
-    l0: 23
-  - id: layer_21/width_65k/average_l0_42
-    path: layer_21/width_65k/average_l0_42
-    l0: 42
-  - id: layer_21/width_65k/average_l0_472
-    path: layer_21/width_65k/average_l0_472
-    l0: 472
-  - id: layer_21/width_65k/average_l0_86
-    path: layer_21/width_65k/average_l0_86
-    l0: 86
-  - id: layer_22/width_65k/average_l0_203
-    path: layer_22/width_65k/average_l0_203
-    l0: 203
-  - id: layer_22/width_65k/average_l0_23
-    path: layer_22/width_65k/average_l0_23
-    l0: 23
-  - id: layer_22/width_65k/average_l0_46
-    path: layer_22/width_65k/average_l0_46
-    l0: 46
-  - id: layer_22/width_65k/average_l0_487
-    path: layer_22/width_65k/average_l0_487
-    l0: 487
-  - id: layer_22/width_65k/average_l0_92
-    path: layer_22/width_65k/average_l0_92
-    l0: 92
-  - id: layer_23/width_65k/average_l0_102
-    path: layer_23/width_65k/average_l0_102
-    l0: 102
-  - id: layer_23/width_65k/average_l0_218
-    path: layer_23/width_65k/average_l0_218
-    l0: 218
-  - id: layer_23/width_65k/average_l0_25
-    path: layer_23/width_65k/average_l0_25
-    l0: 25
-  - id: layer_23/width_65k/average_l0_49
-    path: layer_23/width_65k/average_l0_49
-    l0: 49
-  - id: layer_23/width_65k/average_l0_497
-    path: layer_23/width_65k/average_l0_497
-    l0: 497
-  - id: layer_24/width_65k/average_l0_128
-    path: layer_24/width_65k/average_l0_128
-    l0: 128
-  - id: layer_24/width_65k/average_l0_18
-    path: layer_24/width_65k/average_l0_18
-    l0: 18
-  - id: layer_24/width_65k/average_l0_268
-    path: layer_24/width_65k/average_l0_268
-    l0: 268
-  - id: layer_24/width_65k/average_l0_32
-    path: layer_24/width_65k/average_l0_32
-    l0: 32
-  - id: layer_24/width_65k/average_l0_62
-    path: layer_24/width_65k/average_l0_62
-    l0: 62
-  - id: layer_25/width_65k/average_l0_107
-    path: layer_25/width_65k/average_l0_107
-    l0: 107
-  - id: layer_25/width_65k/average_l0_14
-    path: layer_25/width_65k/average_l0_14
-    l0: 14
-  - id: layer_25/width_65k/average_l0_215
-    path: layer_25/width_65k/average_l0_215
-    l0: 215
-  - id: layer_25/width_65k/average_l0_26
-    path: layer_25/width_65k/average_l0_26
-    l0: 26
-  - id: layer_25/width_65k/average_l0_52
-    path: layer_25/width_65k/average_l0_52
-    l0: 52
-gemma-scope-2b-pt-mlp-canonical:
-  repo_id: google/gemma-scope-2b-pt-mlp
-  model: gemma-2-2b
-  conversion_func: gemma_2
-  saes:
-  - id: layer_0/width_16k/canonical
-    path: layer_0/width_16k/average_l0_119
-    neuronpedia: gemma-2-2b/0-gemmascope-mlp-16k
-  - id: layer_1/width_16k/canonical
-    path: layer_1/width_16k/average_l0_105
-    neuronpedia: gemma-2-2b/1-gemmascope-mlp-16k
-  - id: layer_2/width_16k/canonical
-    path: layer_2/width_16k/average_l0_95
-    neuronpedia: gemma-2-2b/2-gemmascope-mlp-16k
-  - id: layer_3/width_16k/canonical
-    path: layer_3/width_16k/average_l0_95
-    neuronpedia: gemma-2-2b/3-gemmascope-mlp-16k
-  - id: layer_4/width_16k/canonical
-    path: layer_4/width_16k/average_l0_85
-    neuronpedia: gemma-2-2b/4-gemmascope-mlp-16k
-  - id: layer_5/width_16k/canonical
-    path: layer_5/width_16k/average_l0_114
-    neuronpedia: gemma-2-2b/5-gemmascope-mlp-16k
-  - id: layer_6/width_16k/canonical
-    path: layer_6/width_16k/average_l0_133
-    neuronpedia: gemma-2-2b/6-gemmascope-mlp-16k
-  - id: layer_7/width_16k/canonical
-    path: layer_7/width_16k/average_l0_60
-    neuronpedia: gemma-2-2b/7-gemmascope-mlp-16k
-  - id: layer_8/width_16k/canonical
-    path: layer_8/width_16k/average_l0_136
-    neuronpedia: gemma-2-2b/8-gemmascope-mlp-16k
-  - id: layer_9/width_16k/canonical
-    path: layer_9/width_16k/average_l0_88
-    neuronpedia: gemma-2-2b/9-gemmascope-mlp-16k
-  - id: layer_10/width_16k/canonical
-    path: layer_10/width_16k/average_l0_110
-    neuronpedia: gemma-2-2b/10-gemmascope-mlp-16k
-  - id: layer_11/width_16k/canonical
-    path: layer_11/width_16k/average_l0_98
-    neuronpedia: gemma-2-2b/11-gemmascope-mlp-16k
-  - id: layer_12/width_16k/canonical
-    path: layer_12/width_16k/average_l0_108
-    neuronpedia: gemma-2-2b/12-gemmascope-mlp-16k
-  - id: layer_13/width_16k/canonical
-    path: layer_13/width_16k/average_l0_112
-    neuronpedia: gemma-2-2b/13-gemmascope-mlp-16k
-  - id: layer_14/width_16k/canonical
-    path: layer_14/width_16k/average_l0_97
-    neuronpedia: gemma-2-2b/14-gemmascope-mlp-16k
-  - id: layer_15/width_16k/canonical
-    path: layer_15/width_16k/average_l0_80
-    neuronpedia: gemma-2-2b/15-gemmascope-mlp-16k
-  - id: layer_16/width_16k/canonical
-    path: layer_16/width_16k/average_l0_72
-    neuronpedia: gemma-2-2b/16-gemmascope-mlp-16k
-  - id: layer_17/width_16k/canonical
-    path: layer_17/width_16k/average_l0_68
-    neuronpedia: gemma-2-2b/17-gemmascope-mlp-16k
-  - id: layer_18/width_16k/canonical
-    path: layer_18/width_16k/average_l0_106
-    neuronpedia: gemma-2-2b/18-gemmascope-mlp-16k
-  - id: layer_19/width_16k/canonical
-    path: layer_19/width_16k/average_l0_109
-    neuronpedia: gemma-2-2b/19-gemmascope-mlp-16k
-  - id: layer_20/width_16k/canonical
-    path: layer_20/width_16k/average_l0_109
-    neuronpedia: gemma-2-2b/20-gemmascope-mlp-16k
-  - id: layer_21/width_16k/canonical
-    path: layer_21/width_16k/average_l0_113
-    neuronpedia: gemma-2-2b/21-gemmascope-mlp-16k
-  - id: layer_22/width_16k/canonical
-    path: layer_22/width_16k/average_l0_121
-    neuronpedia: gemma-2-2b/22-gemmascope-mlp-16k
-  - id: layer_23/width_16k/canonical
-    path: layer_23/width_16k/average_l0_128
-    neuronpedia: gemma-2-2b/23-gemmascope-mlp-16k
-  - id: layer_24/width_16k/canonical
-    path: layer_24/width_16k/average_l0_73
-    neuronpedia: gemma-2-2b/24-gemmascope-mlp-16k
-  - id: layer_25/width_16k/canonical
-    path: layer_25/width_16k/average_l0_126
-    neuronpedia: gemma-2-2b/25-gemmascope-mlp-16k
-  - id: layer_0/width_65k/canonical
-    path: layer_0/width_65k/average_l0_72
-    neuronpedia: gemma-2-2b/0-gemmascope-mlp-65k
-  - id: layer_1/width_65k/canonical
-    path: layer_1/width_65k/average_l0_127
-    neuronpedia: gemma-2-2b/1-gemmascope-mlp-65k
-  - id: layer_2/width_65k/canonical
-    path: layer_2/width_65k/average_l0_134
-    neuronpedia: gemma-2-2b/2-gemmascope-mlp-65k
-  - id: layer_3/width_65k/canonical
-    path: layer_3/width_65k/average_l0_68
-    neuronpedia: gemma-2-2b/3-gemmascope-mlp-65k
-  - id: layer_4/width_65k/canonical
-    path: layer_4/width_65k/average_l0_66
-    neuronpedia: gemma-2-2b/4-gemmascope-mlp-65k
-  - id: layer_5/width_65k/canonical
-    path: layer_5/width_65k/average_l0_86
-    neuronpedia: gemma-2-2b/5-gemmascope-mlp-65k
-  - id: layer_6/width_65k/canonical
-    path: layer_6/width_65k/average_l0_101
-    neuronpedia: gemma-2-2b/6-gemmascope-mlp-65k
-  - id: layer_7/width_65k/canonical
-    path: layer_7/width_65k/average_l0_115
-    neuronpedia: gemma-2-2b/7-gemmascope-mlp-65k
-  - id: layer_8/width_65k/canonical
-    path: layer_8/width_65k/average_l0_110
-    neuronpedia: gemma-2-2b/8-gemmascope-mlp-65k
-  - id: layer_9/width_65k/canonical
-    path: layer_9/width_65k/average_l0_77
-    neuronpedia: gemma-2-2b/9-gemmascope-mlp-65k
-  - id: layer_10/width_65k/canonical
-    path: layer_10/width_65k/average_l0_95
-    neuronpedia: gemma-2-2b/10-gemmascope-mlp-65k
-  - id: layer_11/width_65k/canonical
-    path: layer_11/width_65k/average_l0_88
-    neuronpedia: gemma-2-2b/11-gemmascope-mlp-65k
-  - id: layer_12/width_65k/canonical
-    path: layer_12/width_65k/average_l0_96
-    neuronpedia: gemma-2-2b/12-gemmascope-mlp-65k
-  - id: layer_13/width_65k/canonical
-    path: layer_13/width_65k/average_l0_98
-    neuronpedia: gemma-2-2b/13-gemmascope-mlp-65k
-  - id: layer_14/width_65k/canonical
-    path: layer_14/width_65k/average_l0_89
-    neuronpedia: gemma-2-2b/14-gemmascope-mlp-65k
-  - id: layer_15/width_65k/canonical
-    path: layer_15/width_65k/average_l0_72
-    neuronpedia: gemma-2-2b/15-gemmascope-mlp-65k
-  - id: layer_16/width_65k/canonical
-    path: layer_16/width_65k/average_l0_66
-    neuronpedia: gemma-2-2b/16-gemmascope-mlp-65k
-  - id: layer_17/width_65k/canonical
-    path: layer_17/width_65k/average_l0_136
-    neuronpedia: gemma-2-2b/17-gemmascope-mlp-65k
-  - id: layer_18/width_65k/canonical
-    path: layer_18/width_65k/average_l0_88
-    neuronpedia: gemma-2-2b/18-gemmascope-mlp-65k
-  - id: layer_19/width_65k/canonical
-    path: layer_19/width_65k/average_l0_88
-    neuronpedia: gemma-2-2b/19-gemmascope-mlp-65k
-  - id: layer_20/width_65k/canonical
-    path: layer_20/width_65k/average_l0_88
-    neuronpedia: gemma-2-2b/20-gemmascope-mlp-65k
-  - id: layer_21/width_65k/canonical
-    path: layer_21/width_65k/average_l0_86
-    neuronpedia: gemma-2-2b/21-gemmascope-mlp-65k
-  - id: layer_22/width_65k/canonical
-    path: layer_22/width_65k/average_l0_92
-    neuronpedia: gemma-2-2b/22-gemmascope-mlp-65k
-  - id: layer_23/width_65k/canonical
-    path: layer_23/width_65k/average_l0_102
-    neuronpedia: gemma-2-2b/23-gemmascope-mlp-65k
-  - id: layer_24/width_65k/canonical
-    path: layer_24/width_65k/average_l0_128
-    neuronpedia: gemma-2-2b/24-gemmascope-mlp-65k
-  - id: layer_25/width_65k/canonical
-    path: layer_25/width_65k/average_l0_107
-    neuronpedia: gemma-2-2b/25-gemmascope-mlp-65k
-gemma-scope-2b-pt-att:
-  repo_id: google/gemma-scope-2b-pt-att
-  model: gemma-2-2b
-  conversion_func: gemma_2
-  saes:
-  - id: layer_0/width_16k/average_l0_104
-    path: layer_0/width_16k/average_l0_104
-    l0: 104
-  - id: layer_0/width_16k/average_l0_12
-    path: layer_0/width_16k/average_l0_12
-    l0: 12
-  - id: layer_0/width_16k/average_l0_18
-    path: layer_0/width_16k/average_l0_18
-    l0: 18
-  - id: layer_0/width_16k/average_l0_30
-    path: layer_0/width_16k/average_l0_30
-    l0: 30
-  - id: layer_0/width_16k/average_l0_57
-    path: layer_0/width_16k/average_l0_57
-    l0: 57
-  - id: layer_1/width_16k/average_l0_146
-    path: layer_1/width_16k/average_l0_146
-    l0: 146
-  - id: layer_1/width_16k/average_l0_20
-    path: layer_1/width_16k/average_l0_20
-    l0: 20
-  - id: layer_1/width_16k/average_l0_251
-    path: layer_1/width_16k/average_l0_251
-    l0: 251
-  - id: layer_1/width_16k/average_l0_40
-    path: layer_1/width_16k/average_l0_40
-    l0: 40
-  - id: layer_1/width_16k/average_l0_79
-    path: layer_1/width_16k/average_l0_79
-    l0: 79
-  - id: layer_2/width_16k/average_l0_174
-    path: layer_2/width_16k/average_l0_174
-    l0: 174
-  - id: layer_2/width_16k/average_l0_19
-    path: layer_2/width_16k/average_l0_19
-    l0: 19
-  - id: layer_2/width_16k/average_l0_297
-    path: layer_2/width_16k/average_l0_297
-    l0: 297
-  - id: layer_2/width_16k/average_l0_43
-    path: layer_2/width_16k/average_l0_43
-    l0: 43
-  - id: layer_2/width_16k/average_l0_93
-    path: layer_2/width_16k/average_l0_93
-    l0: 93
-  - id: layer_3/width_16k/average_l0_117
-    path: layer_3/width_16k/average_l0_117
-    l0: 117
-  - id: layer_3/width_16k/average_l0_219
-    path: layer_3/width_16k/average_l0_219
-    l0: 219
-  - id: layer_3/width_16k/average_l0_24
-    path: layer_3/width_16k/average_l0_24
-    l0: 24
-  - id: layer_3/width_16k/average_l0_386
-    path: layer_3/width_16k/average_l0_386
-    l0: 386
-  - id: layer_3/width_16k/average_l0_55
-    path: layer_3/width_16k/average_l0_55
-    l0: 55
-  - id: layer_4/width_16k/average_l0_116
-    path: layer_4/width_16k/average_l0_116
-    l0: 116
-  - id: layer_4/width_16k/average_l0_249
-    path: layer_4/width_16k/average_l0_249
-    l0: 249
-  - id: layer_4/width_16k/average_l0_26
-    path: layer_4/width_16k/average_l0_26
-    l0: 26
-  - id: layer_4/width_16k/average_l0_454
-    path: layer_4/width_16k/average_l0_454
-    l0: 454
-  - id: layer_4/width_16k/average_l0_53
-    path: layer_4/width_16k/average_l0_53
-    l0: 53
-  - id: layer_5/width_16k/average_l0_135
-    path: layer_5/width_16k/average_l0_135
-    l0: 135
-  - id: layer_5/width_16k/average_l0_268
-    path: layer_5/width_16k/average_l0_268
-    l0: 268
-  - id: layer_5/width_16k/average_l0_30
-    path: layer_5/width_16k/average_l0_30
-    l0: 30
-  - id: layer_5/width_16k/average_l0_449
-    path: layer_5/width_16k/average_l0_449
-    l0: 449
-  - id: layer_5/width_16k/average_l0_59
-    path: layer_5/width_16k/average_l0_59
-    l0: 59
-  - id: layer_6/width_16k/average_l0_143
-    path: layer_6/width_16k/average_l0_143
-    l0: 143
-  - id: layer_6/width_16k/average_l0_292
-    path: layer_6/width_16k/average_l0_292
-    l0: 292
-  - id: layer_6/width_16k/average_l0_30
-    path: layer_6/width_16k/average_l0_30
-    l0: 30
-  - id: layer_6/width_16k/average_l0_479
-    path: layer_6/width_16k/average_l0_479
-    l0: 479
-  - id: layer_6/width_16k/average_l0_61
-    path: layer_6/width_16k/average_l0_61
-    l0: 61
-  - id: layer_7/width_16k/average_l0_184
-    path: layer_7/width_16k/average_l0_184
-    l0: 184
-  - id: layer_7/width_16k/average_l0_331
-    path: layer_7/width_16k/average_l0_331
-    l0: 331
-  - id: layer_7/width_16k/average_l0_46
-    path: layer_7/width_16k/average_l0_46
-    l0: 46
-  - id: layer_7/width_16k/average_l0_537
-    path: layer_7/width_16k/average_l0_537
-    l0: 537
-  - id: layer_7/width_16k/average_l0_99
-    path: layer_7/width_16k/average_l0_99
-    l0: 99
-  - id: layer_8/width_16k/average_l0_129
-    path: layer_8/width_16k/average_l0_129
-    l0: 129
-  - id: layer_8/width_16k/average_l0_282
-    path: layer_8/width_16k/average_l0_282
-    l0: 282
-  - id: layer_8/width_16k/average_l0_32
-    path: layer_8/width_16k/average_l0_32
-    l0: 32
-  - id: layer_8/width_16k/average_l0_482
-    path: layer_8/width_16k/average_l0_482
-    l0: 482
-  - id: layer_8/width_16k/average_l0_64
-    path: layer_8/width_16k/average_l0_64
-    l0: 64
-  - id: layer_9/width_16k/average_l0_127
-    path: layer_9/width_16k/average_l0_127
-    l0: 127
-  - id: layer_9/width_16k/average_l0_270
-    path: layer_9/width_16k/average_l0_270
-    l0: 270
-  - id: layer_9/width_16k/average_l0_34
-    path: layer_9/width_16k/average_l0_34
-    l0: 34
-  - id: layer_9/width_16k/average_l0_499
-    path: layer_9/width_16k/average_l0_499
-    l0: 499
-  - id: layer_9/width_16k/average_l0_64
-    path: layer_9/width_16k/average_l0_64
-    l0: 64
-  - id: layer_10/width_16k/average_l0_148
-    path: layer_10/width_16k/average_l0_148
-    l0: 148
-  - id: layer_10/width_16k/average_l0_307
-    path: layer_10/width_16k/average_l0_307
-    l0: 307
-  - id: layer_10/width_16k/average_l0_36
-    path: layer_10/width_16k/average_l0_36
-    l0: 36
-  - id: layer_10/width_16k/average_l0_541
-    path: layer_10/width_16k/average_l0_541
-    l0: 541
-  - id: layer_10/width_16k/average_l0_70
-    path: layer_10/width_16k/average_l0_70
-    l0: 70
-  - id: layer_11/width_16k/average_l0_170
-    path: layer_11/width_16k/average_l0_170
-    l0: 170
-  - id: layer_11/width_16k/average_l0_350
-    path: layer_11/width_16k/average_l0_350
-    l0: 350
-  - id: layer_11/width_16k/average_l0_41
-    path: layer_11/width_16k/average_l0_41
-    l0: 41
-  - id: layer_11/width_16k/average_l0_593
-    path: layer_11/width_16k/average_l0_593
-    l0: 593
-  - id: layer_11/width_16k/average_l0_80
-    path: layer_11/width_16k/average_l0_80
-    l0: 80
-  - id: layer_12/width_16k/average_l0_184
-    path: layer_12/width_16k/average_l0_184
-    l0: 184
-  - id: layer_12/width_16k/average_l0_328
-    path: layer_12/width_16k/average_l0_328
-    l0: 328
-  - id: layer_12/width_16k/average_l0_41
-    path: layer_12/width_16k/average_l0_41
-    l0: 41
-  - id: layer_12/width_16k/average_l0_514
-    path: layer_12/width_16k/average_l0_514
-    l0: 514
-  - id: layer_12/width_16k/average_l0_85
-    path: layer_12/width_16k/average_l0_85
-    l0: 85
-  - id: layer_13/width_16k/average_l0_203
-    path: layer_13/width_16k/average_l0_203
-    l0: 203
-  - id: layer_13/width_16k/average_l0_372
-    path: layer_13/width_16k/average_l0_372
-    l0: 372
-  - id: layer_13/width_16k/average_l0_43
-    path: layer_13/width_16k/average_l0_43
-    l0: 43
-  - id: layer_13/width_16k/average_l0_570
-    path: layer_13/width_16k/average_l0_570
-    l0: 570
-  - id: layer_13/width_16k/average_l0_92
-    path: layer_13/width_16k/average_l0_92
-    l0: 92
-  - id: layer_14/width_16k/average_l0_161
-    path: layer_14/width_16k/average_l0_161
-    l0: 161
-  - id: layer_14/width_16k/average_l0_298
-    path: layer_14/width_16k/average_l0_298
-    l0: 298
-  - id: layer_14/width_16k/average_l0_37
-    path: layer_14/width_16k/average_l0_37
-    l0: 37
-  - id: layer_14/width_16k/average_l0_468
-    path: layer_14/width_16k/average_l0_468
-    l0: 468
-  - id: layer_14/width_16k/average_l0_71
-    path: layer_14/width_16k/average_l0_71
-    l0: 71
-  - id: layer_15/width_16k/average_l0_195
-    path: layer_15/width_16k/average_l0_195
-    l0: 195
-  - id: layer_15/width_16k/average_l0_342
-    path: layer_15/width_16k/average_l0_342
-    l0: 342
-  - id: layer_15/width_16k/average_l0_44
-    path: layer_15/width_16k/average_l0_44
-    l0: 44
-  - id: layer_15/width_16k/average_l0_535
-    path: layer_15/width_16k/average_l0_535
-    l0: 535
-  - id: layer_15/width_16k/average_l0_98
-    path: layer_15/width_16k/average_l0_98
-    l0: 98
-  - id: layer_16/width_16k/average_l0_144
-    path: layer_16/width_16k/average_l0_144
-    l0: 144
-  - id: layer_16/width_16k/average_l0_293
-    path: layer_16/width_16k/average_l0_293
-    l0: 293
-  - id: layer_16/width_16k/average_l0_37
-    path: layer_16/width_16k/average_l0_37
-    l0: 37
-  - id: layer_16/width_16k/average_l0_527
-    path: layer_16/width_16k/average_l0_527
-    l0: 527
-  - id: layer_16/width_16k/average_l0_71
-    path: layer_16/width_16k/average_l0_71
-    l0: 71
-  - id: layer_17/width_16k/average_l0_176
-    path: layer_17/width_16k/average_l0_176
-    l0: 176
-  - id: layer_17/width_16k/average_l0_316
-    path: layer_17/width_16k/average_l0_316
-    l0: 316
-  - id: layer_17/width_16k/average_l0_38
-    path: layer_17/width_16k/average_l0_38
-    l0: 38
-  - id: layer_17/width_16k/average_l0_509
-    path: layer_17/width_16k/average_l0_509
-    l0: 509
-  - id: layer_17/width_16k/average_l0_79
-    path: layer_17/width_16k/average_l0_79
-    l0: 79
-  - id: layer_18/width_16k/average_l0_144
-    path: layer_18/width_16k/average_l0_144
-    l0: 144
-  - id: layer_18/width_16k/average_l0_292
-    path: layer_18/width_16k/average_l0_292
-    l0: 292
-  - id: layer_18/width_16k/average_l0_34
-    path: layer_18/width_16k/average_l0_34
-    l0: 34
-  - id: layer_18/width_16k/average_l0_491
-    path: layer_18/width_16k/average_l0_491
-    l0: 491
-  - id: layer_18/width_16k/average_l0_72
-    path: layer_18/width_16k/average_l0_72
-    l0: 72
-  - id: layer_19/width_16k/average_l0_122
-    path: layer_19/width_16k/average_l0_122
-    l0: 122
-  - id: layer_19/width_16k/average_l0_249
-    path: layer_19/width_16k/average_l0_249
-    l0: 249
-  - id: layer_19/width_16k/average_l0_28
-    path: layer_19/width_16k/average_l0_28
-    l0: 28
-  - id: layer_19/width_16k/average_l0_423
-    path: layer_19/width_16k/average_l0_423
-    l0: 423
-  - id: layer_19/width_16k/average_l0_56
-    path: layer_19/width_16k/average_l0_56
-    l0: 56
-  - id: layer_20/width_16k/average_l0_141
-    path: layer_20/width_16k/average_l0_141
-    l0: 141
-  - id: layer_20/width_16k/average_l0_274
-    path: layer_20/width_16k/average_l0_274
-    l0: 274
-  - id: layer_20/width_16k/average_l0_31
-    path: layer_20/width_16k/average_l0_31
-    l0: 31
-  - id: layer_20/width_16k/average_l0_446
-    path: layer_20/width_16k/average_l0_446
-    l0: 446
-  - id: layer_20/width_16k/average_l0_62
-    path: layer_20/width_16k/average_l0_62
-    l0: 62
-  - id: layer_21/width_16k/average_l0_142
-    path: layer_21/width_16k/average_l0_142
-    l0: 142
-  - id: layer_21/width_16k/average_l0_301
-    path: layer_21/width_16k/average_l0_301
-    l0: 301
-  - id: layer_21/width_16k/average_l0_32
-    path: layer_21/width_16k/average_l0_32
-    l0: 32
-  - id: layer_21/width_16k/average_l0_505
-    path: layer_21/width_16k/average_l0_505
-    l0: 505
-  - id: layer_21/width_16k/average_l0_65
-    path: layer_21/width_16k/average_l0_65
-    l0: 65
-  - id: layer_22/width_16k/average_l0_106
-    path: layer_22/width_16k/average_l0_106
-    l0: 106
-  - id: layer_22/width_16k/average_l0_215
-    path: layer_22/width_16k/average_l0_215
-    l0: 215
-  - id: layer_22/width_16k/average_l0_22
-    path: layer_22/width_16k/average_l0_22
-    l0: 22
-  - id: layer_22/width_16k/average_l0_373
-    path: layer_22/width_16k/average_l0_373
-    l0: 373
-  - id: layer_22/width_16k/average_l0_47
-    path: layer_22/width_16k/average_l0_47
-    l0: 47
-  - id: layer_23/width_16k/average_l0_161
-    path: layer_23/width_16k/average_l0_161
-    l0: 161
-  - id: layer_23/width_16k/average_l0_30
-    path: layer_23/width_16k/average_l0_30
-    l0: 30
-  - id: layer_23/width_16k/average_l0_300
-    path: layer_23/width_16k/average_l0_300
-    l0: 300
-  - id: layer_23/width_16k/average_l0_474
-    path: layer_23/width_16k/average_l0_474
-    l0: 474
-  - id: layer_23/width_16k/average_l0_73
-    path: layer_23/width_16k/average_l0_73
-    l0: 73
-  - id: layer_24/width_16k/average_l0_212
-    path: layer_24/width_16k/average_l0_212
-    l0: 212
-  - id: layer_24/width_16k/average_l0_372
-    path: layer_24/width_16k/average_l0_372
-    l0: 372
-  - id: layer_24/width_16k/average_l0_39
-    path: layer_24/width_16k/average_l0_39
-    l0: 39
-  - id: layer_24/width_16k/average_l0_558
-    path: layer_24/width_16k/average_l0_558
-    l0: 558
-  - id: layer_24/width_16k/average_l0_96
-    path: layer_24/width_16k/average_l0_96
-    l0: 96
-  - id: layer_25/width_16k/average_l0_177
-    path: layer_25/width_16k/average_l0_177
-    l0: 177
-  - id: layer_25/width_16k/average_l0_313
-    path: layer_25/width_16k/average_l0_313
-    l0: 313
-  - id: layer_25/width_16k/average_l0_35
-    path: layer_25/width_16k/average_l0_35
-    l0: 35
-  - id: layer_25/width_16k/average_l0_492
-    path: layer_25/width_16k/average_l0_492
-    l0: 492
-  - id: layer_25/width_16k/average_l0_77
-    path: layer_25/width_16k/average_l0_77
-    l0: 77
-  - id: layer_0/width_65k/average_l0_10
-    path: layer_0/width_65k/average_l0_10
-    l0: 10
-  - id: layer_0/width_65k/average_l0_16
-    path: layer_0/width_65k/average_l0_16
-    l0: 16
-  - id: layer_0/width_65k/average_l0_24
-    path: layer_0/width_65k/average_l0_24
-    l0: 24
-  - id: layer_0/width_65k/average_l0_43
-    path: layer_0/width_65k/average_l0_43
-    l0: 43
-  - id: layer_0/width_65k/average_l0_75
-    path: layer_0/width_65k/average_l0_75
-    l0: 75
-  - id: layer_1/width_65k/average_l0_15
-    path: layer_1/width_65k/average_l0_15
-    l0: 15
-  - id: layer_1/width_65k/average_l0_181
-    path: layer_1/width_65k/average_l0_181
-    l0: 181
-  - id: layer_1/width_65k/average_l0_28
-    path: layer_1/width_65k/average_l0_28
-    l0: 28
-  - id: layer_1/width_65k/average_l0_55
-    path: layer_1/width_65k/average_l0_55
-    l0: 55
-  - id: layer_1/width_65k/average_l0_98
-    path: layer_1/width_65k/average_l0_98
-    l0: 98
-  - id: layer_2/width_65k/average_l0_125
-    path: layer_2/width_65k/average_l0_125
-    l0: 125
-  - id: layer_2/width_65k/average_l0_14
-    path: layer_2/width_65k/average_l0_14
-    l0: 14
-  - id: layer_2/width_65k/average_l0_228
-    path: layer_2/width_65k/average_l0_228
-    l0: 228
-  - id: layer_2/width_65k/average_l0_28
-    path: layer_2/width_65k/average_l0_28
-    l0: 28
-  - id: layer_2/width_65k/average_l0_59
-    path: layer_2/width_65k/average_l0_59
-    l0: 59
-  - id: layer_3/width_65k/average_l0_174
-    path: layer_3/width_65k/average_l0_174
-    l0: 174
-  - id: layer_3/width_65k/average_l0_19
-    path: layer_3/width_65k/average_l0_19
-    l0: 19
-  - id: layer_3/width_65k/average_l0_320
-    path: layer_3/width_65k/average_l0_320
-    l0: 320
-  - id: layer_3/width_65k/average_l0_39
-    path: layer_3/width_65k/average_l0_39
-    l0: 39
-  - id: layer_3/width_65k/average_l0_83
-    path: layer_3/width_65k/average_l0_83
-    l0: 83
-  - id: layer_4/width_65k/average_l0_188
-    path: layer_4/width_65k/average_l0_188
-    l0: 188
-  - id: layer_4/width_65k/average_l0_22
-    path: layer_4/width_65k/average_l0_22
-    l0: 22
-  - id: layer_4/width_65k/average_l0_382
-    path: layer_4/width_65k/average_l0_382
-    l0: 382
-  - id: layer_4/width_65k/average_l0_43
-    path: layer_4/width_65k/average_l0_43
-    l0: 43
-  - id: layer_4/width_65k/average_l0_87
-    path: layer_4/width_65k/average_l0_87
-    l0: 87
-  - id: layer_5/width_65k/average_l0_227
-    path: layer_5/width_65k/average_l0_227
-    l0: 227
-  - id: layer_5/width_65k/average_l0_28
-    path: layer_5/width_65k/average_l0_28
-    l0: 28
-  - id: layer_5/width_65k/average_l0_400
-    path: layer_5/width_65k/average_l0_400
-    l0: 400
-  - id: layer_5/width_65k/average_l0_51
-    path: layer_5/width_65k/average_l0_51
-    l0: 51
-  - id: layer_5/width_65k/average_l0_99
-    path: layer_5/width_65k/average_l0_99
-    l0: 99
-  - id: layer_6/width_65k/average_l0_112
-    path: layer_6/width_65k/average_l0_112
-    l0: 112
-  - id: layer_6/width_65k/average_l0_261
-    path: layer_6/width_65k/average_l0_261
-    l0: 261
-  - id: layer_6/width_65k/average_l0_30
-    path: layer_6/width_65k/average_l0_30
-    l0: 30
-  - id: layer_6/width_65k/average_l0_449
-    path: layer_6/width_65k/average_l0_449
-    l0: 449
-  - id: layer_6/width_65k/average_l0_55
-    path: layer_6/width_65k/average_l0_55
-    l0: 55
-  - id: layer_7/width_65k/average_l0_176
-    path: layer_7/width_65k/average_l0_176
-    l0: 176
-  - id: layer_7/width_65k/average_l0_311
-    path: layer_7/width_65k/average_l0_311
-    l0: 311
-  - id: layer_7/width_65k/average_l0_519
-    path: layer_7/width_65k/average_l0_519
-    l0: 519
-  - id: layer_7/width_65k/average_l0_52
-    path: layer_7/width_65k/average_l0_52
-    l0: 52
-  - id: layer_7/width_65k/average_l0_96
-    path: layer_7/width_65k/average_l0_96
-    l0: 96
-  - id: layer_8/width_65k/average_l0_112
-    path: layer_8/width_65k/average_l0_112
-    l0: 112
-  - id: layer_8/width_65k/average_l0_246
-    path: layer_8/width_65k/average_l0_246
-    l0: 246
-  - id: layer_8/width_65k/average_l0_35
-    path: layer_8/width_65k/average_l0_35
-    l0: 35
-  - id: layer_8/width_65k/average_l0_454
-    path: layer_8/width_65k/average_l0_454
-    l0: 454
-  - id: layer_8/width_65k/average_l0_56
-    path: layer_8/width_65k/average_l0_56
-    l0: 56
-  - id: layer_9/width_65k/average_l0_107
-    path: layer_9/width_65k/average_l0_107
-    l0: 107
-  - id: layer_9/width_65k/average_l0_231
-    path: layer_9/width_65k/average_l0_231
-    l0: 231
-  - id: layer_9/width_65k/average_l0_31
-    path: layer_9/width_65k/average_l0_31
-    l0: 31
-  - id: layer_9/width_65k/average_l0_454
-    path: layer_9/width_65k/average_l0_454
-    l0: 454
-  - id: layer_9/width_65k/average_l0_57
-    path: layer_9/width_65k/average_l0_57
-    l0: 57
-  - id: layer_10/width_65k/average_l0_134
-    path: layer_10/width_65k/average_l0_134
-    l0: 134
-  - id: layer_10/width_65k/average_l0_292
-    path: layer_10/width_65k/average_l0_292
-    l0: 292
-  - id: layer_10/width_65k/average_l0_35
-    path: layer_10/width_65k/average_l0_35
-    l0: 35
-  - id: layer_10/width_65k/average_l0_521
-    path: layer_10/width_65k/average_l0_521
-    l0: 521
-  - id: layer_10/width_65k/average_l0_67
-    path: layer_10/width_65k/average_l0_67
-    l0: 67
-  - id: layer_11/width_65k/average_l0_154
-    path: layer_11/width_65k/average_l0_154
-    l0: 154
-  - id: layer_11/width_65k/average_l0_330
-    path: layer_11/width_65k/average_l0_330
-    l0: 330
-  - id: layer_11/width_65k/average_l0_41
-    path: layer_11/width_65k/average_l0_41
-    l0: 41
-  - id: layer_11/width_65k/average_l0_576
-    path: layer_11/width_65k/average_l0_576
-    l0: 576
-  - id: layer_11/width_65k/average_l0_75
-    path: layer_11/width_65k/average_l0_75
-    l0: 75
-  - id: layer_12/width_65k/average_l0_172
-    path: layer_12/width_65k/average_l0_172
-    l0: 172
-  - id: layer_12/width_65k/average_l0_320
-    path: layer_12/width_65k/average_l0_320
-    l0: 320
-  - id: layer_12/width_65k/average_l0_39
-    path: layer_12/width_65k/average_l0_39
-    l0: 39
-  - id: layer_12/width_65k/average_l0_503
-    path: layer_12/width_65k/average_l0_503
-    l0: 503
-  - id: layer_12/width_65k/average_l0_79
-    path: layer_12/width_65k/average_l0_79
-    l0: 79
-  - id: layer_13/width_65k/average_l0_191
-    path: layer_13/width_65k/average_l0_191
-    l0: 191
-  - id: layer_13/width_65k/average_l0_363
-    path: layer_13/width_65k/average_l0_363
-    l0: 363
-  - id: layer_13/width_65k/average_l0_41
-    path: layer_13/width_65k/average_l0_41
-    l0: 41
-  - id: layer_13/width_65k/average_l0_556
-    path: layer_13/width_65k/average_l0_556
-    l0: 556
-  - id: layer_13/width_65k/average_l0_87
-    path: layer_13/width_65k/average_l0_87
-    l0: 87
-  - id: layer_14/width_65k/average_l0_138
-    path: layer_14/width_65k/average_l0_138
-    l0: 138
-  - id: layer_14/width_65k/average_l0_283
-    path: layer_14/width_65k/average_l0_283
-    l0: 283
-  - id: layer_14/width_65k/average_l0_37
-    path: layer_14/width_65k/average_l0_37
-    l0: 37
-  - id: layer_14/width_65k/average_l0_453
-    path: layer_14/width_65k/average_l0_453
-    l0: 453
-  - id: layer_14/width_65k/average_l0_66
-    path: layer_14/width_65k/average_l0_66
-    l0: 66
-  - id: layer_15/width_65k/average_l0_182
-    path: layer_15/width_65k/average_l0_182
-    l0: 182
-  - id: layer_15/width_65k/average_l0_327
-    path: layer_15/width_65k/average_l0_327
-    l0: 327
-  - id: layer_15/width_65k/average_l0_42
-    path: layer_15/width_65k/average_l0_42
-    l0: 42
-  - id: layer_15/width_65k/average_l0_517
-    path: layer_15/width_65k/average_l0_517
-    l0: 517
-  - id: layer_15/width_65k/average_l0_90
-    path: layer_15/width_65k/average_l0_90
-    l0: 90
-  - id: layer_16/width_65k/average_l0_129
-    path: layer_16/width_65k/average_l0_129
-    l0: 129
-  - id: layer_16/width_65k/average_l0_260
-    path: layer_16/width_65k/average_l0_260
-    l0: 260
-  - id: layer_16/width_65k/average_l0_35
-    path: layer_16/width_65k/average_l0_35
-    l0: 35
-  - id: layer_16/width_65k/average_l0_502
-    path: layer_16/width_65k/average_l0_502
-    l0: 502
-  - id: layer_16/width_65k/average_l0_64
-    path: layer_16/width_65k/average_l0_64
-    l0: 64
-  - id: layer_17/width_65k/average_l0_157
-    path: layer_17/width_65k/average_l0_157
-    l0: 157
-  - id: layer_17/width_65k/average_l0_293
-    path: layer_17/width_65k/average_l0_293
-    l0: 293
-  - id: layer_17/width_65k/average_l0_35
-    path: layer_17/width_65k/average_l0_35
-    l0: 35
-  - id: layer_17/width_65k/average_l0_489
-    path: layer_17/width_65k/average_l0_489
-    l0: 489
-  - id: layer_17/width_65k/average_l0_70
-    path: layer_17/width_65k/average_l0_70
-    l0: 70
-  - id: layer_18/width_65k/average_l0_123
-    path: layer_18/width_65k/average_l0_123
-    l0: 123
-  - id: layer_18/width_65k/average_l0_255
-    path: layer_18/width_65k/average_l0_255
-    l0: 255
-  - id: layer_18/width_65k/average_l0_29
-    path: layer_18/width_65k/average_l0_29
-    l0: 29
-  - id: layer_18/width_65k/average_l0_466
-    path: layer_18/width_65k/average_l0_466
-    l0: 466
-  - id: layer_18/width_65k/average_l0_58
-    path: layer_18/width_65k/average_l0_58
-    l0: 58
-  - id: layer_19/width_65k/average_l0_106
-    path: layer_19/width_65k/average_l0_106
-    l0: 106
-  - id: layer_19/width_65k/average_l0_220
-    path: layer_19/width_65k/average_l0_220
-    l0: 220
-  - id: layer_19/width_65k/average_l0_26
-    path: layer_19/width_65k/average_l0_26
-    l0: 26
-  - id: layer_19/width_65k/average_l0_411
-    path: layer_19/width_65k/average_l0_411
-    l0: 411
-  - id: layer_19/width_65k/average_l0_49
-    path: layer_19/width_65k/average_l0_49
-    l0: 49
-  - id: layer_20/width_65k/average_l0_102
-    path: layer_20/width_65k/average_l0_102
-    l0: 102
-  - id: layer_20/width_65k/average_l0_242
-    path: layer_20/width_65k/average_l0_242
-    l0: 242
-  - id: layer_20/width_65k/average_l0_26
-    path: layer_20/width_65k/average_l0_26
-    l0: 26
-  - id: layer_20/width_65k/average_l0_419
-    path: layer_20/width_65k/average_l0_419
-    l0: 419
-  - id: layer_20/width_65k/average_l0_49
-    path: layer_20/width_65k/average_l0_49
-    l0: 49
-  - id: layer_21/width_65k/average_l0_118
-    path: layer_21/width_65k/average_l0_118
-    l0: 118
-  - id: layer_21/width_65k/average_l0_266
-    path: layer_21/width_65k/average_l0_266
-    l0: 266
-  - id: layer_21/width_65k/average_l0_29
-    path: layer_21/width_65k/average_l0_29
-    l0: 29
-  - id: layer_21/width_65k/average_l0_474
-    path: layer_21/width_65k/average_l0_474
-    l0: 474
-  - id: layer_21/width_65k/average_l0_56
-    path: layer_21/width_65k/average_l0_56
-    l0: 56
-  - id: layer_22/width_65k/average_l0_112
-    path: layer_22/width_65k/average_l0_112
-    l0: 112
-  - id: layer_22/width_65k/average_l0_196
-    path: layer_22/width_65k/average_l0_196
-    l0: 196
-  - id: layer_22/width_65k/average_l0_20
-    path: layer_22/width_65k/average_l0_20
-    l0: 20
-  - id: layer_22/width_65k/average_l0_361
-    path: layer_22/width_65k/average_l0_361
-    l0: 361
-  - id: layer_22/width_65k/average_l0_37
-    path: layer_22/width_65k/average_l0_37
-    l0: 37
-  - id: layer_23/width_65k/average_l0_140
-    path: layer_23/width_65k/average_l0_140
-    l0: 140
-  - id: layer_23/width_65k/average_l0_27
-    path: layer_23/width_65k/average_l0_27
-    l0: 27
-  - id: layer_23/width_65k/average_l0_276
-    path: layer_23/width_65k/average_l0_276
-    l0: 276
-  - id: layer_23/width_65k/average_l0_457
-    path: layer_23/width_65k/average_l0_457
-    l0: 457
-  - id: layer_23/width_65k/average_l0_56
-    path: layer_23/width_65k/average_l0_56
-    l0: 56
-  - id: layer_24/width_65k/average_l0_186
-    path: layer_24/width_65k/average_l0_186
-    l0: 186
-  - id: layer_24/width_65k/average_l0_32
-    path: layer_24/width_65k/average_l0_32
-    l0: 32
-  - id: layer_24/width_65k/average_l0_347
-    path: layer_24/width_65k/average_l0_347
-    l0: 347
-  - id: layer_24/width_65k/average_l0_537
-    path: layer_24/width_65k/average_l0_537
-    l0: 537
-  - id: layer_24/width_65k/average_l0_77
-    path: layer_24/width_65k/average_l0_77
-    l0: 77
-  - id: layer_25/width_65k/average_l0_153
-    path: layer_25/width_65k/average_l0_153
-    l0: 153
-  - id: layer_25/width_65k/average_l0_290
-    path: layer_25/width_65k/average_l0_290
-    l0: 290
-  - id: layer_25/width_65k/average_l0_30
-    path: layer_25/width_65k/average_l0_30
-    l0: 30
-  - id: layer_25/width_65k/average_l0_465
-    path: layer_25/width_65k/average_l0_465
-    l0: 465
-  - id: layer_25/width_65k/average_l0_63
-    path: layer_25/width_65k/average_l0_63
-    l0: 63
-gemma-scope-2b-pt-att-canonical:
-  repo_id: google/gemma-scope-2b-pt-att
-  model: gemma-2-2b
-  conversion_func: gemma_2
-  saes:
-  - id: layer_0/width_16k/canonical
-    path: layer_0/width_16k/average_l0_104
-    neuronpedia: gemma-2-2b/0-gemmascope-att-16k
-  - id: layer_1/width_16k/canonical
-    path: layer_1/width_16k/average_l0_79
-    neuronpedia: gemma-2-2b/1-gemmascope-att-16k
-  - id: layer_2/width_16k/canonical
-    path: layer_2/width_16k/average_l0_93
-    neuronpedia: gemma-2-2b/2-gemmascope-att-16k
-  - id: layer_3/width_16k/canonical
-    path: layer_3/width_16k/average_l0_117
-    neuronpedia: gemma-2-2b/3-gemmascope-att-16k
-  - id: layer_4/width_16k/canonical
-    path: layer_4/width_16k/average_l0_116
-    neuronpedia: gemma-2-2b/4-gemmascope-att-16k
-  - id: layer_5/width_16k/canonical
-    path: layer_5/width_16k/average_l0_135
-    neuronpedia: gemma-2-2b/5-gemmascope-att-16k
-  - id: layer_6/width_16k/canonical
-    path: layer_6/width_16k/average_l0_61
-    neuronpedia: gemma-2-2b/6-gemmascope-att-16k
-  - id: layer_7/width_16k/canonical
-    path: layer_7/width_16k/average_l0_99
-    neuronpedia: gemma-2-2b/7-gemmascope-att-16k
-  - id: layer_8/width_16k/canonical
-    path: layer_8/width_16k/average_l0_129
-    neuronpedia: gemma-2-2b/8-gemmascope-att-16k
-  - id: layer_9/width_16k/canonical
-    path: layer_9/width_16k/average_l0_127
-    neuronpedia: gemma-2-2b/9-gemmascope-att-16k
-  - id: layer_10/width_16k/canonical
-    path: layer_10/width_16k/average_l0_70
-    neuronpedia: gemma-2-2b/10-gemmascope-att-16k
-  - id: layer_11/width_16k/canonical
-    path: layer_11/width_16k/average_l0_80
-    neuronpedia: gemma-2-2b/11-gemmascope-att-16k
-  - id: layer_12/width_16k/canonical
-    path: layer_12/width_16k/average_l0_85
-    neuronpedia: gemma-2-2b/12-gemmascope-att-16k
-  - id: layer_13/width_16k/canonical
-    path: layer_13/width_16k/average_l0_92
-    neuronpedia: gemma-2-2b/13-gemmascope-att-16k
-  - id: layer_14/width_16k/canonical
-    path: layer_14/width_16k/average_l0_71
-    neuronpedia: gemma-2-2b/14-gemmascope-att-16k
-  - id: layer_15/width_16k/canonical
-    path: layer_15/width_16k/average_l0_98
-    neuronpedia: gemma-2-2b/15-gemmascope-att-16k
-  - id: layer_16/width_16k/canonical
-    path: layer_16/width_16k/average_l0_71
-    neuronpedia: gemma-2-2b/16-gemmascope-att-16k
-  - id: layer_17/width_16k/canonical
-    path: layer_17/width_16k/average_l0_79
-    neuronpedia: gemma-2-2b/17-gemmascope-att-16k
-  - id: layer_18/width_16k/canonical
-    path: layer_18/width_16k/average_l0_72
-    neuronpedia: gemma-2-2b/18-gemmascope-att-16k
-  - id: layer_19/width_16k/canonical
-    path: layer_19/width_16k/average_l0_122
-    neuronpedia: gemma-2-2b/19-gemmascope-att-16k
-  - id: layer_20/width_16k/canonical
-    path: layer_20/width_16k/average_l0_62
-    neuronpedia: gemma-2-2b/20-gemmascope-att-16k
-  - id: layer_21/width_16k/canonical
-    path: layer_21/width_16k/average_l0_65
-    neuronpedia: gemma-2-2b/21-gemmascope-att-16k
-  - id: layer_22/width_16k/canonical
-    path: layer_22/width_16k/average_l0_106
-    neuronpedia: gemma-2-2b/22-gemmascope-att-16k
-  - id: layer_23/width_16k/canonical
-    path: layer_23/width_16k/average_l0_73
-    neuronpedia: gemma-2-2b/23-gemmascope-att-16k
-  - id: layer_24/width_16k/canonical
-    path: layer_24/width_16k/average_l0_96
-    neuronpedia: gemma-2-2b/24-gemmascope-att-16k
-  - id: layer_25/width_16k/canonical
-    path: layer_25/width_16k/average_l0_77
-    neuronpedia: gemma-2-2b/25-gemmascope-att-16k
-  - id: layer_0/width_65k/canonical
-    path: layer_0/width_65k/average_l0_75
-    neuronpedia: gemma-2-2b/0-gemmascope-att-65k
-  - id: layer_1/width_65k/canonical
-    path: layer_1/width_65k/average_l0_98
-    neuronpedia: gemma-2-2b/1-gemmascope-att-65k
-  - id: layer_2/width_65k/canonical
-    path: layer_2/width_65k/average_l0_125
-    neuronpedia: gemma-2-2b/2-gemmascope-att-65k
-  - id: layer_3/width_65k/canonical
-    path: layer_3/width_65k/average_l0_83
-    neuronpedia: gemma-2-2b/3-gemmascope-att-65k
-  - id: layer_4/width_65k/canonical
-    path: layer_4/width_65k/average_l0_87
-    neuronpedia: gemma-2-2b/4-gemmascope-att-65k
-  - id: layer_5/width_65k/canonical
-    path: layer_5/width_65k/average_l0_99
-    neuronpedia: gemma-2-2b/5-gemmascope-att-65k
-  - id: layer_6/width_65k/canonical
-    path: layer_6/width_65k/average_l0_112
-    neuronpedia: gemma-2-2b/6-gemmascope-att-65k
-  - id: layer_7/width_65k/canonical
-    path: layer_7/width_65k/average_l0_96
-    neuronpedia: gemma-2-2b/7-gemmascope-att-65k
-  - id: layer_8/width_65k/canonical
-    path: layer_8/width_65k/average_l0_112
-    neuronpedia: gemma-2-2b/8-gemmascope-att-65k
-  - id: layer_9/width_65k/canonical
-    path: layer_9/width_65k/average_l0_107
-    neuronpedia: gemma-2-2b/9-gemmascope-att-65k
-  - id: layer_10/width_65k/canonical
-    path: layer_10/width_65k/average_l0_67
-    neuronpedia: gemma-2-2b/10-gemmascope-att-65k
-  - id: layer_11/width_65k/canonical
-    path: layer_11/width_65k/average_l0_75
-    neuronpedia: gemma-2-2b/11-gemmascope-att-65k
-  - id: layer_12/width_65k/canonical
-    path: layer_12/width_65k/average_l0_79
-    neuronpedia: gemma-2-2b/12-gemmascope-att-65k
-  - id: layer_13/width_65k/canonical
-    path: layer_13/width_65k/average_l0_87
-    neuronpedia: gemma-2-2b/13-gemmascope-att-65k
-  - id: layer_14/width_65k/canonical
-    path: layer_14/width_65k/average_l0_66
-    neuronpedia: gemma-2-2b/14-gemmascope-att-65k
-  - id: layer_15/width_65k/canonical
-    path: layer_15/width_65k/average_l0_90
-    neuronpedia: gemma-2-2b/15-gemmascope-att-65k
-  - id: layer_16/width_65k/canonical
-    path: layer_16/width_65k/average_l0_129
-    neuronpedia: gemma-2-2b/16-gemmascope-att-65k
-  - id: layer_17/width_65k/canonical
-    path: layer_17/width_65k/average_l0_70
-    neuronpedia: gemma-2-2b/17-gemmascope-att-65k
-  - id: layer_18/width_65k/canonical
-    path: layer_18/width_65k/average_l0_123
-    neuronpedia: gemma-2-2b/18-gemmascope-att-65k
-  - id: layer_19/width_65k/canonical
-    path: layer_19/width_65k/average_l0_106
-    neuronpedia: gemma-2-2b/19-gemmascope-att-65k
-  - id: layer_20/width_65k/canonical
-    path: layer_20/width_65k/average_l0_102
-    neuronpedia: gemma-2-2b/20-gemmascope-att-65k
-  - id: layer_21/width_65k/canonical
-    path: layer_21/width_65k/average_l0_118
-    neuronpedia: gemma-2-2b/21-gemmascope-att-65k
-  - id: layer_22/width_65k/canonical
-    path: layer_22/width_65k/average_l0_112
-    neuronpedia: gemma-2-2b/22-gemmascope-att-65k
-  - id: layer_23/width_65k/canonical
-    path: layer_23/width_65k/average_l0_140
-    neuronpedia: gemma-2-2b/23-gemmascope-att-65k
-  - id: layer_24/width_65k/canonical
-    path: layer_24/width_65k/average_l0_77
-    neuronpedia: gemma-2-2b/24-gemmascope-att-65k
-  - id: layer_25/width_65k/canonical
-    path: layer_25/width_65k/average_l0_63
-    neuronpedia: gemma-2-2b/25-gemmascope-att-65k
-gemma-scope-9b-pt-res:
-  repo_id: google/gemma-scope-9b-pt-res
   model: gemma-2-9b
+  repo_id: google/gemma-scope-9b-it-res
+  saes:
+  - id: layer_20/width_131k/average_l0_13
+    l0: 13
+    path: layer_20/width_131k/average_l0_13
+  - id: layer_20/width_131k/average_l0_153
+    l0: 153
+    path: layer_20/width_131k/average_l0_153
+  - id: layer_20/width_131k/average_l0_24
+    l0: 24
+    path: layer_20/width_131k/average_l0_24
+  - id: layer_20/width_131k/average_l0_43
+    l0: 43
+    path: layer_20/width_131k/average_l0_43
+  - id: layer_20/width_131k/average_l0_81
+    l0: 81
+    path: layer_20/width_131k/average_l0_81
+  - id: layer_20/width_16k/average_l0_14
+    l0: 14
+    path: layer_20/width_16k/average_l0_14
+  - id: layer_20/width_16k/average_l0_189
+    l0: 189
+    path: layer_20/width_16k/average_l0_189
+  - id: layer_20/width_16k/average_l0_25
+    l0: 25
+    path: layer_20/width_16k/average_l0_25
+  - id: layer_20/width_16k/average_l0_47
+    l0: 47
+    path: layer_20/width_16k/average_l0_47
+  - id: layer_20/width_16k/average_l0_91
+    l0: 91
+    path: layer_20/width_16k/average_l0_91
+  - id: layer_31/width_131k/average_l0_109
+    l0: 109
+    path: layer_31/width_131k/average_l0_109
+  - id: layer_31/width_131k/average_l0_13
+    l0: 13
+    path: layer_31/width_131k/average_l0_13
+  - id: layer_31/width_131k/average_l0_22
+    l0: 22
+    path: layer_31/width_131k/average_l0_22
+  - id: layer_31/width_131k/average_l0_37
+    l0: 37
+    path: layer_31/width_131k/average_l0_37
+  - id: layer_31/width_131k/average_l0_63
+    l0: 63
+    path: layer_31/width_131k/average_l0_63
+  - id: layer_31/width_16k/average_l0_14
+    l0: 14
+    path: layer_31/width_16k/average_l0_14
+  - id: layer_31/width_16k/average_l0_142
+    l0: 142
+    path: layer_31/width_16k/average_l0_142
+  - id: layer_31/width_16k/average_l0_24
+    l0: 24
+    path: layer_31/width_16k/average_l0_24
+  - id: layer_31/width_16k/average_l0_43
+    l0: 43
+    path: layer_31/width_16k/average_l0_43
+  - id: layer_31/width_16k/average_l0_76
+    l0: 76
+    path: layer_31/width_16k/average_l0_76
+  - id: layer_9/width_131k/average_l0_121
+    l0: 121
+    path: layer_9/width_131k/average_l0_121
+  - id: layer_9/width_131k/average_l0_13
+    l0: 13
+    path: layer_9/width_131k/average_l0_13
+  - id: layer_9/width_131k/average_l0_22
+    l0: 22
+    path: layer_9/width_131k/average_l0_22
+  - id: layer_9/width_131k/average_l0_39
+    l0: 39
+    path: layer_9/width_131k/average_l0_39
+  - id: layer_9/width_131k/average_l0_67
+    l0: 67
+    path: layer_9/width_131k/average_l0_67
+  - id: layer_9/width_16k/average_l0_14
+    l0: 14
+    path: layer_9/width_16k/average_l0_14
+  - id: layer_9/width_16k/average_l0_186
+    l0: 186
+    path: layer_9/width_16k/average_l0_186
+  - id: layer_9/width_16k/average_l0_26
+    l0: 26
+    path: layer_9/width_16k/average_l0_26
+  - id: layer_9/width_16k/average_l0_47
+    l0: 47
+    path: layer_9/width_16k/average_l0_47
+  - id: layer_9/width_16k/average_l0_88
+    l0: 88
+    path: layer_9/width_16k/average_l0_88
+gemma-scope-9b-it-res-canonical:
   conversion_func: gemma_2
+  model: gemma-2-9b-it
+  repo_id: google/gemma-scope-9b-it-res
+  saes:
+  - id: layer_9/width_16k/canonical
+    neuronpedia: gemma-2-9b-it/9-gemmascope-res-16k
+    path: layer_9/width_16k/average_l0_88
+  - id: layer_20/width_16k/canonical
+    neuronpedia: gemma-2-9b-it/20-gemmascope-res-16k
+    path: layer_20/width_16k/average_l0_91
+  - id: layer_31/width_16k/canonical
+    neuronpedia: gemma-2-9b-it/31-gemmascope-res-16k
+    path: layer_31/width_16k/average_l0_76
+  - id: layer_9/width_131k/canonical
+    neuronpedia: gemma-2-9b-it/9-gemmascope-res-131k
+    path: layer_9/width_131k/average_l0_121
+  - id: layer_20/width_131k/canonical
+    neuronpedia: gemma-2-9b-it/20-gemmascope-res-131k
+    path: layer_20/width_131k/average_l0_81
+  - id: layer_31/width_131k/canonical
+    neuronpedia: gemma-2-9b-it/31-gemmascope-res-131k
+    path: layer_31/width_131k/average_l0_109
+gemma-scope-9b-pt-att:
+  conversion_func: gemma_2
+  model: gemma-2-9b
+  repo_id: google/gemma-scope-9b-pt-att
+  saes:
+  - id: layer_0/width_16k/average_l0_12
+    l0: 12
+    path: layer_0/width_16k/average_l0_12
+  - id: layer_0/width_16k/average_l0_16
+    l0: 16
+    path: layer_0/width_16k/average_l0_16
+  - id: layer_0/width_16k/average_l0_25
+    l0: 25
+    path: layer_0/width_16k/average_l0_25
+  - id: layer_0/width_16k/average_l0_38
+    l0: 38
+    path: layer_0/width_16k/average_l0_38
+  - id: layer_0/width_16k/average_l0_61
+    l0: 61
+    path: layer_0/width_16k/average_l0_61
+  - id: layer_0/width_131k/average_l0_8
+    l0: 8
+    path: layer_0/width_131k/average_l0_8
+  - id: layer_0/width_131k/average_l0_11
+    l0: 11
+    path: layer_0/width_131k/average_l0_11
+  - id: layer_0/width_131k/average_l0_15
+    l0: 15
+    path: layer_0/width_131k/average_l0_15
+  - id: layer_0/width_131k/average_l0_22
+    l0: 22
+    path: layer_0/width_131k/average_l0_22
+  - id: layer_0/width_131k/average_l0_33
+    l0: 33
+    path: layer_0/width_131k/average_l0_33
+  - id: layer_0/width_131k/average_l0_55
+    l0: 55
+    path: layer_0/width_131k/average_l0_55
+  - id: layer_1/width_16k/average_l0_17
+    l0: 17
+    path: layer_1/width_16k/average_l0_17
+  - id: layer_1/width_16k/average_l0_34
+    l0: 34
+    path: layer_1/width_16k/average_l0_34
+  - id: layer_1/width_16k/average_l0_77
+    l0: 77
+    path: layer_1/width_16k/average_l0_77
+  - id: layer_1/width_16k/average_l0_147
+    l0: 147
+    path: layer_1/width_16k/average_l0_147
+  - id: layer_1/width_16k/average_l0_266
+    l0: 266
+    path: layer_1/width_16k/average_l0_266
+  - id: layer_1/width_131k/average_l0_8
+    l0: 8
+    path: layer_1/width_131k/average_l0_8
+  - id: layer_1/width_131k/average_l0_12
+    l0: 12
+    path: layer_1/width_131k/average_l0_12
+  - id: layer_1/width_131k/average_l0_18
+    l0: 18
+    path: layer_1/width_131k/average_l0_18
+  - id: layer_1/width_131k/average_l0_29
+    l0: 29
+    path: layer_1/width_131k/average_l0_29
+  - id: layer_1/width_131k/average_l0_63
+    l0: 63
+    path: layer_1/width_131k/average_l0_63
+  - id: layer_1/width_131k/average_l0_116
+    l0: 116
+    path: layer_1/width_131k/average_l0_116
+  - id: layer_10/width_16k/average_l0_18
+    l0: 18
+    path: layer_10/width_16k/average_l0_18
+  - id: layer_10/width_16k/average_l0_33
+    l0: 33
+    path: layer_10/width_16k/average_l0_33
+  - id: layer_10/width_16k/average_l0_63
+    l0: 63
+    path: layer_10/width_16k/average_l0_63
+  - id: layer_10/width_16k/average_l0_132
+    l0: 132
+    path: layer_10/width_16k/average_l0_132
+  - id: layer_10/width_16k/average_l0_301
+    l0: 301
+    path: layer_10/width_16k/average_l0_301
+  - id: layer_10/width_131k/average_l0_16
+    l0: 16
+    path: layer_10/width_131k/average_l0_16
+  - id: layer_10/width_131k/average_l0_28
+    l0: 28
+    path: layer_10/width_131k/average_l0_28
+  - id: layer_10/width_131k/average_l0_51
+    l0: 51
+    path: layer_10/width_131k/average_l0_51
+  - id: layer_10/width_131k/average_l0_97
+    l0: 97
+    path: layer_10/width_131k/average_l0_97
+  - id: layer_10/width_131k/average_l0_199
+    l0: 199
+    path: layer_10/width_131k/average_l0_199
+  - id: layer_10/width_131k/average_l0_440
+    l0: 440
+    path: layer_10/width_131k/average_l0_440
+  - id: layer_11/width_16k/average_l0_18
+    l0: 18
+    path: layer_11/width_16k/average_l0_18
+  - id: layer_11/width_16k/average_l0_34
+    l0: 34
+    path: layer_11/width_16k/average_l0_34
+  - id: layer_11/width_16k/average_l0_67
+    l0: 67
+    path: layer_11/width_16k/average_l0_67
+  - id: layer_11/width_16k/average_l0_153
+    l0: 153
+    path: layer_11/width_16k/average_l0_153
+  - id: layer_11/width_16k/average_l0_366
+    l0: 366
+    path: layer_11/width_16k/average_l0_366
+  - id: layer_11/width_131k/average_l0_17
+    l0: 17
+    path: layer_11/width_131k/average_l0_17
+  - id: layer_11/width_131k/average_l0_29
+    l0: 29
+    path: layer_11/width_131k/average_l0_29
+  - id: layer_11/width_131k/average_l0_54
+    l0: 54
+    path: layer_11/width_131k/average_l0_54
+  - id: layer_11/width_131k/average_l0_104
+    l0: 104
+    path: layer_11/width_131k/average_l0_104
+  - id: layer_11/width_131k/average_l0_241
+    l0: 241
+    path: layer_11/width_131k/average_l0_241
+  - id: layer_11/width_131k/average_l0_552
+    l0: 552
+    path: layer_11/width_131k/average_l0_552
+  - id: layer_12/width_16k/average_l0_19
+    l0: 19
+    path: layer_12/width_16k/average_l0_19
+  - id: layer_12/width_16k/average_l0_35
+    l0: 35
+    path: layer_12/width_16k/average_l0_35
+  - id: layer_12/width_16k/average_l0_68
+    l0: 68
+    path: layer_12/width_16k/average_l0_68
+  - id: layer_12/width_16k/average_l0_149
+    l0: 149
+    path: layer_12/width_16k/average_l0_149
+  - id: layer_12/width_16k/average_l0_337
+    l0: 337
+    path: layer_12/width_16k/average_l0_337
+  - id: layer_12/width_16k/average_l0_654
+    l0: 654
+    path: layer_12/width_16k/average_l0_654
+  - id: layer_12/width_131k/average_l0_17
+    l0: 17
+    path: layer_12/width_131k/average_l0_17
+  - id: layer_12/width_131k/average_l0_29
+    l0: 29
+    path: layer_12/width_131k/average_l0_29
+  - id: layer_12/width_131k/average_l0_55
+    l0: 55
+    path: layer_12/width_131k/average_l0_55
+  - id: layer_12/width_131k/average_l0_110
+    l0: 110
+    path: layer_12/width_131k/average_l0_110
+  - id: layer_12/width_131k/average_l0_237
+    l0: 237
+    path: layer_12/width_131k/average_l0_237
+  - id: layer_12/width_131k/average_l0_525
+    l0: 525
+    path: layer_12/width_131k/average_l0_525
+  - id: layer_13/width_16k/average_l0_20
+    l0: 20
+    path: layer_13/width_16k/average_l0_20
+  - id: layer_13/width_16k/average_l0_38
+    l0: 38
+    path: layer_13/width_16k/average_l0_38
+  - id: layer_13/width_16k/average_l0_77
+    l0: 77
+    path: layer_13/width_16k/average_l0_77
+  - id: layer_13/width_16k/average_l0_170
+    l0: 170
+    path: layer_13/width_16k/average_l0_170
+  - id: layer_13/width_16k/average_l0_380
+    l0: 380
+    path: layer_13/width_16k/average_l0_380
+  - id: layer_13/width_16k/average_l0_675
+    l0: 675
+    path: layer_13/width_16k/average_l0_675
+  - id: layer_13/width_131k/average_l0_18
+    l0: 18
+    path: layer_13/width_131k/average_l0_18
+  - id: layer_13/width_131k/average_l0_33
+    l0: 33
+    path: layer_13/width_131k/average_l0_33
+  - id: layer_13/width_131k/average_l0_64
+    l0: 64
+    path: layer_13/width_131k/average_l0_64
+  - id: layer_13/width_131k/average_l0_126
+    l0: 126
+    path: layer_13/width_131k/average_l0_126
+  - id: layer_13/width_131k/average_l0_283
+    l0: 283
+    path: layer_13/width_131k/average_l0_283
+  - id: layer_13/width_131k/average_l0_611
+    l0: 611
+    path: layer_13/width_131k/average_l0_611
+  - id: layer_14/width_16k/average_l0_21
+    l0: 21
+    path: layer_14/width_16k/average_l0_21
+  - id: layer_14/width_16k/average_l0_40
+    l0: 40
+    path: layer_14/width_16k/average_l0_40
+  - id: layer_14/width_16k/average_l0_81
+    l0: 81
+    path: layer_14/width_16k/average_l0_81
+  - id: layer_14/width_16k/average_l0_179
+    l0: 179
+    path: layer_14/width_16k/average_l0_179
+  - id: layer_14/width_16k/average_l0_411
+    l0: 411
+    path: layer_14/width_16k/average_l0_411
+  - id: layer_14/width_16k/average_l0_767
+    l0: 767
+    path: layer_14/width_16k/average_l0_767
+  - id: layer_14/width_131k/average_l0_18
+    l0: 18
+    path: layer_14/width_131k/average_l0_18
+  - id: layer_14/width_131k/average_l0_35
+    l0: 35
+    path: layer_14/width_131k/average_l0_35
+  - id: layer_14/width_131k/average_l0_67
+    l0: 67
+    path: layer_14/width_131k/average_l0_67
+  - id: layer_14/width_131k/average_l0_131
+    l0: 131
+    path: layer_14/width_131k/average_l0_131
+  - id: layer_14/width_131k/average_l0_306
+    l0: 306
+    path: layer_14/width_131k/average_l0_306
+  - id: layer_14/width_131k/average_l0_650
+    l0: 650
+    path: layer_14/width_131k/average_l0_650
+  - id: layer_15/width_16k/average_l0_21
+    l0: 21
+    path: layer_15/width_16k/average_l0_21
+  - id: layer_15/width_16k/average_l0_40
+    l0: 40
+    path: layer_15/width_16k/average_l0_40
+  - id: layer_15/width_16k/average_l0_79
+    l0: 79
+    path: layer_15/width_16k/average_l0_79
+  - id: layer_15/width_16k/average_l0_168
+    l0: 168
+    path: layer_15/width_16k/average_l0_168
+  - id: layer_15/width_16k/average_l0_344
+    l0: 344
+    path: layer_15/width_16k/average_l0_344
+  - id: layer_15/width_16k/average_l0_638
+    l0: 638
+    path: layer_15/width_16k/average_l0_638
+  - id: layer_15/width_131k/average_l0_19
+    l0: 19
+    path: layer_15/width_131k/average_l0_19
+  - id: layer_15/width_131k/average_l0_35
+    l0: 35
+    path: layer_15/width_131k/average_l0_35
+  - id: layer_15/width_131k/average_l0_67
+    l0: 67
+    path: layer_15/width_131k/average_l0_67
+  - id: layer_15/width_131k/average_l0_130
+    l0: 130
+    path: layer_15/width_131k/average_l0_130
+  - id: layer_15/width_131k/average_l0_283
+    l0: 283
+    path: layer_15/width_131k/average_l0_283
+  - id: layer_15/width_131k/average_l0_540
+    l0: 540
+    path: layer_15/width_131k/average_l0_540
+  - id: layer_16/width_16k/average_l0_21
+    l0: 21
+    path: layer_16/width_16k/average_l0_21
+  - id: layer_16/width_16k/average_l0_40
+    l0: 40
+    path: layer_16/width_16k/average_l0_40
+  - id: layer_16/width_16k/average_l0_81
+    l0: 81
+    path: layer_16/width_16k/average_l0_81
+  - id: layer_16/width_16k/average_l0_172
+    l0: 172
+    path: layer_16/width_16k/average_l0_172
+  - id: layer_16/width_16k/average_l0_376
+    l0: 376
+    path: layer_16/width_16k/average_l0_376
+  - id: layer_16/width_16k/average_l0_705
+    l0: 705
+    path: layer_16/width_16k/average_l0_705
+  - id: layer_16/width_131k/average_l0_19
+    l0: 19
+    path: layer_16/width_131k/average_l0_19
+  - id: layer_16/width_131k/average_l0_36
+    l0: 36
+    path: layer_16/width_131k/average_l0_36
+  - id: layer_16/width_131k/average_l0_71
+    l0: 71
+    path: layer_16/width_131k/average_l0_71
+  - id: layer_16/width_131k/average_l0_140
+    l0: 140
+    path: layer_16/width_131k/average_l0_140
+  - id: layer_16/width_131k/average_l0_298
+    l0: 298
+    path: layer_16/width_131k/average_l0_298
+  - id: layer_16/width_131k/average_l0_621
+    l0: 621
+    path: layer_16/width_131k/average_l0_621
+  - id: layer_17/width_16k/average_l0_24
+    l0: 24
+    path: layer_17/width_16k/average_l0_24
+  - id: layer_17/width_16k/average_l0_50
+    l0: 50
+    path: layer_17/width_16k/average_l0_50
+  - id: layer_17/width_16k/average_l0_110
+    l0: 110
+    path: layer_17/width_16k/average_l0_110
+  - id: layer_17/width_16k/average_l0_227
+    l0: 227
+    path: layer_17/width_16k/average_l0_227
+  - id: layer_17/width_16k/average_l0_435
+    l0: 435
+    path: layer_17/width_16k/average_l0_435
+  - id: layer_17/width_16k/average_l0_719
+    l0: 719
+    path: layer_17/width_16k/average_l0_719
+  - id: layer_17/width_131k/average_l0_22
+    l0: 22
+    path: layer_17/width_131k/average_l0_22
+  - id: layer_17/width_131k/average_l0_44
+    l0: 44
+    path: layer_17/width_131k/average_l0_44
+  - id: layer_17/width_131k/average_l0_90
+    l0: 90
+    path: layer_17/width_131k/average_l0_90
+  - id: layer_17/width_131k/average_l0_191
+    l0: 191
+    path: layer_17/width_131k/average_l0_191
+  - id: layer_17/width_131k/average_l0_380
+    l0: 380
+    path: layer_17/width_131k/average_l0_380
+  - id: layer_17/width_131k/average_l0_672
+    l0: 672
+    path: layer_17/width_131k/average_l0_672
+  - id: layer_18/width_16k/average_l0_21
+    l0: 21
+    path: layer_18/width_16k/average_l0_21
+  - id: layer_18/width_16k/average_l0_40
+    l0: 40
+    path: layer_18/width_16k/average_l0_40
+  - id: layer_18/width_16k/average_l0_80
+    l0: 80
+    path: layer_18/width_16k/average_l0_80
+  - id: layer_18/width_16k/average_l0_171
+    l0: 171
+    path: layer_18/width_16k/average_l0_171
+  - id: layer_18/width_16k/average_l0_352
+    l0: 352
+    path: layer_18/width_16k/average_l0_352
+  - id: layer_18/width_16k/average_l0_646
+    l0: 646
+    path: layer_18/width_16k/average_l0_646
+  - id: layer_18/width_131k/average_l0_19
+    l0: 19
+    path: layer_18/width_131k/average_l0_19
+  - id: layer_18/width_131k/average_l0_35
+    l0: 35
+    path: layer_18/width_131k/average_l0_35
+  - id: layer_18/width_131k/average_l0_69
+    l0: 69
+    path: layer_18/width_131k/average_l0_69
+  - id: layer_18/width_131k/average_l0_133
+    l0: 133
+    path: layer_18/width_131k/average_l0_133
+  - id: layer_18/width_131k/average_l0_294
+    l0: 294
+    path: layer_18/width_131k/average_l0_294
+  - id: layer_18/width_131k/average_l0_557
+    l0: 557
+    path: layer_18/width_131k/average_l0_557
+  - id: layer_19/width_16k/average_l0_21
+    l0: 21
+    path: layer_19/width_16k/average_l0_21
+  - id: layer_19/width_16k/average_l0_41
+    l0: 41
+    path: layer_19/width_16k/average_l0_41
+  - id: layer_19/width_16k/average_l0_86
+    l0: 86
+    path: layer_19/width_16k/average_l0_86
+  - id: layer_19/width_16k/average_l0_186
+    l0: 186
+    path: layer_19/width_16k/average_l0_186
+  - id: layer_19/width_16k/average_l0_360
+    l0: 360
+    path: layer_19/width_16k/average_l0_360
+  - id: layer_19/width_16k/average_l0_661
+    l0: 661
+    path: layer_19/width_16k/average_l0_661
+  - id: layer_19/width_131k/average_l0_19
+    l0: 19
+    path: layer_19/width_131k/average_l0_19
+  - id: layer_19/width_131k/average_l0_38
+    l0: 38
+    path: layer_19/width_131k/average_l0_38
+  - id: layer_19/width_131k/average_l0_71
+    l0: 71
+    path: layer_19/width_131k/average_l0_71
+  - id: layer_19/width_131k/average_l0_152
+    l0: 152
+    path: layer_19/width_131k/average_l0_152
+  - id: layer_19/width_131k/average_l0_307
+    l0: 307
+    path: layer_19/width_131k/average_l0_307
+  - id: layer_19/width_131k/average_l0_571
+    l0: 571
+    path: layer_19/width_131k/average_l0_571
+  - id: layer_2/width_16k/average_l0_15
+    l0: 15
+    path: layer_2/width_16k/average_l0_15
+  - id: layer_2/width_16k/average_l0_30
+    l0: 30
+    path: layer_2/width_16k/average_l0_30
+  - id: layer_2/width_16k/average_l0_69
+    l0: 69
+    path: layer_2/width_16k/average_l0_69
+  - id: layer_2/width_16k/average_l0_180
+    l0: 180
+    path: layer_2/width_16k/average_l0_180
+  - id: layer_2/width_16k/average_l0_384
+    l0: 384
+    path: layer_2/width_16k/average_l0_384
+  - id: layer_2/width_131k/average_l0_7
+    l0: 7
+    path: layer_2/width_131k/average_l0_7
+  - id: layer_2/width_131k/average_l0_11
+    l0: 11
+    path: layer_2/width_131k/average_l0_11
+  - id: layer_2/width_131k/average_l0_18
+    l0: 18
+    path: layer_2/width_131k/average_l0_18
+  - id: layer_2/width_131k/average_l0_32
+    l0: 32
+    path: layer_2/width_131k/average_l0_32
+  - id: layer_2/width_131k/average_l0_62
+    l0: 62
+    path: layer_2/width_131k/average_l0_62
+  - id: layer_2/width_131k/average_l0_135
+    l0: 135
+    path: layer_2/width_131k/average_l0_135
+  - id: layer_20/width_16k/average_l0_20
+    l0: 20
+    path: layer_20/width_16k/average_l0_20
+  - id: layer_20/width_16k/average_l0_39
+    l0: 39
+    path: layer_20/width_16k/average_l0_39
+  - id: layer_20/width_16k/average_l0_76
+    l0: 76
+    path: layer_20/width_16k/average_l0_76
+  - id: layer_20/width_16k/average_l0_158
+    l0: 158
+    path: layer_20/width_16k/average_l0_158
+  - id: layer_20/width_16k/average_l0_342
+    l0: 342
+    path: layer_20/width_16k/average_l0_342
+  - id: layer_20/width_16k/average_l0_674
+    l0: 674
+    path: layer_20/width_16k/average_l0_674
+  - id: layer_20/width_131k/average_l0_18
+    l0: 18
+    path: layer_20/width_131k/average_l0_18
+  - id: layer_20/width_131k/average_l0_34
+    l0: 34
+    path: layer_20/width_131k/average_l0_34
+  - id: layer_20/width_131k/average_l0_65
+    l0: 65
+    path: layer_20/width_131k/average_l0_65
+  - id: layer_20/width_131k/average_l0_125
+    l0: 125
+    path: layer_20/width_131k/average_l0_125
+  - id: layer_20/width_131k/average_l0_270
+    l0: 270
+    path: layer_20/width_131k/average_l0_270
+  - id: layer_20/width_131k/average_l0_558
+    l0: 558
+    path: layer_20/width_131k/average_l0_558
+  - id: layer_21/width_16k/average_l0_21
+    l0: 21
+    path: layer_21/width_16k/average_l0_21
+  - id: layer_21/width_16k/average_l0_41
+    l0: 41
+    path: layer_21/width_16k/average_l0_41
+  - id: layer_21/width_16k/average_l0_86
+    l0: 86
+    path: layer_21/width_16k/average_l0_86
+  - id: layer_21/width_16k/average_l0_195
+    l0: 195
+    path: layer_21/width_16k/average_l0_195
+  - id: layer_21/width_16k/average_l0_420
+    l0: 420
+    path: layer_21/width_16k/average_l0_420
+  - id: layer_21/width_16k/average_l0_792
+    l0: 792
+    path: layer_21/width_16k/average_l0_792
+  - id: layer_21/width_131k/average_l0_18
+    l0: 18
+    path: layer_21/width_131k/average_l0_18
+  - id: layer_21/width_131k/average_l0_35
+    l0: 35
+    path: layer_21/width_131k/average_l0_35
+  - id: layer_21/width_131k/average_l0_71
+    l0: 71
+    path: layer_21/width_131k/average_l0_71
+  - id: layer_21/width_131k/average_l0_150
+    l0: 150
+    path: layer_21/width_131k/average_l0_150
+  - id: layer_21/width_131k/average_l0_333
+    l0: 333
+    path: layer_21/width_131k/average_l0_333
+  - id: layer_21/width_131k/average_l0_665
+    l0: 665
+    path: layer_21/width_131k/average_l0_665
+  - id: layer_22/width_16k/average_l0_20
+    l0: 20
+    path: layer_22/width_16k/average_l0_20
+  - id: layer_22/width_16k/average_l0_36
+    l0: 36
+    path: layer_22/width_16k/average_l0_36
+  - id: layer_22/width_16k/average_l0_70
+    l0: 70
+    path: layer_22/width_16k/average_l0_70
+  - id: layer_22/width_16k/average_l0_141
+    l0: 141
+    path: layer_22/width_16k/average_l0_141
+  - id: layer_22/width_16k/average_l0_289
+    l0: 289
+    path: layer_22/width_16k/average_l0_289
+  - id: layer_22/width_16k/average_l0_569
+    l0: 569
+    path: layer_22/width_16k/average_l0_569
+  - id: layer_22/width_131k/average_l0_17
+    l0: 17
+    path: layer_22/width_131k/average_l0_17
+  - id: layer_22/width_131k/average_l0_32
+    l0: 32
+    path: layer_22/width_131k/average_l0_32
+  - id: layer_22/width_131k/average_l0_59
+    l0: 59
+    path: layer_22/width_131k/average_l0_59
+  - id: layer_22/width_131k/average_l0_115
+    l0: 115
+    path: layer_22/width_131k/average_l0_115
+  - id: layer_22/width_131k/average_l0_231
+    l0: 231
+    path: layer_22/width_131k/average_l0_231
+  - id: layer_22/width_131k/average_l0_446
+    l0: 446
+    path: layer_22/width_131k/average_l0_446
+  - id: layer_23/width_16k/average_l0_21
+    l0: 21
+    path: layer_23/width_16k/average_l0_21
+  - id: layer_23/width_16k/average_l0_41
+    l0: 41
+    path: layer_23/width_16k/average_l0_41
+  - id: layer_23/width_16k/average_l0_80
+    l0: 80
+    path: layer_23/width_16k/average_l0_80
+  - id: layer_23/width_16k/average_l0_173
+    l0: 173
+    path: layer_23/width_16k/average_l0_173
+  - id: layer_23/width_16k/average_l0_356
+    l0: 356
+    path: layer_23/width_16k/average_l0_356
+  - id: layer_23/width_16k/average_l0_649
+    l0: 649
+    path: layer_23/width_16k/average_l0_649
+  - id: layer_23/width_131k/average_l0_19
+    l0: 19
+    path: layer_23/width_131k/average_l0_19
+  - id: layer_23/width_131k/average_l0_36
+    l0: 36
+    path: layer_23/width_131k/average_l0_36
+  - id: layer_23/width_131k/average_l0_66
+    l0: 66
+    path: layer_23/width_131k/average_l0_66
+  - id: layer_23/width_131k/average_l0_134
+    l0: 134
+    path: layer_23/width_131k/average_l0_134
+  - id: layer_23/width_131k/average_l0_288
+    l0: 288
+    path: layer_23/width_131k/average_l0_288
+  - id: layer_23/width_131k/average_l0_568
+    l0: 568
+    path: layer_23/width_131k/average_l0_568
+  - id: layer_24/width_16k/average_l0_21
+    l0: 21
+    path: layer_24/width_16k/average_l0_21
+  - id: layer_24/width_16k/average_l0_40
+    l0: 40
+    path: layer_24/width_16k/average_l0_40
+  - id: layer_24/width_16k/average_l0_79
+    l0: 79
+    path: layer_24/width_16k/average_l0_79
+  - id: layer_24/width_16k/average_l0_167
+    l0: 167
+    path: layer_24/width_16k/average_l0_167
+  - id: layer_24/width_16k/average_l0_348
+    l0: 348
+    path: layer_24/width_16k/average_l0_348
+  - id: layer_24/width_16k/average_l0_615
+    l0: 615
+    path: layer_24/width_16k/average_l0_615
+  - id: layer_24/width_131k/average_l0_19
+    l0: 19
+    path: layer_24/width_131k/average_l0_19
+  - id: layer_24/width_131k/average_l0_35
+    l0: 35
+    path: layer_24/width_131k/average_l0_35
+  - id: layer_24/width_131k/average_l0_66
+    l0: 66
+    path: layer_24/width_131k/average_l0_66
+  - id: layer_24/width_131k/average_l0_130
+    l0: 130
+    path: layer_24/width_131k/average_l0_130
+  - id: layer_24/width_131k/average_l0_273
+    l0: 273
+    path: layer_24/width_131k/average_l0_273
+  - id: layer_24/width_131k/average_l0_542
+    l0: 542
+    path: layer_24/width_131k/average_l0_542
+  - id: layer_25/width_16k/average_l0_19
+    l0: 19
+    path: layer_25/width_16k/average_l0_19
+  - id: layer_25/width_16k/average_l0_36
+    l0: 36
+    path: layer_25/width_16k/average_l0_36
+  - id: layer_25/width_16k/average_l0_73
+    l0: 73
+    path: layer_25/width_16k/average_l0_73
+  - id: layer_25/width_16k/average_l0_156
+    l0: 156
+    path: layer_25/width_16k/average_l0_156
+  - id: layer_25/width_16k/average_l0_371
+    l0: 371
+    path: layer_25/width_16k/average_l0_371
+  - id: layer_25/width_16k/average_l0_686
+    l0: 686
+    path: layer_25/width_16k/average_l0_686
+  - id: layer_25/width_131k/average_l0_17
+    l0: 17
+    path: layer_25/width_131k/average_l0_17
+  - id: layer_25/width_131k/average_l0_31
+    l0: 31
+    path: layer_25/width_131k/average_l0_31
+  - id: layer_25/width_131k/average_l0_59
+    l0: 59
+    path: layer_25/width_131k/average_l0_59
+  - id: layer_25/width_131k/average_l0_115
+    l0: 115
+    path: layer_25/width_131k/average_l0_115
+  - id: layer_25/width_131k/average_l0_261
+    l0: 261
+    path: layer_25/width_131k/average_l0_261
+  - id: layer_25/width_131k/average_l0_605
+    l0: 605
+    path: layer_25/width_131k/average_l0_605
+  - id: layer_26/width_16k/average_l0_20
+    l0: 20
+    path: layer_26/width_16k/average_l0_20
+  - id: layer_26/width_16k/average_l0_38
+    l0: 38
+    path: layer_26/width_16k/average_l0_38
+  - id: layer_26/width_16k/average_l0_75
+    l0: 75
+    path: layer_26/width_16k/average_l0_75
+  - id: layer_26/width_16k/average_l0_159
+    l0: 159
+    path: layer_26/width_16k/average_l0_159
+  - id: layer_26/width_16k/average_l0_336
+    l0: 336
+    path: layer_26/width_16k/average_l0_336
+  - id: layer_26/width_16k/average_l0_634
+    l0: 634
+    path: layer_26/width_16k/average_l0_634
+  - id: layer_26/width_131k/average_l0_18
+    l0: 18
+    path: layer_26/width_131k/average_l0_18
+  - id: layer_26/width_131k/average_l0_32
+    l0: 32
+    path: layer_26/width_131k/average_l0_32
+  - id: layer_26/width_131k/average_l0_62
+    l0: 62
+    path: layer_26/width_131k/average_l0_62
+  - id: layer_26/width_131k/average_l0_120
+    l0: 120
+    path: layer_26/width_131k/average_l0_120
+  - id: layer_26/width_131k/average_l0_267
+    l0: 267
+    path: layer_26/width_131k/average_l0_267
+  - id: layer_26/width_131k/average_l0_525
+    l0: 525
+    path: layer_26/width_131k/average_l0_525
+  - id: layer_27/width_16k/average_l0_18
+    l0: 18
+    path: layer_27/width_16k/average_l0_18
+  - id: layer_27/width_16k/average_l0_33
+    l0: 33
+    path: layer_27/width_16k/average_l0_33
+  - id: layer_27/width_16k/average_l0_64
+    l0: 64
+    path: layer_27/width_16k/average_l0_64
+  - id: layer_27/width_16k/average_l0_136
+    l0: 136
+    path: layer_27/width_16k/average_l0_136
+  - id: layer_27/width_16k/average_l0_306
+    l0: 306
+    path: layer_27/width_16k/average_l0_306
+  - id: layer_27/width_16k/average_l0_613
+    l0: 613
+    path: layer_27/width_16k/average_l0_613
+  - id: layer_27/width_131k/average_l0_16
+    l0: 16
+    path: layer_27/width_131k/average_l0_16
+  - id: layer_27/width_131k/average_l0_28
+    l0: 28
+    path: layer_27/width_131k/average_l0_28
+  - id: layer_27/width_131k/average_l0_53
+    l0: 53
+    path: layer_27/width_131k/average_l0_53
+  - id: layer_27/width_131k/average_l0_102
+    l0: 102
+    path: layer_27/width_131k/average_l0_102
+  - id: layer_27/width_131k/average_l0_211
+    l0: 211
+    path: layer_27/width_131k/average_l0_211
+  - id: layer_27/width_131k/average_l0_458
+    l0: 458
+    path: layer_27/width_131k/average_l0_458
+  - id: layer_28/width_16k/average_l0_20
+    l0: 20
+    path: layer_28/width_16k/average_l0_20
+  - id: layer_28/width_16k/average_l0_37
+    l0: 37
+    path: layer_28/width_16k/average_l0_37
+  - id: layer_28/width_16k/average_l0_71
+    l0: 71
+    path: layer_28/width_16k/average_l0_71
+  - id: layer_28/width_16k/average_l0_143
+    l0: 143
+    path: layer_28/width_16k/average_l0_143
+  - id: layer_28/width_16k/average_l0_279
+    l0: 279
+    path: layer_28/width_16k/average_l0_279
+  - id: layer_28/width_16k/average_l0_498
+    l0: 498
+    path: layer_28/width_16k/average_l0_498
+  - id: layer_28/width_131k/average_l0_19
+    l0: 19
+    path: layer_28/width_131k/average_l0_19
+  - id: layer_28/width_131k/average_l0_32
+    l0: 32
+    path: layer_28/width_131k/average_l0_32
+  - id: layer_28/width_131k/average_l0_59
+    l0: 59
+    path: layer_28/width_131k/average_l0_59
+  - id: layer_28/width_131k/average_l0_115
+    l0: 115
+    path: layer_28/width_131k/average_l0_115
+  - id: layer_28/width_131k/average_l0_230
+    l0: 230
+    path: layer_28/width_131k/average_l0_230
+  - id: layer_28/width_131k/average_l0_452
+    l0: 452
+    path: layer_28/width_131k/average_l0_452
+  - id: layer_29/width_16k/average_l0_18
+    l0: 18
+    path: layer_29/width_16k/average_l0_18
+  - id: layer_29/width_16k/average_l0_35
+    l0: 35
+    path: layer_29/width_16k/average_l0_35
+  - id: layer_29/width_16k/average_l0_76
+    l0: 76
+    path: layer_29/width_16k/average_l0_76
+  - id: layer_29/width_16k/average_l0_171
+    l0: 171
+    path: layer_29/width_16k/average_l0_171
+  - id: layer_29/width_16k/average_l0_308
+    l0: 308
+    path: layer_29/width_16k/average_l0_308
+  - id: layer_29/width_16k/average_l0_559
+    l0: 559
+    path: layer_29/width_16k/average_l0_559
+  - id: layer_29/width_131k/average_l0_17
+    l0: 17
+    path: layer_29/width_131k/average_l0_17
+  - id: layer_29/width_131k/average_l0_30
+    l0: 30
+    path: layer_29/width_131k/average_l0_30
+  - id: layer_29/width_131k/average_l0_57
+    l0: 57
+    path: layer_29/width_131k/average_l0_57
+  - id: layer_29/width_131k/average_l0_128
+    l0: 128
+    path: layer_29/width_131k/average_l0_128
+  - id: layer_29/width_131k/average_l0_265
+    l0: 265
+    path: layer_29/width_131k/average_l0_265
+  - id: layer_29/width_131k/average_l0_446
+    l0: 446
+    path: layer_29/width_131k/average_l0_446
+  - id: layer_3/width_16k/average_l0_23
+    l0: 23
+    path: layer_3/width_16k/average_l0_23
+  - id: layer_3/width_16k/average_l0_44
+    l0: 44
+    path: layer_3/width_16k/average_l0_44
+  - id: layer_3/width_16k/average_l0_102
+    l0: 102
+    path: layer_3/width_16k/average_l0_102
+  - id: layer_3/width_16k/average_l0_221
+    l0: 221
+    path: layer_3/width_16k/average_l0_221
+  - id: layer_3/width_16k/average_l0_435
+    l0: 435
+    path: layer_3/width_16k/average_l0_435
+  - id: layer_3/width_131k/average_l0_10
+    l0: 10
+    path: layer_3/width_131k/average_l0_10
+  - id: layer_3/width_131k/average_l0_17
+    l0: 17
+    path: layer_3/width_131k/average_l0_17
+  - id: layer_3/width_131k/average_l0_31
+    l0: 31
+    path: layer_3/width_131k/average_l0_31
+  - id: layer_3/width_131k/average_l0_58
+    l0: 58
+    path: layer_3/width_131k/average_l0_58
+  - id: layer_3/width_131k/average_l0_119
+    l0: 119
+    path: layer_3/width_131k/average_l0_119
+  - id: layer_3/width_131k/average_l0_252
+    l0: 252
+    path: layer_3/width_131k/average_l0_252
+  - id: layer_30/width_16k/average_l0_19
+    l0: 19
+    path: layer_30/width_16k/average_l0_19
+  - id: layer_30/width_16k/average_l0_36
+    l0: 36
+    path: layer_30/width_16k/average_l0_36
+  - id: layer_30/width_16k/average_l0_73
+    l0: 73
+    path: layer_30/width_16k/average_l0_73
+  - id: layer_30/width_16k/average_l0_157
+    l0: 157
+    path: layer_30/width_16k/average_l0_157
+  - id: layer_30/width_16k/average_l0_313
+    l0: 313
+    path: layer_30/width_16k/average_l0_313
+  - id: layer_30/width_16k/average_l0_558
+    l0: 558
+    path: layer_30/width_16k/average_l0_558
+  - id: layer_30/width_131k/average_l0_17
+    l0: 17
+    path: layer_30/width_131k/average_l0_17
+  - id: layer_30/width_131k/average_l0_29
+    l0: 29
+    path: layer_30/width_131k/average_l0_29
+  - id: layer_30/width_131k/average_l0_55
+    l0: 55
+    path: layer_30/width_131k/average_l0_55
+  - id: layer_30/width_131k/average_l0_109
+    l0: 109
+    path: layer_30/width_131k/average_l0_109
+  - id: layer_30/width_131k/average_l0_236
+    l0: 236
+    path: layer_30/width_131k/average_l0_236
+  - id: layer_30/width_131k/average_l0_491
+    l0: 491
+    path: layer_30/width_131k/average_l0_491
+  - id: layer_31/width_16k/average_l0_18
+    l0: 18
+    path: layer_31/width_16k/average_l0_18
+  - id: layer_31/width_16k/average_l0_36
+    l0: 36
+    path: layer_31/width_16k/average_l0_36
+  - id: layer_31/width_16k/average_l0_73
+    l0: 73
+    path: layer_31/width_16k/average_l0_73
+  - id: layer_31/width_16k/average_l0_168
+    l0: 168
+    path: layer_31/width_16k/average_l0_168
+  - id: layer_31/width_16k/average_l0_356
+    l0: 356
+    path: layer_31/width_16k/average_l0_356
+  - id: layer_31/width_16k/average_l0_630
+    l0: 630
+    path: layer_31/width_16k/average_l0_630
+  - id: layer_31/width_131k/average_l0_16
+    l0: 16
+    path: layer_31/width_131k/average_l0_16
+  - id: layer_31/width_131k/average_l0_29
+    l0: 29
+    path: layer_31/width_131k/average_l0_29
+  - id: layer_31/width_131k/average_l0_56
+    l0: 56
+    path: layer_31/width_131k/average_l0_56
+  - id: layer_31/width_131k/average_l0_117
+    l0: 117
+    path: layer_31/width_131k/average_l0_117
+  - id: layer_31/width_131k/average_l0_265
+    l0: 265
+    path: layer_31/width_131k/average_l0_265
+  - id: layer_31/width_131k/average_l0_543
+    l0: 543
+    path: layer_31/width_131k/average_l0_543
+  - id: layer_32/width_16k/average_l0_18
+    l0: 18
+    path: layer_32/width_16k/average_l0_18
+  - id: layer_32/width_16k/average_l0_35
+    l0: 35
+    path: layer_32/width_16k/average_l0_35
+  - id: layer_32/width_16k/average_l0_74
+    l0: 74
+    path: layer_32/width_16k/average_l0_74
+  - id: layer_32/width_16k/average_l0_158
+    l0: 158
+    path: layer_32/width_16k/average_l0_158
+  - id: layer_32/width_16k/average_l0_306
+    l0: 306
+    path: layer_32/width_16k/average_l0_306
+  - id: layer_32/width_16k/average_l0_534
+    l0: 534
+    path: layer_32/width_16k/average_l0_534
+  - id: layer_32/width_131k/average_l0_16
+    l0: 16
+    path: layer_32/width_131k/average_l0_16
+  - id: layer_32/width_131k/average_l0_31
+    l0: 31
+    path: layer_32/width_131k/average_l0_31
+  - id: layer_32/width_131k/average_l0_56
+    l0: 56
+    path: layer_32/width_131k/average_l0_56
+  - id: layer_32/width_131k/average_l0_117
+    l0: 117
+    path: layer_32/width_131k/average_l0_117
+  - id: layer_32/width_131k/average_l0_248
+    l0: 248
+    path: layer_32/width_131k/average_l0_248
+  - id: layer_32/width_131k/average_l0_464
+    l0: 464
+    path: layer_32/width_131k/average_l0_464
+  - id: layer_33/width_16k/average_l0_17
+    l0: 17
+    path: layer_33/width_16k/average_l0_17
+  - id: layer_33/width_16k/average_l0_37
+    l0: 37
+    path: layer_33/width_16k/average_l0_37
+  - id: layer_33/width_16k/average_l0_78
+    l0: 78
+    path: layer_33/width_16k/average_l0_78
+  - id: layer_33/width_16k/average_l0_158
+    l0: 158
+    path: layer_33/width_16k/average_l0_158
+  - id: layer_33/width_16k/average_l0_318
+    l0: 318
+    path: layer_33/width_16k/average_l0_318
+  - id: layer_33/width_16k/average_l0_531
+    l0: 531
+    path: layer_33/width_16k/average_l0_531
+  - id: layer_33/width_131k/average_l0_16
+    l0: 16
+    path: layer_33/width_131k/average_l0_16
+  - id: layer_33/width_131k/average_l0_28
+    l0: 28
+    path: layer_33/width_131k/average_l0_28
+  - id: layer_33/width_131k/average_l0_58
+    l0: 58
+    path: layer_33/width_131k/average_l0_58
+  - id: layer_33/width_131k/average_l0_128
+    l0: 128
+    path: layer_33/width_131k/average_l0_128
+  - id: layer_33/width_131k/average_l0_248
+    l0: 248
+    path: layer_33/width_131k/average_l0_248
+  - id: layer_33/width_131k/average_l0_471
+    l0: 471
+    path: layer_33/width_131k/average_l0_471
+  - id: layer_34/width_16k/average_l0_17
+    l0: 17
+    path: layer_34/width_16k/average_l0_17
+  - id: layer_34/width_16k/average_l0_38
+    l0: 38
+    path: layer_34/width_16k/average_l0_38
+  - id: layer_34/width_16k/average_l0_91
+    l0: 91
+    path: layer_34/width_16k/average_l0_91
+  - id: layer_34/width_16k/average_l0_192
+    l0: 192
+    path: layer_34/width_16k/average_l0_192
+  - id: layer_34/width_16k/average_l0_339
+    l0: 339
+    path: layer_34/width_16k/average_l0_339
+  - id: layer_34/width_16k/average_l0_527
+    l0: 527
+    path: layer_34/width_16k/average_l0_527
+  - id: layer_34/width_131k/average_l0_15
+    l0: 15
+    path: layer_34/width_131k/average_l0_15
+  - id: layer_34/width_131k/average_l0_29
+    l0: 29
+    path: layer_34/width_131k/average_l0_29
+  - id: layer_34/width_131k/average_l0_63
+    l0: 63
+    path: layer_34/width_131k/average_l0_63
+  - id: layer_34/width_131k/average_l0_199
+    l0: 199
+    path: layer_34/width_131k/average_l0_199
+  - id: layer_34/width_131k/average_l0_291
+    l0: 291
+    path: layer_34/width_131k/average_l0_291
+  - id: layer_34/width_131k/average_l0_483
+    l0: 483
+    path: layer_34/width_131k/average_l0_483
+  - id: layer_35/width_16k/average_l0_14
+    l0: 14
+    path: layer_35/width_16k/average_l0_14
+  - id: layer_35/width_16k/average_l0_33
+    l0: 33
+    path: layer_35/width_16k/average_l0_33
+  - id: layer_35/width_16k/average_l0_77
+    l0: 77
+    path: layer_35/width_16k/average_l0_77
+  - id: layer_35/width_16k/average_l0_168
+    l0: 168
+    path: layer_35/width_16k/average_l0_168
+  - id: layer_35/width_16k/average_l0_303
+    l0: 303
+    path: layer_35/width_16k/average_l0_303
+  - id: layer_35/width_16k/average_l0_488
+    l0: 488
+    path: layer_35/width_16k/average_l0_488
+  - id: layer_35/width_131k/average_l0_13
+    l0: 13
+    path: layer_35/width_131k/average_l0_13
+  - id: layer_35/width_131k/average_l0_26
+    l0: 26
+    path: layer_35/width_131k/average_l0_26
+  - id: layer_35/width_131k/average_l0_54
+    l0: 54
+    path: layer_35/width_131k/average_l0_54
+  - id: layer_35/width_131k/average_l0_124
+    l0: 124
+    path: layer_35/width_131k/average_l0_124
+  - id: layer_35/width_131k/average_l0_258
+    l0: 258
+    path: layer_35/width_131k/average_l0_258
+  - id: layer_35/width_131k/average_l0_427
+    l0: 427
+    path: layer_35/width_131k/average_l0_427
+  - id: layer_36/width_16k/average_l0_15
+    l0: 15
+    path: layer_36/width_16k/average_l0_15
+  - id: layer_36/width_16k/average_l0_32
+    l0: 32
+    path: layer_36/width_16k/average_l0_32
+  - id: layer_36/width_16k/average_l0_69
+    l0: 69
+    path: layer_36/width_16k/average_l0_69
+  - id: layer_36/width_16k/average_l0_144
+    l0: 144
+    path: layer_36/width_16k/average_l0_144
+  - id: layer_36/width_16k/average_l0_293
+    l0: 293
+    path: layer_36/width_16k/average_l0_293
+  - id: layer_36/width_16k/average_l0_544
+    l0: 544
+    path: layer_36/width_16k/average_l0_544
+  - id: layer_36/width_131k/average_l0_16
+    l0: 16
+    path: layer_36/width_131k/average_l0_16
+  - id: layer_36/width_131k/average_l0_26
+    l0: 26
+    path: layer_36/width_131k/average_l0_26
+  - id: layer_36/width_131k/average_l0_51
+    l0: 51
+    path: layer_36/width_131k/average_l0_51
+  - id: layer_36/width_131k/average_l0_105
+    l0: 105
+    path: layer_36/width_131k/average_l0_105
+  - id: layer_36/width_131k/average_l0_229
+    l0: 229
+    path: layer_36/width_131k/average_l0_229
+  - id: layer_36/width_131k/average_l0_455
+    l0: 455
+    path: layer_36/width_131k/average_l0_455
+  - id: layer_37/width_16k/average_l0_17
+    l0: 17
+    path: layer_37/width_16k/average_l0_17
+  - id: layer_37/width_16k/average_l0_34
+    l0: 34
+    path: layer_37/width_16k/average_l0_34
+  - id: layer_37/width_16k/average_l0_82
+    l0: 82
+    path: layer_37/width_16k/average_l0_82
+  - id: layer_37/width_16k/average_l0_172
+    l0: 172
+    path: layer_37/width_16k/average_l0_172
+  - id: layer_37/width_16k/average_l0_309
+    l0: 309
+    path: layer_37/width_16k/average_l0_309
+  - id: layer_37/width_16k/average_l0_519
+    l0: 519
+    path: layer_37/width_16k/average_l0_519
+  - id: layer_37/width_131k/average_l0_15
+    l0: 15
+    path: layer_37/width_131k/average_l0_15
+  - id: layer_37/width_131k/average_l0_28
+    l0: 28
+    path: layer_37/width_131k/average_l0_28
+  - id: layer_37/width_131k/average_l0_55
+    l0: 55
+    path: layer_37/width_131k/average_l0_55
+  - id: layer_37/width_131k/average_l0_124
+    l0: 124
+    path: layer_37/width_131k/average_l0_124
+  - id: layer_37/width_131k/average_l0_248
+    l0: 248
+    path: layer_37/width_131k/average_l0_248
+  - id: layer_37/width_131k/average_l0_450
+    l0: 450
+    path: layer_37/width_131k/average_l0_450
+  - id: layer_38/width_16k/average_l0_18
+    l0: 18
+    path: layer_38/width_16k/average_l0_18
+  - id: layer_38/width_16k/average_l0_36
+    l0: 36
+    path: layer_38/width_16k/average_l0_36
+  - id: layer_38/width_16k/average_l0_81
+    l0: 81
+    path: layer_38/width_16k/average_l0_81
+  - id: layer_38/width_16k/average_l0_175
+    l0: 175
+    path: layer_38/width_16k/average_l0_175
+  - id: layer_38/width_16k/average_l0_334
+    l0: 334
+    path: layer_38/width_16k/average_l0_334
+  - id: layer_38/width_16k/average_l0_547
+    l0: 547
+    path: layer_38/width_16k/average_l0_547
+  - id: layer_38/width_131k/average_l0_17
+    l0: 17
+    path: layer_38/width_131k/average_l0_17
+  - id: layer_38/width_131k/average_l0_30
+    l0: 30
+    path: layer_38/width_131k/average_l0_30
+  - id: layer_38/width_131k/average_l0_60
+    l0: 60
+    path: layer_38/width_131k/average_l0_60
+  - id: layer_38/width_131k/average_l0_135
+    l0: 135
+    path: layer_38/width_131k/average_l0_135
+  - id: layer_38/width_131k/average_l0_284
+    l0: 284
+    path: layer_38/width_131k/average_l0_284
+  - id: layer_38/width_131k/average_l0_489
+    l0: 489
+    path: layer_38/width_131k/average_l0_489
+  - id: layer_39/width_16k/average_l0_15
+    l0: 15
+    path: layer_39/width_16k/average_l0_15
+  - id: layer_39/width_16k/average_l0_33
+    l0: 33
+    path: layer_39/width_16k/average_l0_33
+  - id: layer_39/width_16k/average_l0_77
+    l0: 77
+    path: layer_39/width_16k/average_l0_77
+  - id: layer_39/width_16k/average_l0_176
+    l0: 176
+    path: layer_39/width_16k/average_l0_176
+  - id: layer_39/width_16k/average_l0_391
+    l0: 391
+    path: layer_39/width_16k/average_l0_391
+  - id: layer_39/width_16k/average_l0_694
+    l0: 694
+    path: layer_39/width_16k/average_l0_694
+  - id: layer_39/width_131k/average_l0_17
+    l0: 17
+    path: layer_39/width_131k/average_l0_17
+  - id: layer_39/width_131k/average_l0_27
+    l0: 27
+    path: layer_39/width_131k/average_l0_27
+  - id: layer_39/width_131k/average_l0_54
+    l0: 54
+    path: layer_39/width_131k/average_l0_54
+  - id: layer_39/width_131k/average_l0_120
+    l0: 120
+    path: layer_39/width_131k/average_l0_120
+  - id: layer_39/width_131k/average_l0_273
+    l0: 273
+    path: layer_39/width_131k/average_l0_273
+  - id: layer_39/width_131k/average_l0_604
+    l0: 604
+    path: layer_39/width_131k/average_l0_604
+  - id: layer_4/width_16k/average_l0_26
+    l0: 26
+    path: layer_4/width_16k/average_l0_26
+  - id: layer_4/width_16k/average_l0_54
+    l0: 54
+    path: layer_4/width_16k/average_l0_54
+  - id: layer_4/width_16k/average_l0_126
+    l0: 126
+    path: layer_4/width_16k/average_l0_126
+  - id: layer_4/width_16k/average_l0_274
+    l0: 274
+    path: layer_4/width_16k/average_l0_274
+  - id: layer_4/width_16k/average_l0_524
+    l0: 524
+    path: layer_4/width_16k/average_l0_524
+  - id: layer_4/width_131k/average_l0_12
+    l0: 12
+    path: layer_4/width_131k/average_l0_12
+  - id: layer_4/width_131k/average_l0_21
+    l0: 21
+    path: layer_4/width_131k/average_l0_21
+  - id: layer_4/width_131k/average_l0_38
+    l0: 38
+    path: layer_4/width_131k/average_l0_38
+  - id: layer_4/width_131k/average_l0_75
+    l0: 75
+    path: layer_4/width_131k/average_l0_75
+  - id: layer_4/width_131k/average_l0_163
+    l0: 163
+    path: layer_4/width_131k/average_l0_163
+  - id: layer_4/width_131k/average_l0_330
+    l0: 330
+    path: layer_4/width_131k/average_l0_330
+  - id: layer_40/width_16k/average_l0_18
+    l0: 18
+    path: layer_40/width_16k/average_l0_18
+  - id: layer_40/width_16k/average_l0_38
+    l0: 38
+    path: layer_40/width_16k/average_l0_38
+  - id: layer_40/width_16k/average_l0_91
+    l0: 91
+    path: layer_40/width_16k/average_l0_91
+  - id: layer_40/width_16k/average_l0_189
+    l0: 189
+    path: layer_40/width_16k/average_l0_189
+  - id: layer_40/width_16k/average_l0_341
+    l0: 341
+    path: layer_40/width_16k/average_l0_341
+  - id: layer_40/width_16k/average_l0_603
+    l0: 603
+    path: layer_40/width_16k/average_l0_603
+  - id: layer_40/width_131k/average_l0_16
+    l0: 16
+    path: layer_40/width_131k/average_l0_16
+  - id: layer_40/width_131k/average_l0_30
+    l0: 30
+    path: layer_40/width_131k/average_l0_30
+  - id: layer_40/width_131k/average_l0_64
+    l0: 64
+    path: layer_40/width_131k/average_l0_64
+  - id: layer_40/width_131k/average_l0_144
+    l0: 144
+    path: layer_40/width_131k/average_l0_144
+  - id: layer_40/width_131k/average_l0_269
+    l0: 269
+    path: layer_40/width_131k/average_l0_269
+  - id: layer_40/width_131k/average_l0_493
+    l0: 493
+    path: layer_40/width_131k/average_l0_493
+  - id: layer_41/width_16k/average_l0_13
+    l0: 13
+    path: layer_41/width_16k/average_l0_13
+  - id: layer_41/width_16k/average_l0_25
+    l0: 25
+    path: layer_41/width_16k/average_l0_25
+  - id: layer_41/width_16k/average_l0_56
+    l0: 56
+    path: layer_41/width_16k/average_l0_56
+  - id: layer_41/width_16k/average_l0_129
+    l0: 129
+    path: layer_41/width_16k/average_l0_129
+  - id: layer_41/width_16k/average_l0_254
+    l0: 254
+    path: layer_41/width_16k/average_l0_254
+  - id: layer_41/width_16k/average_l0_450
+    l0: 450
+    path: layer_41/width_16k/average_l0_450
+  - id: layer_41/width_131k/average_l0_13
+    l0: 13
+    path: layer_41/width_131k/average_l0_13
+  - id: layer_41/width_131k/average_l0_22
+    l0: 22
+    path: layer_41/width_131k/average_l0_22
+  - id: layer_41/width_131k/average_l0_43
+    l0: 43
+    path: layer_41/width_131k/average_l0_43
+  - id: layer_41/width_131k/average_l0_92
+    l0: 92
+    path: layer_41/width_131k/average_l0_92
+  - id: layer_41/width_131k/average_l0_202
+    l0: 202
+    path: layer_41/width_131k/average_l0_202
+  - id: layer_41/width_131k/average_l0_370
+    l0: 370
+    path: layer_41/width_131k/average_l0_370
+  - id: layer_5/width_16k/average_l0_25
+    l0: 25
+    path: layer_5/width_16k/average_l0_25
+  - id: layer_5/width_16k/average_l0_53
+    l0: 53
+    path: layer_5/width_16k/average_l0_53
+  - id: layer_5/width_16k/average_l0_125
+    l0: 125
+    path: layer_5/width_16k/average_l0_125
+  - id: layer_5/width_16k/average_l0_270
+    l0: 270
+    path: layer_5/width_16k/average_l0_270
+  - id: layer_5/width_16k/average_l0_529
+    l0: 529
+    path: layer_5/width_16k/average_l0_529
+  - id: layer_5/width_131k/average_l0_12
+    l0: 12
+    path: layer_5/width_131k/average_l0_12
+  - id: layer_5/width_131k/average_l0_21
+    l0: 21
+    path: layer_5/width_131k/average_l0_21
+  - id: layer_5/width_131k/average_l0_39
+    l0: 39
+    path: layer_5/width_131k/average_l0_39
+  - id: layer_5/width_131k/average_l0_78
+    l0: 78
+    path: layer_5/width_131k/average_l0_78
+  - id: layer_5/width_131k/average_l0_160
+    l0: 160
+    path: layer_5/width_131k/average_l0_160
+  - id: layer_5/width_131k/average_l0_351
+    l0: 351
+    path: layer_5/width_131k/average_l0_351
+  - id: layer_6/width_16k/average_l0_16
+    l0: 16
+    path: layer_6/width_16k/average_l0_16
+  - id: layer_6/width_16k/average_l0_28
+    l0: 28
+    path: layer_6/width_16k/average_l0_28
+  - id: layer_6/width_16k/average_l0_51
+    l0: 51
+    path: layer_6/width_16k/average_l0_51
+  - id: layer_6/width_16k/average_l0_108
+    l0: 108
+    path: layer_6/width_16k/average_l0_108
+  - id: layer_6/width_16k/average_l0_258
+    l0: 258
+    path: layer_6/width_16k/average_l0_258
+  - id: layer_6/width_131k/average_l0_14
+    l0: 14
+    path: layer_6/width_131k/average_l0_14
+  - id: layer_6/width_131k/average_l0_24
+    l0: 24
+    path: layer_6/width_131k/average_l0_24
+  - id: layer_6/width_131k/average_l0_41
+    l0: 41
+    path: layer_6/width_131k/average_l0_41
+  - id: layer_6/width_131k/average_l0_73
+    l0: 73
+    path: layer_6/width_131k/average_l0_73
+  - id: layer_6/width_131k/average_l0_148
+    l0: 148
+    path: layer_6/width_131k/average_l0_148
+  - id: layer_6/width_131k/average_l0_353
+    l0: 353
+    path: layer_6/width_131k/average_l0_353
+  - id: layer_7/width_16k/average_l0_18
+    l0: 18
+    path: layer_7/width_16k/average_l0_18
+  - id: layer_7/width_16k/average_l0_33
+    l0: 33
+    path: layer_7/width_16k/average_l0_33
+  - id: layer_7/width_16k/average_l0_70
+    l0: 70
+    path: layer_7/width_16k/average_l0_70
+  - id: layer_7/width_16k/average_l0_160
+    l0: 160
+    path: layer_7/width_16k/average_l0_160
+  - id: layer_7/width_16k/average_l0_335
+    l0: 335
+    path: layer_7/width_16k/average_l0_335
+  - id: layer_7/width_131k/average_l0_16
+    l0: 16
+    path: layer_7/width_131k/average_l0_16
+  - id: layer_7/width_131k/average_l0_28
+    l0: 28
+    path: layer_7/width_131k/average_l0_28
+  - id: layer_7/width_131k/average_l0_52
+    l0: 52
+    path: layer_7/width_131k/average_l0_52
+  - id: layer_7/width_131k/average_l0_106
+    l0: 106
+    path: layer_7/width_131k/average_l0_106
+  - id: layer_7/width_131k/average_l0_229
+    l0: 229
+    path: layer_7/width_131k/average_l0_229
+  - id: layer_7/width_131k/average_l0_473
+    l0: 473
+    path: layer_7/width_131k/average_l0_473
+  - id: layer_8/width_16k/average_l0_17
+    l0: 17
+    path: layer_8/width_16k/average_l0_17
+  - id: layer_8/width_16k/average_l0_32
+    l0: 32
+    path: layer_8/width_16k/average_l0_32
+  - id: layer_8/width_16k/average_l0_65
+    l0: 65
+    path: layer_8/width_16k/average_l0_65
+  - id: layer_8/width_16k/average_l0_150
+    l0: 150
+    path: layer_8/width_16k/average_l0_150
+  - id: layer_8/width_16k/average_l0_362
+    l0: 362
+    path: layer_8/width_16k/average_l0_362
+  - id: layer_8/width_131k/average_l0_16
+    l0: 16
+    path: layer_8/width_131k/average_l0_16
+  - id: layer_8/width_131k/average_l0_27
+    l0: 27
+    path: layer_8/width_131k/average_l0_27
+  - id: layer_8/width_131k/average_l0_51
+    l0: 51
+    path: layer_8/width_131k/average_l0_51
+  - id: layer_8/width_131k/average_l0_98
+    l0: 98
+    path: layer_8/width_131k/average_l0_98
+  - id: layer_8/width_131k/average_l0_222
+    l0: 222
+    path: layer_8/width_131k/average_l0_222
+  - id: layer_8/width_131k/average_l0_531
+    l0: 531
+    path: layer_8/width_131k/average_l0_531
+  - id: layer_9/width_16k/average_l0_18
+    l0: 18
+    path: layer_9/width_16k/average_l0_18
+  - id: layer_9/width_16k/average_l0_34
+    l0: 34
+    path: layer_9/width_16k/average_l0_34
+  - id: layer_9/width_16k/average_l0_71
+    l0: 71
+    path: layer_9/width_16k/average_l0_71
+  - id: layer_9/width_16k/average_l0_172
+    l0: 172
+    path: layer_9/width_16k/average_l0_172
+  - id: layer_9/width_16k/average_l0_349
+    l0: 349
+    path: layer_9/width_16k/average_l0_349
+  - id: layer_9/width_131k/average_l0_16
+    l0: 16
+    path: layer_9/width_131k/average_l0_16
+  - id: layer_9/width_131k/average_l0_30
+    l0: 30
+    path: layer_9/width_131k/average_l0_30
+  - id: layer_9/width_131k/average_l0_54
+    l0: 54
+    path: layer_9/width_131k/average_l0_54
+  - id: layer_9/width_131k/average_l0_111
+    l0: 111
+    path: layer_9/width_131k/average_l0_111
+  - id: layer_9/width_131k/average_l0_263
+    l0: 263
+    path: layer_9/width_131k/average_l0_263
+  - id: layer_9/width_131k/average_l0_511
+    l0: 511
+    path: layer_9/width_131k/average_l0_511
+gemma-scope-9b-pt-att-canonical:
+  conversion_func: gemma_2
+  model: gemma-2-9b
+  repo_id: google/gemma-scope-9b-pt-att
+  saes:
+  - id: layer_0/width_16k/canonical
+    neuronpedia: gemma-2-9b/0-gemmascope-att-16k
+    path: layer_0/width_16k/average_l0_61
+  - id: layer_1/width_16k/canonical
+    neuronpedia: gemma-2-9b/1-gemmascope-att-16k
+    path: layer_1/width_16k/average_l0_77
+  - id: layer_2/width_16k/canonical
+    neuronpedia: gemma-2-9b/2-gemmascope-att-16k
+    path: layer_2/width_16k/average_l0_69
+  - id: layer_3/width_16k/canonical
+    neuronpedia: gemma-2-9b/3-gemmascope-att-16k
+    path: layer_3/width_16k/average_l0_102
+  - id: layer_4/width_16k/canonical
+    neuronpedia: gemma-2-9b/4-gemmascope-att-16k
+    path: layer_4/width_16k/average_l0_126
+  - id: layer_5/width_16k/canonical
+    neuronpedia: gemma-2-9b/5-gemmascope-att-16k
+    path: layer_5/width_16k/average_l0_125
+  - id: layer_6/width_16k/canonical
+    neuronpedia: gemma-2-9b/6-gemmascope-att-16k
+    path: layer_6/width_16k/average_l0_108
+  - id: layer_7/width_16k/canonical
+    neuronpedia: gemma-2-9b/7-gemmascope-att-16k
+    path: layer_7/width_16k/average_l0_70
+  - id: layer_8/width_16k/canonical
+    neuronpedia: gemma-2-9b/8-gemmascope-att-16k
+    path: layer_8/width_16k/average_l0_65
+  - id: layer_9/width_16k/canonical
+    neuronpedia: gemma-2-9b/9-gemmascope-att-16k
+    path: layer_9/width_16k/average_l0_71
+  - id: layer_10/width_16k/canonical
+    neuronpedia: gemma-2-9b/10-gemmascope-att-16k
+    path: layer_10/width_16k/average_l0_132
+  - id: layer_11/width_16k/canonical
+    neuronpedia: gemma-2-9b/11-gemmascope-att-16k
+    path: layer_11/width_16k/average_l0_67
+  - id: layer_12/width_16k/canonical
+    neuronpedia: gemma-2-9b/12-gemmascope-att-16k
+    path: layer_12/width_16k/average_l0_68
+  - id: layer_13/width_16k/canonical
+    neuronpedia: gemma-2-9b/13-gemmascope-att-16k
+    path: layer_13/width_16k/average_l0_77
+  - id: layer_14/width_16k/canonical
+    neuronpedia: gemma-2-9b/14-gemmascope-att-16k
+    path: layer_14/width_16k/average_l0_81
+  - id: layer_15/width_16k/canonical
+    neuronpedia: gemma-2-9b/15-gemmascope-att-16k
+    path: layer_15/width_16k/average_l0_79
+  - id: layer_16/width_16k/canonical
+    neuronpedia: gemma-2-9b/16-gemmascope-att-16k
+    path: layer_16/width_16k/average_l0_81
+  - id: layer_17/width_16k/canonical
+    neuronpedia: gemma-2-9b/17-gemmascope-att-16k
+    path: layer_17/width_16k/average_l0_110
+  - id: layer_18/width_16k/canonical
+    neuronpedia: gemma-2-9b/18-gemmascope-att-16k
+    path: layer_18/width_16k/average_l0_80
+  - id: layer_19/width_16k/canonical
+    neuronpedia: gemma-2-9b/19-gemmascope-att-16k
+    path: layer_19/width_16k/average_l0_86
+  - id: layer_20/width_16k/canonical
+    neuronpedia: gemma-2-9b/20-gemmascope-att-16k
+    path: layer_20/width_16k/average_l0_76
+  - id: layer_21/width_16k/canonical
+    neuronpedia: gemma-2-9b/21-gemmascope-att-16k
+    path: layer_21/width_16k/average_l0_86
+  - id: layer_22/width_16k/canonical
+    neuronpedia: gemma-2-9b/22-gemmascope-att-16k
+    path: layer_22/width_16k/average_l0_70
+  - id: layer_23/width_16k/canonical
+    neuronpedia: gemma-2-9b/23-gemmascope-att-16k
+    path: layer_23/width_16k/average_l0_80
+  - id: layer_24/width_16k/canonical
+    neuronpedia: gemma-2-9b/24-gemmascope-att-16k
+    path: layer_24/width_16k/average_l0_79
+  - id: layer_25/width_16k/canonical
+    neuronpedia: gemma-2-9b/25-gemmascope-att-16k
+    path: layer_25/width_16k/average_l0_73
+  - id: layer_26/width_16k/canonical
+    neuronpedia: gemma-2-9b/26-gemmascope-att-16k
+    path: layer_26/width_16k/average_l0_75
+  - id: layer_27/width_16k/canonical
+    neuronpedia: gemma-2-9b/27-gemmascope-att-16k
+    path: layer_27/width_16k/average_l0_136
+  - id: layer_28/width_16k/canonical
+    neuronpedia: gemma-2-9b/28-gemmascope-att-16k
+    path: layer_28/width_16k/average_l0_71
+  - id: layer_29/width_16k/canonical
+    neuronpedia: gemma-2-9b/29-gemmascope-att-16k
+    path: layer_29/width_16k/average_l0_76
+  - id: layer_30/width_16k/canonical
+    neuronpedia: gemma-2-9b/30-gemmascope-att-16k
+    path: layer_30/width_16k/average_l0_73
+  - id: layer_31/width_16k/canonical
+    neuronpedia: gemma-2-9b/31-gemmascope-att-16k
+    path: layer_31/width_16k/average_l0_73
+  - id: layer_32/width_16k/canonical
+    neuronpedia: gemma-2-9b/32-gemmascope-att-16k
+    path: layer_32/width_16k/average_l0_74
+  - id: layer_33/width_16k/canonical
+    neuronpedia: gemma-2-9b/33-gemmascope-att-16k
+    path: layer_33/width_16k/average_l0_78
+  - id: layer_34/width_16k/canonical
+    neuronpedia: gemma-2-9b/34-gemmascope-att-16k
+    path: layer_34/width_16k/average_l0_91
+  - id: layer_35/width_16k/canonical
+    neuronpedia: gemma-2-9b/35-gemmascope-att-16k
+    path: layer_35/width_16k/average_l0_77
+  - id: layer_36/width_16k/canonical
+    neuronpedia: gemma-2-9b/36-gemmascope-att-16k
+    path: layer_36/width_16k/average_l0_69
+  - id: layer_37/width_16k/canonical
+    neuronpedia: gemma-2-9b/37-gemmascope-att-16k
+    path: layer_37/width_16k/average_l0_82
+  - id: layer_38/width_16k/canonical
+    neuronpedia: gemma-2-9b/38-gemmascope-att-16k
+    path: layer_38/width_16k/average_l0_81
+  - id: layer_39/width_16k/canonical
+    neuronpedia: gemma-2-9b/39-gemmascope-att-16k
+    path: layer_39/width_16k/average_l0_77
+  - id: layer_40/width_16k/canonical
+    neuronpedia: gemma-2-9b/40-gemmascope-att-16k
+    path: layer_40/width_16k/average_l0_91
+  - id: layer_41/width_16k/canonical
+    neuronpedia: gemma-2-9b/41-gemmascope-att-16k
+    path: layer_41/width_16k/average_l0_129
+  - id: layer_0/width_131k/canonical
+    neuronpedia: gemma-2-9b/0-gemmascope-att-131k
+    path: layer_0/width_131k/average_l0_55
+  - id: layer_1/width_131k/canonical
+    neuronpedia: gemma-2-9b/1-gemmascope-att-131k
+    path: layer_1/width_131k/average_l0_116
+  - id: layer_2/width_131k/canonical
+    neuronpedia: gemma-2-9b/2-gemmascope-att-131k
+    path: layer_2/width_131k/average_l0_135
+  - id: layer_3/width_131k/canonical
+    neuronpedia: gemma-2-9b/3-gemmascope-att-131k
+    path: layer_3/width_131k/average_l0_119
+  - id: layer_4/width_131k/canonical
+    neuronpedia: gemma-2-9b/4-gemmascope-att-131k
+    path: layer_4/width_131k/average_l0_75
+  - id: layer_5/width_131k/canonical
+    neuronpedia: gemma-2-9b/5-gemmascope-att-131k
+    path: layer_5/width_131k/average_l0_78
+  - id: layer_6/width_131k/canonical
+    neuronpedia: gemma-2-9b/6-gemmascope-att-131k
+    path: layer_6/width_131k/average_l0_73
+  - id: layer_7/width_131k/canonical
+    neuronpedia: gemma-2-9b/7-gemmascope-att-131k
+    path: layer_7/width_131k/average_l0_106
+  - id: layer_8/width_131k/canonical
+    neuronpedia: gemma-2-9b/8-gemmascope-att-131k
+    path: layer_8/width_131k/average_l0_98
+  - id: layer_9/width_131k/canonical
+    neuronpedia: gemma-2-9b/9-gemmascope-att-131k
+    path: layer_9/width_131k/average_l0_111
+  - id: layer_10/width_131k/canonical
+    neuronpedia: gemma-2-9b/10-gemmascope-att-131k
+    path: layer_10/width_131k/average_l0_97
+  - id: layer_11/width_131k/canonical
+    neuronpedia: gemma-2-9b/11-gemmascope-att-131k
+    path: layer_11/width_131k/average_l0_104
+  - id: layer_12/width_131k/canonical
+    neuronpedia: gemma-2-9b/12-gemmascope-att-131k
+    path: layer_12/width_131k/average_l0_110
+  - id: layer_13/width_131k/canonical
+    neuronpedia: gemma-2-9b/13-gemmascope-att-131k
+    path: layer_13/width_131k/average_l0_126
+  - id: layer_14/width_131k/canonical
+    neuronpedia: gemma-2-9b/14-gemmascope-att-131k
+    path: layer_14/width_131k/average_l0_131
+  - id: layer_15/width_131k/canonical
+    neuronpedia: gemma-2-9b/15-gemmascope-att-131k
+    path: layer_15/width_131k/average_l0_130
+  - id: layer_16/width_131k/canonical
+    neuronpedia: gemma-2-9b/16-gemmascope-att-131k
+    path: layer_16/width_131k/average_l0_71
+  - id: layer_17/width_131k/canonical
+    neuronpedia: gemma-2-9b/17-gemmascope-att-131k
+    path: layer_17/width_131k/average_l0_90
+  - id: layer_18/width_131k/canonical
+    neuronpedia: gemma-2-9b/18-gemmascope-att-131k
+    path: layer_18/width_131k/average_l0_69
+  - id: layer_19/width_131k/canonical
+    neuronpedia: gemma-2-9b/19-gemmascope-att-131k
+    path: layer_19/width_131k/average_l0_71
+  - id: layer_20/width_131k/canonical
+    neuronpedia: gemma-2-9b/20-gemmascope-att-131k
+    path: layer_20/width_131k/average_l0_125
+  - id: layer_21/width_131k/canonical
+    neuronpedia: gemma-2-9b/21-gemmascope-att-131k
+    path: layer_21/width_131k/average_l0_71
+  - id: layer_22/width_131k/canonical
+    neuronpedia: gemma-2-9b/22-gemmascope-att-131k
+    path: layer_22/width_131k/average_l0_115
+  - id: layer_23/width_131k/canonical
+    neuronpedia: gemma-2-9b/23-gemmascope-att-131k
+    path: layer_23/width_131k/average_l0_66
+  - id: layer_24/width_131k/canonical
+    neuronpedia: gemma-2-9b/24-gemmascope-att-131k
+    path: layer_24/width_131k/average_l0_130
+  - id: layer_25/width_131k/canonical
+    neuronpedia: gemma-2-9b/25-gemmascope-att-131k
+    path: layer_25/width_131k/average_l0_115
+  - id: layer_26/width_131k/canonical
+    neuronpedia: gemma-2-9b/26-gemmascope-att-131k
+    path: layer_26/width_131k/average_l0_120
+  - id: layer_27/width_131k/canonical
+    neuronpedia: gemma-2-9b/27-gemmascope-att-131k
+    path: layer_27/width_131k/average_l0_102
+  - id: layer_28/width_131k/canonical
+    neuronpedia: gemma-2-9b/28-gemmascope-att-131k
+    path: layer_28/width_131k/average_l0_115
+  - id: layer_29/width_131k/canonical
+    neuronpedia: gemma-2-9b/29-gemmascope-att-131k
+    path: layer_29/width_131k/average_l0_128
+  - id: layer_30/width_131k/canonical
+    neuronpedia: gemma-2-9b/30-gemmascope-att-131k
+    path: layer_30/width_131k/average_l0_109
+  - id: layer_31/width_131k/canonical
+    neuronpedia: gemma-2-9b/31-gemmascope-att-131k
+    path: layer_31/width_131k/average_l0_117
+  - id: layer_32/width_131k/canonical
+    neuronpedia: gemma-2-9b/32-gemmascope-att-131k
+    path: layer_32/width_131k/average_l0_117
+  - id: layer_33/width_131k/canonical
+    neuronpedia: gemma-2-9b/33-gemmascope-att-131k
+    path: layer_33/width_131k/average_l0_128
+  - id: layer_34/width_131k/canonical
+    neuronpedia: gemma-2-9b/34-gemmascope-att-131k
+    path: layer_34/width_131k/average_l0_63
+  - id: layer_35/width_131k/canonical
+    neuronpedia: gemma-2-9b/35-gemmascope-att-131k
+    path: layer_35/width_131k/average_l0_124
+  - id: layer_36/width_131k/canonical
+    neuronpedia: gemma-2-9b/36-gemmascope-att-131k
+    path: layer_36/width_131k/average_l0_105
+  - id: layer_37/width_131k/canonical
+    neuronpedia: gemma-2-9b/37-gemmascope-att-131k
+    path: layer_37/width_131k/average_l0_124
+  - id: layer_38/width_131k/canonical
+    neuronpedia: gemma-2-9b/38-gemmascope-att-131k
+    path: layer_38/width_131k/average_l0_135
+  - id: layer_39/width_131k/canonical
+    neuronpedia: gemma-2-9b/39-gemmascope-att-131k
+    path: layer_39/width_131k/average_l0_120
+  - id: layer_40/width_131k/canonical
+    neuronpedia: gemma-2-9b/40-gemmascope-att-131k
+    path: layer_40/width_131k/average_l0_64
+  - id: layer_41/width_131k/canonical
+    neuronpedia: gemma-2-9b/41-gemmascope-att-131k
+    path: layer_41/width_131k/average_l0_92
+gemma-scope-9b-pt-mlp:
+  conversion_func: gemma_2
+  model: gemma-2-9b
+  repo_id: google/gemma-scope-9b-pt-mlp
+  saes:
+  - id: layer_0/width_16k/average_l0_6
+    l0: 6
+    path: layer_0/width_16k/average_l0_6
+  - id: layer_0/width_16k/average_l0_10
+    l0: 10
+    path: layer_0/width_16k/average_l0_10
+  - id: layer_0/width_16k/average_l0_16
+    l0: 16
+    path: layer_0/width_16k/average_l0_16
+  - id: layer_0/width_16k/average_l0_28
+    l0: 28
+    path: layer_0/width_16k/average_l0_28
+  - id: layer_0/width_16k/average_l0_50
+    l0: 50
+    neuronpedia: gemma-2-9b/0-gemmascope-mlp-16k__l0-50
+    path: layer_0/width_16k/average_l0_50
+  - id: layer_0/width_131k/average_l0_3
+    l0: 3
+    path: layer_0/width_131k/average_l0_3
+  - id: layer_0/width_131k/average_l0_5
+    l0: 5
+    path: layer_0/width_131k/average_l0_5
+  - id: layer_0/width_131k/average_l0_7
+    l0: 7
+    path: layer_0/width_131k/average_l0_7
+  - id: layer_0/width_131k/average_l0_11
+    l0: 11
+    path: layer_0/width_131k/average_l0_11
+  - id: layer_0/width_131k/average_l0_18
+    l0: 18
+    path: layer_0/width_131k/average_l0_18
+  - id: layer_0/width_131k/average_l0_30
+    l0: 30
+    path: layer_0/width_131k/average_l0_30
+  - id: layer_1/width_16k/average_l0_12
+    l0: 12
+    path: layer_1/width_16k/average_l0_12
+  - id: layer_1/width_16k/average_l0_26
+    l0: 26
+    path: layer_1/width_16k/average_l0_26
+  - id: layer_1/width_16k/average_l0_56
+    l0: 56
+    neuronpedia: gemma-2-9b/1-gemmascope-mlp-16k__l0-56
+    path: layer_1/width_16k/average_l0_56
+  - id: layer_1/width_16k/average_l0_128
+    l0: 128
+    path: layer_1/width_16k/average_l0_128
+  - id: layer_1/width_16k/average_l0_278
+    l0: 278
+    path: layer_1/width_16k/average_l0_278
+  - id: layer_1/width_131k/average_l0_6
+    l0: 6
+    path: layer_1/width_131k/average_l0_6
+  - id: layer_1/width_131k/average_l0_10
+    l0: 10
+    path: layer_1/width_131k/average_l0_10
+  - id: layer_1/width_131k/average_l0_18
+    l0: 18
+    path: layer_1/width_131k/average_l0_18
+  - id: layer_1/width_131k/average_l0_32
+    l0: 32
+    path: layer_1/width_131k/average_l0_32
+  - id: layer_1/width_131k/average_l0_59
+    l0: 59
+    path: layer_1/width_131k/average_l0_59
+  - id: layer_1/width_131k/average_l0_106
+    l0: 106
+    path: layer_1/width_131k/average_l0_106
+  - id: layer_10/width_16k/average_l0_13
+    l0: 13
+    path: layer_10/width_16k/average_l0_13
+  - id: layer_10/width_16k/average_l0_24
+    l0: 24
+    path: layer_10/width_16k/average_l0_24
+  - id: layer_10/width_16k/average_l0_49
+    l0: 49
+    neuronpedia: gemma-2-9b/10-gemmascope-mlp-16k__l0-49
+    path: layer_10/width_16k/average_l0_49
+  - id: layer_10/width_16k/average_l0_114
+    l0: 114
+    path: layer_10/width_16k/average_l0_114
+  - id: layer_10/width_16k/average_l0_276
+    l0: 276
+    path: layer_10/width_16k/average_l0_276
+  - id: layer_10/width_131k/average_l0_12
+    l0: 12
+    path: layer_10/width_131k/average_l0_12
+  - id: layer_10/width_131k/average_l0_22
+    l0: 22
+    path: layer_10/width_131k/average_l0_22
+  - id: layer_10/width_131k/average_l0_42
+    l0: 42
+    path: layer_10/width_131k/average_l0_42
+  - id: layer_10/width_131k/average_l0_83
+    l0: 83
+    path: layer_10/width_131k/average_l0_83
+  - id: layer_10/width_131k/average_l0_167
+    l0: 167
+    path: layer_10/width_131k/average_l0_167
+  - id: layer_10/width_131k/average_l0_362
+    l0: 362
+    path: layer_10/width_131k/average_l0_362
+  - id: layer_11/width_16k/average_l0_17
+    l0: 17
+    path: layer_11/width_16k/average_l0_17
+  - id: layer_11/width_16k/average_l0_34
+    l0: 34
+    neuronpedia: gemma-2-9b/11-gemmascope-mlp-16k__l0-34
+    path: layer_11/width_16k/average_l0_34
+  - id: layer_11/width_16k/average_l0_76
+    l0: 76
+    path: layer_11/width_16k/average_l0_76
+  - id: layer_11/width_16k/average_l0_180
+    l0: 180
+    path: layer_11/width_16k/average_l0_180
+  - id: layer_11/width_16k/average_l0_421
+    l0: 421
+    path: layer_11/width_16k/average_l0_421
+  - id: layer_11/width_131k/average_l0_17
+    l0: 17
+    path: layer_11/width_131k/average_l0_17
+  - id: layer_11/width_131k/average_l0_31
+    l0: 31
+    path: layer_11/width_131k/average_l0_31
+  - id: layer_11/width_131k/average_l0_60
+    l0: 60
+    path: layer_11/width_131k/average_l0_60
+  - id: layer_11/width_131k/average_l0_120
+    l0: 120
+    path: layer_11/width_131k/average_l0_120
+  - id: layer_11/width_131k/average_l0_259
+    l0: 259
+    path: layer_11/width_131k/average_l0_259
+  - id: layer_11/width_131k/average_l0_569
+    l0: 569
+    path: layer_11/width_131k/average_l0_569
+  - id: layer_12/width_16k/average_l0_20
+    l0: 20
+    path: layer_12/width_16k/average_l0_20
+  - id: layer_12/width_16k/average_l0_42
+    l0: 42
+    neuronpedia: gemma-2-9b/12-gemmascope-mlp-16k__l0-42
+    path: layer_12/width_16k/average_l0_42
+  - id: layer_12/width_16k/average_l0_96
+    l0: 96
+    path: layer_12/width_16k/average_l0_96
+  - id: layer_12/width_16k/average_l0_237
+    l0: 237
+    path: layer_12/width_16k/average_l0_237
+  - id: layer_12/width_16k/average_l0_543
+    l0: 543
+    path: layer_12/width_16k/average_l0_543
+  - id: layer_12/width_16k/average_l0_1033
+    l0: 1033
+    path: layer_12/width_16k/average_l0_1033
+  - id: layer_12/width_131k/average_l0_19
+    l0: 19
+    path: layer_12/width_131k/average_l0_19
+  - id: layer_12/width_131k/average_l0_38
+    l0: 38
+    path: layer_12/width_131k/average_l0_38
+  - id: layer_12/width_131k/average_l0_77
+    l0: 77
+    path: layer_12/width_131k/average_l0_77
+  - id: layer_12/width_131k/average_l0_159
+    l0: 159
+    path: layer_12/width_131k/average_l0_159
+  - id: layer_12/width_131k/average_l0_338
+    l0: 338
+    path: layer_12/width_131k/average_l0_338
+  - id: layer_12/width_131k/average_l0_745
+    l0: 745
+    path: layer_12/width_131k/average_l0_745
+  - id: layer_13/width_16k/average_l0_19
+    l0: 19
+    path: layer_13/width_16k/average_l0_19
+  - id: layer_13/width_16k/average_l0_40
+    l0: 40
+    neuronpedia: gemma-2-9b/13-gemmascope-mlp-16k__l0-40
+    path: layer_13/width_16k/average_l0_40
+  - id: layer_13/width_16k/average_l0_94
+    l0: 94
+    path: layer_13/width_16k/average_l0_94
+  - id: layer_13/width_16k/average_l0_225
+    l0: 225
+    path: layer_13/width_16k/average_l0_225
+  - id: layer_13/width_16k/average_l0_512
+    l0: 512
+    path: layer_13/width_16k/average_l0_512
+  - id: layer_13/width_16k/average_l0_992
+    l0: 992
+    path: layer_13/width_16k/average_l0_992
+  - id: layer_13/width_131k/average_l0_20
+    l0: 20
+    path: layer_13/width_131k/average_l0_20
+  - id: layer_13/width_131k/average_l0_38
+    l0: 38
+    path: layer_13/width_131k/average_l0_38
+  - id: layer_13/width_131k/average_l0_75
+    l0: 75
+    path: layer_13/width_131k/average_l0_75
+  - id: layer_13/width_131k/average_l0_160
+    l0: 160
+    path: layer_13/width_131k/average_l0_160
+  - id: layer_13/width_131k/average_l0_351
+    l0: 351
+    path: layer_13/width_131k/average_l0_351
+  - id: layer_13/width_131k/average_l0_703
+    l0: 703
+    path: layer_13/width_131k/average_l0_703
+  - id: layer_14/width_16k/average_l0_19
+    l0: 19
+    path: layer_14/width_16k/average_l0_19
+  - id: layer_14/width_16k/average_l0_41
+    l0: 41
+    neuronpedia: gemma-2-9b/14-gemmascope-mlp-16k__l0-41
+    path: layer_14/width_16k/average_l0_41
+  - id: layer_14/width_16k/average_l0_97
+    l0: 97
+    path: layer_14/width_16k/average_l0_97
+  - id: layer_14/width_16k/average_l0_236
+    l0: 236
+    path: layer_14/width_16k/average_l0_236
+  - id: layer_14/width_16k/average_l0_538
+    l0: 538
+    path: layer_14/width_16k/average_l0_538
+  - id: layer_14/width_16k/average_l0_1023
+    l0: 1023
+    path: layer_14/width_16k/average_l0_1023
+  - id: layer_14/width_131k/average_l0_20
+    l0: 20
+    path: layer_14/width_131k/average_l0_20
+  - id: layer_14/width_131k/average_l0_40
+    l0: 40
+    path: layer_14/width_131k/average_l0_40
+  - id: layer_14/width_131k/average_l0_80
+    l0: 80
+    path: layer_14/width_131k/average_l0_80
+  - id: layer_14/width_131k/average_l0_174
+    l0: 174
+    path: layer_14/width_131k/average_l0_174
+  - id: layer_14/width_131k/average_l0_374
+    l0: 374
+    path: layer_14/width_131k/average_l0_374
+  - id: layer_14/width_131k/average_l0_743
+    l0: 743
+    path: layer_14/width_131k/average_l0_743
+  - id: layer_15/width_16k/average_l0_20
+    l0: 20
+    path: layer_15/width_16k/average_l0_20
+  - id: layer_15/width_16k/average_l0_45
+    l0: 45
+    neuronpedia: gemma-2-9b/15-gemmascope-mlp-16k__l0-45
+    path: layer_15/width_16k/average_l0_45
+  - id: layer_15/width_16k/average_l0_107
+    l0: 107
+    path: layer_15/width_16k/average_l0_107
+  - id: layer_15/width_16k/average_l0_260
+    l0: 260
+    path: layer_15/width_16k/average_l0_260
+  - id: layer_15/width_16k/average_l0_572
+    l0: 572
+    path: layer_15/width_16k/average_l0_572
+  - id: layer_15/width_16k/average_l0_1053
+    l0: 1053
+    path: layer_15/width_16k/average_l0_1053
+  - id: layer_15/width_131k/average_l0_21
+    l0: 21
+    path: layer_15/width_131k/average_l0_21
+  - id: layer_15/width_131k/average_l0_43
+    l0: 43
+    path: layer_15/width_131k/average_l0_43
+  - id: layer_15/width_131k/average_l0_89
+    l0: 89
+    path: layer_15/width_131k/average_l0_89
+  - id: layer_15/width_131k/average_l0_194
+    l0: 194
+    path: layer_15/width_131k/average_l0_194
+  - id: layer_15/width_131k/average_l0_421
+    l0: 421
+    path: layer_15/width_131k/average_l0_421
+  - id: layer_15/width_131k/average_l0_828
+    l0: 828
+    path: layer_15/width_131k/average_l0_828
+  - id: layer_16/width_16k/average_l0_16
+    l0: 16
+    path: layer_16/width_16k/average_l0_16
+  - id: layer_16/width_16k/average_l0_37
+    l0: 37
+    neuronpedia: gemma-2-9b/16-gemmascope-mlp-16k__l0-37
+    path: layer_16/width_16k/average_l0_37
+  - id: layer_16/width_16k/average_l0_91
+    l0: 91
+    path: layer_16/width_16k/average_l0_91
+  - id: layer_16/width_16k/average_l0_221
+    l0: 221
+    path: layer_16/width_16k/average_l0_221
+  - id: layer_16/width_16k/average_l0_489
+    l0: 489
+    path: layer_16/width_16k/average_l0_489
+  - id: layer_16/width_16k/average_l0_916
+    l0: 916
+    path: layer_16/width_16k/average_l0_916
+  - id: layer_16/width_131k/average_l0_17
+    l0: 17
+    path: layer_16/width_131k/average_l0_17
+  - id: layer_16/width_131k/average_l0_38
+    l0: 38
+    path: layer_16/width_131k/average_l0_38
+  - id: layer_16/width_131k/average_l0_81
+    l0: 81
+    path: layer_16/width_131k/average_l0_81
+  - id: layer_16/width_131k/average_l0_175
+    l0: 175
+    path: layer_16/width_131k/average_l0_175
+  - id: layer_16/width_131k/average_l0_384
+    l0: 384
+    path: layer_16/width_131k/average_l0_384
+  - id: layer_16/width_131k/average_l0_744
+    l0: 744
+    path: layer_16/width_131k/average_l0_744
+  - id: layer_17/width_16k/average_l0_18
+    l0: 18
+    path: layer_17/width_16k/average_l0_18
+  - id: layer_17/width_16k/average_l0_41
+    l0: 41
+    neuronpedia: gemma-2-9b/17-gemmascope-mlp-16k__l0-41
+    path: layer_17/width_16k/average_l0_41
+  - id: layer_17/width_16k/average_l0_104
+    l0: 104
+    path: layer_17/width_16k/average_l0_104
+  - id: layer_17/width_16k/average_l0_274
+    l0: 274
+    path: layer_17/width_16k/average_l0_274
+  - id: layer_17/width_16k/average_l0_624
+    l0: 624
+    path: layer_17/width_16k/average_l0_624
+  - id: layer_17/width_16k/average_l0_1137
+    l0: 1137
+    path: layer_17/width_16k/average_l0_1137
+  - id: layer_17/width_131k/average_l0_22
+    l0: 22
+    path: layer_17/width_131k/average_l0_22
+  - id: layer_17/width_131k/average_l0_43
+    l0: 43
+    path: layer_17/width_131k/average_l0_43
+  - id: layer_17/width_131k/average_l0_91
+    l0: 91
+    path: layer_17/width_131k/average_l0_91
+  - id: layer_17/width_131k/average_l0_207
+    l0: 207
+    path: layer_17/width_131k/average_l0_207
+  - id: layer_17/width_131k/average_l0_483
+    l0: 483
+    path: layer_17/width_131k/average_l0_483
+  - id: layer_17/width_131k/average_l0_950
+    l0: 950
+    path: layer_17/width_131k/average_l0_950
+  - id: layer_18/width_16k/average_l0_16
+    l0: 16
+    path: layer_18/width_16k/average_l0_16
+  - id: layer_18/width_16k/average_l0_36
+    l0: 36
+    neuronpedia: gemma-2-9b/18-gemmascope-mlp-16k__l0-36
+    path: layer_18/width_16k/average_l0_36
+  - id: layer_18/width_16k/average_l0_89
+    l0: 89
+    path: layer_18/width_16k/average_l0_89
+  - id: layer_18/width_16k/average_l0_235
+    l0: 235
+    path: layer_18/width_16k/average_l0_235
+  - id: layer_18/width_16k/average_l0_564
+    l0: 564
+    path: layer_18/width_16k/average_l0_564
+  - id: layer_18/width_16k/average_l0_1052
+    l0: 1052
+    path: layer_18/width_16k/average_l0_1052
+  - id: layer_18/width_131k/average_l0_19
+    l0: 19
+    path: layer_18/width_131k/average_l0_19
+  - id: layer_18/width_131k/average_l0_37
+    l0: 37
+    path: layer_18/width_131k/average_l0_37
+  - id: layer_18/width_131k/average_l0_82
+    l0: 82
+    path: layer_18/width_131k/average_l0_82
+  - id: layer_18/width_131k/average_l0_174
+    l0: 174
+    path: layer_18/width_131k/average_l0_174
+  - id: layer_18/width_131k/average_l0_420
+    l0: 420
+    path: layer_18/width_131k/average_l0_420
+  - id: layer_18/width_131k/average_l0_865
+    l0: 865
+    path: layer_18/width_131k/average_l0_865
+  - id: layer_19/width_16k/average_l0_16
+    l0: 16
+    path: layer_19/width_16k/average_l0_16
+  - id: layer_19/width_16k/average_l0_38
+    l0: 38
+    neuronpedia: gemma-2-9b/19-gemmascope-mlp-16k__l0-38
+    path: layer_19/width_16k/average_l0_38
+  - id: layer_19/width_16k/average_l0_98
+    l0: 98
+    path: layer_19/width_16k/average_l0_98
+  - id: layer_19/width_16k/average_l0_255
+    l0: 255
+    path: layer_19/width_16k/average_l0_255
+  - id: layer_19/width_16k/average_l0_599
+    l0: 599
+    path: layer_19/width_16k/average_l0_599
+  - id: layer_19/width_16k/average_l0_1097
+    l0: 1097
+    path: layer_19/width_16k/average_l0_1097
+  - id: layer_19/width_131k/average_l0_19
+    l0: 19
+    path: layer_19/width_131k/average_l0_19
+  - id: layer_19/width_131k/average_l0_40
+    l0: 40
+    path: layer_19/width_131k/average_l0_40
+  - id: layer_19/width_131k/average_l0_85
+    l0: 85
+    path: layer_19/width_131k/average_l0_85
+  - id: layer_19/width_131k/average_l0_189
+    l0: 189
+    path: layer_19/width_131k/average_l0_189
+  - id: layer_19/width_131k/average_l0_440
+    l0: 440
+    path: layer_19/width_131k/average_l0_440
+  - id: layer_19/width_131k/average_l0_899
+    l0: 899
+    path: layer_19/width_131k/average_l0_899
+  - id: layer_2/width_16k/average_l0_8
+    l0: 8
+    path: layer_2/width_16k/average_l0_8
+  - id: layer_2/width_16k/average_l0_16
+    l0: 16
+    path: layer_2/width_16k/average_l0_16
+  - id: layer_2/width_16k/average_l0_33
+    l0: 33
+    neuronpedia: gemma-2-9b/2-gemmascope-mlp-16k__l0-33
+    path: layer_2/width_16k/average_l0_33
+  - id: layer_2/width_16k/average_l0_81
+    l0: 81
+    path: layer_2/width_16k/average_l0_81
+  - id: layer_2/width_16k/average_l0_163
+    l0: 163
+    path: layer_2/width_16k/average_l0_163
+  - id: layer_2/width_131k/average_l0_4
+    l0: 4
+    path: layer_2/width_131k/average_l0_4
+  - id: layer_2/width_131k/average_l0_7
+    l0: 7
+    path: layer_2/width_131k/average_l0_7
+  - id: layer_2/width_131k/average_l0_12
+    l0: 12
+    path: layer_2/width_131k/average_l0_12
+  - id: layer_2/width_131k/average_l0_20
+    l0: 20
+    path: layer_2/width_131k/average_l0_20
+  - id: layer_2/width_131k/average_l0_35
+    l0: 35
+    path: layer_2/width_131k/average_l0_35
+  - id: layer_2/width_131k/average_l0_61
+    l0: 61
+    path: layer_2/width_131k/average_l0_61
+  - id: layer_20/width_16k/average_l0_17
+    l0: 17
+    path: layer_20/width_16k/average_l0_17
+  - id: layer_20/width_16k/average_l0_41
+    l0: 41
+    neuronpedia: gemma-2-9b/20-gemmascope-mlp-16k__l0-41
+    path: layer_20/width_16k/average_l0_41
+  - id: layer_20/width_16k/average_l0_108
+    l0: 108
+    path: layer_20/width_16k/average_l0_108
+  - id: layer_20/width_16k/average_l0_284
+    l0: 284
+    path: layer_20/width_16k/average_l0_284
+  - id: layer_20/width_16k/average_l0_643
+    l0: 643
+    path: layer_20/width_16k/average_l0_643
+  - id: layer_20/width_16k/average_l0_1127
+    l0: 1127
+    path: layer_20/width_16k/average_l0_1127
+  - id: layer_20/width_131k/average_l0_20
+    l0: 20
+    path: layer_20/width_131k/average_l0_20
+  - id: layer_20/width_131k/average_l0_41
+    l0: 41
+    path: layer_20/width_131k/average_l0_41
+  - id: layer_20/width_131k/average_l0_93
+    l0: 93
+    path: layer_20/width_131k/average_l0_93
+  - id: layer_20/width_131k/average_l0_212
+    l0: 212
+    path: layer_20/width_131k/average_l0_212
+  - id: layer_20/width_131k/average_l0_477
+    l0: 477
+    path: layer_20/width_131k/average_l0_477
+  - id: layer_20/width_131k/average_l0_992
+    l0: 992
+    path: layer_20/width_131k/average_l0_992
+  - id: layer_21/width_16k/average_l0_15
+    l0: 15
+    path: layer_21/width_16k/average_l0_15
+  - id: layer_21/width_16k/average_l0_34
+    l0: 34
+    neuronpedia: gemma-2-9b/21-gemmascope-mlp-16k__l0-34
+    path: layer_21/width_16k/average_l0_34
+  - id: layer_21/width_16k/average_l0_88
+    l0: 88
+    path: layer_21/width_16k/average_l0_88
+  - id: layer_21/width_16k/average_l0_241
+    l0: 241
+    path: layer_21/width_16k/average_l0_241
+  - id: layer_21/width_16k/average_l0_571
+    l0: 571
+    path: layer_21/width_16k/average_l0_571
+  - id: layer_21/width_16k/average_l0_1063
+    l0: 1063
+    path: layer_21/width_16k/average_l0_1063
+  - id: layer_21/width_131k/average_l0_16
+    l0: 16
+    path: layer_21/width_131k/average_l0_16
+  - id: layer_21/width_131k/average_l0_35
+    l0: 35
+    path: layer_21/width_131k/average_l0_35
+  - id: layer_21/width_131k/average_l0_79
+    l0: 79
+    path: layer_21/width_131k/average_l0_79
+  - id: layer_21/width_131k/average_l0_179
+    l0: 179
+    path: layer_21/width_131k/average_l0_179
+  - id: layer_21/width_131k/average_l0_417
+    l0: 417
+    path: layer_21/width_131k/average_l0_417
+  - id: layer_21/width_131k/average_l0_884
+    l0: 884
+    path: layer_21/width_131k/average_l0_884
+  - id: layer_22/width_16k/average_l0_15
+    l0: 15
+    path: layer_22/width_16k/average_l0_15
+  - id: layer_22/width_16k/average_l0_34
+    l0: 34
+    neuronpedia: gemma-2-9b/22-gemmascope-mlp-16k__l0-34
+    path: layer_22/width_16k/average_l0_34
+  - id: layer_22/width_16k/average_l0_85
+    l0: 85
+    path: layer_22/width_16k/average_l0_85
+  - id: layer_22/width_16k/average_l0_226
+    l0: 226
+    path: layer_22/width_16k/average_l0_226
+  - id: layer_22/width_16k/average_l0_566
+    l0: 566
+    path: layer_22/width_16k/average_l0_566
+  - id: layer_22/width_16k/average_l0_1065
+    l0: 1065
+    path: layer_22/width_16k/average_l0_1065
+  - id: layer_22/width_131k/average_l0_17
+    l0: 17
+    path: layer_22/width_131k/average_l0_17
+  - id: layer_22/width_131k/average_l0_35
+    l0: 35
+    path: layer_22/width_131k/average_l0_35
+  - id: layer_22/width_131k/average_l0_77
+    l0: 77
+    path: layer_22/width_131k/average_l0_77
+  - id: layer_22/width_131k/average_l0_172
+    l0: 172
+    path: layer_22/width_131k/average_l0_172
+  - id: layer_22/width_131k/average_l0_404
+    l0: 404
+    path: layer_22/width_131k/average_l0_404
+  - id: layer_22/width_131k/average_l0_861
+    l0: 861
+    path: layer_22/width_131k/average_l0_861
+  - id: layer_23/width_16k/average_l0_15
+    l0: 15
+    path: layer_23/width_16k/average_l0_15
+  - id: layer_23/width_16k/average_l0_31
+    l0: 31
+    path: layer_23/width_16k/average_l0_31
+  - id: layer_23/width_16k/average_l0_73
+    l0: 73
+    neuronpedia: gemma-2-9b/23-gemmascope-mlp-16k__l0-73
+    path: layer_23/width_16k/average_l0_73
+  - id: layer_23/width_16k/average_l0_190
+    l0: 190
+    path: layer_23/width_16k/average_l0_190
+  - id: layer_23/width_16k/average_l0_492
+    l0: 492
+    path: layer_23/width_16k/average_l0_492
+  - id: layer_23/width_16k/average_l0_990
+    l0: 990
+    path: layer_23/width_16k/average_l0_990
+  - id: layer_23/width_131k/average_l0_17
+    l0: 17
+    path: layer_23/width_131k/average_l0_17
+  - id: layer_23/width_131k/average_l0_32
+    l0: 32
+    path: layer_23/width_131k/average_l0_32
+  - id: layer_23/width_131k/average_l0_67
+    l0: 67
+    path: layer_23/width_131k/average_l0_67
+  - id: layer_23/width_131k/average_l0_146
+    l0: 146
+    path: layer_23/width_131k/average_l0_146
+  - id: layer_23/width_131k/average_l0_354
+    l0: 354
+    path: layer_23/width_131k/average_l0_354
+  - id: layer_23/width_131k/average_l0_754
+    l0: 754
+    path: layer_23/width_131k/average_l0_754
+  - id: layer_24/width_16k/average_l0_15
+    l0: 15
+    path: layer_24/width_16k/average_l0_15
+  - id: layer_24/width_16k/average_l0_32
+    l0: 32
+    neuronpedia: gemma-2-9b/24-gemmascope-mlp-16k__l0-32
+    path: layer_24/width_16k/average_l0_32
+  - id: layer_24/width_16k/average_l0_73
+    l0: 73
+    path: layer_24/width_16k/average_l0_73
+  - id: layer_24/width_16k/average_l0_192
+    l0: 192
+    path: layer_24/width_16k/average_l0_192
+  - id: layer_24/width_16k/average_l0_494
+    l0: 494
+    path: layer_24/width_16k/average_l0_494
+  - id: layer_24/width_16k/average_l0_999
+    l0: 999
+    path: layer_24/width_16k/average_l0_999
+  - id: layer_24/width_131k/average_l0_17
+    l0: 17
+    path: layer_24/width_131k/average_l0_17
+  - id: layer_24/width_131k/average_l0_33
+    l0: 33
+    path: layer_24/width_131k/average_l0_33
+  - id: layer_24/width_131k/average_l0_67
+    l0: 67
+    path: layer_24/width_131k/average_l0_67
+  - id: layer_24/width_131k/average_l0_147
+    l0: 147
+    path: layer_24/width_131k/average_l0_147
+  - id: layer_24/width_131k/average_l0_351
+    l0: 351
+    path: layer_24/width_131k/average_l0_351
+  - id: layer_24/width_131k/average_l0_709
+    l0: 709
+    path: layer_24/width_131k/average_l0_709
+  - id: layer_25/width_16k/average_l0_15
+    l0: 15
+    path: layer_25/width_16k/average_l0_15
+  - id: layer_25/width_16k/average_l0_31
+    l0: 31
+    path: layer_25/width_16k/average_l0_31
+  - id: layer_25/width_16k/average_l0_72
+    l0: 72
+    neuronpedia: gemma-2-9b/25-gemmascope-mlp-16k__l0-72
+    path: layer_25/width_16k/average_l0_72
+  - id: layer_25/width_16k/average_l0_184
+    l0: 184
+    path: layer_25/width_16k/average_l0_184
+  - id: layer_25/width_16k/average_l0_494
+    l0: 494
+    path: layer_25/width_16k/average_l0_494
+  - id: layer_25/width_16k/average_l0_1013
+    l0: 1013
+    path: layer_25/width_16k/average_l0_1013
+  - id: layer_25/width_131k/average_l0_16
+    l0: 16
+    path: layer_25/width_131k/average_l0_16
+  - id: layer_25/width_131k/average_l0_32
+    l0: 32
+    path: layer_25/width_131k/average_l0_32
+  - id: layer_25/width_131k/average_l0_65
+    l0: 65
+    path: layer_25/width_131k/average_l0_65
+  - id: layer_25/width_131k/average_l0_139
+    l0: 139
+    path: layer_25/width_131k/average_l0_139
+  - id: layer_25/width_131k/average_l0_326
+    l0: 326
+    path: layer_25/width_131k/average_l0_326
+  - id: layer_25/width_131k/average_l0_691
+    l0: 691
+    path: layer_25/width_131k/average_l0_691
+  - id: layer_26/width_16k/average_l0_14
+    l0: 14
+    path: layer_26/width_16k/average_l0_14
+  - id: layer_26/width_16k/average_l0_26
+    l0: 26
+    path: layer_26/width_16k/average_l0_26
+  - id: layer_26/width_16k/average_l0_57
+    l0: 57
+    neuronpedia: gemma-2-9b/26-gemmascope-mlp-16k__l0-57
+    path: layer_26/width_16k/average_l0_57
+  - id: layer_26/width_16k/average_l0_142
+    l0: 142
+    path: layer_26/width_16k/average_l0_142
+  - id: layer_26/width_16k/average_l0_394
+    l0: 394
+    path: layer_26/width_16k/average_l0_394
+  - id: layer_26/width_16k/average_l0_887
+    l0: 887
+    path: layer_26/width_16k/average_l0_887
+  - id: layer_26/width_131k/average_l0_14
+    l0: 14
+    path: layer_26/width_131k/average_l0_14
+  - id: layer_26/width_131k/average_l0_27
+    l0: 27
+    path: layer_26/width_131k/average_l0_27
+  - id: layer_26/width_131k/average_l0_53
+    l0: 53
+    path: layer_26/width_131k/average_l0_53
+  - id: layer_26/width_131k/average_l0_110
+    l0: 110
+    path: layer_26/width_131k/average_l0_110
+  - id: layer_26/width_131k/average_l0_249
+    l0: 249
+    path: layer_26/width_131k/average_l0_249
+  - id: layer_26/width_131k/average_l0_568
+    l0: 568
+    path: layer_26/width_131k/average_l0_568
+  - id: layer_27/width_16k/average_l0_14
+    l0: 14
+    path: layer_27/width_16k/average_l0_14
+  - id: layer_27/width_16k/average_l0_25
+    l0: 25
+    path: layer_27/width_16k/average_l0_25
+  - id: layer_27/width_16k/average_l0_52
+    l0: 52
+    neuronpedia: gemma-2-9b/27-gemmascope-mlp-16k__l0-52
+    path: layer_27/width_16k/average_l0_52
+  - id: layer_27/width_16k/average_l0_126
+    l0: 126
+    path: layer_27/width_16k/average_l0_126
+  - id: layer_27/width_16k/average_l0_352
+    l0: 352
+    path: layer_27/width_16k/average_l0_352
+  - id: layer_27/width_16k/average_l0_813
+    l0: 813
+    path: layer_27/width_16k/average_l0_813
+  - id: layer_27/width_131k/average_l0_14
+    l0: 14
+    path: layer_27/width_131k/average_l0_14
+  - id: layer_27/width_131k/average_l0_26
+    l0: 26
+    path: layer_27/width_131k/average_l0_26
+  - id: layer_27/width_131k/average_l0_49
+    l0: 49
+    path: layer_27/width_131k/average_l0_49
+  - id: layer_27/width_131k/average_l0_99
+    l0: 99
+    path: layer_27/width_131k/average_l0_99
+  - id: layer_27/width_131k/average_l0_211
+    l0: 211
+    path: layer_27/width_131k/average_l0_211
+  - id: layer_27/width_131k/average_l0_487
+    l0: 487
+    path: layer_27/width_131k/average_l0_487
+  - id: layer_28/width_16k/average_l0_14
+    l0: 14
+    path: layer_28/width_16k/average_l0_14
+  - id: layer_28/width_16k/average_l0_26
+    l0: 26
+    path: layer_28/width_16k/average_l0_26
+  - id: layer_28/width_16k/average_l0_50
+    l0: 50
+    neuronpedia: gemma-2-9b/28-gemmascope-mlp-16k__l0-50
+    path: layer_28/width_16k/average_l0_50
+  - id: layer_28/width_16k/average_l0_115
+    l0: 115
+    path: layer_28/width_16k/average_l0_115
+  - id: layer_28/width_16k/average_l0_324
+    l0: 324
+    path: layer_28/width_16k/average_l0_324
+  - id: layer_28/width_16k/average_l0_773
+    l0: 773
+    path: layer_28/width_16k/average_l0_773
+  - id: layer_28/width_131k/average_l0_15
+    l0: 15
+    path: layer_28/width_131k/average_l0_15
+  - id: layer_28/width_131k/average_l0_26
+    l0: 26
+    path: layer_28/width_131k/average_l0_26
+  - id: layer_28/width_131k/average_l0_47
+    l0: 47
+    path: layer_28/width_131k/average_l0_47
+  - id: layer_28/width_131k/average_l0_91
+    l0: 91
+    path: layer_28/width_131k/average_l0_91
+  - id: layer_28/width_131k/average_l0_189
+    l0: 189
+    path: layer_28/width_131k/average_l0_189
+  - id: layer_28/width_131k/average_l0_425
+    l0: 425
+    path: layer_28/width_131k/average_l0_425
+  - id: layer_29/width_16k/average_l0_15
+    l0: 15
+    path: layer_29/width_16k/average_l0_15
+  - id: layer_29/width_16k/average_l0_26
+    l0: 26
+    path: layer_29/width_16k/average_l0_26
+  - id: layer_29/width_16k/average_l0_49
+    l0: 49
+    neuronpedia: gemma-2-9b/29-gemmascope-mlp-16k__l0-49
+    path: layer_29/width_16k/average_l0_49
+  - id: layer_29/width_16k/average_l0_111
+    l0: 111
+    path: layer_29/width_16k/average_l0_111
+  - id: layer_29/width_16k/average_l0_311
+    l0: 311
+    path: layer_29/width_16k/average_l0_311
+  - id: layer_29/width_16k/average_l0_725
+    l0: 725
+    path: layer_29/width_16k/average_l0_725
+  - id: layer_29/width_131k/average_l0_15
+    l0: 15
+    path: layer_29/width_131k/average_l0_15
+  - id: layer_29/width_131k/average_l0_26
+    l0: 26
+    path: layer_29/width_131k/average_l0_26
+  - id: layer_29/width_131k/average_l0_47
+    l0: 47
+    path: layer_29/width_131k/average_l0_47
+  - id: layer_29/width_131k/average_l0_87
+    l0: 87
+    path: layer_29/width_131k/average_l0_87
+  - id: layer_29/width_131k/average_l0_174
+    l0: 174
+    path: layer_29/width_131k/average_l0_174
+  - id: layer_29/width_131k/average_l0_386
+    l0: 386
+    path: layer_29/width_131k/average_l0_386
+  - id: layer_3/width_16k/average_l0_13
+    l0: 13
+    path: layer_3/width_16k/average_l0_13
+  - id: layer_3/width_16k/average_l0_25
+    l0: 25
+    path: layer_3/width_16k/average_l0_25
+  - id: layer_3/width_16k/average_l0_55
+    l0: 55
+    neuronpedia: gemma-2-9b/3-gemmascope-mlp-16k__l0-55
+    path: layer_3/width_16k/average_l0_55
+  - id: layer_3/width_16k/average_l0_126
+    l0: 126
+    path: layer_3/width_16k/average_l0_126
+  - id: layer_3/width_16k/average_l0_234
+    l0: 234
+    path: layer_3/width_16k/average_l0_234
+  - id: layer_3/width_131k/average_l0_6
+    l0: 6
+    path: layer_3/width_131k/average_l0_6
+  - id: layer_3/width_131k/average_l0_11
+    l0: 11
+    path: layer_3/width_131k/average_l0_11
+  - id: layer_3/width_131k/average_l0_19
+    l0: 19
+    path: layer_3/width_131k/average_l0_19
+  - id: layer_3/width_131k/average_l0_33
+    l0: 33
+    path: layer_3/width_131k/average_l0_33
+  - id: layer_3/width_131k/average_l0_58
+    l0: 58
+    path: layer_3/width_131k/average_l0_58
+  - id: layer_3/width_131k/average_l0_109
+    l0: 109
+    path: layer_3/width_131k/average_l0_109
+  - id: layer_30/width_16k/average_l0_14
+    l0: 14
+    path: layer_30/width_16k/average_l0_14
+  - id: layer_30/width_16k/average_l0_26
+    l0: 26
+    path: layer_30/width_16k/average_l0_26
+  - id: layer_30/width_16k/average_l0_51
+    l0: 51
+    neuronpedia: gemma-2-9b/30-gemmascope-mlp-16k__l0-51
+    path: layer_30/width_16k/average_l0_51
+  - id: layer_30/width_16k/average_l0_116
+    l0: 116
+    path: layer_30/width_16k/average_l0_116
+  - id: layer_30/width_16k/average_l0_333
+    l0: 333
+    path: layer_30/width_16k/average_l0_333
+  - id: layer_30/width_16k/average_l0_806
+    l0: 806
+    path: layer_30/width_16k/average_l0_806
+  - id: layer_30/width_131k/average_l0_14
+    l0: 14
+    path: layer_30/width_131k/average_l0_14
+  - id: layer_30/width_131k/average_l0_26
+    l0: 26
+    path: layer_30/width_131k/average_l0_26
+  - id: layer_30/width_131k/average_l0_47
+    l0: 47
+    path: layer_30/width_131k/average_l0_47
+  - id: layer_30/width_131k/average_l0_89
+    l0: 89
+    path: layer_30/width_131k/average_l0_89
+  - id: layer_30/width_131k/average_l0_179
+    l0: 179
+    path: layer_30/width_131k/average_l0_179
+  - id: layer_30/width_131k/average_l0_391
+    l0: 391
+    path: layer_30/width_131k/average_l0_391
+  - id: layer_31/width_16k/average_l0_12
+    l0: 12
+    path: layer_31/width_16k/average_l0_12
+  - id: layer_31/width_16k/average_l0_22
+    l0: 22
+    path: layer_31/width_16k/average_l0_22
+  - id: layer_31/width_16k/average_l0_43
+    l0: 43
+    neuronpedia: gemma-2-9b/31-gemmascope-mlp-16k__l0-43
+    path: layer_31/width_16k/average_l0_43
+  - id: layer_31/width_16k/average_l0_94
+    l0: 94
+    path: layer_31/width_16k/average_l0_94
+  - id: layer_31/width_16k/average_l0_263
+    l0: 263
+    path: layer_31/width_16k/average_l0_263
+  - id: layer_31/width_16k/average_l0_671
+    l0: 671
+    path: layer_31/width_16k/average_l0_671
+  - id: layer_31/width_131k/average_l0_12
+    l0: 12
+    path: layer_31/width_131k/average_l0_12
+  - id: layer_31/width_131k/average_l0_22
+    l0: 22
+    path: layer_31/width_131k/average_l0_22
+  - id: layer_31/width_131k/average_l0_40
+    l0: 40
+    path: layer_31/width_131k/average_l0_40
+  - id: layer_31/width_131k/average_l0_77
+    l0: 77
+    path: layer_31/width_131k/average_l0_77
+  - id: layer_31/width_131k/average_l0_153
+    l0: 153
+    path: layer_31/width_131k/average_l0_153
+  - id: layer_31/width_131k/average_l0_326
+    l0: 326
+    path: layer_31/width_131k/average_l0_326
+  - id: layer_32/width_16k/average_l0_11
+    l0: 11
+    path: layer_32/width_16k/average_l0_11
+  - id: layer_32/width_16k/average_l0_21
+    l0: 21
+    path: layer_32/width_16k/average_l0_21
+  - id: layer_32/width_16k/average_l0_44
+    l0: 44
+    neuronpedia: gemma-2-9b/32-gemmascope-mlp-16k__l0-44
+    path: layer_32/width_16k/average_l0_44
+  - id: layer_32/width_16k/average_l0_98
+    l0: 98
+    path: layer_32/width_16k/average_l0_98
+  - id: layer_32/width_16k/average_l0_267
+    l0: 267
+    path: layer_32/width_16k/average_l0_267
+  - id: layer_32/width_16k/average_l0_623
+    l0: 623
+    path: layer_32/width_16k/average_l0_623
+  - id: layer_32/width_131k/average_l0_12
+    l0: 12
+    path: layer_32/width_131k/average_l0_12
+  - id: layer_32/width_131k/average_l0_21
+    l0: 21
+    path: layer_32/width_131k/average_l0_21
+  - id: layer_32/width_131k/average_l0_40
+    l0: 40
+    path: layer_32/width_131k/average_l0_40
+  - id: layer_32/width_131k/average_l0_76
+    l0: 76
+    path: layer_32/width_131k/average_l0_76
+  - id: layer_32/width_131k/average_l0_155
+    l0: 155
+    path: layer_32/width_131k/average_l0_155
+  - id: layer_32/width_131k/average_l0_336
+    l0: 336
+    path: layer_32/width_131k/average_l0_336
+  - id: layer_33/width_16k/average_l0_12
+    l0: 12
+    path: layer_33/width_16k/average_l0_12
+  - id: layer_33/width_16k/average_l0_23
+    l0: 23
+    path: layer_33/width_16k/average_l0_23
+  - id: layer_33/width_16k/average_l0_48
+    l0: 48
+    neuronpedia: gemma-2-9b/33-gemmascope-mlp-16k__l0-48
+    path: layer_33/width_16k/average_l0_48
+  - id: layer_33/width_16k/average_l0_107
+    l0: 107
+    path: layer_33/width_16k/average_l0_107
+  - id: layer_33/width_16k/average_l0_282
+    l0: 282
+    path: layer_33/width_16k/average_l0_282
+  - id: layer_33/width_16k/average_l0_628
+    l0: 628
+    path: layer_33/width_16k/average_l0_628
+  - id: layer_33/width_131k/average_l0_12
+    l0: 12
+    path: layer_33/width_131k/average_l0_12
+  - id: layer_33/width_131k/average_l0_22
+    l0: 22
+    path: layer_33/width_131k/average_l0_22
+  - id: layer_33/width_131k/average_l0_42
+    l0: 42
+    path: layer_33/width_131k/average_l0_42
+  - id: layer_33/width_131k/average_l0_83
+    l0: 83
+    path: layer_33/width_131k/average_l0_83
+  - id: layer_33/width_131k/average_l0_168
+    l0: 168
+    path: layer_33/width_131k/average_l0_168
+  - id: layer_33/width_131k/average_l0_394
+    l0: 394
+    path: layer_33/width_131k/average_l0_394
+  - id: layer_34/width_16k/average_l0_11
+    l0: 11
+    path: layer_34/width_16k/average_l0_11
+  - id: layer_34/width_16k/average_l0_22
+    l0: 22
+    path: layer_34/width_16k/average_l0_22
+  - id: layer_34/width_16k/average_l0_47
+    l0: 47
+    neuronpedia: gemma-2-9b/34-gemmascope-mlp-16k__l0-47
+    path: layer_34/width_16k/average_l0_47
+  - id: layer_34/width_16k/average_l0_107
+    l0: 107
+    path: layer_34/width_16k/average_l0_107
+  - id: layer_34/width_16k/average_l0_268
+    l0: 268
+    path: layer_34/width_16k/average_l0_268
+  - id: layer_34/width_16k/average_l0_559
+    l0: 559
+    path: layer_34/width_16k/average_l0_559
+  - id: layer_34/width_131k/average_l0_10
+    l0: 10
+    path: layer_34/width_131k/average_l0_10
+  - id: layer_34/width_131k/average_l0_20
+    l0: 20
+    path: layer_34/width_131k/average_l0_20
+  - id: layer_34/width_131k/average_l0_40
+    l0: 40
+    path: layer_34/width_131k/average_l0_40
+  - id: layer_34/width_131k/average_l0_82
+    l0: 82
+    path: layer_34/width_131k/average_l0_82
+  - id: layer_34/width_131k/average_l0_167
+    l0: 167
+    path: layer_34/width_131k/average_l0_167
+  - id: layer_34/width_131k/average_l0_390
+    l0: 390
+    path: layer_34/width_131k/average_l0_390
+  - id: layer_35/width_16k/average_l0_10
+    l0: 10
+    path: layer_35/width_16k/average_l0_10
+  - id: layer_35/width_16k/average_l0_21
+    l0: 21
+    path: layer_35/width_16k/average_l0_21
+  - id: layer_35/width_16k/average_l0_46
+    l0: 46
+    neuronpedia: gemma-2-9b/35-gemmascope-mlp-16k__l0-46
+    path: layer_35/width_16k/average_l0_46
+  - id: layer_35/width_16k/average_l0_108
+    l0: 108
+    path: layer_35/width_16k/average_l0_108
+  - id: layer_35/width_16k/average_l0_254
+    l0: 254
+    path: layer_35/width_16k/average_l0_254
+  - id: layer_35/width_16k/average_l0_538
+    l0: 538
+    path: layer_35/width_16k/average_l0_538
+  - id: layer_35/width_131k/average_l0_10
+    l0: 10
+    path: layer_35/width_131k/average_l0_10
+  - id: layer_35/width_131k/average_l0_19
+    l0: 19
+    path: layer_35/width_131k/average_l0_19
+  - id: layer_35/width_131k/average_l0_39
+    l0: 39
+    path: layer_35/width_131k/average_l0_39
+  - id: layer_35/width_131k/average_l0_80
+    l0: 80
+    path: layer_35/width_131k/average_l0_80
+  - id: layer_35/width_131k/average_l0_176
+    l0: 176
+    path: layer_35/width_131k/average_l0_176
+  - id: layer_35/width_131k/average_l0_389
+    l0: 389
+    path: layer_35/width_131k/average_l0_389
+  - id: layer_36/width_16k/average_l0_11
+    l0: 11
+    path: layer_36/width_16k/average_l0_11
+  - id: layer_36/width_16k/average_l0_22
+    l0: 22
+    path: layer_36/width_16k/average_l0_22
+  - id: layer_36/width_16k/average_l0_47
+    l0: 47
+    neuronpedia: gemma-2-9b/36-gemmascope-mlp-16k__l0-47
+    path: layer_36/width_16k/average_l0_47
+  - id: layer_36/width_16k/average_l0_109
+    l0: 109
+    path: layer_36/width_16k/average_l0_109
+  - id: layer_36/width_16k/average_l0_256
+    l0: 256
+    path: layer_36/width_16k/average_l0_256
+  - id: layer_36/width_16k/average_l0_523
+    l0: 523
+    path: layer_36/width_16k/average_l0_523
+  - id: layer_36/width_131k/average_l0_11
+    l0: 11
+    path: layer_36/width_131k/average_l0_11
+  - id: layer_36/width_131k/average_l0_20
+    l0: 20
+    path: layer_36/width_131k/average_l0_20
+  - id: layer_36/width_131k/average_l0_40
+    l0: 40
+    path: layer_36/width_131k/average_l0_40
+  - id: layer_36/width_131k/average_l0_81
+    l0: 81
+    path: layer_36/width_131k/average_l0_81
+  - id: layer_36/width_131k/average_l0_174
+    l0: 174
+    path: layer_36/width_131k/average_l0_174
+  - id: layer_36/width_131k/average_l0_389
+    l0: 389
+    path: layer_36/width_131k/average_l0_389
+  - id: layer_37/width_16k/average_l0_12
+    l0: 12
+    path: layer_37/width_16k/average_l0_12
+  - id: layer_37/width_16k/average_l0_24
+    l0: 24
+    path: layer_37/width_16k/average_l0_24
+  - id: layer_37/width_16k/average_l0_53
+    l0: 53
+    neuronpedia: gemma-2-9b/37-gemmascope-mlp-16k__l0-53
+    path: layer_37/width_16k/average_l0_53
+  - id: layer_37/width_16k/average_l0_119
+    l0: 119
+    path: layer_37/width_16k/average_l0_119
+  - id: layer_37/width_16k/average_l0_267
+    l0: 267
+    path: layer_37/width_16k/average_l0_267
+  - id: layer_37/width_16k/average_l0_549
+    l0: 549
+    path: layer_37/width_16k/average_l0_549
+  - id: layer_37/width_131k/average_l0_12
+    l0: 12
+    path: layer_37/width_131k/average_l0_12
+  - id: layer_37/width_131k/average_l0_23
+    l0: 23
+    path: layer_37/width_131k/average_l0_23
+  - id: layer_37/width_131k/average_l0_44
+    l0: 44
+    path: layer_37/width_131k/average_l0_44
+  - id: layer_37/width_131k/average_l0_90
+    l0: 90
+    path: layer_37/width_131k/average_l0_90
+  - id: layer_37/width_131k/average_l0_203
+    l0: 203
+    path: layer_37/width_131k/average_l0_203
+  - id: layer_37/width_131k/average_l0_403
+    l0: 403
+    path: layer_37/width_131k/average_l0_403
+  - id: layer_38/width_16k/average_l0_11
+    l0: 11
+    path: layer_38/width_16k/average_l0_11
+  - id: layer_38/width_16k/average_l0_22
+    l0: 22
+    path: layer_38/width_16k/average_l0_22
+  - id: layer_38/width_16k/average_l0_45
+    l0: 45
+    neuronpedia: gemma-2-9b/38-gemmascope-mlp-16k__l0-45
+    path: layer_38/width_16k/average_l0_45
+  - id: layer_38/width_16k/average_l0_98
+    l0: 98
+    path: layer_38/width_16k/average_l0_98
+  - id: layer_38/width_16k/average_l0_225
+    l0: 225
+    path: layer_38/width_16k/average_l0_225
+  - id: layer_38/width_16k/average_l0_491
+    l0: 491
+    path: layer_38/width_16k/average_l0_491
+  - id: layer_38/width_131k/average_l0_11
+    l0: 11
+    path: layer_38/width_131k/average_l0_11
+  - id: layer_38/width_131k/average_l0_21
+    l0: 21
+    path: layer_38/width_131k/average_l0_21
+  - id: layer_38/width_131k/average_l0_40
+    l0: 40
+    path: layer_38/width_131k/average_l0_40
+  - id: layer_38/width_131k/average_l0_79
+    l0: 79
+    path: layer_38/width_131k/average_l0_79
+  - id: layer_38/width_131k/average_l0_161
+    l0: 161
+    path: layer_38/width_131k/average_l0_161
+  - id: layer_38/width_131k/average_l0_347
+    l0: 347
+    path: layer_38/width_131k/average_l0_347
+  - id: layer_39/width_16k/average_l0_12
+    l0: 12
+    path: layer_39/width_16k/average_l0_12
+  - id: layer_39/width_16k/average_l0_22
+    l0: 22
+    path: layer_39/width_16k/average_l0_22
+  - id: layer_39/width_16k/average_l0_43
+    l0: 43
+    neuronpedia: gemma-2-9b/39-gemmascope-mlp-16k__l0-43
+    path: layer_39/width_16k/average_l0_43
+  - id: layer_39/width_16k/average_l0_90
+    l0: 90
+    path: layer_39/width_16k/average_l0_90
+  - id: layer_39/width_16k/average_l0_207
+    l0: 207
+    path: layer_39/width_16k/average_l0_207
+  - id: layer_39/width_16k/average_l0_458
+    l0: 458
+    path: layer_39/width_16k/average_l0_458
+  - id: layer_39/width_131k/average_l0_11
+    l0: 11
+    path: layer_39/width_131k/average_l0_11
+  - id: layer_39/width_131k/average_l0_21
+    l0: 21
+    path: layer_39/width_131k/average_l0_21
+  - id: layer_39/width_131k/average_l0_38
+    l0: 38
+    path: layer_39/width_131k/average_l0_38
+  - id: layer_39/width_131k/average_l0_75
+    l0: 75
+    path: layer_39/width_131k/average_l0_75
+  - id: layer_39/width_131k/average_l0_150
+    l0: 150
+    path: layer_39/width_131k/average_l0_150
+  - id: layer_39/width_131k/average_l0_319
+    l0: 319
+    path: layer_39/width_131k/average_l0_319
+  - id: layer_4/width_16k/average_l0_15
+    l0: 15
+    path: layer_4/width_16k/average_l0_15
+  - id: layer_4/width_16k/average_l0_30
+    l0: 30
+    path: layer_4/width_16k/average_l0_30
+  - id: layer_4/width_16k/average_l0_66
+    l0: 66
+    neuronpedia: gemma-2-9b/4-gemmascope-mlp-16k__l0-66
+    path: layer_4/width_16k/average_l0_66
+  - id: layer_4/width_16k/average_l0_151
+    l0: 151
+    path: layer_4/width_16k/average_l0_151
+  - id: layer_4/width_16k/average_l0_343
+    l0: 343
+    path: layer_4/width_16k/average_l0_343
+  - id: layer_4/width_131k/average_l0_8
+    l0: 8
+    path: layer_4/width_131k/average_l0_8
+  - id: layer_4/width_131k/average_l0_14
+    l0: 14
+    path: layer_4/width_131k/average_l0_14
+  - id: layer_4/width_131k/average_l0_24
+    l0: 24
+    path: layer_4/width_131k/average_l0_24
+  - id: layer_4/width_131k/average_l0_45
+    l0: 45
+    path: layer_4/width_131k/average_l0_45
+  - id: layer_4/width_131k/average_l0_84
+    l0: 84
+    path: layer_4/width_131k/average_l0_84
+  - id: layer_4/width_131k/average_l0_157
+    l0: 157
+    path: layer_4/width_131k/average_l0_157
+  - id: layer_40/width_16k/average_l0_11
+    l0: 11
+    path: layer_40/width_16k/average_l0_11
+  - id: layer_40/width_16k/average_l0_19
+    l0: 19
+    path: layer_40/width_16k/average_l0_19
+  - id: layer_40/width_16k/average_l0_37
+    l0: 37
+    neuronpedia: gemma-2-9b/40-gemmascope-mlp-16k__l0-37
+    path: layer_40/width_16k/average_l0_37
+  - id: layer_40/width_16k/average_l0_74
+    l0: 74
+    path: layer_40/width_16k/average_l0_74
+  - id: layer_40/width_16k/average_l0_162
+    l0: 162
+    path: layer_40/width_16k/average_l0_162
+  - id: layer_40/width_16k/average_l0_371
+    l0: 371
+    path: layer_40/width_16k/average_l0_371
+  - id: layer_40/width_131k/average_l0_11
+    l0: 11
+    path: layer_40/width_131k/average_l0_11
+  - id: layer_40/width_131k/average_l0_18
+    l0: 18
+    path: layer_40/width_131k/average_l0_18
+  - id: layer_40/width_131k/average_l0_33
+    l0: 33
+    path: layer_40/width_131k/average_l0_33
+  - id: layer_40/width_131k/average_l0_63
+    l0: 63
+    path: layer_40/width_131k/average_l0_63
+  - id: layer_40/width_131k/average_l0_125
+    l0: 125
+    path: layer_40/width_131k/average_l0_125
+  - id: layer_40/width_131k/average_l0_267
+    l0: 267
+    path: layer_40/width_131k/average_l0_267
+  - id: layer_41/width_16k/average_l0_8
+    l0: 8
+    path: layer_41/width_16k/average_l0_8
+  - id: layer_41/width_16k/average_l0_15
+    l0: 15
+    path: layer_41/width_16k/average_l0_15
+  - id: layer_41/width_16k/average_l0_28
+    l0: 28
+    path: layer_41/width_16k/average_l0_28
+  - id: layer_41/width_16k/average_l0_58
+    l0: 58
+    neuronpedia: gemma-2-9b/41-gemmascope-mlp-16k__l0-58
+    path: layer_41/width_16k/average_l0_58
+  - id: layer_41/width_16k/average_l0_126
+    l0: 126
+    path: layer_41/width_16k/average_l0_126
+  - id: layer_41/width_16k/average_l0_288
+    l0: 288
+    path: layer_41/width_16k/average_l0_288
+  - id: layer_41/width_131k/average_l0_8
+    l0: 8
+    path: layer_41/width_131k/average_l0_8
+  - id: layer_41/width_131k/average_l0_14
+    l0: 14
+    path: layer_41/width_131k/average_l0_14
+  - id: layer_41/width_131k/average_l0_25
+    l0: 25
+    path: layer_41/width_131k/average_l0_25
+  - id: layer_41/width_131k/average_l0_49
+    l0: 49
+    path: layer_41/width_131k/average_l0_49
+  - id: layer_41/width_131k/average_l0_99
+    l0: 99
+    path: layer_41/width_131k/average_l0_99
+  - id: layer_41/width_131k/average_l0_208
+    l0: 208
+    path: layer_41/width_131k/average_l0_208
+  - id: layer_5/width_16k/average_l0_14
+    l0: 14
+    path: layer_5/width_16k/average_l0_14
+  - id: layer_5/width_16k/average_l0_24
+    l0: 24
+    path: layer_5/width_16k/average_l0_24
+  - id: layer_5/width_16k/average_l0_46
+    l0: 46
+    neuronpedia: gemma-2-9b/5-gemmascope-mlp-16k__l0-46
+    path: layer_5/width_16k/average_l0_46
+  - id: layer_5/width_16k/average_l0_93
+    l0: 93
+    path: layer_5/width_16k/average_l0_93
+  - id: layer_5/width_16k/average_l0_194
+    l0: 194
+    path: layer_5/width_16k/average_l0_194
+  - id: layer_5/width_131k/average_l0_7
+    l0: 7
+    path: layer_5/width_131k/average_l0_7
+  - id: layer_5/width_131k/average_l0_12
+    l0: 12
+    path: layer_5/width_131k/average_l0_12
+  - id: layer_5/width_131k/average_l0_21
+    l0: 21
+    path: layer_5/width_131k/average_l0_21
+  - id: layer_5/width_131k/average_l0_37
+    l0: 37
+    path: layer_5/width_131k/average_l0_37
+  - id: layer_5/width_131k/average_l0_68
+    l0: 68
+    path: layer_5/width_131k/average_l0_68
+  - id: layer_5/width_131k/average_l0_131
+    l0: 131
+    path: layer_5/width_131k/average_l0_131
+  - id: layer_6/width_16k/average_l0_12
+    l0: 12
+    path: layer_6/width_16k/average_l0_12
+  - id: layer_6/width_16k/average_l0_23
+    l0: 23
+    path: layer_6/width_16k/average_l0_23
+  - id: layer_6/width_16k/average_l0_46
+    l0: 46
+    neuronpedia: gemma-2-9b/6-gemmascope-mlp-16k__l0-46
+    path: layer_6/width_16k/average_l0_46
+  - id: layer_6/width_16k/average_l0_96
+    l0: 96
+    path: layer_6/width_16k/average_l0_96
+  - id: layer_6/width_16k/average_l0_206
+    l0: 206
+    path: layer_6/width_16k/average_l0_206
+  - id: layer_6/width_131k/average_l0_12
+    l0: 12
+    path: layer_6/width_131k/average_l0_12
+  - id: layer_6/width_131k/average_l0_22
+    l0: 22
+    path: layer_6/width_131k/average_l0_22
+  - id: layer_6/width_131k/average_l0_40
+    l0: 40
+    path: layer_6/width_131k/average_l0_40
+  - id: layer_6/width_131k/average_l0_72
+    l0: 72
+    path: layer_6/width_131k/average_l0_72
+  - id: layer_6/width_131k/average_l0_135
+    l0: 135
+    path: layer_6/width_131k/average_l0_135
+  - id: layer_6/width_131k/average_l0_271
+    l0: 271
+    path: layer_6/width_131k/average_l0_271
+  - id: layer_7/width_16k/average_l0_14
+    l0: 14
+    path: layer_7/width_16k/average_l0_14
+  - id: layer_7/width_16k/average_l0_25
+    l0: 25
+    path: layer_7/width_16k/average_l0_25
+  - id: layer_7/width_16k/average_l0_47
+    l0: 47
+    neuronpedia: gemma-2-9b/7-gemmascope-mlp-16k__l0-47
+    path: layer_7/width_16k/average_l0_47
+  - id: layer_7/width_16k/average_l0_101
+    l0: 101
+    path: layer_7/width_16k/average_l0_101
+  - id: layer_7/width_16k/average_l0_231
+    l0: 231
+    path: layer_7/width_16k/average_l0_231
+  - id: layer_7/width_131k/average_l0_13
+    l0: 13
+    path: layer_7/width_131k/average_l0_13
+  - id: layer_7/width_131k/average_l0_23
+    l0: 23
+    path: layer_7/width_131k/average_l0_23
+  - id: layer_7/width_131k/average_l0_41
+    l0: 41
+    path: layer_7/width_131k/average_l0_41
+  - id: layer_7/width_131k/average_l0_75
+    l0: 75
+    path: layer_7/width_131k/average_l0_75
+  - id: layer_7/width_131k/average_l0_143
+    l0: 143
+    path: layer_7/width_131k/average_l0_143
+  - id: layer_7/width_131k/average_l0_309
+    l0: 309
+    path: layer_7/width_131k/average_l0_309
+  - id: layer_8/width_16k/average_l0_15
+    l0: 15
+    path: layer_8/width_16k/average_l0_15
+  - id: layer_8/width_16k/average_l0_27
+    l0: 27
+    path: layer_8/width_16k/average_l0_27
+  - id: layer_8/width_16k/average_l0_55
+    l0: 55
+    neuronpedia: gemma-2-9b/8-gemmascope-mlp-16k__l0-55
+    path: layer_8/width_16k/average_l0_55
+  - id: layer_8/width_16k/average_l0_124
+    l0: 124
+    path: layer_8/width_16k/average_l0_124
+  - id: layer_8/width_16k/average_l0_309
+    l0: 309
+    path: layer_8/width_16k/average_l0_309
+  - id: layer_8/width_131k/average_l0_15
+    l0: 15
+    path: layer_8/width_131k/average_l0_15
+  - id: layer_8/width_131k/average_l0_26
+    l0: 26
+    path: layer_8/width_131k/average_l0_26
+  - id: layer_8/width_131k/average_l0_48
+    l0: 48
+    path: layer_8/width_131k/average_l0_48
+  - id: layer_8/width_131k/average_l0_89
+    l0: 89
+    path: layer_8/width_131k/average_l0_89
+  - id: layer_8/width_131k/average_l0_184
+    l0: 184
+    path: layer_8/width_131k/average_l0_184
+  - id: layer_8/width_131k/average_l0_423
+    l0: 423
+    path: layer_8/width_131k/average_l0_423
+  - id: layer_9/width_16k/average_l0_12
+    l0: 12
+    path: layer_9/width_16k/average_l0_12
+  - id: layer_9/width_16k/average_l0_21
+    l0: 21
+    path: layer_9/width_16k/average_l0_21
+  - id: layer_9/width_16k/average_l0_40
+    l0: 40
+    path: layer_9/width_16k/average_l0_40
+  - id: layer_9/width_16k/average_l0_83
+    l0: 83
+    neuronpedia: gemma-2-9b/9-gemmascope-mlp-16k__l0-83
+    path: layer_9/width_16k/average_l0_83
+  - id: layer_9/width_16k/average_l0_200
+    l0: 200
+    path: layer_9/width_16k/average_l0_200
+  - id: layer_9/width_131k/average_l0_12
+    l0: 12
+    path: layer_9/width_131k/average_l0_12
+  - id: layer_9/width_131k/average_l0_21
+    l0: 21
+    path: layer_9/width_131k/average_l0_21
+  - id: layer_9/width_131k/average_l0_38
+    l0: 38
+    path: layer_9/width_131k/average_l0_38
+  - id: layer_9/width_131k/average_l0_67
+    l0: 67
+    path: layer_9/width_131k/average_l0_67
+  - id: layer_9/width_131k/average_l0_129
+    l0: 129
+    path: layer_9/width_131k/average_l0_129
+  - id: layer_9/width_131k/average_l0_269
+    l0: 269
+    path: layer_9/width_131k/average_l0_269
+gemma-scope-9b-pt-mlp-canonical:
+  conversion_func: gemma_2
+  model: gemma-2-9b
+  repo_id: google/gemma-scope-9b-pt-mlp
+  saes:
+  - id: layer_0/width_16k/canonical
+    neuronpedia: gemma-2-9b/0-gemmascope-mlp-16k
+    path: layer_0/width_16k/average_l0_50
+  - id: layer_1/width_16k/canonical
+    neuronpedia: gemma-2-9b/1-gemmascope-mlp-16k
+    path: layer_1/width_16k/average_l0_128
+  - id: layer_2/width_16k/canonical
+    neuronpedia: gemma-2-9b/2-gemmascope-mlp-16k
+    path: layer_2/width_16k/average_l0_81
+  - id: layer_3/width_16k/canonical
+    neuronpedia: gemma-2-9b/3-gemmascope-mlp-16k
+    path: layer_3/width_16k/average_l0_126
+  - id: layer_4/width_16k/canonical
+    neuronpedia: gemma-2-9b/4-gemmascope-mlp-16k
+    path: layer_4/width_16k/average_l0_66
+  - id: layer_5/width_16k/canonical
+    neuronpedia: gemma-2-9b/5-gemmascope-mlp-16k
+    path: layer_5/width_16k/average_l0_93
+  - id: layer_6/width_16k/canonical
+    neuronpedia: gemma-2-9b/6-gemmascope-mlp-16k
+    path: layer_6/width_16k/average_l0_96
+  - id: layer_7/width_16k/canonical
+    neuronpedia: gemma-2-9b/7-gemmascope-mlp-16k
+    path: layer_7/width_16k/average_l0_101
+  - id: layer_8/width_16k/canonical
+    neuronpedia: gemma-2-9b/8-gemmascope-mlp-16k
+    path: layer_8/width_16k/average_l0_124
+  - id: layer_9/width_16k/canonical
+    neuronpedia: gemma-2-9b/9-gemmascope-mlp-16k
+    path: layer_9/width_16k/average_l0_83
+  - id: layer_10/width_16k/canonical
+    neuronpedia: gemma-2-9b/10-gemmascope-mlp-16k
+    path: layer_10/width_16k/average_l0_114
+  - id: layer_11/width_16k/canonical
+    neuronpedia: gemma-2-9b/11-gemmascope-mlp-16k
+    path: layer_11/width_16k/average_l0_76
+  - id: layer_12/width_16k/canonical
+    neuronpedia: gemma-2-9b/12-gemmascope-mlp-16k
+    path: layer_12/width_16k/average_l0_96
+  - id: layer_13/width_16k/canonical
+    neuronpedia: gemma-2-9b/13-gemmascope-mlp-16k
+    path: layer_13/width_16k/average_l0_94
+  - id: layer_14/width_16k/canonical
+    neuronpedia: gemma-2-9b/14-gemmascope-mlp-16k
+    path: layer_14/width_16k/average_l0_97
+  - id: layer_15/width_16k/canonical
+    neuronpedia: gemma-2-9b/15-gemmascope-mlp-16k
+    path: layer_15/width_16k/average_l0_107
+  - id: layer_16/width_16k/canonical
+    neuronpedia: gemma-2-9b/16-gemmascope-mlp-16k
+    path: layer_16/width_16k/average_l0_91
+  - id: layer_17/width_16k/canonical
+    neuronpedia: gemma-2-9b/17-gemmascope-mlp-16k
+    path: layer_17/width_16k/average_l0_104
+  - id: layer_18/width_16k/canonical
+    neuronpedia: gemma-2-9b/18-gemmascope-mlp-16k
+    path: layer_18/width_16k/average_l0_89
+  - id: layer_19/width_16k/canonical
+    neuronpedia: gemma-2-9b/19-gemmascope-mlp-16k
+    path: layer_19/width_16k/average_l0_98
+  - id: layer_20/width_16k/canonical
+    neuronpedia: gemma-2-9b/20-gemmascope-mlp-16k
+    path: layer_20/width_16k/average_l0_108
+  - id: layer_21/width_16k/canonical
+    neuronpedia: gemma-2-9b/21-gemmascope-mlp-16k
+    path: layer_21/width_16k/average_l0_88
+  - id: layer_22/width_16k/canonical
+    neuronpedia: gemma-2-9b/22-gemmascope-mlp-16k
+    path: layer_22/width_16k/average_l0_85
+  - id: layer_23/width_16k/canonical
+    neuronpedia: gemma-2-9b/23-gemmascope-mlp-16k
+    path: layer_23/width_16k/average_l0_73
+  - id: layer_24/width_16k/canonical
+    neuronpedia: gemma-2-9b/24-gemmascope-mlp-16k
+    path: layer_24/width_16k/average_l0_73
+  - id: layer_25/width_16k/canonical
+    neuronpedia: gemma-2-9b/25-gemmascope-mlp-16k
+    path: layer_25/width_16k/average_l0_72
+  - id: layer_26/width_16k/canonical
+    neuronpedia: gemma-2-9b/26-gemmascope-mlp-16k
+    path: layer_26/width_16k/average_l0_142
+  - id: layer_27/width_16k/canonical
+    neuronpedia: gemma-2-9b/27-gemmascope-mlp-16k
+    path: layer_27/width_16k/average_l0_126
+  - id: layer_28/width_16k/canonical
+    neuronpedia: gemma-2-9b/28-gemmascope-mlp-16k
+    path: layer_28/width_16k/average_l0_115
+  - id: layer_29/width_16k/canonical
+    neuronpedia: gemma-2-9b/29-gemmascope-mlp-16k
+    path: layer_29/width_16k/average_l0_111
+  - id: layer_30/width_16k/canonical
+    neuronpedia: gemma-2-9b/30-gemmascope-mlp-16k
+    path: layer_30/width_16k/average_l0_116
+  - id: layer_31/width_16k/canonical
+    neuronpedia: gemma-2-9b/31-gemmascope-mlp-16k
+    path: layer_31/width_16k/average_l0_94
+  - id: layer_32/width_16k/canonical
+    neuronpedia: gemma-2-9b/32-gemmascope-mlp-16k
+    path: layer_32/width_16k/average_l0_98
+  - id: layer_33/width_16k/canonical
+    neuronpedia: gemma-2-9b/33-gemmascope-mlp-16k
+    path: layer_33/width_16k/average_l0_107
+  - id: layer_34/width_16k/canonical
+    neuronpedia: gemma-2-9b/34-gemmascope-mlp-16k
+    path: layer_34/width_16k/average_l0_107
+  - id: layer_35/width_16k/canonical
+    neuronpedia: gemma-2-9b/35-gemmascope-mlp-16k
+    path: layer_35/width_16k/average_l0_108
+  - id: layer_36/width_16k/canonical
+    neuronpedia: gemma-2-9b/36-gemmascope-mlp-16k
+    path: layer_36/width_16k/average_l0_109
+  - id: layer_37/width_16k/canonical
+    neuronpedia: gemma-2-9b/37-gemmascope-mlp-16k
+    path: layer_37/width_16k/average_l0_119
+  - id: layer_38/width_16k/canonical
+    neuronpedia: gemma-2-9b/38-gemmascope-mlp-16k
+    path: layer_38/width_16k/average_l0_98
+  - id: layer_39/width_16k/canonical
+    neuronpedia: gemma-2-9b/39-gemmascope-mlp-16k
+    path: layer_39/width_16k/average_l0_90
+  - id: layer_40/width_16k/canonical
+    neuronpedia: gemma-2-9b/40-gemmascope-mlp-16k
+    path: layer_40/width_16k/average_l0_74
+  - id: layer_41/width_16k/canonical
+    neuronpedia: gemma-2-9b/41-gemmascope-mlp-16k
+    path: layer_41/width_16k/average_l0_126
+  - id: layer_0/width_131k/canonical
+    neuronpedia: gemma-2-9b/0-gemmascope-mlp-131k
+    path: layer_0/width_131k/average_l0_30
+  - id: layer_1/width_131k/canonical
+    neuronpedia: gemma-2-9b/1-gemmascope-mlp-131k
+    path: layer_1/width_131k/average_l0_106
+  - id: layer_2/width_131k/canonical
+    neuronpedia: gemma-2-9b/2-gemmascope-mlp-131k
+    path: layer_2/width_131k/average_l0_61
+  - id: layer_3/width_131k/canonical
+    neuronpedia: gemma-2-9b/3-gemmascope-mlp-131k
+    path: layer_3/width_131k/average_l0_109
+  - id: layer_4/width_131k/canonical
+    neuronpedia: gemma-2-9b/4-gemmascope-mlp-131k
+    path: layer_4/width_131k/average_l0_84
+  - id: layer_5/width_131k/canonical
+    neuronpedia: gemma-2-9b/5-gemmascope-mlp-131k
+    path: layer_5/width_131k/average_l0_131
+  - id: layer_6/width_131k/canonical
+    neuronpedia: gemma-2-9b/6-gemmascope-mlp-131k
+    path: layer_6/width_131k/average_l0_72
+  - id: layer_7/width_131k/canonical
+    neuronpedia: gemma-2-9b/7-gemmascope-mlp-131k
+    path: layer_7/width_131k/average_l0_75
+  - id: layer_8/width_131k/canonical
+    neuronpedia: gemma-2-9b/8-gemmascope-mlp-131k
+    path: layer_8/width_131k/average_l0_89
+  - id: layer_9/width_131k/canonical
+    neuronpedia: gemma-2-9b/9-gemmascope-mlp-131k
+    path: layer_9/width_131k/average_l0_129
+  - id: layer_10/width_131k/canonical
+    neuronpedia: gemma-2-9b/10-gemmascope-mlp-131k
+    path: layer_10/width_131k/average_l0_83
+  - id: layer_11/width_131k/canonical
+    neuronpedia: gemma-2-9b/11-gemmascope-mlp-131k
+    path: layer_11/width_131k/average_l0_120
+  - id: layer_12/width_131k/canonical
+    neuronpedia: gemma-2-9b/12-gemmascope-mlp-131k
+    path: layer_12/width_131k/average_l0_77
+  - id: layer_13/width_131k/canonical
+    neuronpedia: gemma-2-9b/13-gemmascope-mlp-131k
+    path: layer_13/width_131k/average_l0_75
+  - id: layer_14/width_131k/canonical
+    neuronpedia: gemma-2-9b/14-gemmascope-mlp-131k
+    path: layer_14/width_131k/average_l0_80
+  - id: layer_15/width_131k/canonical
+    neuronpedia: gemma-2-9b/15-gemmascope-mlp-131k
+    path: layer_15/width_131k/average_l0_89
+  - id: layer_16/width_131k/canonical
+    neuronpedia: gemma-2-9b/16-gemmascope-mlp-131k
+    path: layer_16/width_131k/average_l0_81
+  - id: layer_17/width_131k/canonical
+    neuronpedia: gemma-2-9b/17-gemmascope-mlp-131k
+    path: layer_17/width_131k/average_l0_91
+  - id: layer_18/width_131k/canonical
+    neuronpedia: gemma-2-9b/18-gemmascope-mlp-131k
+    path: layer_18/width_131k/average_l0_82
+  - id: layer_19/width_131k/canonical
+    neuronpedia: gemma-2-9b/19-gemmascope-mlp-131k
+    path: layer_19/width_131k/average_l0_85
+  - id: layer_20/width_131k/canonical
+    neuronpedia: gemma-2-9b/20-gemmascope-mlp-131k
+    path: layer_20/width_131k/average_l0_93
+  - id: layer_21/width_131k/canonical
+    neuronpedia: gemma-2-9b/21-gemmascope-mlp-131k
+    path: layer_21/width_131k/average_l0_79
+  - id: layer_22/width_131k/canonical
+    neuronpedia: gemma-2-9b/22-gemmascope-mlp-131k
+    path: layer_22/width_131k/average_l0_77
+  - id: layer_23/width_131k/canonical
+    neuronpedia: gemma-2-9b/23-gemmascope-mlp-131k
+    path: layer_23/width_131k/average_l0_67
+  - id: layer_24/width_131k/canonical
+    neuronpedia: gemma-2-9b/24-gemmascope-mlp-131k
+    path: layer_24/width_131k/average_l0_67
+  - id: layer_25/width_131k/canonical
+    neuronpedia: gemma-2-9b/25-gemmascope-mlp-131k
+    path: layer_25/width_131k/average_l0_65
+  - id: layer_26/width_131k/canonical
+    neuronpedia: gemma-2-9b/26-gemmascope-mlp-131k
+    path: layer_26/width_131k/average_l0_110
+  - id: layer_27/width_131k/canonical
+    neuronpedia: gemma-2-9b/27-gemmascope-mlp-131k
+    path: layer_27/width_131k/average_l0_99
+  - id: layer_28/width_131k/canonical
+    neuronpedia: gemma-2-9b/28-gemmascope-mlp-131k
+    path: layer_28/width_131k/average_l0_91
+  - id: layer_29/width_131k/canonical
+    neuronpedia: gemma-2-9b/29-gemmascope-mlp-131k
+    path: layer_29/width_131k/average_l0_87
+  - id: layer_30/width_131k/canonical
+    neuronpedia: gemma-2-9b/30-gemmascope-mlp-131k
+    path: layer_30/width_131k/average_l0_89
+  - id: layer_31/width_131k/canonical
+    neuronpedia: gemma-2-9b/31-gemmascope-mlp-131k
+    path: layer_31/width_131k/average_l0_77
+  - id: layer_32/width_131k/canonical
+    neuronpedia: gemma-2-9b/32-gemmascope-mlp-131k
+    path: layer_32/width_131k/average_l0_76
+  - id: layer_33/width_131k/canonical
+    neuronpedia: gemma-2-9b/33-gemmascope-mlp-131k
+    path: layer_33/width_131k/average_l0_83
+  - id: layer_34/width_131k/canonical
+    neuronpedia: gemma-2-9b/34-gemmascope-mlp-131k
+    path: layer_34/width_131k/average_l0_82
+  - id: layer_35/width_131k/canonical
+    neuronpedia: gemma-2-9b/35-gemmascope-mlp-131k
+    path: layer_35/width_131k/average_l0_80
+  - id: layer_36/width_131k/canonical
+    neuronpedia: gemma-2-9b/36-gemmascope-mlp-131k
+    path: layer_36/width_131k/average_l0_81
+  - id: layer_37/width_131k/canonical
+    neuronpedia: gemma-2-9b/37-gemmascope-mlp-131k
+    path: layer_37/width_131k/average_l0_90
+  - id: layer_38/width_131k/canonical
+    neuronpedia: gemma-2-9b/38-gemmascope-mlp-131k
+    path: layer_38/width_131k/average_l0_79
+  - id: layer_39/width_131k/canonical
+    neuronpedia: gemma-2-9b/39-gemmascope-mlp-131k
+    path: layer_39/width_131k/average_l0_75
+  - id: layer_40/width_131k/canonical
+    neuronpedia: gemma-2-9b/40-gemmascope-mlp-131k
+    path: layer_40/width_131k/average_l0_125
+  - id: layer_41/width_131k/canonical
+    neuronpedia: gemma-2-9b/41-gemmascope-mlp-131k
+    path: layer_41/width_131k/average_l0_99
+gemma-scope-9b-pt-res:
+  conversion_func: gemma_2
+  model: gemma-2-9b
+  repo_id: google/gemma-scope-9b-pt-res
   saes:
   - id: embedding/width_4k/average_l0_14
     path: embedding/width_4k/average_l0_14
@@ -3803,5924 +6841,5873 @@ gemma-scope-9b-pt-res:
   - id: embedding/width_4k/average_l0_80
     path: embedding/width_4k/average_l0_80
   - id: layer_0/width_131k/average_l0_11
-    path: layer_0/width_131k/average_l0_11
     l0: 11
+    path: layer_0/width_131k/average_l0_11
   - id: layer_0/width_131k/average_l0_15
-    path: layer_0/width_131k/average_l0_15
     l0: 15
+    path: layer_0/width_131k/average_l0_15
   - id: layer_0/width_131k/average_l0_21
-    path: layer_0/width_131k/average_l0_21
     l0: 21
+    path: layer_0/width_131k/average_l0_21
   - id: layer_0/width_131k/average_l0_30
-    path: layer_0/width_131k/average_l0_30
     l0: 30
     neuronpedia: gemma-2-9b/0-gemmascope-res-131k__l0-30
+    path: layer_0/width_131k/average_l0_30
   - id: layer_0/width_131k/average_l0_41
-    path: layer_0/width_131k/average_l0_41
     l0: 41
+    path: layer_0/width_131k/average_l0_41
   - id: layer_0/width_131k/average_l0_8
-    path: layer_0/width_131k/average_l0_8
     l0: 8
+    path: layer_0/width_131k/average_l0_8
   - id: layer_0/width_16k/average_l0_11
-    path: layer_0/width_16k/average_l0_11
     l0: 11
+    path: layer_0/width_16k/average_l0_11
   - id: layer_0/width_16k/average_l0_129
-    path: layer_0/width_16k/average_l0_129
     l0: 129
+    path: layer_0/width_16k/average_l0_129
   - id: layer_0/width_16k/average_l0_17
-    path: layer_0/width_16k/average_l0_17
     l0: 17
+    path: layer_0/width_16k/average_l0_17
   - id: layer_0/width_16k/average_l0_35
-    path: layer_0/width_16k/average_l0_35
     l0: 35
     neuronpedia: gemma-2-9b/0-gemmascope-res-16k__l0-35
+    path: layer_0/width_16k/average_l0_35
   - id: layer_0/width_16k/average_l0_68
-    path: layer_0/width_16k/average_l0_68
     l0: 68
+    path: layer_0/width_16k/average_l0_68
   - id: layer_1/width_131k/average_l0_13
-    path: layer_1/width_131k/average_l0_13
     l0: 13
+    path: layer_1/width_131k/average_l0_13
   - id: layer_1/width_131k/average_l0_20
-    path: layer_1/width_131k/average_l0_20
     l0: 20
+    path: layer_1/width_131k/average_l0_20
   - id: layer_1/width_131k/average_l0_33
-    path: layer_1/width_131k/average_l0_33
     l0: 33
     neuronpedia: gemma-2-9b/1-gemmascope-res-131k__l0-33
+    path: layer_1/width_131k/average_l0_33
   - id: layer_1/width_131k/average_l0_56
-    path: layer_1/width_131k/average_l0_56
     l0: 56
+    path: layer_1/width_131k/average_l0_56
   - id: layer_1/width_131k/average_l0_6
-    path: layer_1/width_131k/average_l0_6
     l0: 6
+    path: layer_1/width_131k/average_l0_6
   - id: layer_1/width_131k/average_l0_9
-    path: layer_1/width_131k/average_l0_9
     l0: 9
+    path: layer_1/width_131k/average_l0_9
   - id: layer_1/width_16k/average_l0_15
-    path: layer_1/width_16k/average_l0_15
     l0: 15
+    path: layer_1/width_16k/average_l0_15
   - id: layer_1/width_16k/average_l0_175
-    path: layer_1/width_16k/average_l0_175
     l0: 175
+    path: layer_1/width_16k/average_l0_175
   - id: layer_1/width_16k/average_l0_31
-    path: layer_1/width_16k/average_l0_31
     l0: 31
+    path: layer_1/width_16k/average_l0_31
   - id: layer_1/width_16k/average_l0_69
-    path: layer_1/width_16k/average_l0_69
     l0: 69
     neuronpedia: gemma-2-9b/1-gemmascope-res-16k__l0-69
+    path: layer_1/width_16k/average_l0_69
   - id: layer_1/width_16k/average_l0_9
-    path: layer_1/width_16k/average_l0_9
     l0: 9
+    path: layer_1/width_16k/average_l0_9
   - id: layer_10/width_131k/average_l0_15
-    path: layer_10/width_131k/average_l0_15
     l0: 15
+    path: layer_10/width_131k/average_l0_15
   - id: layer_10/width_131k/average_l0_151
-    path: layer_10/width_131k/average_l0_151
     l0: 151
+    path: layer_10/width_131k/average_l0_151
   - id: layer_10/width_131k/average_l0_27
-    path: layer_10/width_131k/average_l0_27
     l0: 27
+    path: layer_10/width_131k/average_l0_27
   - id: layer_10/width_131k/average_l0_47
-    path: layer_10/width_131k/average_l0_47
     l0: 47
     neuronpedia: gemma-2-9b/10-gemmascope-res-131k__l0-47
+    path: layer_10/width_131k/average_l0_47
   - id: layer_10/width_131k/average_l0_84
-    path: layer_10/width_131k/average_l0_84
     l0: 84
+    path: layer_10/width_131k/average_l0_84
   - id: layer_10/width_131k/average_l0_9
-    path: layer_10/width_131k/average_l0_9
     l0: 9
+    path: layer_10/width_131k/average_l0_9
   - id: layer_10/width_16k/average_l0_10
-    path: layer_10/width_16k/average_l0_10
     l0: 10
+    path: layer_10/width_16k/average_l0_10
   - id: layer_10/width_16k/average_l0_113
-    path: layer_10/width_16k/average_l0_113
     l0: 113
+    path: layer_10/width_16k/average_l0_113
   - id: layer_10/width_16k/average_l0_17
-    path: layer_10/width_16k/average_l0_17
     l0: 17
+    path: layer_10/width_16k/average_l0_17
   - id: layer_10/width_16k/average_l0_243
-    path: layer_10/width_16k/average_l0_243
     l0: 243
+    path: layer_10/width_16k/average_l0_243
   - id: layer_10/width_16k/average_l0_31
-    path: layer_10/width_16k/average_l0_31
     l0: 31
+    path: layer_10/width_16k/average_l0_31
   - id: layer_10/width_16k/average_l0_57
-    path: layer_10/width_16k/average_l0_57
     l0: 57
     neuronpedia: gemma-2-9b/10-gemmascope-res-16k__l0-57
+    path: layer_10/width_16k/average_l0_57
   - id: layer_11/width_131k/average_l0_16
-    path: layer_11/width_131k/average_l0_16
     l0: 16
+    path: layer_11/width_131k/average_l0_16
   - id: layer_11/width_131k/average_l0_162
-    path: layer_11/width_131k/average_l0_162
     l0: 162
+    path: layer_11/width_131k/average_l0_162
   - id: layer_11/width_131k/average_l0_27
-    path: layer_11/width_131k/average_l0_27
     l0: 27
+    path: layer_11/width_131k/average_l0_27
   - id: layer_11/width_131k/average_l0_49
-    path: layer_11/width_131k/average_l0_49
     l0: 49
     neuronpedia: gemma-2-9b/11-gemmascope-res-131k__l0-49
+    path: layer_11/width_131k/average_l0_49
   - id: layer_11/width_131k/average_l0_88
-    path: layer_11/width_131k/average_l0_88
     l0: 88
+    path: layer_11/width_131k/average_l0_88
   - id: layer_11/width_131k/average_l0_9
-    path: layer_11/width_131k/average_l0_9
     l0: 9
+    path: layer_11/width_131k/average_l0_9
   - id: layer_11/width_16k/average_l0_10
-    path: layer_11/width_16k/average_l0_10
     l0: 10
+    path: layer_11/width_16k/average_l0_10
   - id: layer_11/width_16k/average_l0_118
-    path: layer_11/width_16k/average_l0_118
     l0: 118
+    path: layer_11/width_16k/average_l0_118
   - id: layer_11/width_16k/average_l0_18
-    path: layer_11/width_16k/average_l0_18
     l0: 18
+    path: layer_11/width_16k/average_l0_18
   - id: layer_11/width_16k/average_l0_255
-    path: layer_11/width_16k/average_l0_255
     l0: 255
+    path: layer_11/width_16k/average_l0_255
   - id: layer_11/width_16k/average_l0_32
-    path: layer_11/width_16k/average_l0_32
     l0: 32
     neuronpedia: gemma-2-9b/11-gemmascope-res-16k__l0-32
+    path: layer_11/width_16k/average_l0_32
   - id: layer_11/width_16k/average_l0_60
-    path: layer_11/width_16k/average_l0_60
     l0: 60
+    path: layer_11/width_16k/average_l0_60
   - id: layer_12/width_131k/average_l0_10
-    path: layer_12/width_131k/average_l0_10
     l0: 10
+    path: layer_12/width_131k/average_l0_10
   - id: layer_12/width_131k/average_l0_17
-    path: layer_12/width_131k/average_l0_17
     l0: 17
+    path: layer_12/width_131k/average_l0_17
   - id: layer_12/width_131k/average_l0_183
-    path: layer_12/width_131k/average_l0_183
     l0: 183
+    path: layer_12/width_131k/average_l0_183
   - id: layer_12/width_131k/average_l0_29
-    path: layer_12/width_131k/average_l0_29
     l0: 29
+    path: layer_12/width_131k/average_l0_29
   - id: layer_12/width_131k/average_l0_52
-    path: layer_12/width_131k/average_l0_52
     l0: 52
     neuronpedia: gemma-2-9b/12-gemmascope-res-131k__l0-52
+    path: layer_12/width_131k/average_l0_52
   - id: layer_12/width_131k/average_l0_96
-    path: layer_12/width_131k/average_l0_96
     l0: 96
+    path: layer_12/width_131k/average_l0_96
   - id: layer_12/width_16k/average_l0_10
-    path: layer_12/width_16k/average_l0_10
     l0: 10
+    path: layer_12/width_16k/average_l0_10
   - id: layer_12/width_16k/average_l0_130
-    path: layer_12/width_16k/average_l0_130
     l0: 130
+    path: layer_12/width_16k/average_l0_130
   - id: layer_12/width_16k/average_l0_19
-    path: layer_12/width_16k/average_l0_19
     l0: 19
+    path: layer_12/width_16k/average_l0_19
   - id: layer_12/width_16k/average_l0_287
-    path: layer_12/width_16k/average_l0_287
     l0: 287
+    path: layer_12/width_16k/average_l0_287
   - id: layer_12/width_16k/average_l0_33
-    path: layer_12/width_16k/average_l0_33
     l0: 33
     neuronpedia: gemma-2-9b/12-gemmascope-res-16k__l0-33
+    path: layer_12/width_16k/average_l0_33
   - id: layer_12/width_16k/average_l0_64
-    path: layer_12/width_16k/average_l0_64
     l0: 64
+    path: layer_12/width_16k/average_l0_64
   - id: layer_13/width_131k/average_l0_10
-    path: layer_13/width_131k/average_l0_10
     l0: 10
+    path: layer_13/width_131k/average_l0_10
   - id: layer_13/width_131k/average_l0_17
-    path: layer_13/width_131k/average_l0_17
     l0: 17
+    path: layer_13/width_131k/average_l0_17
   - id: layer_13/width_131k/average_l0_189
-    path: layer_13/width_131k/average_l0_189
     l0: 189
+    path: layer_13/width_131k/average_l0_189
   - id: layer_13/width_131k/average_l0_30
-    path: layer_13/width_131k/average_l0_30
     l0: 30
     neuronpedia: gemma-2-9b/13-gemmascope-res-131k__l0-30
+    path: layer_13/width_131k/average_l0_30
   - id: layer_13/width_131k/average_l0_54
-    path: layer_13/width_131k/average_l0_54
     l0: 54
+    path: layer_13/width_131k/average_l0_54
   - id: layer_13/width_131k/average_l0_99
-    path: layer_13/width_131k/average_l0_99
     l0: 99
+    path: layer_13/width_131k/average_l0_99
   - id: layer_13/width_16k/average_l0_11
-    path: layer_13/width_16k/average_l0_11
     l0: 11
+    path: layer_13/width_16k/average_l0_11
   - id: layer_13/width_16k/average_l0_132
-    path: layer_13/width_16k/average_l0_132
     l0: 132
+    path: layer_13/width_16k/average_l0_132
   - id: layer_13/width_16k/average_l0_19
-    path: layer_13/width_16k/average_l0_19
     l0: 19
+    path: layer_13/width_16k/average_l0_19
   - id: layer_13/width_16k/average_l0_285
-    path: layer_13/width_16k/average_l0_285
     l0: 285
+    path: layer_13/width_16k/average_l0_285
   - id: layer_13/width_16k/average_l0_34
-    path: layer_13/width_16k/average_l0_34
     l0: 34
     neuronpedia: gemma-2-9b/13-gemmascope-res-16k__l0-34
+    path: layer_13/width_16k/average_l0_34
   - id: layer_13/width_16k/average_l0_65
-    path: layer_13/width_16k/average_l0_65
     l0: 65
+    path: layer_13/width_16k/average_l0_65
   - id: layer_14/width_131k/average_l0_10
-    path: layer_14/width_131k/average_l0_10
     l0: 10
+    path: layer_14/width_131k/average_l0_10
   - id: layer_14/width_131k/average_l0_105
-    path: layer_14/width_131k/average_l0_105
     l0: 105
+    path: layer_14/width_131k/average_l0_105
   - id: layer_14/width_131k/average_l0_18
-    path: layer_14/width_131k/average_l0_18
     l0: 18
+    path: layer_14/width_131k/average_l0_18
   - id: layer_14/width_131k/average_l0_197
-    path: layer_14/width_131k/average_l0_197
     l0: 197
+    path: layer_14/width_131k/average_l0_197
   - id: layer_14/width_131k/average_l0_31
-    path: layer_14/width_131k/average_l0_31
     l0: 31
+    path: layer_14/width_131k/average_l0_31
   - id: layer_14/width_131k/average_l0_56
-    path: layer_14/width_131k/average_l0_56
     l0: 56
     neuronpedia: gemma-2-9b/14-gemmascope-res-131k__l0-56
+    path: layer_14/width_131k/average_l0_56
   - id: layer_14/width_16k/average_l0_11
-    path: layer_14/width_16k/average_l0_11
     l0: 11
+    path: layer_14/width_16k/average_l0_11
   - id: layer_14/width_16k/average_l0_137
-    path: layer_14/width_16k/average_l0_137
     l0: 137
+    path: layer_14/width_16k/average_l0_137
   - id: layer_14/width_16k/average_l0_19
-    path: layer_14/width_16k/average_l0_19
     l0: 19
+    path: layer_14/width_16k/average_l0_19
   - id: layer_14/width_16k/average_l0_294
-    path: layer_14/width_16k/average_l0_294
     l0: 294
+    path: layer_14/width_16k/average_l0_294
   - id: layer_14/width_16k/average_l0_35
-    path: layer_14/width_16k/average_l0_35
     l0: 35
     neuronpedia: gemma-2-9b/14-gemmascope-res-16k__l0-35
+    path: layer_14/width_16k/average_l0_35
   - id: layer_14/width_16k/average_l0_67
-    path: layer_14/width_16k/average_l0_67
     l0: 67
+    path: layer_14/width_16k/average_l0_67
   - id: layer_15/width_131k/average_l0_10
-    path: layer_15/width_131k/average_l0_10
     l0: 10
+    path: layer_15/width_131k/average_l0_10
   - id: layer_15/width_131k/average_l0_103
-    path: layer_15/width_131k/average_l0_103
     l0: 103
+    path: layer_15/width_131k/average_l0_103
   - id: layer_15/width_131k/average_l0_17
-    path: layer_15/width_131k/average_l0_17
     l0: 17
+    path: layer_15/width_131k/average_l0_17
   - id: layer_15/width_131k/average_l0_198
-    path: layer_15/width_131k/average_l0_198
     l0: 198
+    path: layer_15/width_131k/average_l0_198
   - id: layer_15/width_131k/average_l0_30
-    path: layer_15/width_131k/average_l0_30
     l0: 30
+    path: layer_15/width_131k/average_l0_30
   - id: layer_15/width_131k/average_l0_55
-    path: layer_15/width_131k/average_l0_55
     l0: 55
     neuronpedia: gemma-2-9b/15-gemmascope-res-131k__l0-55
+    path: layer_15/width_131k/average_l0_55
   - id: layer_15/width_16k/average_l0_10
-    path: layer_15/width_16k/average_l0_10
     l0: 10
+    path: layer_15/width_16k/average_l0_10
   - id: layer_15/width_16k/average_l0_131
-    path: layer_15/width_16k/average_l0_131
     l0: 131
+    path: layer_15/width_16k/average_l0_131
   - id: layer_15/width_16k/average_l0_18
-    path: layer_15/width_16k/average_l0_18
     l0: 18
+    path: layer_15/width_16k/average_l0_18
   - id: layer_15/width_16k/average_l0_290
-    path: layer_15/width_16k/average_l0_290
     l0: 290
+    path: layer_15/width_16k/average_l0_290
   - id: layer_15/width_16k/average_l0_34
-    path: layer_15/width_16k/average_l0_34
     l0: 34
     neuronpedia: gemma-2-9b/15-gemmascope-res-16k__l0-34
+    path: layer_15/width_16k/average_l0_34
   - id: layer_15/width_16k/average_l0_65
-    path: layer_15/width_16k/average_l0_65
     l0: 65
+    path: layer_15/width_16k/average_l0_65
   - id: layer_16/width_131k/average_l0_11
-    path: layer_16/width_131k/average_l0_11
     l0: 11
+    path: layer_16/width_131k/average_l0_11
   - id: layer_16/width_131k/average_l0_121
-    path: layer_16/width_131k/average_l0_121
     l0: 121
+    path: layer_16/width_131k/average_l0_121
   - id: layer_16/width_131k/average_l0_20
-    path: layer_16/width_131k/average_l0_20
     l0: 20
+    path: layer_16/width_131k/average_l0_20
   - id: layer_16/width_131k/average_l0_232
-    path: layer_16/width_131k/average_l0_232
     l0: 232
+    path: layer_16/width_131k/average_l0_232
   - id: layer_16/width_131k/average_l0_35
-    path: layer_16/width_131k/average_l0_35
     l0: 35
     neuronpedia: gemma-2-9b/16-gemmascope-res-131k__l0-35
+    path: layer_16/width_131k/average_l0_35
   - id: layer_16/width_131k/average_l0_65
-    path: layer_16/width_131k/average_l0_65
     l0: 65
+    path: layer_16/width_131k/average_l0_65
   - id: layer_16/width_16k/average_l0_11
-    path: layer_16/width_16k/average_l0_11
     l0: 11
+    path: layer_16/width_16k/average_l0_11
   - id: layer_16/width_16k/average_l0_152
-    path: layer_16/width_16k/average_l0_152
     l0: 152
+    path: layer_16/width_16k/average_l0_152
   - id: layer_16/width_16k/average_l0_21
-    path: layer_16/width_16k/average_l0_21
     l0: 21
+    path: layer_16/width_16k/average_l0_21
   - id: layer_16/width_16k/average_l0_346
-    path: layer_16/width_16k/average_l0_346
     l0: 346
+    path: layer_16/width_16k/average_l0_346
   - id: layer_16/width_16k/average_l0_39
-    path: layer_16/width_16k/average_l0_39
     l0: 39
     neuronpedia: gemma-2-9b/16-gemmascope-res-16k__l0-39
+    path: layer_16/width_16k/average_l0_39
   - id: layer_16/width_16k/average_l0_75
-    path: layer_16/width_16k/average_l0_75
     l0: 75
+    path: layer_16/width_16k/average_l0_75
   - id: layer_17/width_131k/average_l0_11
-    path: layer_17/width_131k/average_l0_11
     l0: 11
+    path: layer_17/width_131k/average_l0_11
   - id: layer_17/width_131k/average_l0_117
-    path: layer_17/width_131k/average_l0_117
     l0: 117
+    path: layer_17/width_131k/average_l0_117
   - id: layer_17/width_131k/average_l0_19
-    path: layer_17/width_131k/average_l0_19
     l0: 19
+    path: layer_17/width_131k/average_l0_19
   - id: layer_17/width_131k/average_l0_221
-    path: layer_17/width_131k/average_l0_221
     l0: 221
+    path: layer_17/width_131k/average_l0_221
   - id: layer_17/width_131k/average_l0_35
-    path: layer_17/width_131k/average_l0_35
     l0: 35
     neuronpedia: gemma-2-9b/17-gemmascope-res-131k__l0-35
+    path: layer_17/width_131k/average_l0_35
   - id: layer_17/width_131k/average_l0_64
-    path: layer_17/width_131k/average_l0_64
     l0: 64
+    path: layer_17/width_131k/average_l0_64
   - id: layer_17/width_16k/average_l0_12
-    path: layer_17/width_16k/average_l0_12
     l0: 12
+    path: layer_17/width_16k/average_l0_12
   - id: layer_17/width_16k/average_l0_144
-    path: layer_17/width_16k/average_l0_144
     l0: 144
+    path: layer_17/width_16k/average_l0_144
   - id: layer_17/width_16k/average_l0_21
-    path: layer_17/width_16k/average_l0_21
     l0: 21
+    path: layer_17/width_16k/average_l0_21
   - id: layer_17/width_16k/average_l0_317
-    path: layer_17/width_16k/average_l0_317
     l0: 317
+    path: layer_17/width_16k/average_l0_317
   - id: layer_17/width_16k/average_l0_38
-    path: layer_17/width_16k/average_l0_38
     l0: 38
     neuronpedia: gemma-2-9b/17-gemmascope-res-16k__l0-38
+    path: layer_17/width_16k/average_l0_38
   - id: layer_17/width_16k/average_l0_73
-    path: layer_17/width_16k/average_l0_73
     l0: 73
+    path: layer_17/width_16k/average_l0_73
   - id: layer_18/width_131k/average_l0_11
-    path: layer_18/width_131k/average_l0_11
     l0: 11
+    path: layer_18/width_131k/average_l0_11
   - id: layer_18/width_131k/average_l0_113
-    path: layer_18/width_131k/average_l0_113
     l0: 113
+    path: layer_18/width_131k/average_l0_113
   - id: layer_18/width_131k/average_l0_19
-    path: layer_18/width_131k/average_l0_19
     l0: 19
+    path: layer_18/width_131k/average_l0_19
   - id: layer_18/width_131k/average_l0_221
-    path: layer_18/width_131k/average_l0_221
     l0: 221
+    path: layer_18/width_131k/average_l0_221
   - id: layer_18/width_131k/average_l0_34
-    path: layer_18/width_131k/average_l0_34
     l0: 34
     neuronpedia: gemma-2-9b/18-gemmascope-res-131k__l0-34
+    path: layer_18/width_131k/average_l0_34
   - id: layer_18/width_131k/average_l0_62
-    path: layer_18/width_131k/average_l0_62
     l0: 62
+    path: layer_18/width_131k/average_l0_62
   - id: layer_18/width_16k/average_l0_11
-    path: layer_18/width_16k/average_l0_11
     l0: 11
+    path: layer_18/width_16k/average_l0_11
   - id: layer_18/width_16k/average_l0_140
-    path: layer_18/width_16k/average_l0_140
     l0: 140
+    path: layer_18/width_16k/average_l0_140
   - id: layer_18/width_16k/average_l0_20
-    path: layer_18/width_16k/average_l0_20
     l0: 20
+    path: layer_18/width_16k/average_l0_20
   - id: layer_18/width_16k/average_l0_309
-    path: layer_18/width_16k/average_l0_309
     l0: 309
+    path: layer_18/width_16k/average_l0_309
   - id: layer_18/width_16k/average_l0_37
-    path: layer_18/width_16k/average_l0_37
     l0: 37
     neuronpedia: gemma-2-9b/18-gemmascope-res-16k__l0-37
+    path: layer_18/width_16k/average_l0_37
   - id: layer_18/width_16k/average_l0_71
-    path: layer_18/width_16k/average_l0_71
     l0: 71
+    path: layer_18/width_16k/average_l0_71
   - id: layer_19/width_131k/average_l0_10
-    path: layer_19/width_131k/average_l0_10
     l0: 10
+    path: layer_19/width_131k/average_l0_10
   - id: layer_19/width_131k/average_l0_110
-    path: layer_19/width_131k/average_l0_110
     l0: 110
+    path: layer_19/width_131k/average_l0_110
   - id: layer_19/width_131k/average_l0_18
-    path: layer_19/width_131k/average_l0_18
     l0: 18
+    path: layer_19/width_131k/average_l0_18
   - id: layer_19/width_131k/average_l0_210
-    path: layer_19/width_131k/average_l0_210
     l0: 210
+    path: layer_19/width_131k/average_l0_210
   - id: layer_19/width_131k/average_l0_32
-    path: layer_19/width_131k/average_l0_32
     l0: 32
     neuronpedia: gemma-2-9b/19-gemmascope-res-131k__l0-32
+    path: layer_19/width_131k/average_l0_32
   - id: layer_19/width_131k/average_l0_60
-    path: layer_19/width_131k/average_l0_60
     l0: 60
+    path: layer_19/width_131k/average_l0_60
   - id: layer_19/width_16k/average_l0_11
-    path: layer_19/width_16k/average_l0_11
     l0: 11
+    path: layer_19/width_16k/average_l0_11
   - id: layer_19/width_16k/average_l0_132
-    path: layer_19/width_16k/average_l0_132
     l0: 132
+    path: layer_19/width_16k/average_l0_132
   - id: layer_19/width_16k/average_l0_19
-    path: layer_19/width_16k/average_l0_19
     l0: 19
+    path: layer_19/width_16k/average_l0_19
   - id: layer_19/width_16k/average_l0_293
-    path: layer_19/width_16k/average_l0_293
     l0: 293
+    path: layer_19/width_16k/average_l0_293
   - id: layer_19/width_16k/average_l0_35
-    path: layer_19/width_16k/average_l0_35
     l0: 35
     neuronpedia: gemma-2-9b/19-gemmascope-res-16k__l0-35
+    path: layer_19/width_16k/average_l0_35
   - id: layer_19/width_16k/average_l0_67
-    path: layer_19/width_16k/average_l0_67
     l0: 67
+    path: layer_19/width_16k/average_l0_67
   - id: layer_2/width_131k/average_l0_12
-    path: layer_2/width_131k/average_l0_12
     l0: 12
+    path: layer_2/width_131k/average_l0_12
   - id: layer_2/width_131k/average_l0_19
-    path: layer_2/width_131k/average_l0_19
     l0: 19
+    path: layer_2/width_131k/average_l0_19
   - id: layer_2/width_131k/average_l0_36
-    path: layer_2/width_131k/average_l0_36
     l0: 36
     neuronpedia: gemma-2-9b/2-gemmascope-res-131k__l0-36
+    path: layer_2/width_131k/average_l0_36
   - id: layer_2/width_131k/average_l0_5
-    path: layer_2/width_131k/average_l0_5
     l0: 5
+    path: layer_2/width_131k/average_l0_5
   - id: layer_2/width_131k/average_l0_70
-    path: layer_2/width_131k/average_l0_70
     l0: 70
+    path: layer_2/width_131k/average_l0_70
   - id: layer_2/width_131k/average_l0_8
-    path: layer_2/width_131k/average_l0_8
     l0: 8
+    path: layer_2/width_131k/average_l0_8
   - id: layer_2/width_16k/average_l0_14
-    path: layer_2/width_16k/average_l0_14
     l0: 14
+    path: layer_2/width_16k/average_l0_14
   - id: layer_2/width_16k/average_l0_189
-    path: layer_2/width_16k/average_l0_189
     l0: 189
+    path: layer_2/width_16k/average_l0_189
   - id: layer_2/width_16k/average_l0_29
-    path: layer_2/width_16k/average_l0_29
     l0: 29
+    path: layer_2/width_16k/average_l0_29
   - id: layer_2/width_16k/average_l0_67
-    path: layer_2/width_16k/average_l0_67
     l0: 67
     neuronpedia: gemma-2-9b/2-gemmascope-res-16k__l0-67
+    path: layer_2/width_16k/average_l0_67
   - id: layer_2/width_16k/average_l0_8
-    path: layer_2/width_16k/average_l0_8
     l0: 8
     neuronpedia: gemma-2-9b/20-gemmascope-res-131k__l0-10
+    path: layer_2/width_16k/average_l0_8
   - id: layer_20/width_131k/average_l0_11
-    path: layer_20/width_131k/average_l0_11
     l0: 11
     neuronpedia: gemma-2-9b/20-gemmascope-res-131k__l0-11
+    path: layer_20/width_131k/average_l0_11
   - id: layer_20/width_131k/average_l0_114
-    path: layer_20/width_131k/average_l0_114
     l0: 114
     neuronpedia: gemma-2-9b/20-gemmascope-res-131k__l0-12
+    path: layer_20/width_131k/average_l0_114
   - id: layer_20/width_131k/average_l0_19
-    path: layer_20/width_131k/average_l0_19
     l0: 19
     neuronpedia: gemma-2-9b/20-gemmascope-res-131k__l0-19
+    path: layer_20/width_131k/average_l0_19
   - id: layer_20/width_131k/average_l0_221
-    path: layer_20/width_131k/average_l0_221
     l0: 221
     neuronpedia: gemma-2-9b/20-gemmascope-res-131k__l0-221
+    path: layer_20/width_131k/average_l0_221
   - id: layer_20/width_131k/average_l0_276
-    path: layer_20/width_131k/average_l0_276
     l0: 276
     neuronpedia: gemma-2-9b/20-gemmascope-res-131k__l0-276
+    path: layer_20/width_131k/average_l0_276
   - id: layer_20/width_131k/average_l0_34
-    path: layer_20/width_131k/average_l0_34
     l0: 34
     neuronpedia: gemma-2-9b/20-gemmascope-res-131k__l0-34
+    path: layer_20/width_131k/average_l0_34
   - id: layer_20/width_131k/average_l0_53
-    path: layer_20/width_131k/average_l0_53
     l0: 53
     neuronpedia: gemma-2-9b/20-gemmascope-res-131k__l0-53
+    path: layer_20/width_131k/average_l0_53
   - id: layer_20/width_131k/average_l0_62
-    path: layer_20/width_131k/average_l0_62
     l0: 62
     neuronpedia: gemma-2-9b/20-gemmascope-res-131k__l0-62
+    path: layer_20/width_131k/average_l0_62
   - id: layer_20/width_16k/average_l0_11
-    path: layer_20/width_16k/average_l0_11
     l0: 11
     neuronpedia: gemma-2-9b/20-gemmascope-res-16k__l0-11
+    path: layer_20/width_16k/average_l0_11
   - id: layer_20/width_16k/average_l0_138
-    path: layer_20/width_16k/average_l0_138
     l0: 138
     neuronpedia: gemma-2-9b/20-gemmascope-res-16k__l0-138
+    path: layer_20/width_16k/average_l0_138
   - id: layer_20/width_16k/average_l0_20
-    path: layer_20/width_16k/average_l0_20
     l0: 20
     neuronpedia: gemma-2-9b/20-gemmascope-res-16k__l0-20
+    path: layer_20/width_16k/average_l0_20
   - id: layer_20/width_16k/average_l0_310
-    path: layer_20/width_16k/average_l0_310
     l0: 310
     neuronpedia: gemma-2-9b/20-gemmascope-res-16k__l0-310
+    path: layer_20/width_16k/average_l0_310
   - id: layer_20/width_16k/average_l0_36
-    path: layer_20/width_16k/average_l0_36
     l0: 36
     neuronpedia: gemma-2-9b/20-gemmascope-res-16k__l0-36
+    path: layer_20/width_16k/average_l0_36
   - id: layer_20/width_16k/average_l0_408
-    path: layer_20/width_16k/average_l0_408
     l0: 408
     neuronpedia: gemma-2-9b/20-gemmascope-res-16k__l0-408
+    path: layer_20/width_16k/average_l0_408
   - id: layer_20/width_16k/average_l0_58
-    path: layer_20/width_16k/average_l0_58
     l0: 58
     neuronpedia: gemma-2-9b/20-gemmascope-res-16k__l0-58
+    path: layer_20/width_16k/average_l0_58
   - id: layer_20/width_16k/average_l0_68
-    path: layer_20/width_16k/average_l0_68
     l0: 68
+    path: layer_20/width_16k/average_l0_68
   - id: layer_20/width_1m/average_l0_101
-    path: layer_20/width_1m/average_l0_101
     l0: 101
+    path: layer_20/width_1m/average_l0_101
   - id: layer_20/width_1m/average_l0_11
-    path: layer_20/width_1m/average_l0_11
     l0: 11
     neuronpedia: gemma-2-9b/20-gemmascope-res-1m__l0-11
+    path: layer_20/width_1m/average_l0_11
   - id: layer_20/width_1m/average_l0_19
-    path: layer_20/width_1m/average_l0_19
     l0: 19
     neuronpedia: gemma-2-9b/20-gemmascope-res-1m__l0-19
+    path: layer_20/width_1m/average_l0_19
   - id: layer_20/width_1m/average_l0_193
-    path: layer_20/width_1m/average_l0_193
     l0: 193
     neuronpedia: gemma-2-9b/20-gemmascope-res-1m__l0-193
+    path: layer_20/width_1m/average_l0_193
   - id: layer_20/width_1m/average_l0_34
-    path: layer_20/width_1m/average_l0_34
     l0: 34
     neuronpedia: gemma-2-9b/20-gemmascope-res-1m__l0-34
+    path: layer_20/width_1m/average_l0_34
   - id: layer_20/width_1m/average_l0_57
-    path: layer_20/width_1m/average_l0_57
     l0: 57
     neuronpedia: gemma-2-9b/20-gemmascope-res-1m__l0-57
+    path: layer_20/width_1m/average_l0_57
   - id: layer_20/width_262k/average_l0_11
+    l0: 11
     path: layer_20/width_262k/average_l0_11
-    l0: 11
   - id: layer_20/width_262k/average_l0_259
-    path: layer_20/width_262k/average_l0_259
     l0: 259
+    path: layer_20/width_262k/average_l0_259
   - id: layer_20/width_262k/average_l0_50
-    path: layer_20/width_262k/average_l0_50
     l0: 50
+    path: layer_20/width_262k/average_l0_50
   - id: layer_20/width_32k/average_l0_11
+    l0: 11
     path: layer_20/width_32k/average_l0_11
-    l0: 11
   - id: layer_20/width_32k/average_l0_344
-    path: layer_20/width_32k/average_l0_344
     l0: 344
+    path: layer_20/width_32k/average_l0_344
   - id: layer_20/width_32k/average_l0_57
-    path: layer_20/width_32k/average_l0_57
     l0: 57
+    path: layer_20/width_32k/average_l0_57
   - id: layer_20/width_524k/average_l0_10
-    path: layer_20/width_524k/average_l0_10
     l0: 10
+    path: layer_20/width_524k/average_l0_10
   - id: layer_20/width_524k/average_l0_241
-    path: layer_20/width_524k/average_l0_241
     l0: 241
+    path: layer_20/width_524k/average_l0_241
   - id: layer_20/width_524k/average_l0_48
-    path: layer_20/width_524k/average_l0_48
     l0: 48
+    path: layer_20/width_524k/average_l0_48
   - id: layer_20/width_65k/average_l0_11
+    l0: 11
     path: layer_20/width_65k/average_l0_11
-    l0: 11
   - id: layer_20/width_65k/average_l0_55
-    path: layer_20/width_65k/average_l0_55
     l0: 55
+    path: layer_20/width_65k/average_l0_55
   - id: layer_20/width_65k/average_l0_298
-    path: layer_20/width_65k/average_l0_298
     l0: 298
+    path: layer_20/width_65k/average_l0_298
   - id: layer_21/width_131k/average_l0_109
-    path: layer_21/width_131k/average_l0_109
     l0: 109
+    path: layer_21/width_131k/average_l0_109
   - id: layer_21/width_131k/average_l0_11
-    path: layer_21/width_131k/average_l0_11
     l0: 11
+    path: layer_21/width_131k/average_l0_11
   - id: layer_21/width_131k/average_l0_19
-    path: layer_21/width_131k/average_l0_19
     l0: 19
+    path: layer_21/width_131k/average_l0_19
   - id: layer_21/width_131k/average_l0_204
-    path: layer_21/width_131k/average_l0_204
     l0: 204
+    path: layer_21/width_131k/average_l0_204
   - id: layer_21/width_131k/average_l0_33
-    path: layer_21/width_131k/average_l0_33
     l0: 33
     neuronpedia: gemma-2-9b/21-gemmascope-res-131k__l0-33
+    path: layer_21/width_131k/average_l0_33
   - id: layer_21/width_131k/average_l0_58
-    path: layer_21/width_131k/average_l0_58
     l0: 58
+    path: layer_21/width_131k/average_l0_58
   - id: layer_21/width_16k/average_l0_11
-    path: layer_21/width_16k/average_l0_11
     l0: 11
+    path: layer_21/width_16k/average_l0_11
   - id: layer_21/width_16k/average_l0_129
-    path: layer_21/width_16k/average_l0_129
     l0: 129
+    path: layer_21/width_16k/average_l0_129
   - id: layer_21/width_16k/average_l0_19
-    path: layer_21/width_16k/average_l0_19
     l0: 19
+    path: layer_21/width_16k/average_l0_19
   - id: layer_21/width_16k/average_l0_278
-    path: layer_21/width_16k/average_l0_278
     l0: 278
+    path: layer_21/width_16k/average_l0_278
   - id: layer_21/width_16k/average_l0_36
-    path: layer_21/width_16k/average_l0_36
     l0: 36
     neuronpedia: gemma-2-9b/21-gemmascope-res-16k__l0-36
+    path: layer_21/width_16k/average_l0_36
   - id: layer_21/width_16k/average_l0_66
-    path: layer_21/width_16k/average_l0_66
     l0: 66
+    path: layer_21/width_16k/average_l0_66
   - id: layer_22/width_131k/average_l0_10
-    path: layer_22/width_131k/average_l0_10
     l0: 10
+    path: layer_22/width_131k/average_l0_10
   - id: layer_22/width_131k/average_l0_105
-    path: layer_22/width_131k/average_l0_105
     l0: 105
+    path: layer_22/width_131k/average_l0_105
   - id: layer_22/width_131k/average_l0_18
-    path: layer_22/width_131k/average_l0_18
     l0: 18
+    path: layer_22/width_131k/average_l0_18
   - id: layer_22/width_131k/average_l0_197
-    path: layer_22/width_131k/average_l0_197
     l0: 197
+    path: layer_22/width_131k/average_l0_197
   - id: layer_22/width_131k/average_l0_32
-    path: layer_22/width_131k/average_l0_32
     l0: 32
     neuronpedia: gemma-2-9b/22-gemmascope-res-131k__l0-32
+    path: layer_22/width_131k/average_l0_32
   - id: layer_22/width_131k/average_l0_58
-    path: layer_22/width_131k/average_l0_58
     l0: 58
+    path: layer_22/width_131k/average_l0_58
   - id: layer_22/width_16k/average_l0_11
-    path: layer_22/width_16k/average_l0_11
     l0: 11
+    path: layer_22/width_16k/average_l0_11
   - id: layer_22/width_16k/average_l0_123
-    path: layer_22/width_16k/average_l0_123
     l0: 123
+    path: layer_22/width_16k/average_l0_123
   - id: layer_22/width_16k/average_l0_19
-    path: layer_22/width_16k/average_l0_19
     l0: 19
+    path: layer_22/width_16k/average_l0_19
   - id: layer_22/width_16k/average_l0_268
-    path: layer_22/width_16k/average_l0_268
     l0: 268
+    path: layer_22/width_16k/average_l0_268
   - id: layer_22/width_16k/average_l0_35
-    path: layer_22/width_16k/average_l0_35
     l0: 35
     neuronpedia: gemma-2-9b/22-gemmascope-res-16k__l0-35
+    path: layer_22/width_16k/average_l0_35
   - id: layer_22/width_16k/average_l0_65
-    path: layer_22/width_16k/average_l0_65
     l0: 65
+    path: layer_22/width_16k/average_l0_65
   - id: layer_23/width_131k/average_l0_10
-    path: layer_23/width_131k/average_l0_10
     l0: 10
+    path: layer_23/width_131k/average_l0_10
   - id: layer_23/width_131k/average_l0_101
-    path: layer_23/width_131k/average_l0_101
     l0: 101
+    path: layer_23/width_131k/average_l0_101
   - id: layer_23/width_131k/average_l0_18
-    path: layer_23/width_131k/average_l0_18
     l0: 18
+    path: layer_23/width_131k/average_l0_18
   - id: layer_23/width_131k/average_l0_187
-    path: layer_23/width_131k/average_l0_187
     l0: 187
+    path: layer_23/width_131k/average_l0_187
   - id: layer_23/width_131k/average_l0_32
-    path: layer_23/width_131k/average_l0_32
     l0: 32
     neuronpedia: gemma-2-9b/23-gemmascope-res-131k__l0-32
+    path: layer_23/width_131k/average_l0_32
   - id: layer_23/width_131k/average_l0_56
-    path: layer_23/width_131k/average_l0_56
     l0: 56
+    path: layer_23/width_131k/average_l0_56
   - id: layer_23/width_16k/average_l0_11
-    path: layer_23/width_16k/average_l0_11
     l0: 11
+    path: layer_23/width_16k/average_l0_11
   - id: layer_23/width_16k/average_l0_120
-    path: layer_23/width_16k/average_l0_120
     l0: 120
+    path: layer_23/width_16k/average_l0_120
   - id: layer_23/width_16k/average_l0_19
-    path: layer_23/width_16k/average_l0_19
     l0: 19
+    path: layer_23/width_16k/average_l0_19
   - id: layer_23/width_16k/average_l0_248
-    path: layer_23/width_16k/average_l0_248
     l0: 248
+    path: layer_23/width_16k/average_l0_248
   - id: layer_23/width_16k/average_l0_35
-    path: layer_23/width_16k/average_l0_35
     l0: 35
     neuronpedia: gemma-2-9b/23-gemmascope-res-16k__l0-35
+    path: layer_23/width_16k/average_l0_35
   - id: layer_23/width_16k/average_l0_63
-    path: layer_23/width_16k/average_l0_63
     l0: 63
+    path: layer_23/width_16k/average_l0_63
   - id: layer_24/width_131k/average_l0_10
-    path: layer_24/width_131k/average_l0_10
     l0: 10
+    path: layer_24/width_131k/average_l0_10
   - id: layer_24/width_131k/average_l0_17
-    path: layer_24/width_131k/average_l0_17
     l0: 17
+    path: layer_24/width_131k/average_l0_17
   - id: layer_24/width_131k/average_l0_180
-    path: layer_24/width_131k/average_l0_180
     l0: 180
+    path: layer_24/width_131k/average_l0_180
   - id: layer_24/width_131k/average_l0_30
-    path: layer_24/width_131k/average_l0_30
     l0: 30
+    path: layer_24/width_131k/average_l0_30
   - id: layer_24/width_131k/average_l0_55
-    path: layer_24/width_131k/average_l0_55
     l0: 55
     neuronpedia: gemma-2-9b/24-gemmascope-res-131k__l0-55
+    path: layer_24/width_131k/average_l0_55
   - id: layer_24/width_131k/average_l0_97
-    path: layer_24/width_131k/average_l0_97
     l0: 97
+    path: layer_24/width_131k/average_l0_97
   - id: layer_24/width_16k/average_l0_10
-    path: layer_24/width_16k/average_l0_10
     l0: 10
+    path: layer_24/width_16k/average_l0_10
   - id: layer_24/width_16k/average_l0_114
-    path: layer_24/width_16k/average_l0_114
     l0: 114
+    path: layer_24/width_16k/average_l0_114
   - id: layer_24/width_16k/average_l0_19
-    path: layer_24/width_16k/average_l0_19
     l0: 19
+    path: layer_24/width_16k/average_l0_19
   - id: layer_24/width_16k/average_l0_234
-    path: layer_24/width_16k/average_l0_234
     l0: 234
+    path: layer_24/width_16k/average_l0_234
   - id: layer_24/width_16k/average_l0_34
-    path: layer_24/width_16k/average_l0_34
     l0: 34
     neuronpedia: gemma-2-9b/24-gemmascope-res-16k__l0-34
+    path: layer_24/width_16k/average_l0_34
   - id: layer_24/width_16k/average_l0_61
-    path: layer_24/width_16k/average_l0_61
     l0: 61
+    path: layer_24/width_16k/average_l0_61
   - id: layer_25/width_131k/average_l0_10
-    path: layer_25/width_131k/average_l0_10
     l0: 10
+    path: layer_25/width_131k/average_l0_10
   - id: layer_25/width_131k/average_l0_177
-    path: layer_25/width_131k/average_l0_177
     l0: 177
+    path: layer_25/width_131k/average_l0_177
   - id: layer_25/width_131k/average_l0_18
-    path: layer_25/width_131k/average_l0_18
     l0: 18
+    path: layer_25/width_131k/average_l0_18
   - id: layer_25/width_131k/average_l0_31
-    path: layer_25/width_131k/average_l0_31
     l0: 31
+    path: layer_25/width_131k/average_l0_31
   - id: layer_25/width_131k/average_l0_54
-    path: layer_25/width_131k/average_l0_54
     l0: 54
     neuronpedia: gemma-2-9b/25-gemmascope-res-131k__l0-54
+    path: layer_25/width_131k/average_l0_54
   - id: layer_25/width_131k/average_l0_96
-    path: layer_25/width_131k/average_l0_96
     l0: 96
+    path: layer_25/width_131k/average_l0_96
   - id: layer_25/width_16k/average_l0_11
-    path: layer_25/width_16k/average_l0_11
     l0: 11
+    path: layer_25/width_16k/average_l0_11
   - id: layer_25/width_16k/average_l0_114
-    path: layer_25/width_16k/average_l0_114
     l0: 114
+    path: layer_25/width_16k/average_l0_114
   - id: layer_25/width_16k/average_l0_19
-    path: layer_25/width_16k/average_l0_19
     l0: 19
+    path: layer_25/width_16k/average_l0_19
   - id: layer_25/width_16k/average_l0_231
-    path: layer_25/width_16k/average_l0_231
     l0: 231
+    path: layer_25/width_16k/average_l0_231
   - id: layer_25/width_16k/average_l0_34
-    path: layer_25/width_16k/average_l0_34
     l0: 34
     neuronpedia: gemma-2-9b/25-gemmascope-res-16k__l0-34
+    path: layer_25/width_16k/average_l0_34
   - id: layer_25/width_16k/average_l0_61
-    path: layer_25/width_16k/average_l0_61
     l0: 61
+    path: layer_25/width_16k/average_l0_61
   - id: layer_26/width_131k/average_l0_10
-    path: layer_26/width_131k/average_l0_10
     l0: 10
+    path: layer_26/width_131k/average_l0_10
   - id: layer_26/width_131k/average_l0_176
-    path: layer_26/width_131k/average_l0_176
     l0: 176
+    path: layer_26/width_131k/average_l0_176
   - id: layer_26/width_131k/average_l0_18
-    path: layer_26/width_131k/average_l0_18
     l0: 18
+    path: layer_26/width_131k/average_l0_18
   - id: layer_26/width_131k/average_l0_32
-    path: layer_26/width_131k/average_l0_32
     l0: 32
     neuronpedia: gemma-2-9b/26-gemmascope-res-131k__l0-32
+    path: layer_26/width_131k/average_l0_32
   - id: layer_26/width_131k/average_l0_55
-    path: layer_26/width_131k/average_l0_55
     l0: 55
+    path: layer_26/width_131k/average_l0_55
   - id: layer_26/width_131k/average_l0_97
-    path: layer_26/width_131k/average_l0_97
     l0: 97
+    path: layer_26/width_131k/average_l0_97
   - id: layer_26/width_16k/average_l0_11
-    path: layer_26/width_16k/average_l0_11
     l0: 11
+    path: layer_26/width_16k/average_l0_11
   - id: layer_26/width_16k/average_l0_116
-    path: layer_26/width_16k/average_l0_116
     l0: 116
+    path: layer_26/width_16k/average_l0_116
   - id: layer_26/width_16k/average_l0_20
-    path: layer_26/width_16k/average_l0_20
     l0: 20
+    path: layer_26/width_16k/average_l0_20
   - id: layer_26/width_16k/average_l0_233
-    path: layer_26/width_16k/average_l0_233
     l0: 233
+    path: layer_26/width_16k/average_l0_233
   - id: layer_26/width_16k/average_l0_35
-    path: layer_26/width_16k/average_l0_35
     l0: 35
     neuronpedia: gemma-2-9b/26-gemmascope-res-16k__l0-35
+    path: layer_26/width_16k/average_l0_35
   - id: layer_26/width_16k/average_l0_63
-    path: layer_26/width_16k/average_l0_63
     l0: 63
+    path: layer_26/width_16k/average_l0_63
   - id: layer_27/width_131k/average_l0_11
-    path: layer_27/width_131k/average_l0_11
     l0: 11
+    path: layer_27/width_131k/average_l0_11
   - id: layer_27/width_131k/average_l0_171
-    path: layer_27/width_131k/average_l0_171
     l0: 171
+    path: layer_27/width_131k/average_l0_171
   - id: layer_27/width_131k/average_l0_19
-    path: layer_27/width_131k/average_l0_19
     l0: 19
+    path: layer_27/width_131k/average_l0_19
   - id: layer_27/width_131k/average_l0_33
-    path: layer_27/width_131k/average_l0_33
     l0: 33
     neuronpedia: gemma-2-9b/27-gemmascope-res-131k__l0-33
+    path: layer_27/width_131k/average_l0_33
   - id: layer_27/width_131k/average_l0_56
-    path: layer_27/width_131k/average_l0_56
     l0: 56
+    path: layer_27/width_131k/average_l0_56
   - id: layer_27/width_131k/average_l0_96
-    path: layer_27/width_131k/average_l0_96
     l0: 96
+    path: layer_27/width_131k/average_l0_96
   - id: layer_27/width_16k/average_l0_118
-    path: layer_27/width_16k/average_l0_118
     l0: 118
+    path: layer_27/width_16k/average_l0_118
   - id: layer_27/width_16k/average_l0_12
-    path: layer_27/width_16k/average_l0_12
     l0: 12
+    path: layer_27/width_16k/average_l0_12
   - id: layer_27/width_16k/average_l0_21
-    path: layer_27/width_16k/average_l0_21
     l0: 21
+    path: layer_27/width_16k/average_l0_21
   - id: layer_27/width_16k/average_l0_230
-    path: layer_27/width_16k/average_l0_230
     l0: 230
+    path: layer_27/width_16k/average_l0_230
   - id: layer_27/width_16k/average_l0_36
-    path: layer_27/width_16k/average_l0_36
     l0: 36
     neuronpedia: gemma-2-9b/27-gemmascope-res-16k__l0-36
+    path: layer_27/width_16k/average_l0_36
   - id: layer_27/width_16k/average_l0_65
-    path: layer_27/width_16k/average_l0_65
     l0: 65
+    path: layer_27/width_16k/average_l0_65
   - id: layer_28/width_131k/average_l0_11
-    path: layer_28/width_131k/average_l0_11
     l0: 11
+    path: layer_28/width_131k/average_l0_11
   - id: layer_28/width_131k/average_l0_171
-    path: layer_28/width_131k/average_l0_171
     l0: 171
+    path: layer_28/width_131k/average_l0_171
   - id: layer_28/width_131k/average_l0_19
-    path: layer_28/width_131k/average_l0_19
     l0: 19
+    path: layer_28/width_131k/average_l0_19
   - id: layer_28/width_131k/average_l0_32
-    path: layer_28/width_131k/average_l0_32
     l0: 32
     neuronpedia: gemma-2-9b/28-gemmascope-res-131k__l0-32
+    path: layer_28/width_131k/average_l0_32
   - id: layer_28/width_131k/average_l0_57
-    path: layer_28/width_131k/average_l0_57
     l0: 57
+    path: layer_28/width_131k/average_l0_57
   - id: layer_28/width_131k/average_l0_98
-    path: layer_28/width_131k/average_l0_98
     l0: 98
+    path: layer_28/width_131k/average_l0_98
   - id: layer_28/width_16k/average_l0_119
-    path: layer_28/width_16k/average_l0_119
     l0: 119
+    path: layer_28/width_16k/average_l0_119
   - id: layer_28/width_16k/average_l0_12
-    path: layer_28/width_16k/average_l0_12
     l0: 12
+    path: layer_28/width_16k/average_l0_12
   - id: layer_28/width_16k/average_l0_21
-    path: layer_28/width_16k/average_l0_21
     l0: 21
+    path: layer_28/width_16k/average_l0_21
   - id: layer_28/width_16k/average_l0_229
-    path: layer_28/width_16k/average_l0_229
     l0: 229
+    path: layer_28/width_16k/average_l0_229
   - id: layer_28/width_16k/average_l0_37
-    path: layer_28/width_16k/average_l0_37
     l0: 37
     neuronpedia: gemma-2-9b/28-gemmascope-res-16k__l0-37
+    path: layer_28/width_16k/average_l0_37
   - id: layer_28/width_16k/average_l0_65
-    path: layer_28/width_16k/average_l0_65
     l0: 65
+    path: layer_28/width_16k/average_l0_65
   - id: layer_29/width_131k/average_l0_11
-    path: layer_29/width_131k/average_l0_11
     l0: 11
+    path: layer_29/width_131k/average_l0_11
   - id: layer_29/width_131k/average_l0_171
-    path: layer_29/width_131k/average_l0_171
     l0: 171
+    path: layer_29/width_131k/average_l0_171
   - id: layer_29/width_131k/average_l0_19
-    path: layer_29/width_131k/average_l0_19
     l0: 19
+    path: layer_29/width_131k/average_l0_19
   - id: layer_29/width_131k/average_l0_33
-    path: layer_29/width_131k/average_l0_33
     l0: 33
     neuronpedia: gemma-2-9b/29-gemmascope-res-131k__l0-33
+    path: layer_29/width_131k/average_l0_33
   - id: layer_29/width_131k/average_l0_56
-    path: layer_29/width_131k/average_l0_56
     l0: 56
+    path: layer_29/width_131k/average_l0_56
   - id: layer_29/width_131k/average_l0_97
-    path: layer_29/width_131k/average_l0_97
     l0: 97
+    path: layer_29/width_131k/average_l0_97
   - id: layer_29/width_16k/average_l0_119
-    path: layer_29/width_16k/average_l0_119
     l0: 119
+    path: layer_29/width_16k/average_l0_119
   - id: layer_29/width_16k/average_l0_12
-    path: layer_29/width_16k/average_l0_12
     l0: 12
+    path: layer_29/width_16k/average_l0_12
   - id: layer_29/width_16k/average_l0_21
-    path: layer_29/width_16k/average_l0_21
     l0: 21
+    path: layer_29/width_16k/average_l0_21
   - id: layer_29/width_16k/average_l0_224
-    path: layer_29/width_16k/average_l0_224
     l0: 224
+    path: layer_29/width_16k/average_l0_224
   - id: layer_29/width_16k/average_l0_38
-    path: layer_29/width_16k/average_l0_38
     l0: 38
     neuronpedia: gemma-2-9b/29-gemmascope-res-16k__l0-38
+    path: layer_29/width_16k/average_l0_38
   - id: layer_29/width_16k/average_l0_66
-    path: layer_29/width_16k/average_l0_66
     l0: 66
+    path: layer_29/width_16k/average_l0_66
   - id: layer_3/width_131k/average_l0_103
-    path: layer_3/width_131k/average_l0_103
     l0: 103
+    path: layer_3/width_131k/average_l0_103
   - id: layer_3/width_131k/average_l0_14
-    path: layer_3/width_131k/average_l0_14
     l0: 14
+    path: layer_3/width_131k/average_l0_14
   - id: layer_3/width_131k/average_l0_25
-    path: layer_3/width_131k/average_l0_25
     l0: 25
+    path: layer_3/width_131k/average_l0_25
   - id: layer_3/width_131k/average_l0_46
-    path: layer_3/width_131k/average_l0_46
     l0: 46
     neuronpedia: gemma-2-9b/3-gemmascope-res-131k__l0-46
+    path: layer_3/width_131k/average_l0_46
   - id: layer_3/width_131k/average_l0_6
-    path: layer_3/width_131k/average_l0_6
     l0: 6
+    path: layer_3/width_131k/average_l0_6
   - id: layer_3/width_131k/average_l0_9
-    path: layer_3/width_131k/average_l0_9
     l0: 9
+    path: layer_3/width_131k/average_l0_9
   - id: layer_3/width_16k/average_l0_10
-    path: layer_3/width_16k/average_l0_10
     l0: 10
+    path: layer_3/width_16k/average_l0_10
   - id: layer_3/width_16k/average_l0_17
-    path: layer_3/width_16k/average_l0_17
     l0: 17
+    path: layer_3/width_16k/average_l0_17
   - id: layer_3/width_16k/average_l0_229
-    path: layer_3/width_16k/average_l0_229
     l0: 229
+    path: layer_3/width_16k/average_l0_229
   - id: layer_3/width_16k/average_l0_37
-    path: layer_3/width_16k/average_l0_37
     l0: 37
     neuronpedia: gemma-2-9b/3-gemmascope-res-16k__l0-37
+    path: layer_3/width_16k/average_l0_37
   - id: layer_3/width_16k/average_l0_90
-    path: layer_3/width_16k/average_l0_90
     l0: 90
+    path: layer_3/width_16k/average_l0_90
   - id: layer_30/width_131k/average_l0_11
-    path: layer_30/width_131k/average_l0_11
     l0: 11
+    path: layer_30/width_131k/average_l0_11
   - id: layer_30/width_131k/average_l0_170
-    path: layer_30/width_131k/average_l0_170
     l0: 170
+    path: layer_30/width_131k/average_l0_170
   - id: layer_30/width_131k/average_l0_18
-    path: layer_30/width_131k/average_l0_18
     l0: 18
+    path: layer_30/width_131k/average_l0_18
   - id: layer_30/width_131k/average_l0_32
-    path: layer_30/width_131k/average_l0_32
     l0: 32
     neuronpedia: gemma-2-9b/30-gemmascope-res-131k__l0-32
+    path: layer_30/width_131k/average_l0_32
   - id: layer_30/width_131k/average_l0_56
-    path: layer_30/width_131k/average_l0_56
     l0: 56
+    path: layer_30/width_131k/average_l0_56
   - id: layer_30/width_131k/average_l0_95
-    path: layer_30/width_131k/average_l0_95
     l0: 95
+    path: layer_30/width_131k/average_l0_95
   - id: layer_30/width_16k/average_l0_12
-    path: layer_30/width_16k/average_l0_12
     l0: 12
+    path: layer_30/width_16k/average_l0_12
   - id: layer_30/width_16k/average_l0_120
-    path: layer_30/width_16k/average_l0_120
     l0: 120
+    path: layer_30/width_16k/average_l0_120
   - id: layer_30/width_16k/average_l0_21
-    path: layer_30/width_16k/average_l0_21
     l0: 21
+    path: layer_30/width_16k/average_l0_21
   - id: layer_30/width_16k/average_l0_226
-    path: layer_30/width_16k/average_l0_226
     l0: 226
+    path: layer_30/width_16k/average_l0_226
   - id: layer_30/width_16k/average_l0_37
-    path: layer_30/width_16k/average_l0_37
     l0: 37
     neuronpedia: gemma-2-9b/30-gemmascope-res-16k__l0-37
+    path: layer_30/width_16k/average_l0_37
   - id: layer_30/width_16k/average_l0_66
-    path: layer_30/width_16k/average_l0_66
     l0: 66
+    path: layer_30/width_16k/average_l0_66
   - id: layer_31/width_131k/average_l0_10
-    path: layer_31/width_131k/average_l0_10
     l0: 10
     neuronpedia: gemma-2-9b/31-gemmascope-res-131k__l0-10
+    path: layer_31/width_131k/average_l0_10
   - id: layer_31/width_131k/average_l0_160
-    path: layer_31/width_131k/average_l0_160
     l0: 160
     neuronpedia: gemma-2-9b/31-gemmascope-res-131k__l0-160
+    path: layer_31/width_131k/average_l0_160
   - id: layer_31/width_131k/average_l0_18
-    path: layer_31/width_131k/average_l0_18
     l0: 18
     neuronpedia: gemma-2-9b/31-gemmascope-res-131k__l0-18
+    path: layer_31/width_131k/average_l0_18
   - id: layer_31/width_131k/average_l0_31
-    path: layer_31/width_131k/average_l0_31
     l0: 31
     neuronpedia: gemma-2-9b/31-gemmascope-res-131k__l0-31
+    path: layer_31/width_131k/average_l0_31
   - id: layer_31/width_131k/average_l0_52
-    path: layer_31/width_131k/average_l0_52
     l0: 52
     neuronpedia: gemma-2-9b/31-gemmascope-res-131k__l0-52
+    path: layer_31/width_131k/average_l0_52
   - id: layer_31/width_131k/average_l0_92
-    path: layer_31/width_131k/average_l0_92
     l0: 92
+    path: layer_31/width_131k/average_l0_92
   - id: layer_31/width_16k/average_l0_11
-    path: layer_31/width_16k/average_l0_11
     l0: 11
     neuronpedia: gemma-2-9b/31-gemmascope-res-16k__l0-11
+    path: layer_31/width_16k/average_l0_11
   - id: layer_31/width_16k/average_l0_114
-    path: layer_31/width_16k/average_l0_114
     l0: 114
     neuronpedia: gemma-2-9b/31-gemmascope-res-16k__l0-114
+    path: layer_31/width_16k/average_l0_114
   - id: layer_31/width_16k/average_l0_20
-    path: layer_31/width_16k/average_l0_20
     l0: 20
     neuronpedia: gemma-2-9b/31-gemmascope-res-16k__l0-20
+    path: layer_31/width_16k/average_l0_20
   - id: layer_31/width_16k/average_l0_218
-    path: layer_31/width_16k/average_l0_218
     l0: 218
     neuronpedia: gemma-2-9b/31-gemmascope-res-16k__l0-218
+    path: layer_31/width_16k/average_l0_218
   - id: layer_31/width_16k/average_l0_35
-    path: layer_31/width_16k/average_l0_35
     l0: 35
     neuronpedia: gemma-2-9b/31-gemmascope-res-16k__l0-35
+    path: layer_31/width_16k/average_l0_35
   - id: layer_31/width_16k/average_l0_63
-    path: layer_31/width_16k/average_l0_63
     l0: 63
     neuronpedia: gemma-2-9b/31-gemmascope-res-16k__l0-63
+    path: layer_31/width_16k/average_l0_63
   - id: layer_31/width_1m/average_l0_11
-    path: layer_31/width_1m/average_l0_11
     l0: 11
     neuronpedia: gemma-2-9b/31-gemmascope-res-1m__l0-11
+    path: layer_31/width_1m/average_l0_11
   - id: layer_31/width_1m/average_l0_132
-    path: layer_31/width_1m/average_l0_132
     l0: 132
     neuronpedia: gemma-2-9b/31-gemmascope-res-1m__l0-132
+    path: layer_31/width_1m/average_l0_132
   - id: layer_31/width_1m/average_l0_25
-    path: layer_31/width_1m/average_l0_25
     l0: 25
     neuronpedia: gemma-2-9b/31-gemmascope-res-1m__l0-25
+    path: layer_31/width_1m/average_l0_25
   - id: layer_31/width_1m/average_l0_27
-    path: layer_31/width_1m/average_l0_27
     l0: 27
     neuronpedia: gemma-2-9b/31-gemmascope-res-1m__l0-27
+    path: layer_31/width_1m/average_l0_27
   - id: layer_31/width_1m/average_l0_45
-    path: layer_31/width_1m/average_l0_45
     l0: 45
     neuronpedia: gemma-2-9b/31-gemmascope-res-1m__l0-45
+    path: layer_31/width_1m/average_l0_45
   - id: layer_31/width_1m/average_l0_77
-    path: layer_31/width_1m/average_l0_77
     l0: 77
+    path: layer_31/width_1m/average_l0_77
   - id: layer_32/width_131k/average_l0_10
-    path: layer_32/width_131k/average_l0_10
     l0: 10
+    path: layer_32/width_131k/average_l0_10
   - id: layer_32/width_131k/average_l0_158
-    path: layer_32/width_131k/average_l0_158
     l0: 158
+    path: layer_32/width_131k/average_l0_158
   - id: layer_32/width_131k/average_l0_18
-    path: layer_32/width_131k/average_l0_18
     l0: 18
+    path: layer_32/width_131k/average_l0_18
   - id: layer_32/width_131k/average_l0_30
-    path: layer_32/width_131k/average_l0_30
     l0: 30
+    path: layer_32/width_131k/average_l0_30
   - id: layer_32/width_131k/average_l0_51
-    path: layer_32/width_131k/average_l0_51
     l0: 51
     neuronpedia: gemma-2-9b/32-gemmascope-res-131k__l0-51
+    path: layer_32/width_131k/average_l0_51
   - id: layer_32/width_131k/average_l0_88
-    path: layer_32/width_131k/average_l0_88
     l0: 88
+    path: layer_32/width_131k/average_l0_88
   - id: layer_32/width_16k/average_l0_11
-    path: layer_32/width_16k/average_l0_11
     l0: 11
+    path: layer_32/width_16k/average_l0_11
   - id: layer_32/width_16k/average_l0_111
-    path: layer_32/width_16k/average_l0_111
     l0: 111
+    path: layer_32/width_16k/average_l0_111
   - id: layer_32/width_16k/average_l0_20
-    path: layer_32/width_16k/average_l0_20
     l0: 20
+    path: layer_32/width_16k/average_l0_20
   - id: layer_32/width_16k/average_l0_219
-    path: layer_32/width_16k/average_l0_219
     l0: 219
+    path: layer_32/width_16k/average_l0_219
   - id: layer_32/width_16k/average_l0_34
-    path: layer_32/width_16k/average_l0_34
     l0: 34
     neuronpedia: gemma-2-9b/32-gemmascope-res-16k__l0-34
+    path: layer_32/width_16k/average_l0_34
   - id: layer_32/width_16k/average_l0_61
-    path: layer_32/width_16k/average_l0_61
     l0: 61
+    path: layer_32/width_16k/average_l0_61
   - id: layer_33/width_131k/average_l0_10
-    path: layer_33/width_131k/average_l0_10
     l0: 10
+    path: layer_33/width_131k/average_l0_10
   - id: layer_33/width_131k/average_l0_165
-    path: layer_33/width_131k/average_l0_165
     l0: 165
+    path: layer_33/width_131k/average_l0_165
   - id: layer_33/width_131k/average_l0_18
-    path: layer_33/width_131k/average_l0_18
     l0: 18
+    path: layer_33/width_131k/average_l0_18
   - id: layer_33/width_131k/average_l0_30
-    path: layer_33/width_131k/average_l0_30
     l0: 30
+    path: layer_33/width_131k/average_l0_30
   - id: layer_33/width_131k/average_l0_51
-    path: layer_33/width_131k/average_l0_51
     l0: 51
     neuronpedia: gemma-2-9b/33-gemmascope-res-131k__l0-51
+    path: layer_33/width_131k/average_l0_51
   - id: layer_33/width_131k/average_l0_91
-    path: layer_33/width_131k/average_l0_91
     l0: 91
+    path: layer_33/width_131k/average_l0_91
   - id: layer_33/width_16k/average_l0_11
-    path: layer_33/width_16k/average_l0_11
     l0: 11
+    path: layer_33/width_16k/average_l0_11
   - id: layer_33/width_16k/average_l0_114
-    path: layer_33/width_16k/average_l0_114
     l0: 114
+    path: layer_33/width_16k/average_l0_114
   - id: layer_33/width_16k/average_l0_20
-    path: layer_33/width_16k/average_l0_20
     l0: 20
+    path: layer_33/width_16k/average_l0_20
   - id: layer_33/width_16k/average_l0_228
-    path: layer_33/width_16k/average_l0_228
     l0: 228
+    path: layer_33/width_16k/average_l0_228
   - id: layer_33/width_16k/average_l0_34
-    path: layer_33/width_16k/average_l0_34
     l0: 34
     neuronpedia: gemma-2-9b/33-gemmascope-res-16k__l0-34
+    path: layer_33/width_16k/average_l0_34
   - id: layer_33/width_16k/average_l0_63
-    path: layer_33/width_16k/average_l0_63
     l0: 63
+    path: layer_33/width_16k/average_l0_63
   - id: layer_34/width_131k/average_l0_10
-    path: layer_34/width_131k/average_l0_10
     l0: 10
+    path: layer_34/width_131k/average_l0_10
   - id: layer_34/width_131k/average_l0_163
-    path: layer_34/width_131k/average_l0_163
     l0: 163
+    path: layer_34/width_131k/average_l0_163
   - id: layer_34/width_131k/average_l0_17
-    path: layer_34/width_131k/average_l0_17
     l0: 17
+    path: layer_34/width_131k/average_l0_17
   - id: layer_34/width_131k/average_l0_30
-    path: layer_34/width_131k/average_l0_30
     l0: 30
+    path: layer_34/width_131k/average_l0_30
   - id: layer_34/width_131k/average_l0_51
-    path: layer_34/width_131k/average_l0_51
     l0: 51
     neuronpedia: gemma-2-9b/34-gemmascope-res-131k__l0-51
+    path: layer_34/width_131k/average_l0_51
   - id: layer_34/width_131k/average_l0_89
-    path: layer_34/width_131k/average_l0_89
     l0: 89
+    path: layer_34/width_131k/average_l0_89
   - id: layer_34/width_16k/average_l0_11
-    path: layer_34/width_16k/average_l0_11
     l0: 11
+    path: layer_34/width_16k/average_l0_11
   - id: layer_34/width_16k/average_l0_114
-    path: layer_34/width_16k/average_l0_114
     l0: 114
+    path: layer_34/width_16k/average_l0_114
   - id: layer_34/width_16k/average_l0_19
-    path: layer_34/width_16k/average_l0_19
     l0: 19
+    path: layer_34/width_16k/average_l0_19
   - id: layer_34/width_16k/average_l0_229
-    path: layer_34/width_16k/average_l0_229
     l0: 229
+    path: layer_34/width_16k/average_l0_229
   - id: layer_34/width_16k/average_l0_34
-    path: layer_34/width_16k/average_l0_34
     l0: 34
     neuronpedia: gemma-2-9b/34-gemmascope-res-16k__l0-34
+    path: layer_34/width_16k/average_l0_34
   - id: layer_34/width_16k/average_l0_60
-    path: layer_34/width_16k/average_l0_60
     l0: 60
+    path: layer_34/width_16k/average_l0_60
   - id: layer_35/width_131k/average_l0_10
-    path: layer_35/width_131k/average_l0_10
     l0: 10
+    path: layer_35/width_131k/average_l0_10
   - id: layer_35/width_131k/average_l0_17
-    path: layer_35/width_131k/average_l0_17
     l0: 17
+    path: layer_35/width_131k/average_l0_17
   - id: layer_35/width_131k/average_l0_171
-    path: layer_35/width_131k/average_l0_171
     l0: 171
+    path: layer_35/width_131k/average_l0_171
   - id: layer_35/width_131k/average_l0_30
-    path: layer_35/width_131k/average_l0_30
     l0: 30
+    path: layer_35/width_131k/average_l0_30
   - id: layer_35/width_131k/average_l0_51
-    path: layer_35/width_131k/average_l0_51
     l0: 51
     neuronpedia: gemma-2-9b/35-gemmascope-res-131k__l0-51
+    path: layer_35/width_131k/average_l0_51
   - id: layer_35/width_131k/average_l0_94
-    path: layer_35/width_131k/average_l0_94
     l0: 94
+    path: layer_35/width_131k/average_l0_94
   - id: layer_35/width_16k/average_l0_11
-    path: layer_35/width_16k/average_l0_11
     l0: 11
+    path: layer_35/width_16k/average_l0_11
   - id: layer_35/width_16k/average_l0_120
-    path: layer_35/width_16k/average_l0_120
     l0: 120
+    path: layer_35/width_16k/average_l0_120
   - id: layer_35/width_16k/average_l0_19
-    path: layer_35/width_16k/average_l0_19
     l0: 19
+    path: layer_35/width_16k/average_l0_19
   - id: layer_35/width_16k/average_l0_246
-    path: layer_35/width_16k/average_l0_246
     l0: 246
+    path: layer_35/width_16k/average_l0_246
   - id: layer_35/width_16k/average_l0_34
-    path: layer_35/width_16k/average_l0_34
     l0: 34
     neuronpedia: gemma-2-9b/35-gemmascope-res-16k__l0-34
+    path: layer_35/width_16k/average_l0_34
   - id: layer_35/width_16k/average_l0_61
-    path: layer_35/width_16k/average_l0_61
     l0: 61
+    path: layer_35/width_16k/average_l0_61
   - id: layer_36/width_131k/average_l0_10
-    path: layer_36/width_131k/average_l0_10
     l0: 10
+    path: layer_36/width_131k/average_l0_10
   - id: layer_36/width_131k/average_l0_17
-    path: layer_36/width_131k/average_l0_17
     l0: 17
+    path: layer_36/width_131k/average_l0_17
   - id: layer_36/width_131k/average_l0_180
-    path: layer_36/width_131k/average_l0_180
     l0: 180
+    path: layer_36/width_131k/average_l0_180
   - id: layer_36/width_131k/average_l0_30
-    path: layer_36/width_131k/average_l0_30
     l0: 30
+    path: layer_36/width_131k/average_l0_30
   - id: layer_36/width_131k/average_l0_51
-    path: layer_36/width_131k/average_l0_51
     l0: 51
     neuronpedia: gemma-2-9b/36-gemmascope-res-131k__l0-51
+    path: layer_36/width_131k/average_l0_51
   - id: layer_36/width_131k/average_l0_93
-    path: layer_36/width_131k/average_l0_93
     l0: 93
+    path: layer_36/width_131k/average_l0_93
   - id: layer_36/width_16k/average_l0_11
-    path: layer_36/width_16k/average_l0_11
     l0: 11
+    path: layer_36/width_16k/average_l0_11
   - id: layer_36/width_16k/average_l0_120
-    path: layer_36/width_16k/average_l0_120
     l0: 120
+    path: layer_36/width_16k/average_l0_120
   - id: layer_36/width_16k/average_l0_19
-    path: layer_36/width_16k/average_l0_19
     l0: 19
+    path: layer_36/width_16k/average_l0_19
   - id: layer_36/width_16k/average_l0_252
-    path: layer_36/width_16k/average_l0_252
     l0: 252
+    path: layer_36/width_16k/average_l0_252
   - id: layer_36/width_16k/average_l0_34
-    path: layer_36/width_16k/average_l0_34
     l0: 34
     neuronpedia: gemma-2-9b/36-gemmascope-res-16k__l0-34
+    path: layer_36/width_16k/average_l0_34
   - id: layer_36/width_16k/average_l0_61
-    path: layer_36/width_16k/average_l0_61
     l0: 61
+    path: layer_36/width_16k/average_l0_61
   - id: layer_37/width_131k/average_l0_10
-    path: layer_37/width_131k/average_l0_10
     l0: 10
+    path: layer_37/width_131k/average_l0_10
   - id: layer_37/width_131k/average_l0_18
-    path: layer_37/width_131k/average_l0_18
     l0: 18
+    path: layer_37/width_131k/average_l0_18
   - id: layer_37/width_131k/average_l0_184
-    path: layer_37/width_131k/average_l0_184
     l0: 184
+    path: layer_37/width_131k/average_l0_184
   - id: layer_37/width_131k/average_l0_30
-    path: layer_37/width_131k/average_l0_30
     l0: 30
+    path: layer_37/width_131k/average_l0_30
   - id: layer_37/width_131k/average_l0_53
-    path: layer_37/width_131k/average_l0_53
     l0: 53
     neuronpedia: gemma-2-9b/37-gemmascope-res-131k__l0-53
+    path: layer_37/width_131k/average_l0_53
   - id: layer_37/width_131k/average_l0_96
-    path: layer_37/width_131k/average_l0_96
     l0: 96
+    path: layer_37/width_131k/average_l0_96
   - id: layer_37/width_16k/average_l0_11
-    path: layer_37/width_16k/average_l0_11
     l0: 11
+    path: layer_37/width_16k/average_l0_11
   - id: layer_37/width_16k/average_l0_124
-    path: layer_37/width_16k/average_l0_124
     l0: 124
+    path: layer_37/width_16k/average_l0_124
   - id: layer_37/width_16k/average_l0_20
-    path: layer_37/width_16k/average_l0_20
     l0: 20
+    path: layer_37/width_16k/average_l0_20
   - id: layer_37/width_16k/average_l0_266
-    path: layer_37/width_16k/average_l0_266
     l0: 266
+    path: layer_37/width_16k/average_l0_266
   - id: layer_37/width_16k/average_l0_34
-    path: layer_37/width_16k/average_l0_34
     l0: 34
     neuronpedia: gemma-2-9b/37-gemmascope-res-16k__l0-34
+    path: layer_37/width_16k/average_l0_34
   - id: layer_37/width_16k/average_l0_63
-    path: layer_37/width_16k/average_l0_63
     l0: 63
+    path: layer_37/width_16k/average_l0_63
   - id: layer_38/width_131k/average_l0_10
-    path: layer_38/width_131k/average_l0_10
     l0: 10
+    path: layer_38/width_131k/average_l0_10
   - id: layer_38/width_131k/average_l0_101
-    path: layer_38/width_131k/average_l0_101
     l0: 101
+    path: layer_38/width_131k/average_l0_101
   - id: layer_38/width_131k/average_l0_18
-    path: layer_38/width_131k/average_l0_18
     l0: 18
+    path: layer_38/width_131k/average_l0_18
   - id: layer_38/width_131k/average_l0_194
-    path: layer_38/width_131k/average_l0_194
     l0: 194
+    path: layer_38/width_131k/average_l0_194
   - id: layer_38/width_131k/average_l0_30
-    path: layer_38/width_131k/average_l0_30
     l0: 30
+    path: layer_38/width_131k/average_l0_30
   - id: layer_38/width_131k/average_l0_53
-    path: layer_38/width_131k/average_l0_53
     l0: 53
     neuronpedia: gemma-2-9b/38-gemmascope-res-131k__l0-53
+    path: layer_38/width_131k/average_l0_53
   - id: layer_38/width_16k/average_l0_11
-    path: layer_38/width_16k/average_l0_11
     l0: 11
+    path: layer_38/width_16k/average_l0_11
   - id: layer_38/width_16k/average_l0_128
-    path: layer_38/width_16k/average_l0_128
     l0: 128
+    path: layer_38/width_16k/average_l0_128
   - id: layer_38/width_16k/average_l0_20
-    path: layer_38/width_16k/average_l0_20
     l0: 20
+    path: layer_38/width_16k/average_l0_20
   - id: layer_38/width_16k/average_l0_286
-    path: layer_38/width_16k/average_l0_286
     l0: 286
+    path: layer_38/width_16k/average_l0_286
   - id: layer_38/width_16k/average_l0_34
-    path: layer_38/width_16k/average_l0_34
     l0: 34
     neuronpedia: gemma-2-9b/38-gemmascope-res-16k__l0-34
+    path: layer_38/width_16k/average_l0_34
   - id: layer_38/width_16k/average_l0_64
-    path: layer_38/width_16k/average_l0_64
     l0: 64
+    path: layer_38/width_16k/average_l0_64
   - id: layer_39/width_131k/average_l0_10
-    path: layer_39/width_131k/average_l0_10
     l0: 10
+    path: layer_39/width_131k/average_l0_10
   - id: layer_39/width_131k/average_l0_18
-    path: layer_39/width_131k/average_l0_18
     l0: 18
+    path: layer_39/width_131k/average_l0_18
   - id: layer_39/width_131k/average_l0_199
-    path: layer_39/width_131k/average_l0_199
     l0: 199
+    path: layer_39/width_131k/average_l0_199
   - id: layer_39/width_131k/average_l0_30
-    path: layer_39/width_131k/average_l0_30
     l0: 30
+    path: layer_39/width_131k/average_l0_30
   - id: layer_39/width_131k/average_l0_54
-    path: layer_39/width_131k/average_l0_54
     l0: 54
     neuronpedia: gemma-2-9b/39-gemmascope-res-131k__l0-54
+    path: layer_39/width_131k/average_l0_54
   - id: layer_39/width_131k/average_l0_99
-    path: layer_39/width_131k/average_l0_99
     l0: 99
+    path: layer_39/width_131k/average_l0_99
   - id: layer_39/width_16k/average_l0_11
-    path: layer_39/width_16k/average_l0_11
     l0: 11
+    path: layer_39/width_16k/average_l0_11
   - id: layer_39/width_16k/average_l0_131
-    path: layer_39/width_16k/average_l0_131
     l0: 131
+    path: layer_39/width_16k/average_l0_131
   - id: layer_39/width_16k/average_l0_19
-    path: layer_39/width_16k/average_l0_19
     l0: 19
+    path: layer_39/width_16k/average_l0_19
   - id: layer_39/width_16k/average_l0_298
-    path: layer_39/width_16k/average_l0_298
     l0: 298
+    path: layer_39/width_16k/average_l0_298
   - id: layer_39/width_16k/average_l0_34
-    path: layer_39/width_16k/average_l0_34
     l0: 34
     neuronpedia: gemma-2-9b/39-gemmascope-res-16k__l0-34
+    path: layer_39/width_16k/average_l0_34
   - id: layer_39/width_16k/average_l0_64
-    path: layer_39/width_16k/average_l0_64
     l0: 64
+    path: layer_39/width_16k/average_l0_64
   - id: layer_4/width_131k/average_l0_101
-    path: layer_4/width_131k/average_l0_101
     l0: 101
+    path: layer_4/width_131k/average_l0_101
   - id: layer_4/width_131k/average_l0_16
-    path: layer_4/width_131k/average_l0_16
     l0: 16
+    path: layer_4/width_131k/average_l0_16
   - id: layer_4/width_131k/average_l0_28
-    path: layer_4/width_131k/average_l0_28
     l0: 28
+    path: layer_4/width_131k/average_l0_28
   - id: layer_4/width_131k/average_l0_51
-    path: layer_4/width_131k/average_l0_51
     l0: 51
     neuronpedia: gemma-2-9b/4-gemmascope-res-131k__l0-51
+    path: layer_4/width_131k/average_l0_51
   - id: layer_4/width_131k/average_l0_6
-    path: layer_4/width_131k/average_l0_6
     l0: 6
+    path: layer_4/width_131k/average_l0_6
   - id: layer_4/width_131k/average_l0_9
-    path: layer_4/width_131k/average_l0_9
     l0: 9
+    path: layer_4/width_131k/average_l0_9
   - id: layer_4/width_16k/average_l0_10
-    path: layer_4/width_16k/average_l0_10
     l0: 10
+    path: layer_4/width_16k/average_l0_10
   - id: layer_4/width_16k/average_l0_18
-    path: layer_4/width_16k/average_l0_18
     l0: 18
+    path: layer_4/width_16k/average_l0_18
   - id: layer_4/width_16k/average_l0_234
-    path: layer_4/width_16k/average_l0_234
     l0: 234
+    path: layer_4/width_16k/average_l0_234
   - id: layer_4/width_16k/average_l0_37
-    path: layer_4/width_16k/average_l0_37
     l0: 37
     neuronpedia: gemma-2-9b/4-gemmascope-res-16k__l0-37
+    path: layer_4/width_16k/average_l0_37
   - id: layer_4/width_16k/average_l0_91
-    path: layer_4/width_16k/average_l0_91
     l0: 91
+    path: layer_4/width_16k/average_l0_91
   - id: layer_40/width_131k/average_l0_10
-    path: layer_40/width_131k/average_l0_10
     l0: 10
+    path: layer_40/width_131k/average_l0_10
   - id: layer_40/width_131k/average_l0_17
-    path: layer_40/width_131k/average_l0_17
     l0: 17
+    path: layer_40/width_131k/average_l0_17
   - id: layer_40/width_131k/average_l0_193
-    path: layer_40/width_131k/average_l0_193
     l0: 193
+    path: layer_40/width_131k/average_l0_193
   - id: layer_40/width_131k/average_l0_29
-    path: layer_40/width_131k/average_l0_29
     l0: 29
+    path: layer_40/width_131k/average_l0_29
   - id: layer_40/width_131k/average_l0_49
-    path: layer_40/width_131k/average_l0_49
     l0: 49
     neuronpedia: gemma-2-9b/40-gemmascope-res-131k__l0-49
+    path: layer_40/width_131k/average_l0_49
   - id: layer_40/width_131k/average_l0_94
-    path: layer_40/width_131k/average_l0_94
     l0: 94
+    path: layer_40/width_131k/average_l0_94
   - id: layer_40/width_16k/average_l0_10
-    path: layer_40/width_16k/average_l0_10
     l0: 10
+    path: layer_40/width_16k/average_l0_10
   - id: layer_40/width_16k/average_l0_125
-    path: layer_40/width_16k/average_l0_125
     l0: 125
+    path: layer_40/width_16k/average_l0_125
   - id: layer_40/width_16k/average_l0_18
-    path: layer_40/width_16k/average_l0_18
     l0: 18
+    path: layer_40/width_16k/average_l0_18
   - id: layer_40/width_16k/average_l0_292
-    path: layer_40/width_16k/average_l0_292
     l0: 292
+    path: layer_40/width_16k/average_l0_292
   - id: layer_40/width_16k/average_l0_32
-    path: layer_40/width_16k/average_l0_32
     l0: 32
     neuronpedia: gemma-2-9b/40-gemmascope-res-16k__l0-32
+    path: layer_40/width_16k/average_l0_32
   - id: layer_40/width_16k/average_l0_61
-    path: layer_40/width_16k/average_l0_61
     l0: 61
+    path: layer_40/width_16k/average_l0_61
   - id: layer_41/width_131k/average_l0_10
-    path: layer_41/width_131k/average_l0_10
     l0: 10
+    path: layer_41/width_131k/average_l0_10
   - id: layer_41/width_131k/average_l0_15
-    path: layer_41/width_131k/average_l0_15
     l0: 15
+    path: layer_41/width_131k/average_l0_15
   - id: layer_41/width_131k/average_l0_175
-    path: layer_41/width_131k/average_l0_175
     l0: 175
+    path: layer_41/width_131k/average_l0_175
   - id: layer_41/width_131k/average_l0_26
-    path: layer_41/width_131k/average_l0_26
     l0: 26
+    path: layer_41/width_131k/average_l0_26
   - id: layer_41/width_131k/average_l0_45
-    path: layer_41/width_131k/average_l0_45
     l0: 45
     neuronpedia: gemma-2-9b/41-gemmascope-res-131k__l0-45
+    path: layer_41/width_131k/average_l0_45
   - id: layer_41/width_131k/average_l0_84
-    path: layer_41/width_131k/average_l0_84
     l0: 84
+    path: layer_41/width_131k/average_l0_84
   - id: layer_41/width_16k/average_l0_10
-    path: layer_41/width_16k/average_l0_10
     l0: 10
+    path: layer_41/width_16k/average_l0_10
   - id: layer_41/width_16k/average_l0_113
-    path: layer_41/width_16k/average_l0_113
     l0: 113
+    path: layer_41/width_16k/average_l0_113
   - id: layer_41/width_16k/average_l0_16
-    path: layer_41/width_16k/average_l0_16
     l0: 16
+    path: layer_41/width_16k/average_l0_16
   - id: layer_41/width_16k/average_l0_270
-    path: layer_41/width_16k/average_l0_270
     l0: 270
+    path: layer_41/width_16k/average_l0_270
   - id: layer_41/width_16k/average_l0_28
-    path: layer_41/width_16k/average_l0_28
     l0: 28
+    path: layer_41/width_16k/average_l0_28
   - id: layer_41/width_16k/average_l0_52
-    path: layer_41/width_16k/average_l0_52
     l0: 52
     neuronpedia: gemma-2-9b/41-gemmascope-res-16k__l0-52
+    path: layer_41/width_16k/average_l0_52
   - id: layer_5/width_131k/average_l0_10
-    path: layer_5/width_131k/average_l0_10
     l0: 10
+    path: layer_5/width_131k/average_l0_10
   - id: layer_5/width_131k/average_l0_16
-    path: layer_5/width_131k/average_l0_16
     l0: 16
+    path: layer_5/width_131k/average_l0_16
   - id: layer_5/width_131k/average_l0_29
-    path: layer_5/width_131k/average_l0_29
     l0: 29
+    path: layer_5/width_131k/average_l0_29
   - id: layer_5/width_131k/average_l0_51
-    path: layer_5/width_131k/average_l0_51
     l0: 51
     neuronpedia: gemma-2-9b/5-gemmascope-res-131k__l0-51
+    path: layer_5/width_131k/average_l0_51
   - id: layer_5/width_131k/average_l0_6
-    path: layer_5/width_131k/average_l0_6
     l0: 6
+    path: layer_5/width_131k/average_l0_6
   - id: layer_5/width_131k/average_l0_94
-    path: layer_5/width_131k/average_l0_94
     l0: 94
+    path: layer_5/width_131k/average_l0_94
   - id: layer_5/width_16k/average_l0_11
-    path: layer_5/width_16k/average_l0_11
     l0: 11
+    path: layer_5/width_16k/average_l0_11
   - id: layer_5/width_16k/average_l0_193
-    path: layer_5/width_16k/average_l0_193
     l0: 193
+    path: layer_5/width_16k/average_l0_193
   - id: layer_5/width_16k/average_l0_20
-    path: layer_5/width_16k/average_l0_20
     l0: 20
+    path: layer_5/width_16k/average_l0_20
   - id: layer_5/width_16k/average_l0_37
-    path: layer_5/width_16k/average_l0_37
     l0: 37
     neuronpedia: gemma-2-9b/5-gemmascope-res-16k__l0-37
+    path: layer_5/width_16k/average_l0_37
   - id: layer_5/width_16k/average_l0_77
-    path: layer_5/width_16k/average_l0_77
     l0: 77
+    path: layer_5/width_16k/average_l0_77
   - id: layer_6/width_131k/average_l0_12
-    path: layer_6/width_131k/average_l0_12
     l0: 12
+    path: layer_6/width_131k/average_l0_12
   - id: layer_6/width_131k/average_l0_120
-    path: layer_6/width_131k/average_l0_120
     l0: 120
+    path: layer_6/width_131k/average_l0_120
   - id: layer_6/width_131k/average_l0_21
-    path: layer_6/width_131k/average_l0_21
     l0: 21
+    path: layer_6/width_131k/average_l0_21
   - id: layer_6/width_131k/average_l0_36
-    path: layer_6/width_131k/average_l0_36
     l0: 36
+    path: layer_6/width_131k/average_l0_36
   - id: layer_6/width_131k/average_l0_66
-    path: layer_6/width_131k/average_l0_66
     l0: 66
     neuronpedia: gemma-2-9b/6-gemmascope-res-131k__l0-66
+    path: layer_6/width_131k/average_l0_66
   - id: layer_6/width_131k/average_l0_7
-    path: layer_6/width_131k/average_l0_7
     l0: 7
+    path: layer_6/width_131k/average_l0_7
   - id: layer_6/width_16k/average_l0_14
-    path: layer_6/width_16k/average_l0_14
     l0: 14
+    path: layer_6/width_16k/average_l0_14
   - id: layer_6/width_16k/average_l0_224
-    path: layer_6/width_16k/average_l0_224
     l0: 224
+    path: layer_6/width_16k/average_l0_224
   - id: layer_6/width_16k/average_l0_25
-    path: layer_6/width_16k/average_l0_25
     l0: 25
+    path: layer_6/width_16k/average_l0_25
   - id: layer_6/width_16k/average_l0_47
-    path: layer_6/width_16k/average_l0_47
     l0: 47
     neuronpedia: gemma-2-9b/6-gemmascope-res-16k__l0-47
+    path: layer_6/width_16k/average_l0_47
   - id: layer_6/width_16k/average_l0_8
-    path: layer_6/width_16k/average_l0_8
     l0: 8
+    path: layer_6/width_16k/average_l0_8
   - id: layer_6/width_16k/average_l0_93
-    path: layer_6/width_16k/average_l0_93
     l0: 93
+    path: layer_6/width_16k/average_l0_93
   - id: layer_7/width_131k/average_l0_119
-    path: layer_7/width_131k/average_l0_119
     l0: 119
+    path: layer_7/width_131k/average_l0_119
   - id: layer_7/width_131k/average_l0_13
-    path: layer_7/width_131k/average_l0_13
     l0: 13
+    path: layer_7/width_131k/average_l0_13
   - id: layer_7/width_131k/average_l0_21
-    path: layer_7/width_131k/average_l0_21
     l0: 21
+    path: layer_7/width_131k/average_l0_21
   - id: layer_7/width_131k/average_l0_38
-    path: layer_7/width_131k/average_l0_38
     l0: 38
     neuronpedia: gemma-2-9b/7-gemmascope-res-131k__l0-38
+    path: layer_7/width_131k/average_l0_38
   - id: layer_7/width_131k/average_l0_65
-    path: layer_7/width_131k/average_l0_65
     l0: 65
+    path: layer_7/width_131k/average_l0_65
   - id: layer_7/width_131k/average_l0_8
-    path: layer_7/width_131k/average_l0_8
     l0: 8
+    path: layer_7/width_131k/average_l0_8
   - id: layer_7/width_16k/average_l0_14
-    path: layer_7/width_16k/average_l0_14
     l0: 14
+    path: layer_7/width_16k/average_l0_14
   - id: layer_7/width_16k/average_l0_198
-    path: layer_7/width_16k/average_l0_198
     l0: 198
+    path: layer_7/width_16k/average_l0_198
   - id: layer_7/width_16k/average_l0_25
-    path: layer_7/width_16k/average_l0_25
     l0: 25
+    path: layer_7/width_16k/average_l0_25
   - id: layer_7/width_16k/average_l0_46
-    path: layer_7/width_16k/average_l0_46
     l0: 46
     neuronpedia: gemma-2-9b/7-gemmascope-res-16k__l0-46
+    path: layer_7/width_16k/average_l0_46
   - id: layer_7/width_16k/average_l0_8
-    path: layer_7/width_16k/average_l0_8
     l0: 8
+    path: layer_7/width_16k/average_l0_8
   - id: layer_7/width_16k/average_l0_92
-    path: layer_7/width_16k/average_l0_92
     l0: 92
+    path: layer_7/width_16k/average_l0_92
   - id: layer_8/width_131k/average_l0_129
-    path: layer_8/width_131k/average_l0_129
     l0: 129
+    path: layer_8/width_131k/average_l0_129
   - id: layer_8/width_131k/average_l0_14
-    path: layer_8/width_131k/average_l0_14
     l0: 14
+    path: layer_8/width_131k/average_l0_14
   - id: layer_8/width_131k/average_l0_24
-    path: layer_8/width_131k/average_l0_24
     l0: 24
+    path: layer_8/width_131k/average_l0_24
   - id: layer_8/width_131k/average_l0_41
-    path: layer_8/width_131k/average_l0_41
     l0: 41
     neuronpedia: gemma-2-9b/8-gemmascope-res-131k__l0-41
+    path: layer_8/width_131k/average_l0_41
   - id: layer_8/width_131k/average_l0_72
-    path: layer_8/width_131k/average_l0_72
     l0: 72
+    path: layer_8/width_131k/average_l0_72
   - id: layer_8/width_131k/average_l0_8
-    path: layer_8/width_131k/average_l0_8
     l0: 8
+    path: layer_8/width_131k/average_l0_8
   - id: layer_8/width_16k/average_l0_16
-    path: layer_8/width_16k/average_l0_16
     l0: 16
+    path: layer_8/width_16k/average_l0_16
   - id: layer_8/width_16k/average_l0_207
-    path: layer_8/width_16k/average_l0_207
     l0: 207
+    path: layer_8/width_16k/average_l0_207
   - id: layer_8/width_16k/average_l0_28
-    path: layer_8/width_16k/average_l0_28
     l0: 28
+    path: layer_8/width_16k/average_l0_28
   - id: layer_8/width_16k/average_l0_51
-    path: layer_8/width_16k/average_l0_51
     l0: 51
     neuronpedia: gemma-2-9b/8-gemmascope-res-16k__l0-51
+    path: layer_8/width_16k/average_l0_51
   - id: layer_8/width_16k/average_l0_9
-    path: layer_8/width_16k/average_l0_9
     l0: 9
+    path: layer_8/width_16k/average_l0_9
   - id: layer_8/width_16k/average_l0_99
-    path: layer_8/width_16k/average_l0_99
     l0: 99
+    path: layer_8/width_16k/average_l0_99
   - id: layer_9/width_131k/average_l0_134
-    path: layer_9/width_131k/average_l0_134
     l0: 134
     neuronpedia: gemma-2-9b/9-gemmascope-res-131k__l0-134
+    path: layer_9/width_131k/average_l0_134
   - id: layer_9/width_131k/average_l0_14
-    path: layer_9/width_131k/average_l0_14
     l0: 14
     neuronpedia: gemma-2-9b/9-gemmascope-res-131k__l0-14
+    path: layer_9/width_131k/average_l0_14
   - id: layer_9/width_131k/average_l0_25
-    path: layer_9/width_131k/average_l0_25
     l0: 25
     neuronpedia: gemma-2-9b/9-gemmascope-res-131k__l0-25
+    path: layer_9/width_131k/average_l0_25
   - id: layer_9/width_131k/average_l0_42
-    path: layer_9/width_131k/average_l0_42
     l0: 42
     neuronpedia: gemma-2-9b/9-gemmascope-res-131k__l0-42
+    path: layer_9/width_131k/average_l0_42
   - id: layer_9/width_131k/average_l0_75
-    path: layer_9/width_131k/average_l0_75
     l0: 75
+    path: layer_9/width_131k/average_l0_75
   - id: layer_9/width_131k/average_l0_8
-    path: layer_9/width_131k/average_l0_8
     l0: 8
     neuronpedia: gemma-2-9b/9-gemmascope-res-131k__l0-8
+    path: layer_9/width_131k/average_l0_8
   - id: layer_9/width_16k/average_l0_100
-    path: layer_9/width_16k/average_l0_100
     l0: 100
+    path: layer_9/width_16k/average_l0_100
   - id: layer_9/width_16k/average_l0_16
-    path: layer_9/width_16k/average_l0_16
     l0: 16
     neuronpedia: gemma-2-9b/9-gemmascope-res-16k__l0-16
+    path: layer_9/width_16k/average_l0_16
   - id: layer_9/width_16k/average_l0_209
-    path: layer_9/width_16k/average_l0_209
     l0: 209
     neuronpedia: gemma-2-9b/9-gemmascope-res-16k__l0-209
+    path: layer_9/width_16k/average_l0_209
   - id: layer_9/width_16k/average_l0_28
-    path: layer_9/width_16k/average_l0_28
     l0: 28
     neuronpedia: gemma-2-9b/9-gemmascope-res-16k__l0-28
+    path: layer_9/width_16k/average_l0_28
   - id: layer_9/width_16k/average_l0_51
-    path: layer_9/width_16k/average_l0_51
     l0: 51
     neuronpedia: gemma-2-9b/9-gemmascope-res-16k__l0-51
+    path: layer_9/width_16k/average_l0_51
   - id: layer_9/width_16k/average_l0_9
-    path: layer_9/width_16k/average_l0_9
     l0: 9
     neuronpedia: gemma-2-9b/9-gemmascope-res-16k__l0-9
+    path: layer_9/width_16k/average_l0_9
   - id: layer_9/width_1m/average_l0_122
-    path: layer_9/width_1m/average_l0_122
     l0: 122
+    path: layer_9/width_1m/average_l0_122
   - id: layer_9/width_1m/average_l0_14
-    path: layer_9/width_1m/average_l0_14
     l0: 14
     neuronpedia: gemma-2-9b/9-gemmascope-res-1m__l0-14
+    path: layer_9/width_1m/average_l0_14
   - id: layer_9/width_1m/average_l0_24
-    path: layer_9/width_1m/average_l0_24
     l0: 24
     neuronpedia: gemma-2-9b/9-gemmascope-res-1m__l0-24
+    path: layer_9/width_1m/average_l0_24
   - id: layer_9/width_1m/average_l0_41
-    path: layer_9/width_1m/average_l0_41
     l0: 41
     neuronpedia: gemma-2-9b/9-gemmascope-res-1m__l0-41
+    path: layer_9/width_1m/average_l0_41
   - id: layer_9/width_1m/average_l0_70
-    path: layer_9/width_1m/average_l0_70
     l0: 70
     neuronpedia: gemma-2-9b/9-gemmascope-res-1m__l0-70
+    path: layer_9/width_1m/average_l0_70
   - id: layer_9/width_1m/average_l0_9
-    path: layer_9/width_1m/average_l0_9
     l0: 9
     neuronpedia: gemma-2-9b/9-gemmascope-res-1m__l0-9
+    path: layer_9/width_1m/average_l0_9
 gemma-scope-9b-pt-res-canonical:
+  conversion_func: gemma_2
+  model: gemma-2-9b
   repo_id: google/gemma-scope-9b-pt-res
-  model: gemma-2-9b
-  conversion_func: gemma_2
   saes:
   - id: layer_0/width_16k/canonical
-    path: layer_0/width_16k/average_l0_129
     neuronpedia: gemma-2-9b/0-gemmascope-res-16k
+    path: layer_0/width_16k/average_l0_129
   - id: layer_1/width_16k/canonical
-    path: layer_1/width_16k/average_l0_69
     neuronpedia: gemma-2-9b/1-gemmascope-res-16k
+    path: layer_1/width_16k/average_l0_69
   - id: layer_2/width_16k/canonical
-    path: layer_2/width_16k/average_l0_67
     neuronpedia: gemma-2-9b/2-gemmascope-res-16k
+    path: layer_2/width_16k/average_l0_67
   - id: layer_3/width_16k/canonical
-    path: layer_3/width_16k/average_l0_90
     neuronpedia: gemma-2-9b/3-gemmascope-res-16k
+    path: layer_3/width_16k/average_l0_90
   - id: layer_4/width_16k/canonical
-    path: layer_4/width_16k/average_l0_91
     neuronpedia: gemma-2-9b/4-gemmascope-res-16k
+    path: layer_4/width_16k/average_l0_91
   - id: layer_5/width_16k/canonical
-    path: layer_5/width_16k/average_l0_77
     neuronpedia: gemma-2-9b/5-gemmascope-res-16k
+    path: layer_5/width_16k/average_l0_77
   - id: layer_6/width_16k/canonical
-    path: layer_6/width_16k/average_l0_93
     neuronpedia: gemma-2-9b/6-gemmascope-res-16k
+    path: layer_6/width_16k/average_l0_93
   - id: layer_7/width_16k/canonical
-    path: layer_7/width_16k/average_l0_92
     neuronpedia: gemma-2-9b/7-gemmascope-res-16k
+    path: layer_7/width_16k/average_l0_92
   - id: layer_8/width_16k/canonical
-    path: layer_8/width_16k/average_l0_99
     neuronpedia: gemma-2-9b/8-gemmascope-res-16k
+    path: layer_8/width_16k/average_l0_99
   - id: layer_9/width_16k/canonical
-    path: layer_9/width_16k/average_l0_100
     neuronpedia: gemma-2-9b/9-gemmascope-res-16k
+    path: layer_9/width_16k/average_l0_100
   - id: layer_10/width_16k/canonical
-    path: layer_10/width_16k/average_l0_113
     neuronpedia: gemma-2-9b/10-gemmascope-res-16k
+    path: layer_10/width_16k/average_l0_113
   - id: layer_11/width_16k/canonical
-    path: layer_11/width_16k/average_l0_118
     neuronpedia: gemma-2-9b/11-gemmascope-res-16k
+    path: layer_11/width_16k/average_l0_118
   - id: layer_12/width_16k/canonical
-    path: layer_12/width_16k/average_l0_130
     neuronpedia: gemma-2-9b/12-gemmascope-res-16k
+    path: layer_12/width_16k/average_l0_130
   - id: layer_13/width_16k/canonical
-    path: layer_13/width_16k/average_l0_132
     neuronpedia: gemma-2-9b/13-gemmascope-res-16k
+    path: layer_13/width_16k/average_l0_132
   - id: layer_14/width_16k/canonical
-    path: layer_14/width_16k/average_l0_67
     neuronpedia: gemma-2-9b/14-gemmascope-res-16k
+    path: layer_14/width_16k/average_l0_67
   - id: layer_15/width_16k/canonical
-    path: layer_15/width_16k/average_l0_131
     neuronpedia: gemma-2-9b/15-gemmascope-res-16k
+    path: layer_15/width_16k/average_l0_131
   - id: layer_16/width_16k/canonical
-    path: layer_16/width_16k/average_l0_75
     neuronpedia: gemma-2-9b/16-gemmascope-res-16k
+    path: layer_16/width_16k/average_l0_75
   - id: layer_17/width_16k/canonical
-    path: layer_17/width_16k/average_l0_73
     neuronpedia: gemma-2-9b/17-gemmascope-res-16k
+    path: layer_17/width_16k/average_l0_73
   - id: layer_18/width_16k/canonical
-    path: layer_18/width_16k/average_l0_71
     neuronpedia: gemma-2-9b/18-gemmascope-res-16k
+    path: layer_18/width_16k/average_l0_71
   - id: layer_19/width_16k/canonical
-    path: layer_19/width_16k/average_l0_132
     neuronpedia: gemma-2-9b/19-gemmascope-res-16k
+    path: layer_19/width_16k/average_l0_132
   - id: layer_20/width_16k/canonical
-    path: layer_20/width_16k/average_l0_68
     neuronpedia: gemma-2-9b/20-gemmascope-res-16k
+    path: layer_20/width_16k/average_l0_68
   - id: layer_21/width_16k/canonical
-    path: layer_21/width_16k/average_l0_129
     neuronpedia: gemma-2-9b/21-gemmascope-res-16k
+    path: layer_21/width_16k/average_l0_129
   - id: layer_22/width_16k/canonical
-    path: layer_22/width_16k/average_l0_123
     neuronpedia: gemma-2-9b/22-gemmascope-res-16k
+    path: layer_22/width_16k/average_l0_123
   - id: layer_23/width_16k/canonical
-    path: layer_23/width_16k/average_l0_120
     neuronpedia: gemma-2-9b/23-gemmascope-res-16k
+    path: layer_23/width_16k/average_l0_120
   - id: layer_24/width_16k/canonical
-    path: layer_24/width_16k/average_l0_114
     neuronpedia: gemma-2-9b/24-gemmascope-res-16k
+    path: layer_24/width_16k/average_l0_114
   - id: layer_25/width_16k/canonical
-    path: layer_25/width_16k/average_l0_114
     neuronpedia: gemma-2-9b/25-gemmascope-res-16k
+    path: layer_25/width_16k/average_l0_114
   - id: layer_26/width_16k/canonical
-    path: layer_26/width_16k/average_l0_116
     neuronpedia: gemma-2-9b/26-gemmascope-res-16k
+    path: layer_26/width_16k/average_l0_116
   - id: layer_27/width_16k/canonical
-    path: layer_27/width_16k/average_l0_118
     neuronpedia: gemma-2-9b/27-gemmascope-res-16k
+    path: layer_27/width_16k/average_l0_118
   - id: layer_28/width_16k/canonical
-    path: layer_28/width_16k/average_l0_119
     neuronpedia: gemma-2-9b/28-gemmascope-res-16k
+    path: layer_28/width_16k/average_l0_119
   - id: layer_29/width_16k/canonical
-    path: layer_29/width_16k/average_l0_119
     neuronpedia: gemma-2-9b/29-gemmascope-res-16k
+    path: layer_29/width_16k/average_l0_119
   - id: layer_30/width_16k/canonical
-    path: layer_30/width_16k/average_l0_120
     neuronpedia: gemma-2-9b/30-gemmascope-res-16k
+    path: layer_30/width_16k/average_l0_120
   - id: layer_31/width_16k/canonical
-    path: layer_31/width_16k/average_l0_114
     neuronpedia: gemma-2-9b/31-gemmascope-res-16k
+    path: layer_31/width_16k/average_l0_114
   - id: layer_32/width_16k/canonical
-    path: layer_32/width_16k/average_l0_111
     neuronpedia: gemma-2-9b/32-gemmascope-res-16k
+    path: layer_32/width_16k/average_l0_111
   - id: layer_33/width_16k/canonical
-    path: layer_33/width_16k/average_l0_114
     neuronpedia: gemma-2-9b/33-gemmascope-res-16k
+    path: layer_33/width_16k/average_l0_114
   - id: layer_34/width_16k/canonical
-    path: layer_34/width_16k/average_l0_114
     neuronpedia: gemma-2-9b/34-gemmascope-res-16k
+    path: layer_34/width_16k/average_l0_114
   - id: layer_35/width_16k/canonical
-    path: layer_35/width_16k/average_l0_120
     neuronpedia: gemma-2-9b/35-gemmascope-res-16k
+    path: layer_35/width_16k/average_l0_120
   - id: layer_36/width_16k/canonical
-    path: layer_36/width_16k/average_l0_120
     neuronpedia: gemma-2-9b/36-gemmascope-res-16k
+    path: layer_36/width_16k/average_l0_120
   - id: layer_37/width_16k/canonical
-    path: layer_37/width_16k/average_l0_124
     neuronpedia: gemma-2-9b/37-gemmascope-res-16k
+    path: layer_37/width_16k/average_l0_124
   - id: layer_38/width_16k/canonical
-    path: layer_38/width_16k/average_l0_128
     neuronpedia: gemma-2-9b/38-gemmascope-res-16k
+    path: layer_38/width_16k/average_l0_128
   - id: layer_39/width_16k/canonical
-    path: layer_39/width_16k/average_l0_131
     neuronpedia: gemma-2-9b/39-gemmascope-res-16k
+    path: layer_39/width_16k/average_l0_131
   - id: layer_40/width_16k/canonical
-    path: layer_40/width_16k/average_l0_125
     neuronpedia: gemma-2-9b/40-gemmascope-res-16k
+    path: layer_40/width_16k/average_l0_125
   - id: layer_41/width_16k/canonical
-    path: layer_41/width_16k/average_l0_113
     neuronpedia: gemma-2-9b/41-gemmascope-res-16k
+    path: layer_41/width_16k/average_l0_113
   - id: layer_0/width_131k/canonical
-    path: layer_0/width_131k/average_l0_41
     neuronpedia: gemma-2-9b/0-gemmascope-res-131k
+    path: layer_0/width_131k/average_l0_41
   - id: layer_1/width_131k/canonical
-    path: layer_1/width_131k/average_l0_56
     neuronpedia: gemma-2-9b/1-gemmascope-res-131k
+    path: layer_1/width_131k/average_l0_56
   - id: layer_2/width_131k/canonical
-    path: layer_2/width_131k/average_l0_70
     neuronpedia: gemma-2-9b/2-gemmascope-res-131k
+    path: layer_2/width_131k/average_l0_70
   - id: layer_3/width_131k/canonical
-    path: layer_3/width_131k/average_l0_103
     neuronpedia: gemma-2-9b/3-gemmascope-res-131k
+    path: layer_3/width_131k/average_l0_103
   - id: layer_4/width_131k/canonical
-    path: layer_4/width_131k/average_l0_101
     neuronpedia: gemma-2-9b/4-gemmascope-res-131k
+    path: layer_4/width_131k/average_l0_101
   - id: layer_5/width_131k/canonical
-    path: layer_5/width_131k/average_l0_94
     neuronpedia: gemma-2-9b/5-gemmascope-res-131k
+    path: layer_5/width_131k/average_l0_94
   - id: layer_6/width_131k/canonical
-    path: layer_6/width_131k/average_l0_120
     neuronpedia: gemma-2-9b/6-gemmascope-res-131k
+    path: layer_6/width_131k/average_l0_120
   - id: layer_7/width_131k/canonical
-    path: layer_7/width_131k/average_l0_119
     neuronpedia: gemma-2-9b/7-gemmascope-res-131k
+    path: layer_7/width_131k/average_l0_119
   - id: layer_8/width_131k/canonical
-    path: layer_8/width_131k/average_l0_72
     neuronpedia: gemma-2-9b/8-gemmascope-res-131k
+    path: layer_8/width_131k/average_l0_72
   - id: layer_9/width_131k/canonical
-    path: layer_9/width_131k/average_l0_75
     neuronpedia: gemma-2-9b/9-gemmascope-res-131k
+    path: layer_9/width_131k/average_l0_75
   - id: layer_10/width_131k/canonical
-    path: layer_10/width_131k/average_l0_84
     neuronpedia: gemma-2-9b/10-gemmascope-res-131k
+    path: layer_10/width_131k/average_l0_84
   - id: layer_11/width_131k/canonical
-    path: layer_11/width_131k/average_l0_88
     neuronpedia: gemma-2-9b/11-gemmascope-res-131k
+    path: layer_11/width_131k/average_l0_88
   - id: layer_12/width_131k/canonical
-    path: layer_12/width_131k/average_l0_96
     neuronpedia: gemma-2-9b/12-gemmascope-res-131k
+    path: layer_12/width_131k/average_l0_96
   - id: layer_13/width_131k/canonical
-    path: layer_13/width_131k/average_l0_99
     neuronpedia: gemma-2-9b/13-gemmascope-res-131k
+    path: layer_13/width_131k/average_l0_99
   - id: layer_14/width_131k/canonical
-    path: layer_14/width_131k/average_l0_105
     neuronpedia: gemma-2-9b/14-gemmascope-res-131k
+    path: layer_14/width_131k/average_l0_105
   - id: layer_15/width_131k/canonical
-    path: layer_15/width_131k/average_l0_103
     neuronpedia: gemma-2-9b/15-gemmascope-res-131k
+    path: layer_15/width_131k/average_l0_103
   - id: layer_16/width_131k/canonical
-    path: layer_16/width_131k/average_l0_121
     neuronpedia: gemma-2-9b/16-gemmascope-res-131k
+    path: layer_16/width_131k/average_l0_121
   - id: layer_17/width_131k/canonical
-    path: layer_17/width_131k/average_l0_117
     neuronpedia: gemma-2-9b/17-gemmascope-res-131k
+    path: layer_17/width_131k/average_l0_117
   - id: layer_18/width_131k/canonical
-    path: layer_18/width_131k/average_l0_113
     neuronpedia: gemma-2-9b/18-gemmascope-res-131k
+    path: layer_18/width_131k/average_l0_113
   - id: layer_19/width_131k/canonical
-    path: layer_19/width_131k/average_l0_110
     neuronpedia: gemma-2-9b/19-gemmascope-res-131k
+    path: layer_19/width_131k/average_l0_110
   - id: layer_20/width_131k/canonical
-    path: layer_20/width_131k/average_l0_114
     neuronpedia: gemma-2-9b/20-gemmascope-res-131k
+    path: layer_20/width_131k/average_l0_114
   - id: layer_21/width_131k/canonical
-    path: layer_21/width_131k/average_l0_109
     neuronpedia: gemma-2-9b/21-gemmascope-res-131k
+    path: layer_21/width_131k/average_l0_109
   - id: layer_22/width_131k/canonical
-    path: layer_22/width_131k/average_l0_105
     neuronpedia: gemma-2-9b/22-gemmascope-res-131k
+    path: layer_22/width_131k/average_l0_105
   - id: layer_23/width_131k/canonical
-    path: layer_23/width_131k/average_l0_101
     neuronpedia: gemma-2-9b/23-gemmascope-res-131k
+    path: layer_23/width_131k/average_l0_101
   - id: layer_24/width_131k/canonical
-    path: layer_24/width_131k/average_l0_97
     neuronpedia: gemma-2-9b/24-gemmascope-res-131k
+    path: layer_24/width_131k/average_l0_97
   - id: layer_25/width_131k/canonical
-    path: layer_25/width_131k/average_l0_96
     neuronpedia: gemma-2-9b/25-gemmascope-res-131k
+    path: layer_25/width_131k/average_l0_96
   - id: layer_26/width_131k/canonical
-    path: layer_26/width_131k/average_l0_97
     neuronpedia: gemma-2-9b/26-gemmascope-res-131k
+    path: layer_26/width_131k/average_l0_97
   - id: layer_27/width_131k/canonical
-    path: layer_27/width_131k/average_l0_96
     neuronpedia: gemma-2-9b/27-gemmascope-res-131k
+    path: layer_27/width_131k/average_l0_96
   - id: layer_28/width_131k/canonical
-    path: layer_28/width_131k/average_l0_98
     neuronpedia: gemma-2-9b/28-gemmascope-res-131k
+    path: layer_28/width_131k/average_l0_98
   - id: layer_29/width_131k/canonical
-    path: layer_29/width_131k/average_l0_97
     neuronpedia: gemma-2-9b/29-gemmascope-res-131k
+    path: layer_29/width_131k/average_l0_97
   - id: layer_30/width_131k/canonical
-    path: layer_30/width_131k/average_l0_95
     neuronpedia: gemma-2-9b/30-gemmascope-res-131k
+    path: layer_30/width_131k/average_l0_95
   - id: layer_31/width_131k/canonical
-    path: layer_31/width_131k/average_l0_92
     neuronpedia: gemma-2-9b/31-gemmascope-res-131k
+    path: layer_31/width_131k/average_l0_92
   - id: layer_32/width_131k/canonical
-    path: layer_32/width_131k/average_l0_88
     neuronpedia: gemma-2-9b/32-gemmascope-res-131k
+    path: layer_32/width_131k/average_l0_88
   - id: layer_33/width_131k/canonical
-    path: layer_33/width_131k/average_l0_91
     neuronpedia: gemma-2-9b/33-gemmascope-res-131k
+    path: layer_33/width_131k/average_l0_91
   - id: layer_34/width_131k/canonical
-    path: layer_34/width_131k/average_l0_89
     neuronpedia: gemma-2-9b/34-gemmascope-res-131k
+    path: layer_34/width_131k/average_l0_89
   - id: layer_35/width_131k/canonical
-    path: layer_35/width_131k/average_l0_94
     neuronpedia: gemma-2-9b/35-gemmascope-res-131k
+    path: layer_35/width_131k/average_l0_94
   - id: layer_36/width_131k/canonical
-    path: layer_36/width_131k/average_l0_93
     neuronpedia: gemma-2-9b/36-gemmascope-res-131k
+    path: layer_36/width_131k/average_l0_93
   - id: layer_37/width_131k/canonical
-    path: layer_37/width_131k/average_l0_96
     neuronpedia: gemma-2-9b/37-gemmascope-res-131k
+    path: layer_37/width_131k/average_l0_96
   - id: layer_38/width_131k/canonical
-    path: layer_38/width_131k/average_l0_101
     neuronpedia: gemma-2-9b/38-gemmascope-res-131k
+    path: layer_38/width_131k/average_l0_101
   - id: layer_39/width_131k/canonical
-    path: layer_39/width_131k/average_l0_99
     neuronpedia: gemma-2-9b/39-gemmascope-res-131k
+    path: layer_39/width_131k/average_l0_99
   - id: layer_40/width_131k/canonical
-    path: layer_40/width_131k/average_l0_94
     neuronpedia: gemma-2-9b/40-gemmascope-res-131k
+    path: layer_40/width_131k/average_l0_94
   - id: layer_41/width_131k/canonical
-    path: layer_41/width_131k/average_l0_84
     neuronpedia: gemma-2-9b/41-gemmascope-res-131k
+    path: layer_41/width_131k/average_l0_84
   - id: layer_9/width_1m/canonical
-    path: layer_9/width_1m/average_l0_122
-    neuronpedia: gemma-2-9b/9-gemmascope-res-1m
     l0: 122
+    neuronpedia: gemma-2-9b/9-gemmascope-res-1m
+    path: layer_9/width_1m/average_l0_122
   - id: layer_20/width_1m/canonical
-    path: layer_20/width_1m/average_l0_101
+    l0: 101
     neuronpedia: gemma-2-9b/20-gemmascope-res-1m
-    l0: 101
+    path: layer_20/width_1m/average_l0_101
   - id: layer_31/width_1m/canonical
-    path: layer_31/width_1m/average_l0_77
+    l0: 77
     neuronpedia: gemma-2-9b/31-gemmascope-res-1m
-    l0: 77
+    path: layer_31/width_1m/average_l0_77
   - id: layer_20/width_262k/canonical
-    path: layer_20/width_262k/average_l0_64
+    l0: 64
     neuronpedia: gemma-2-9b/20-gemmascope-res-262k
-    l0: 64
+    path: layer_20/width_262k/average_l0_64
   - id: layer_20/width_32k/canonical
-    path: layer_20/width_32k/average_l0_57
+    l0: 57
     neuronpedia: gemma-2-9b/20-gemmascope-res-32k
-    l0: 57
+    path: layer_20/width_32k/average_l0_57
   - id: layer_20/width_524k/canonical
-    path: layer_20/width_524k/average_l0_48
+    l0: 78
     neuronpedia: gemma-2-9b/20-gemmascope-res-524k
-    l0: 78
+    path: layer_20/width_524k/average_l0_48
   - id: layer_20/width_65k/canonical
-    path: layer_20/width_65k/average_l0_55
+    l0: 55
     neuronpedia: gemma-2-9b/20-gemmascope-res-65k
-    l0: 55
-gemma-scope-9b-pt-att:
-  repo_id: google/gemma-scope-9b-pt-att
-  model: gemma-2-9b
-  conversion_func: gemma_2
-  saes:
-  - id: layer_0/width_16k/average_l0_12
-    path: layer_0/width_16k/average_l0_12
-    l0: 12
-  - id: layer_0/width_16k/average_l0_16
-    path: layer_0/width_16k/average_l0_16
-    l0: 16
-  - id: layer_0/width_16k/average_l0_25
-    path: layer_0/width_16k/average_l0_25
-    l0: 25
-  - id: layer_0/width_16k/average_l0_38
-    path: layer_0/width_16k/average_l0_38
-    l0: 38
-  - id: layer_0/width_16k/average_l0_61
-    path: layer_0/width_16k/average_l0_61
-    l0: 61
-  - id: layer_0/width_131k/average_l0_8
-    path: layer_0/width_131k/average_l0_8
-    l0: 8
-  - id: layer_0/width_131k/average_l0_11
-    path: layer_0/width_131k/average_l0_11
-    l0: 11
-  - id: layer_0/width_131k/average_l0_15
-    path: layer_0/width_131k/average_l0_15
-    l0: 15
-  - id: layer_0/width_131k/average_l0_22
-    path: layer_0/width_131k/average_l0_22
-    l0: 22
-  - id: layer_0/width_131k/average_l0_33
-    path: layer_0/width_131k/average_l0_33
-    l0: 33
-  - id: layer_0/width_131k/average_l0_55
-    path: layer_0/width_131k/average_l0_55
-    l0: 55
-  - id: layer_1/width_16k/average_l0_17
-    path: layer_1/width_16k/average_l0_17
-    l0: 17
-  - id: layer_1/width_16k/average_l0_34
-    path: layer_1/width_16k/average_l0_34
-    l0: 34
-  - id: layer_1/width_16k/average_l0_77
-    path: layer_1/width_16k/average_l0_77
-    l0: 77
-  - id: layer_1/width_16k/average_l0_147
-    path: layer_1/width_16k/average_l0_147
-    l0: 147
-  - id: layer_1/width_16k/average_l0_266
-    path: layer_1/width_16k/average_l0_266
-    l0: 266
-  - id: layer_1/width_131k/average_l0_8
-    path: layer_1/width_131k/average_l0_8
-    l0: 8
-  - id: layer_1/width_131k/average_l0_12
-    path: layer_1/width_131k/average_l0_12
-    l0: 12
-  - id: layer_1/width_131k/average_l0_18
-    path: layer_1/width_131k/average_l0_18
-    l0: 18
-  - id: layer_1/width_131k/average_l0_29
-    path: layer_1/width_131k/average_l0_29
-    l0: 29
-  - id: layer_1/width_131k/average_l0_63
-    path: layer_1/width_131k/average_l0_63
-    l0: 63
-  - id: layer_1/width_131k/average_l0_116
-    path: layer_1/width_131k/average_l0_116
-    l0: 116
-  - id: layer_10/width_16k/average_l0_18
-    path: layer_10/width_16k/average_l0_18
-    l0: 18
-  - id: layer_10/width_16k/average_l0_33
-    path: layer_10/width_16k/average_l0_33
-    l0: 33
-  - id: layer_10/width_16k/average_l0_63
-    path: layer_10/width_16k/average_l0_63
-    l0: 63
-  - id: layer_10/width_16k/average_l0_132
-    path: layer_10/width_16k/average_l0_132
-    l0: 132
-  - id: layer_10/width_16k/average_l0_301
-    path: layer_10/width_16k/average_l0_301
-    l0: 301
-  - id: layer_10/width_131k/average_l0_16
-    path: layer_10/width_131k/average_l0_16
-    l0: 16
-  - id: layer_10/width_131k/average_l0_28
-    path: layer_10/width_131k/average_l0_28
-    l0: 28
-  - id: layer_10/width_131k/average_l0_51
-    path: layer_10/width_131k/average_l0_51
-    l0: 51
-  - id: layer_10/width_131k/average_l0_97
-    path: layer_10/width_131k/average_l0_97
-    l0: 97
-  - id: layer_10/width_131k/average_l0_199
-    path: layer_10/width_131k/average_l0_199
-    l0: 199
-  - id: layer_10/width_131k/average_l0_440
-    path: layer_10/width_131k/average_l0_440
-    l0: 440
-  - id: layer_11/width_16k/average_l0_18
-    path: layer_11/width_16k/average_l0_18
-    l0: 18
-  - id: layer_11/width_16k/average_l0_34
-    path: layer_11/width_16k/average_l0_34
-    l0: 34
-  - id: layer_11/width_16k/average_l0_67
-    path: layer_11/width_16k/average_l0_67
-    l0: 67
-  - id: layer_11/width_16k/average_l0_153
-    path: layer_11/width_16k/average_l0_153
-    l0: 153
-  - id: layer_11/width_16k/average_l0_366
-    path: layer_11/width_16k/average_l0_366
-    l0: 366
-  - id: layer_11/width_131k/average_l0_17
-    path: layer_11/width_131k/average_l0_17
-    l0: 17
-  - id: layer_11/width_131k/average_l0_29
-    path: layer_11/width_131k/average_l0_29
-    l0: 29
-  - id: layer_11/width_131k/average_l0_54
-    path: layer_11/width_131k/average_l0_54
-    l0: 54
-  - id: layer_11/width_131k/average_l0_104
-    path: layer_11/width_131k/average_l0_104
-    l0: 104
-  - id: layer_11/width_131k/average_l0_241
-    path: layer_11/width_131k/average_l0_241
-    l0: 241
-  - id: layer_11/width_131k/average_l0_552
-    path: layer_11/width_131k/average_l0_552
-    l0: 552
-  - id: layer_12/width_16k/average_l0_19
-    path: layer_12/width_16k/average_l0_19
-    l0: 19
-  - id: layer_12/width_16k/average_l0_35
-    path: layer_12/width_16k/average_l0_35
-    l0: 35
-  - id: layer_12/width_16k/average_l0_68
-    path: layer_12/width_16k/average_l0_68
-    l0: 68
-  - id: layer_12/width_16k/average_l0_149
-    path: layer_12/width_16k/average_l0_149
-    l0: 149
-  - id: layer_12/width_16k/average_l0_337
-    path: layer_12/width_16k/average_l0_337
-    l0: 337
-  - id: layer_12/width_16k/average_l0_654
-    path: layer_12/width_16k/average_l0_654
-    l0: 654
-  - id: layer_12/width_131k/average_l0_17
-    path: layer_12/width_131k/average_l0_17
-    l0: 17
-  - id: layer_12/width_131k/average_l0_29
-    path: layer_12/width_131k/average_l0_29
-    l0: 29
-  - id: layer_12/width_131k/average_l0_55
-    path: layer_12/width_131k/average_l0_55
-    l0: 55
-  - id: layer_12/width_131k/average_l0_110
-    path: layer_12/width_131k/average_l0_110
-    l0: 110
-  - id: layer_12/width_131k/average_l0_237
-    path: layer_12/width_131k/average_l0_237
-    l0: 237
-  - id: layer_12/width_131k/average_l0_525
-    path: layer_12/width_131k/average_l0_525
-    l0: 525
-  - id: layer_13/width_16k/average_l0_20
-    path: layer_13/width_16k/average_l0_20
-    l0: 20
-  - id: layer_13/width_16k/average_l0_38
-    path: layer_13/width_16k/average_l0_38
-    l0: 38
-  - id: layer_13/width_16k/average_l0_77
-    path: layer_13/width_16k/average_l0_77
-    l0: 77
-  - id: layer_13/width_16k/average_l0_170
-    path: layer_13/width_16k/average_l0_170
-    l0: 170
-  - id: layer_13/width_16k/average_l0_380
-    path: layer_13/width_16k/average_l0_380
-    l0: 380
-  - id: layer_13/width_16k/average_l0_675
-    path: layer_13/width_16k/average_l0_675
-    l0: 675
-  - id: layer_13/width_131k/average_l0_18
-    path: layer_13/width_131k/average_l0_18
-    l0: 18
-  - id: layer_13/width_131k/average_l0_33
-    path: layer_13/width_131k/average_l0_33
-    l0: 33
-  - id: layer_13/width_131k/average_l0_64
-    path: layer_13/width_131k/average_l0_64
-    l0: 64
-  - id: layer_13/width_131k/average_l0_126
-    path: layer_13/width_131k/average_l0_126
-    l0: 126
-  - id: layer_13/width_131k/average_l0_283
-    path: layer_13/width_131k/average_l0_283
-    l0: 283
-  - id: layer_13/width_131k/average_l0_611
-    path: layer_13/width_131k/average_l0_611
-    l0: 611
-  - id: layer_14/width_16k/average_l0_21
-    path: layer_14/width_16k/average_l0_21
-    l0: 21
-  - id: layer_14/width_16k/average_l0_40
-    path: layer_14/width_16k/average_l0_40
-    l0: 40
-  - id: layer_14/width_16k/average_l0_81
-    path: layer_14/width_16k/average_l0_81
-    l0: 81
-  - id: layer_14/width_16k/average_l0_179
-    path: layer_14/width_16k/average_l0_179
-    l0: 179
-  - id: layer_14/width_16k/average_l0_411
-    path: layer_14/width_16k/average_l0_411
-    l0: 411
-  - id: layer_14/width_16k/average_l0_767
-    path: layer_14/width_16k/average_l0_767
-    l0: 767
-  - id: layer_14/width_131k/average_l0_18
-    path: layer_14/width_131k/average_l0_18
-    l0: 18
-  - id: layer_14/width_131k/average_l0_35
-    path: layer_14/width_131k/average_l0_35
-    l0: 35
-  - id: layer_14/width_131k/average_l0_67
-    path: layer_14/width_131k/average_l0_67
-    l0: 67
-  - id: layer_14/width_131k/average_l0_131
-    path: layer_14/width_131k/average_l0_131
-    l0: 131
-  - id: layer_14/width_131k/average_l0_306
-    path: layer_14/width_131k/average_l0_306
-    l0: 306
-  - id: layer_14/width_131k/average_l0_650
-    path: layer_14/width_131k/average_l0_650
-    l0: 650
-  - id: layer_15/width_16k/average_l0_21
-    path: layer_15/width_16k/average_l0_21
-    l0: 21
-  - id: layer_15/width_16k/average_l0_40
-    path: layer_15/width_16k/average_l0_40
-    l0: 40
-  - id: layer_15/width_16k/average_l0_79
-    path: layer_15/width_16k/average_l0_79
-    l0: 79
-  - id: layer_15/width_16k/average_l0_168
-    path: layer_15/width_16k/average_l0_168
-    l0: 168
-  - id: layer_15/width_16k/average_l0_344
-    path: layer_15/width_16k/average_l0_344
-    l0: 344
-  - id: layer_15/width_16k/average_l0_638
-    path: layer_15/width_16k/average_l0_638
-    l0: 638
-  - id: layer_15/width_131k/average_l0_19
-    path: layer_15/width_131k/average_l0_19
-    l0: 19
-  - id: layer_15/width_131k/average_l0_35
-    path: layer_15/width_131k/average_l0_35
-    l0: 35
-  - id: layer_15/width_131k/average_l0_67
-    path: layer_15/width_131k/average_l0_67
-    l0: 67
-  - id: layer_15/width_131k/average_l0_130
-    path: layer_15/width_131k/average_l0_130
-    l0: 130
-  - id: layer_15/width_131k/average_l0_283
-    path: layer_15/width_131k/average_l0_283
-    l0: 283
-  - id: layer_15/width_131k/average_l0_540
-    path: layer_15/width_131k/average_l0_540
-    l0: 540
-  - id: layer_16/width_16k/average_l0_21
-    path: layer_16/width_16k/average_l0_21
-    l0: 21
-  - id: layer_16/width_16k/average_l0_40
-    path: layer_16/width_16k/average_l0_40
-    l0: 40
-  - id: layer_16/width_16k/average_l0_81
-    path: layer_16/width_16k/average_l0_81
-    l0: 81
-  - id: layer_16/width_16k/average_l0_172
-    path: layer_16/width_16k/average_l0_172
-    l0: 172
-  - id: layer_16/width_16k/average_l0_376
-    path: layer_16/width_16k/average_l0_376
-    l0: 376
-  - id: layer_16/width_16k/average_l0_705
-    path: layer_16/width_16k/average_l0_705
-    l0: 705
-  - id: layer_16/width_131k/average_l0_19
-    path: layer_16/width_131k/average_l0_19
-    l0: 19
-  - id: layer_16/width_131k/average_l0_36
-    path: layer_16/width_131k/average_l0_36
-    l0: 36
-  - id: layer_16/width_131k/average_l0_71
-    path: layer_16/width_131k/average_l0_71
-    l0: 71
-  - id: layer_16/width_131k/average_l0_140
-    path: layer_16/width_131k/average_l0_140
-    l0: 140
-  - id: layer_16/width_131k/average_l0_298
-    path: layer_16/width_131k/average_l0_298
-    l0: 298
-  - id: layer_16/width_131k/average_l0_621
-    path: layer_16/width_131k/average_l0_621
-    l0: 621
-  - id: layer_17/width_16k/average_l0_24
-    path: layer_17/width_16k/average_l0_24
-    l0: 24
-  - id: layer_17/width_16k/average_l0_50
-    path: layer_17/width_16k/average_l0_50
-    l0: 50
-  - id: layer_17/width_16k/average_l0_110
-    path: layer_17/width_16k/average_l0_110
-    l0: 110
-  - id: layer_17/width_16k/average_l0_227
-    path: layer_17/width_16k/average_l0_227
-    l0: 227
-  - id: layer_17/width_16k/average_l0_435
-    path: layer_17/width_16k/average_l0_435
-    l0: 435
-  - id: layer_17/width_16k/average_l0_719
-    path: layer_17/width_16k/average_l0_719
-    l0: 719
-  - id: layer_17/width_131k/average_l0_22
-    path: layer_17/width_131k/average_l0_22
-    l0: 22
-  - id: layer_17/width_131k/average_l0_44
-    path: layer_17/width_131k/average_l0_44
-    l0: 44
-  - id: layer_17/width_131k/average_l0_90
-    path: layer_17/width_131k/average_l0_90
-    l0: 90
-  - id: layer_17/width_131k/average_l0_191
-    path: layer_17/width_131k/average_l0_191
-    l0: 191
-  - id: layer_17/width_131k/average_l0_380
-    path: layer_17/width_131k/average_l0_380
-    l0: 380
-  - id: layer_17/width_131k/average_l0_672
-    path: layer_17/width_131k/average_l0_672
-    l0: 672
-  - id: layer_18/width_16k/average_l0_21
-    path: layer_18/width_16k/average_l0_21
-    l0: 21
-  - id: layer_18/width_16k/average_l0_40
-    path: layer_18/width_16k/average_l0_40
-    l0: 40
-  - id: layer_18/width_16k/average_l0_80
-    path: layer_18/width_16k/average_l0_80
-    l0: 80
-  - id: layer_18/width_16k/average_l0_171
-    path: layer_18/width_16k/average_l0_171
-    l0: 171
-  - id: layer_18/width_16k/average_l0_352
-    path: layer_18/width_16k/average_l0_352
-    l0: 352
-  - id: layer_18/width_16k/average_l0_646
-    path: layer_18/width_16k/average_l0_646
-    l0: 646
-  - id: layer_18/width_131k/average_l0_19
-    path: layer_18/width_131k/average_l0_19
-    l0: 19
-  - id: layer_18/width_131k/average_l0_35
-    path: layer_18/width_131k/average_l0_35
-    l0: 35
-  - id: layer_18/width_131k/average_l0_69
-    path: layer_18/width_131k/average_l0_69
-    l0: 69
-  - id: layer_18/width_131k/average_l0_133
-    path: layer_18/width_131k/average_l0_133
-    l0: 133
-  - id: layer_18/width_131k/average_l0_294
-    path: layer_18/width_131k/average_l0_294
-    l0: 294
-  - id: layer_18/width_131k/average_l0_557
-    path: layer_18/width_131k/average_l0_557
-    l0: 557
-  - id: layer_19/width_16k/average_l0_21
-    path: layer_19/width_16k/average_l0_21
-    l0: 21
-  - id: layer_19/width_16k/average_l0_41
-    path: layer_19/width_16k/average_l0_41
-    l0: 41
-  - id: layer_19/width_16k/average_l0_86
-    path: layer_19/width_16k/average_l0_86
-    l0: 86
-  - id: layer_19/width_16k/average_l0_186
-    path: layer_19/width_16k/average_l0_186
-    l0: 186
-  - id: layer_19/width_16k/average_l0_360
-    path: layer_19/width_16k/average_l0_360
-    l0: 360
-  - id: layer_19/width_16k/average_l0_661
-    path: layer_19/width_16k/average_l0_661
-    l0: 661
-  - id: layer_19/width_131k/average_l0_19
-    path: layer_19/width_131k/average_l0_19
-    l0: 19
-  - id: layer_19/width_131k/average_l0_38
-    path: layer_19/width_131k/average_l0_38
-    l0: 38
-  - id: layer_19/width_131k/average_l0_71
-    path: layer_19/width_131k/average_l0_71
-    l0: 71
-  - id: layer_19/width_131k/average_l0_152
-    path: layer_19/width_131k/average_l0_152
-    l0: 152
-  - id: layer_19/width_131k/average_l0_307
-    path: layer_19/width_131k/average_l0_307
-    l0: 307
-  - id: layer_19/width_131k/average_l0_571
-    path: layer_19/width_131k/average_l0_571
-    l0: 571
-  - id: layer_2/width_16k/average_l0_15
-    path: layer_2/width_16k/average_l0_15
-    l0: 15
-  - id: layer_2/width_16k/average_l0_30
-    path: layer_2/width_16k/average_l0_30
-    l0: 30
-  - id: layer_2/width_16k/average_l0_69
-    path: layer_2/width_16k/average_l0_69
-    l0: 69
-  - id: layer_2/width_16k/average_l0_180
-    path: layer_2/width_16k/average_l0_180
-    l0: 180
-  - id: layer_2/width_16k/average_l0_384
-    path: layer_2/width_16k/average_l0_384
-    l0: 384
-  - id: layer_2/width_131k/average_l0_7
-    path: layer_2/width_131k/average_l0_7
-    l0: 7
-  - id: layer_2/width_131k/average_l0_11
-    path: layer_2/width_131k/average_l0_11
-    l0: 11
-  - id: layer_2/width_131k/average_l0_18
-    path: layer_2/width_131k/average_l0_18
-    l0: 18
-  - id: layer_2/width_131k/average_l0_32
-    path: layer_2/width_131k/average_l0_32
-    l0: 32
-  - id: layer_2/width_131k/average_l0_62
-    path: layer_2/width_131k/average_l0_62
-    l0: 62
-  - id: layer_2/width_131k/average_l0_135
-    path: layer_2/width_131k/average_l0_135
-    l0: 135
-  - id: layer_20/width_16k/average_l0_20
-    path: layer_20/width_16k/average_l0_20
-    l0: 20
-  - id: layer_20/width_16k/average_l0_39
-    path: layer_20/width_16k/average_l0_39
-    l0: 39
-  - id: layer_20/width_16k/average_l0_76
-    path: layer_20/width_16k/average_l0_76
-    l0: 76
-  - id: layer_20/width_16k/average_l0_158
-    path: layer_20/width_16k/average_l0_158
-    l0: 158
-  - id: layer_20/width_16k/average_l0_342
-    path: layer_20/width_16k/average_l0_342
-    l0: 342
-  - id: layer_20/width_16k/average_l0_674
-    path: layer_20/width_16k/average_l0_674
-    l0: 674
-  - id: layer_20/width_131k/average_l0_18
-    path: layer_20/width_131k/average_l0_18
-    l0: 18
-  - id: layer_20/width_131k/average_l0_34
-    path: layer_20/width_131k/average_l0_34
-    l0: 34
-  - id: layer_20/width_131k/average_l0_65
-    path: layer_20/width_131k/average_l0_65
-    l0: 65
-  - id: layer_20/width_131k/average_l0_125
-    path: layer_20/width_131k/average_l0_125
-    l0: 125
-  - id: layer_20/width_131k/average_l0_270
-    path: layer_20/width_131k/average_l0_270
-    l0: 270
-  - id: layer_20/width_131k/average_l0_558
-    path: layer_20/width_131k/average_l0_558
-    l0: 558
-  - id: layer_21/width_16k/average_l0_21
-    path: layer_21/width_16k/average_l0_21
-    l0: 21
-  - id: layer_21/width_16k/average_l0_41
-    path: layer_21/width_16k/average_l0_41
-    l0: 41
-  - id: layer_21/width_16k/average_l0_86
-    path: layer_21/width_16k/average_l0_86
-    l0: 86
-  - id: layer_21/width_16k/average_l0_195
-    path: layer_21/width_16k/average_l0_195
-    l0: 195
-  - id: layer_21/width_16k/average_l0_420
-    path: layer_21/width_16k/average_l0_420
-    l0: 420
-  - id: layer_21/width_16k/average_l0_792
-    path: layer_21/width_16k/average_l0_792
-    l0: 792
-  - id: layer_21/width_131k/average_l0_18
-    path: layer_21/width_131k/average_l0_18
-    l0: 18
-  - id: layer_21/width_131k/average_l0_35
-    path: layer_21/width_131k/average_l0_35
-    l0: 35
-  - id: layer_21/width_131k/average_l0_71
-    path: layer_21/width_131k/average_l0_71
-    l0: 71
-  - id: layer_21/width_131k/average_l0_150
-    path: layer_21/width_131k/average_l0_150
-    l0: 150
-  - id: layer_21/width_131k/average_l0_333
-    path: layer_21/width_131k/average_l0_333
-    l0: 333
-  - id: layer_21/width_131k/average_l0_665
-    path: layer_21/width_131k/average_l0_665
-    l0: 665
-  - id: layer_22/width_16k/average_l0_20
-    path: layer_22/width_16k/average_l0_20
-    l0: 20
-  - id: layer_22/width_16k/average_l0_36
-    path: layer_22/width_16k/average_l0_36
-    l0: 36
-  - id: layer_22/width_16k/average_l0_70
-    path: layer_22/width_16k/average_l0_70
-    l0: 70
-  - id: layer_22/width_16k/average_l0_141
-    path: layer_22/width_16k/average_l0_141
-    l0: 141
-  - id: layer_22/width_16k/average_l0_289
-    path: layer_22/width_16k/average_l0_289
-    l0: 289
-  - id: layer_22/width_16k/average_l0_569
-    path: layer_22/width_16k/average_l0_569
-    l0: 569
-  - id: layer_22/width_131k/average_l0_17
-    path: layer_22/width_131k/average_l0_17
-    l0: 17
-  - id: layer_22/width_131k/average_l0_32
-    path: layer_22/width_131k/average_l0_32
-    l0: 32
-  - id: layer_22/width_131k/average_l0_59
-    path: layer_22/width_131k/average_l0_59
-    l0: 59
-  - id: layer_22/width_131k/average_l0_115
-    path: layer_22/width_131k/average_l0_115
-    l0: 115
-  - id: layer_22/width_131k/average_l0_231
-    path: layer_22/width_131k/average_l0_231
-    l0: 231
-  - id: layer_22/width_131k/average_l0_446
-    path: layer_22/width_131k/average_l0_446
-    l0: 446
-  - id: layer_23/width_16k/average_l0_21
-    path: layer_23/width_16k/average_l0_21
-    l0: 21
-  - id: layer_23/width_16k/average_l0_41
-    path: layer_23/width_16k/average_l0_41
-    l0: 41
-  - id: layer_23/width_16k/average_l0_80
-    path: layer_23/width_16k/average_l0_80
-    l0: 80
-  - id: layer_23/width_16k/average_l0_173
-    path: layer_23/width_16k/average_l0_173
-    l0: 173
-  - id: layer_23/width_16k/average_l0_356
-    path: layer_23/width_16k/average_l0_356
-    l0: 356
-  - id: layer_23/width_16k/average_l0_649
-    path: layer_23/width_16k/average_l0_649
-    l0: 649
-  - id: layer_23/width_131k/average_l0_19
-    path: layer_23/width_131k/average_l0_19
-    l0: 19
-  - id: layer_23/width_131k/average_l0_36
-    path: layer_23/width_131k/average_l0_36
-    l0: 36
-  - id: layer_23/width_131k/average_l0_66
-    path: layer_23/width_131k/average_l0_66
-    l0: 66
-  - id: layer_23/width_131k/average_l0_134
-    path: layer_23/width_131k/average_l0_134
-    l0: 134
-  - id: layer_23/width_131k/average_l0_288
-    path: layer_23/width_131k/average_l0_288
-    l0: 288
-  - id: layer_23/width_131k/average_l0_568
-    path: layer_23/width_131k/average_l0_568
-    l0: 568
-  - id: layer_24/width_16k/average_l0_21
-    path: layer_24/width_16k/average_l0_21
-    l0: 21
-  - id: layer_24/width_16k/average_l0_40
-    path: layer_24/width_16k/average_l0_40
-    l0: 40
-  - id: layer_24/width_16k/average_l0_79
-    path: layer_24/width_16k/average_l0_79
-    l0: 79
-  - id: layer_24/width_16k/average_l0_167
-    path: layer_24/width_16k/average_l0_167
-    l0: 167
-  - id: layer_24/width_16k/average_l0_348
-    path: layer_24/width_16k/average_l0_348
-    l0: 348
-  - id: layer_24/width_16k/average_l0_615
-    path: layer_24/width_16k/average_l0_615
-    l0: 615
-  - id: layer_24/width_131k/average_l0_19
-    path: layer_24/width_131k/average_l0_19
-    l0: 19
-  - id: layer_24/width_131k/average_l0_35
-    path: layer_24/width_131k/average_l0_35
-    l0: 35
-  - id: layer_24/width_131k/average_l0_66
-    path: layer_24/width_131k/average_l0_66
-    l0: 66
-  - id: layer_24/width_131k/average_l0_130
-    path: layer_24/width_131k/average_l0_130
-    l0: 130
-  - id: layer_24/width_131k/average_l0_273
-    path: layer_24/width_131k/average_l0_273
-    l0: 273
-  - id: layer_24/width_131k/average_l0_542
-    path: layer_24/width_131k/average_l0_542
-    l0: 542
-  - id: layer_25/width_16k/average_l0_19
-    path: layer_25/width_16k/average_l0_19
-    l0: 19
-  - id: layer_25/width_16k/average_l0_36
-    path: layer_25/width_16k/average_l0_36
-    l0: 36
-  - id: layer_25/width_16k/average_l0_73
-    path: layer_25/width_16k/average_l0_73
-    l0: 73
-  - id: layer_25/width_16k/average_l0_156
-    path: layer_25/width_16k/average_l0_156
-    l0: 156
-  - id: layer_25/width_16k/average_l0_371
-    path: layer_25/width_16k/average_l0_371
-    l0: 371
-  - id: layer_25/width_16k/average_l0_686
-    path: layer_25/width_16k/average_l0_686
-    l0: 686
-  - id: layer_25/width_131k/average_l0_17
-    path: layer_25/width_131k/average_l0_17
-    l0: 17
-  - id: layer_25/width_131k/average_l0_31
-    path: layer_25/width_131k/average_l0_31
-    l0: 31
-  - id: layer_25/width_131k/average_l0_59
-    path: layer_25/width_131k/average_l0_59
-    l0: 59
-  - id: layer_25/width_131k/average_l0_115
-    path: layer_25/width_131k/average_l0_115
-    l0: 115
-  - id: layer_25/width_131k/average_l0_261
-    path: layer_25/width_131k/average_l0_261
-    l0: 261
-  - id: layer_25/width_131k/average_l0_605
-    path: layer_25/width_131k/average_l0_605
-    l0: 605
-  - id: layer_26/width_16k/average_l0_20
-    path: layer_26/width_16k/average_l0_20
-    l0: 20
-  - id: layer_26/width_16k/average_l0_38
-    path: layer_26/width_16k/average_l0_38
-    l0: 38
-  - id: layer_26/width_16k/average_l0_75
-    path: layer_26/width_16k/average_l0_75
-    l0: 75
-  - id: layer_26/width_16k/average_l0_159
-    path: layer_26/width_16k/average_l0_159
-    l0: 159
-  - id: layer_26/width_16k/average_l0_336
-    path: layer_26/width_16k/average_l0_336
-    l0: 336
-  - id: layer_26/width_16k/average_l0_634
-    path: layer_26/width_16k/average_l0_634
-    l0: 634
-  - id: layer_26/width_131k/average_l0_18
-    path: layer_26/width_131k/average_l0_18
-    l0: 18
-  - id: layer_26/width_131k/average_l0_32
-    path: layer_26/width_131k/average_l0_32
-    l0: 32
-  - id: layer_26/width_131k/average_l0_62
-    path: layer_26/width_131k/average_l0_62
-    l0: 62
-  - id: layer_26/width_131k/average_l0_120
-    path: layer_26/width_131k/average_l0_120
-    l0: 120
-  - id: layer_26/width_131k/average_l0_267
-    path: layer_26/width_131k/average_l0_267
-    l0: 267
-  - id: layer_26/width_131k/average_l0_525
-    path: layer_26/width_131k/average_l0_525
-    l0: 525
-  - id: layer_27/width_16k/average_l0_18
-    path: layer_27/width_16k/average_l0_18
-    l0: 18
-  - id: layer_27/width_16k/average_l0_33
-    path: layer_27/width_16k/average_l0_33
-    l0: 33
-  - id: layer_27/width_16k/average_l0_64
-    path: layer_27/width_16k/average_l0_64
-    l0: 64
-  - id: layer_27/width_16k/average_l0_136
-    path: layer_27/width_16k/average_l0_136
-    l0: 136
-  - id: layer_27/width_16k/average_l0_306
-    path: layer_27/width_16k/average_l0_306
-    l0: 306
-  - id: layer_27/width_16k/average_l0_613
-    path: layer_27/width_16k/average_l0_613
-    l0: 613
-  - id: layer_27/width_131k/average_l0_16
-    path: layer_27/width_131k/average_l0_16
-    l0: 16
-  - id: layer_27/width_131k/average_l0_28
-    path: layer_27/width_131k/average_l0_28
-    l0: 28
-  - id: layer_27/width_131k/average_l0_53
-    path: layer_27/width_131k/average_l0_53
-    l0: 53
-  - id: layer_27/width_131k/average_l0_102
-    path: layer_27/width_131k/average_l0_102
-    l0: 102
-  - id: layer_27/width_131k/average_l0_211
-    path: layer_27/width_131k/average_l0_211
-    l0: 211
-  - id: layer_27/width_131k/average_l0_458
-    path: layer_27/width_131k/average_l0_458
-    l0: 458
-  - id: layer_28/width_16k/average_l0_20
-    path: layer_28/width_16k/average_l0_20
-    l0: 20
-  - id: layer_28/width_16k/average_l0_37
-    path: layer_28/width_16k/average_l0_37
-    l0: 37
-  - id: layer_28/width_16k/average_l0_71
-    path: layer_28/width_16k/average_l0_71
-    l0: 71
-  - id: layer_28/width_16k/average_l0_143
-    path: layer_28/width_16k/average_l0_143
-    l0: 143
-  - id: layer_28/width_16k/average_l0_279
-    path: layer_28/width_16k/average_l0_279
-    l0: 279
-  - id: layer_28/width_16k/average_l0_498
-    path: layer_28/width_16k/average_l0_498
-    l0: 498
-  - id: layer_28/width_131k/average_l0_19
-    path: layer_28/width_131k/average_l0_19
-    l0: 19
-  - id: layer_28/width_131k/average_l0_32
-    path: layer_28/width_131k/average_l0_32
-    l0: 32
-  - id: layer_28/width_131k/average_l0_59
-    path: layer_28/width_131k/average_l0_59
-    l0: 59
-  - id: layer_28/width_131k/average_l0_115
-    path: layer_28/width_131k/average_l0_115
-    l0: 115
-  - id: layer_28/width_131k/average_l0_230
-    path: layer_28/width_131k/average_l0_230
-    l0: 230
-  - id: layer_28/width_131k/average_l0_452
-    path: layer_28/width_131k/average_l0_452
-    l0: 452
-  - id: layer_29/width_16k/average_l0_18
-    path: layer_29/width_16k/average_l0_18
-    l0: 18
-  - id: layer_29/width_16k/average_l0_35
-    path: layer_29/width_16k/average_l0_35
-    l0: 35
-  - id: layer_29/width_16k/average_l0_76
-    path: layer_29/width_16k/average_l0_76
-    l0: 76
-  - id: layer_29/width_16k/average_l0_171
-    path: layer_29/width_16k/average_l0_171
-    l0: 171
-  - id: layer_29/width_16k/average_l0_308
-    path: layer_29/width_16k/average_l0_308
-    l0: 308
-  - id: layer_29/width_16k/average_l0_559
-    path: layer_29/width_16k/average_l0_559
-    l0: 559
-  - id: layer_29/width_131k/average_l0_17
-    path: layer_29/width_131k/average_l0_17
-    l0: 17
-  - id: layer_29/width_131k/average_l0_30
-    path: layer_29/width_131k/average_l0_30
-    l0: 30
-  - id: layer_29/width_131k/average_l0_57
-    path: layer_29/width_131k/average_l0_57
-    l0: 57
-  - id: layer_29/width_131k/average_l0_128
-    path: layer_29/width_131k/average_l0_128
-    l0: 128
-  - id: layer_29/width_131k/average_l0_265
-    path: layer_29/width_131k/average_l0_265
-    l0: 265
-  - id: layer_29/width_131k/average_l0_446
-    path: layer_29/width_131k/average_l0_446
-    l0: 446
-  - id: layer_3/width_16k/average_l0_23
-    path: layer_3/width_16k/average_l0_23
-    l0: 23
-  - id: layer_3/width_16k/average_l0_44
-    path: layer_3/width_16k/average_l0_44
-    l0: 44
-  - id: layer_3/width_16k/average_l0_102
-    path: layer_3/width_16k/average_l0_102
-    l0: 102
-  - id: layer_3/width_16k/average_l0_221
-    path: layer_3/width_16k/average_l0_221
-    l0: 221
-  - id: layer_3/width_16k/average_l0_435
-    path: layer_3/width_16k/average_l0_435
-    l0: 435
-  - id: layer_3/width_131k/average_l0_10
-    path: layer_3/width_131k/average_l0_10
-    l0: 10
-  - id: layer_3/width_131k/average_l0_17
-    path: layer_3/width_131k/average_l0_17
-    l0: 17
-  - id: layer_3/width_131k/average_l0_31
-    path: layer_3/width_131k/average_l0_31
-    l0: 31
-  - id: layer_3/width_131k/average_l0_58
-    path: layer_3/width_131k/average_l0_58
-    l0: 58
-  - id: layer_3/width_131k/average_l0_119
-    path: layer_3/width_131k/average_l0_119
-    l0: 119
-  - id: layer_3/width_131k/average_l0_252
-    path: layer_3/width_131k/average_l0_252
-    l0: 252
-  - id: layer_30/width_16k/average_l0_19
-    path: layer_30/width_16k/average_l0_19
-    l0: 19
-  - id: layer_30/width_16k/average_l0_36
-    path: layer_30/width_16k/average_l0_36
-    l0: 36
-  - id: layer_30/width_16k/average_l0_73
-    path: layer_30/width_16k/average_l0_73
-    l0: 73
-  - id: layer_30/width_16k/average_l0_157
-    path: layer_30/width_16k/average_l0_157
-    l0: 157
-  - id: layer_30/width_16k/average_l0_313
-    path: layer_30/width_16k/average_l0_313
-    l0: 313
-  - id: layer_30/width_16k/average_l0_558
-    path: layer_30/width_16k/average_l0_558
-    l0: 558
-  - id: layer_30/width_131k/average_l0_17
-    path: layer_30/width_131k/average_l0_17
-    l0: 17
-  - id: layer_30/width_131k/average_l0_29
-    path: layer_30/width_131k/average_l0_29
-    l0: 29
-  - id: layer_30/width_131k/average_l0_55
-    path: layer_30/width_131k/average_l0_55
-    l0: 55
-  - id: layer_30/width_131k/average_l0_109
-    path: layer_30/width_131k/average_l0_109
-    l0: 109
-  - id: layer_30/width_131k/average_l0_236
-    path: layer_30/width_131k/average_l0_236
-    l0: 236
-  - id: layer_30/width_131k/average_l0_491
-    path: layer_30/width_131k/average_l0_491
-    l0: 491
-  - id: layer_31/width_16k/average_l0_18
-    path: layer_31/width_16k/average_l0_18
-    l0: 18
-  - id: layer_31/width_16k/average_l0_36
-    path: layer_31/width_16k/average_l0_36
-    l0: 36
-  - id: layer_31/width_16k/average_l0_73
-    path: layer_31/width_16k/average_l0_73
-    l0: 73
-  - id: layer_31/width_16k/average_l0_168
-    path: layer_31/width_16k/average_l0_168
-    l0: 168
-  - id: layer_31/width_16k/average_l0_356
-    path: layer_31/width_16k/average_l0_356
-    l0: 356
-  - id: layer_31/width_16k/average_l0_630
-    path: layer_31/width_16k/average_l0_630
-    l0: 630
-  - id: layer_31/width_131k/average_l0_16
-    path: layer_31/width_131k/average_l0_16
-    l0: 16
-  - id: layer_31/width_131k/average_l0_29
-    path: layer_31/width_131k/average_l0_29
-    l0: 29
-  - id: layer_31/width_131k/average_l0_56
-    path: layer_31/width_131k/average_l0_56
-    l0: 56
-  - id: layer_31/width_131k/average_l0_117
-    path: layer_31/width_131k/average_l0_117
-    l0: 117
-  - id: layer_31/width_131k/average_l0_265
-    path: layer_31/width_131k/average_l0_265
-    l0: 265
-  - id: layer_31/width_131k/average_l0_543
-    path: layer_31/width_131k/average_l0_543
-    l0: 543
-  - id: layer_32/width_16k/average_l0_18
-    path: layer_32/width_16k/average_l0_18
-    l0: 18
-  - id: layer_32/width_16k/average_l0_35
-    path: layer_32/width_16k/average_l0_35
-    l0: 35
-  - id: layer_32/width_16k/average_l0_74
-    path: layer_32/width_16k/average_l0_74
-    l0: 74
-  - id: layer_32/width_16k/average_l0_158
-    path: layer_32/width_16k/average_l0_158
-    l0: 158
-  - id: layer_32/width_16k/average_l0_306
-    path: layer_32/width_16k/average_l0_306
-    l0: 306
-  - id: layer_32/width_16k/average_l0_534
-    path: layer_32/width_16k/average_l0_534
-    l0: 534
-  - id: layer_32/width_131k/average_l0_16
-    path: layer_32/width_131k/average_l0_16
-    l0: 16
-  - id: layer_32/width_131k/average_l0_31
-    path: layer_32/width_131k/average_l0_31
-    l0: 31
-  - id: layer_32/width_131k/average_l0_56
-    path: layer_32/width_131k/average_l0_56
-    l0: 56
-  - id: layer_32/width_131k/average_l0_117
-    path: layer_32/width_131k/average_l0_117
-    l0: 117
-  - id: layer_32/width_131k/average_l0_248
-    path: layer_32/width_131k/average_l0_248
-    l0: 248
-  - id: layer_32/width_131k/average_l0_464
-    path: layer_32/width_131k/average_l0_464
-    l0: 464
-  - id: layer_33/width_16k/average_l0_17
-    path: layer_33/width_16k/average_l0_17
-    l0: 17
-  - id: layer_33/width_16k/average_l0_37
-    path: layer_33/width_16k/average_l0_37
-    l0: 37
-  - id: layer_33/width_16k/average_l0_78
-    path: layer_33/width_16k/average_l0_78
-    l0: 78
-  - id: layer_33/width_16k/average_l0_158
-    path: layer_33/width_16k/average_l0_158
-    l0: 158
-  - id: layer_33/width_16k/average_l0_318
-    path: layer_33/width_16k/average_l0_318
-    l0: 318
-  - id: layer_33/width_16k/average_l0_531
-    path: layer_33/width_16k/average_l0_531
-    l0: 531
-  - id: layer_33/width_131k/average_l0_16
-    path: layer_33/width_131k/average_l0_16
-    l0: 16
-  - id: layer_33/width_131k/average_l0_28
-    path: layer_33/width_131k/average_l0_28
-    l0: 28
-  - id: layer_33/width_131k/average_l0_58
-    path: layer_33/width_131k/average_l0_58
-    l0: 58
-  - id: layer_33/width_131k/average_l0_128
-    path: layer_33/width_131k/average_l0_128
-    l0: 128
-  - id: layer_33/width_131k/average_l0_248
-    path: layer_33/width_131k/average_l0_248
-    l0: 248
-  - id: layer_33/width_131k/average_l0_471
-    path: layer_33/width_131k/average_l0_471
-    l0: 471
-  - id: layer_34/width_16k/average_l0_17
-    path: layer_34/width_16k/average_l0_17
-    l0: 17
-  - id: layer_34/width_16k/average_l0_38
-    path: layer_34/width_16k/average_l0_38
-    l0: 38
-  - id: layer_34/width_16k/average_l0_91
-    path: layer_34/width_16k/average_l0_91
-    l0: 91
-  - id: layer_34/width_16k/average_l0_192
-    path: layer_34/width_16k/average_l0_192
-    l0: 192
-  - id: layer_34/width_16k/average_l0_339
-    path: layer_34/width_16k/average_l0_339
-    l0: 339
-  - id: layer_34/width_16k/average_l0_527
-    path: layer_34/width_16k/average_l0_527
-    l0: 527
-  - id: layer_34/width_131k/average_l0_15
-    path: layer_34/width_131k/average_l0_15
-    l0: 15
-  - id: layer_34/width_131k/average_l0_29
-    path: layer_34/width_131k/average_l0_29
-    l0: 29
-  - id: layer_34/width_131k/average_l0_63
-    path: layer_34/width_131k/average_l0_63
-    l0: 63
-  - id: layer_34/width_131k/average_l0_199
-    path: layer_34/width_131k/average_l0_199
-    l0: 199
-  - id: layer_34/width_131k/average_l0_291
-    path: layer_34/width_131k/average_l0_291
-    l0: 291
-  - id: layer_34/width_131k/average_l0_483
-    path: layer_34/width_131k/average_l0_483
-    l0: 483
-  - id: layer_35/width_16k/average_l0_14
-    path: layer_35/width_16k/average_l0_14
-    l0: 14
-  - id: layer_35/width_16k/average_l0_33
-    path: layer_35/width_16k/average_l0_33
-    l0: 33
-  - id: layer_35/width_16k/average_l0_77
-    path: layer_35/width_16k/average_l0_77
-    l0: 77
-  - id: layer_35/width_16k/average_l0_168
-    path: layer_35/width_16k/average_l0_168
-    l0: 168
-  - id: layer_35/width_16k/average_l0_303
-    path: layer_35/width_16k/average_l0_303
-    l0: 303
-  - id: layer_35/width_16k/average_l0_488
-    path: layer_35/width_16k/average_l0_488
-    l0: 488
-  - id: layer_35/width_131k/average_l0_13
-    path: layer_35/width_131k/average_l0_13
-    l0: 13
-  - id: layer_35/width_131k/average_l0_26
-    path: layer_35/width_131k/average_l0_26
-    l0: 26
-  - id: layer_35/width_131k/average_l0_54
-    path: layer_35/width_131k/average_l0_54
-    l0: 54
-  - id: layer_35/width_131k/average_l0_124
-    path: layer_35/width_131k/average_l0_124
-    l0: 124
-  - id: layer_35/width_131k/average_l0_258
-    path: layer_35/width_131k/average_l0_258
-    l0: 258
-  - id: layer_35/width_131k/average_l0_427
-    path: layer_35/width_131k/average_l0_427
-    l0: 427
-  - id: layer_36/width_16k/average_l0_15
-    path: layer_36/width_16k/average_l0_15
-    l0: 15
-  - id: layer_36/width_16k/average_l0_32
-    path: layer_36/width_16k/average_l0_32
-    l0: 32
-  - id: layer_36/width_16k/average_l0_69
-    path: layer_36/width_16k/average_l0_69
-    l0: 69
-  - id: layer_36/width_16k/average_l0_144
-    path: layer_36/width_16k/average_l0_144
-    l0: 144
-  - id: layer_36/width_16k/average_l0_293
-    path: layer_36/width_16k/average_l0_293
-    l0: 293
-  - id: layer_36/width_16k/average_l0_544
-    path: layer_36/width_16k/average_l0_544
-    l0: 544
-  - id: layer_36/width_131k/average_l0_16
-    path: layer_36/width_131k/average_l0_16
-    l0: 16
-  - id: layer_36/width_131k/average_l0_26
-    path: layer_36/width_131k/average_l0_26
-    l0: 26
-  - id: layer_36/width_131k/average_l0_51
-    path: layer_36/width_131k/average_l0_51
-    l0: 51
-  - id: layer_36/width_131k/average_l0_105
-    path: layer_36/width_131k/average_l0_105
-    l0: 105
-  - id: layer_36/width_131k/average_l0_229
-    path: layer_36/width_131k/average_l0_229
-    l0: 229
-  - id: layer_36/width_131k/average_l0_455
-    path: layer_36/width_131k/average_l0_455
-    l0: 455
-  - id: layer_37/width_16k/average_l0_17
-    path: layer_37/width_16k/average_l0_17
-    l0: 17
-  - id: layer_37/width_16k/average_l0_34
-    path: layer_37/width_16k/average_l0_34
-    l0: 34
-  - id: layer_37/width_16k/average_l0_82
-    path: layer_37/width_16k/average_l0_82
-    l0: 82
-  - id: layer_37/width_16k/average_l0_172
-    path: layer_37/width_16k/average_l0_172
-    l0: 172
-  - id: layer_37/width_16k/average_l0_309
-    path: layer_37/width_16k/average_l0_309
-    l0: 309
-  - id: layer_37/width_16k/average_l0_519
-    path: layer_37/width_16k/average_l0_519
-    l0: 519
-  - id: layer_37/width_131k/average_l0_15
-    path: layer_37/width_131k/average_l0_15
-    l0: 15
-  - id: layer_37/width_131k/average_l0_28
-    path: layer_37/width_131k/average_l0_28
-    l0: 28
-  - id: layer_37/width_131k/average_l0_55
-    path: layer_37/width_131k/average_l0_55
-    l0: 55
-  - id: layer_37/width_131k/average_l0_124
-    path: layer_37/width_131k/average_l0_124
-    l0: 124
-  - id: layer_37/width_131k/average_l0_248
-    path: layer_37/width_131k/average_l0_248
-    l0: 248
-  - id: layer_37/width_131k/average_l0_450
-    path: layer_37/width_131k/average_l0_450
-    l0: 450
-  - id: layer_38/width_16k/average_l0_18
-    path: layer_38/width_16k/average_l0_18
-    l0: 18
-  - id: layer_38/width_16k/average_l0_36
-    path: layer_38/width_16k/average_l0_36
-    l0: 36
-  - id: layer_38/width_16k/average_l0_81
-    path: layer_38/width_16k/average_l0_81
-    l0: 81
-  - id: layer_38/width_16k/average_l0_175
-    path: layer_38/width_16k/average_l0_175
-    l0: 175
-  - id: layer_38/width_16k/average_l0_334
-    path: layer_38/width_16k/average_l0_334
-    l0: 334
-  - id: layer_38/width_16k/average_l0_547
-    path: layer_38/width_16k/average_l0_547
-    l0: 547
-  - id: layer_38/width_131k/average_l0_17
-    path: layer_38/width_131k/average_l0_17
-    l0: 17
-  - id: layer_38/width_131k/average_l0_30
-    path: layer_38/width_131k/average_l0_30
-    l0: 30
-  - id: layer_38/width_131k/average_l0_60
-    path: layer_38/width_131k/average_l0_60
-    l0: 60
-  - id: layer_38/width_131k/average_l0_135
-    path: layer_38/width_131k/average_l0_135
-    l0: 135
-  - id: layer_38/width_131k/average_l0_284
-    path: layer_38/width_131k/average_l0_284
-    l0: 284
-  - id: layer_38/width_131k/average_l0_489
-    path: layer_38/width_131k/average_l0_489
-    l0: 489
-  - id: layer_39/width_16k/average_l0_15
-    path: layer_39/width_16k/average_l0_15
-    l0: 15
-  - id: layer_39/width_16k/average_l0_33
-    path: layer_39/width_16k/average_l0_33
-    l0: 33
-  - id: layer_39/width_16k/average_l0_77
-    path: layer_39/width_16k/average_l0_77
-    l0: 77
-  - id: layer_39/width_16k/average_l0_176
-    path: layer_39/width_16k/average_l0_176
-    l0: 176
-  - id: layer_39/width_16k/average_l0_391
-    path: layer_39/width_16k/average_l0_391
-    l0: 391
-  - id: layer_39/width_16k/average_l0_694
-    path: layer_39/width_16k/average_l0_694
-    l0: 694
-  - id: layer_39/width_131k/average_l0_17
-    path: layer_39/width_131k/average_l0_17
-    l0: 17
-  - id: layer_39/width_131k/average_l0_27
-    path: layer_39/width_131k/average_l0_27
-    l0: 27
-  - id: layer_39/width_131k/average_l0_54
-    path: layer_39/width_131k/average_l0_54
-    l0: 54
-  - id: layer_39/width_131k/average_l0_120
-    path: layer_39/width_131k/average_l0_120
-    l0: 120
-  - id: layer_39/width_131k/average_l0_273
-    path: layer_39/width_131k/average_l0_273
-    l0: 273
-  - id: layer_39/width_131k/average_l0_604
-    path: layer_39/width_131k/average_l0_604
-    l0: 604
-  - id: layer_4/width_16k/average_l0_26
-    path: layer_4/width_16k/average_l0_26
-    l0: 26
-  - id: layer_4/width_16k/average_l0_54
-    path: layer_4/width_16k/average_l0_54
-    l0: 54
-  - id: layer_4/width_16k/average_l0_126
-    path: layer_4/width_16k/average_l0_126
-    l0: 126
-  - id: layer_4/width_16k/average_l0_274
-    path: layer_4/width_16k/average_l0_274
-    l0: 274
-  - id: layer_4/width_16k/average_l0_524
-    path: layer_4/width_16k/average_l0_524
-    l0: 524
-  - id: layer_4/width_131k/average_l0_12
-    path: layer_4/width_131k/average_l0_12
-    l0: 12
-  - id: layer_4/width_131k/average_l0_21
-    path: layer_4/width_131k/average_l0_21
-    l0: 21
-  - id: layer_4/width_131k/average_l0_38
-    path: layer_4/width_131k/average_l0_38
-    l0: 38
-  - id: layer_4/width_131k/average_l0_75
-    path: layer_4/width_131k/average_l0_75
-    l0: 75
-  - id: layer_4/width_131k/average_l0_163
-    path: layer_4/width_131k/average_l0_163
-    l0: 163
-  - id: layer_4/width_131k/average_l0_330
-    path: layer_4/width_131k/average_l0_330
-    l0: 330
-  - id: layer_40/width_16k/average_l0_18
-    path: layer_40/width_16k/average_l0_18
-    l0: 18
-  - id: layer_40/width_16k/average_l0_38
-    path: layer_40/width_16k/average_l0_38
-    l0: 38
-  - id: layer_40/width_16k/average_l0_91
-    path: layer_40/width_16k/average_l0_91
-    l0: 91
-  - id: layer_40/width_16k/average_l0_189
-    path: layer_40/width_16k/average_l0_189
-    l0: 189
-  - id: layer_40/width_16k/average_l0_341
-    path: layer_40/width_16k/average_l0_341
-    l0: 341
-  - id: layer_40/width_16k/average_l0_603
-    path: layer_40/width_16k/average_l0_603
-    l0: 603
-  - id: layer_40/width_131k/average_l0_16
-    path: layer_40/width_131k/average_l0_16
-    l0: 16
-  - id: layer_40/width_131k/average_l0_30
-    path: layer_40/width_131k/average_l0_30
-    l0: 30
-  - id: layer_40/width_131k/average_l0_64
-    path: layer_40/width_131k/average_l0_64
-    l0: 64
-  - id: layer_40/width_131k/average_l0_144
-    path: layer_40/width_131k/average_l0_144
-    l0: 144
-  - id: layer_40/width_131k/average_l0_269
-    path: layer_40/width_131k/average_l0_269
-    l0: 269
-  - id: layer_40/width_131k/average_l0_493
-    path: layer_40/width_131k/average_l0_493
-    l0: 493
-  - id: layer_41/width_16k/average_l0_13
-    path: layer_41/width_16k/average_l0_13
-    l0: 13
-  - id: layer_41/width_16k/average_l0_25
-    path: layer_41/width_16k/average_l0_25
-    l0: 25
-  - id: layer_41/width_16k/average_l0_56
-    path: layer_41/width_16k/average_l0_56
-    l0: 56
-  - id: layer_41/width_16k/average_l0_129
-    path: layer_41/width_16k/average_l0_129
-    l0: 129
-  - id: layer_41/width_16k/average_l0_254
-    path: layer_41/width_16k/average_l0_254
-    l0: 254
-  - id: layer_41/width_16k/average_l0_450
-    path: layer_41/width_16k/average_l0_450
-    l0: 450
-  - id: layer_41/width_131k/average_l0_13
-    path: layer_41/width_131k/average_l0_13
-    l0: 13
-  - id: layer_41/width_131k/average_l0_22
-    path: layer_41/width_131k/average_l0_22
-    l0: 22
-  - id: layer_41/width_131k/average_l0_43
-    path: layer_41/width_131k/average_l0_43
-    l0: 43
-  - id: layer_41/width_131k/average_l0_92
-    path: layer_41/width_131k/average_l0_92
-    l0: 92
-  - id: layer_41/width_131k/average_l0_202
-    path: layer_41/width_131k/average_l0_202
-    l0: 202
-  - id: layer_41/width_131k/average_l0_370
-    path: layer_41/width_131k/average_l0_370
-    l0: 370
-  - id: layer_5/width_16k/average_l0_25
-    path: layer_5/width_16k/average_l0_25
-    l0: 25
-  - id: layer_5/width_16k/average_l0_53
-    path: layer_5/width_16k/average_l0_53
-    l0: 53
-  - id: layer_5/width_16k/average_l0_125
-    path: layer_5/width_16k/average_l0_125
-    l0: 125
-  - id: layer_5/width_16k/average_l0_270
-    path: layer_5/width_16k/average_l0_270
-    l0: 270
-  - id: layer_5/width_16k/average_l0_529
-    path: layer_5/width_16k/average_l0_529
-    l0: 529
-  - id: layer_5/width_131k/average_l0_12
-    path: layer_5/width_131k/average_l0_12
-    l0: 12
-  - id: layer_5/width_131k/average_l0_21
-    path: layer_5/width_131k/average_l0_21
-    l0: 21
-  - id: layer_5/width_131k/average_l0_39
-    path: layer_5/width_131k/average_l0_39
-    l0: 39
-  - id: layer_5/width_131k/average_l0_78
-    path: layer_5/width_131k/average_l0_78
-    l0: 78
-  - id: layer_5/width_131k/average_l0_160
-    path: layer_5/width_131k/average_l0_160
-    l0: 160
-  - id: layer_5/width_131k/average_l0_351
-    path: layer_5/width_131k/average_l0_351
-    l0: 351
-  - id: layer_6/width_16k/average_l0_16
-    path: layer_6/width_16k/average_l0_16
-    l0: 16
-  - id: layer_6/width_16k/average_l0_28
-    path: layer_6/width_16k/average_l0_28
-    l0: 28
-  - id: layer_6/width_16k/average_l0_51
-    path: layer_6/width_16k/average_l0_51
-    l0: 51
-  - id: layer_6/width_16k/average_l0_108
-    path: layer_6/width_16k/average_l0_108
-    l0: 108
-  - id: layer_6/width_16k/average_l0_258
-    path: layer_6/width_16k/average_l0_258
-    l0: 258
-  - id: layer_6/width_131k/average_l0_14
-    path: layer_6/width_131k/average_l0_14
-    l0: 14
-  - id: layer_6/width_131k/average_l0_24
-    path: layer_6/width_131k/average_l0_24
-    l0: 24
-  - id: layer_6/width_131k/average_l0_41
-    path: layer_6/width_131k/average_l0_41
-    l0: 41
-  - id: layer_6/width_131k/average_l0_73
-    path: layer_6/width_131k/average_l0_73
-    l0: 73
-  - id: layer_6/width_131k/average_l0_148
-    path: layer_6/width_131k/average_l0_148
-    l0: 148
-  - id: layer_6/width_131k/average_l0_353
-    path: layer_6/width_131k/average_l0_353
-    l0: 353
-  - id: layer_7/width_16k/average_l0_18
-    path: layer_7/width_16k/average_l0_18
-    l0: 18
-  - id: layer_7/width_16k/average_l0_33
-    path: layer_7/width_16k/average_l0_33
-    l0: 33
-  - id: layer_7/width_16k/average_l0_70
-    path: layer_7/width_16k/average_l0_70
-    l0: 70
-  - id: layer_7/width_16k/average_l0_160
-    path: layer_7/width_16k/average_l0_160
-    l0: 160
-  - id: layer_7/width_16k/average_l0_335
-    path: layer_7/width_16k/average_l0_335
-    l0: 335
-  - id: layer_7/width_131k/average_l0_16
-    path: layer_7/width_131k/average_l0_16
-    l0: 16
-  - id: layer_7/width_131k/average_l0_28
-    path: layer_7/width_131k/average_l0_28
-    l0: 28
-  - id: layer_7/width_131k/average_l0_52
-    path: layer_7/width_131k/average_l0_52
-    l0: 52
-  - id: layer_7/width_131k/average_l0_106
-    path: layer_7/width_131k/average_l0_106
-    l0: 106
-  - id: layer_7/width_131k/average_l0_229
-    path: layer_7/width_131k/average_l0_229
-    l0: 229
-  - id: layer_7/width_131k/average_l0_473
-    path: layer_7/width_131k/average_l0_473
-    l0: 473
-  - id: layer_8/width_16k/average_l0_17
-    path: layer_8/width_16k/average_l0_17
-    l0: 17
-  - id: layer_8/width_16k/average_l0_32
-    path: layer_8/width_16k/average_l0_32
-    l0: 32
-  - id: layer_8/width_16k/average_l0_65
-    path: layer_8/width_16k/average_l0_65
-    l0: 65
-  - id: layer_8/width_16k/average_l0_150
-    path: layer_8/width_16k/average_l0_150
-    l0: 150
-  - id: layer_8/width_16k/average_l0_362
-    path: layer_8/width_16k/average_l0_362
-    l0: 362
-  - id: layer_8/width_131k/average_l0_16
-    path: layer_8/width_131k/average_l0_16
-    l0: 16
-  - id: layer_8/width_131k/average_l0_27
-    path: layer_8/width_131k/average_l0_27
-    l0: 27
-  - id: layer_8/width_131k/average_l0_51
-    path: layer_8/width_131k/average_l0_51
-    l0: 51
-  - id: layer_8/width_131k/average_l0_98
-    path: layer_8/width_131k/average_l0_98
-    l0: 98
-  - id: layer_8/width_131k/average_l0_222
-    path: layer_8/width_131k/average_l0_222
-    l0: 222
-  - id: layer_8/width_131k/average_l0_531
-    path: layer_8/width_131k/average_l0_531
-    l0: 531
-  - id: layer_9/width_16k/average_l0_18
-    path: layer_9/width_16k/average_l0_18
-    l0: 18
-  - id: layer_9/width_16k/average_l0_34
-    path: layer_9/width_16k/average_l0_34
-    l0: 34
-  - id: layer_9/width_16k/average_l0_71
-    path: layer_9/width_16k/average_l0_71
-    l0: 71
-  - id: layer_9/width_16k/average_l0_172
-    path: layer_9/width_16k/average_l0_172
-    l0: 172
-  - id: layer_9/width_16k/average_l0_349
-    path: layer_9/width_16k/average_l0_349
-    l0: 349
-  - id: layer_9/width_131k/average_l0_16
-    path: layer_9/width_131k/average_l0_16
-    l0: 16
-  - id: layer_9/width_131k/average_l0_30
-    path: layer_9/width_131k/average_l0_30
-    l0: 30
-  - id: layer_9/width_131k/average_l0_54
-    path: layer_9/width_131k/average_l0_54
-    l0: 54
-  - id: layer_9/width_131k/average_l0_111
-    path: layer_9/width_131k/average_l0_111
-    l0: 111
-  - id: layer_9/width_131k/average_l0_263
-    path: layer_9/width_131k/average_l0_263
-    l0: 263
-  - id: layer_9/width_131k/average_l0_511
-    path: layer_9/width_131k/average_l0_511
-    l0: 511
-gemma-scope-9b-pt-att-canonical:
-  repo_id: google/gemma-scope-9b-pt-att
-  model: gemma-2-9b
-  conversion_func: gemma_2
-  saes:
-  - id: layer_0/width_16k/canonical
-    path: layer_0/width_16k/average_l0_61
-    neuronpedia: gemma-2-9b/0-gemmascope-att-16k
-  - id: layer_1/width_16k/canonical
-    path: layer_1/width_16k/average_l0_77
-    neuronpedia: gemma-2-9b/1-gemmascope-att-16k
-  - id: layer_2/width_16k/canonical
-    path: layer_2/width_16k/average_l0_69
-    neuronpedia: gemma-2-9b/2-gemmascope-att-16k
-  - id: layer_3/width_16k/canonical
-    path: layer_3/width_16k/average_l0_102
-    neuronpedia: gemma-2-9b/3-gemmascope-att-16k
-  - id: layer_4/width_16k/canonical
-    path: layer_4/width_16k/average_l0_126
-    neuronpedia: gemma-2-9b/4-gemmascope-att-16k
-  - id: layer_5/width_16k/canonical
-    path: layer_5/width_16k/average_l0_125
-    neuronpedia: gemma-2-9b/5-gemmascope-att-16k
-  - id: layer_6/width_16k/canonical
-    path: layer_6/width_16k/average_l0_108
-    neuronpedia: gemma-2-9b/6-gemmascope-att-16k
-  - id: layer_7/width_16k/canonical
-    path: layer_7/width_16k/average_l0_70
-    neuronpedia: gemma-2-9b/7-gemmascope-att-16k
-  - id: layer_8/width_16k/canonical
-    path: layer_8/width_16k/average_l0_65
-    neuronpedia: gemma-2-9b/8-gemmascope-att-16k
-  - id: layer_9/width_16k/canonical
-    path: layer_9/width_16k/average_l0_71
-    neuronpedia: gemma-2-9b/9-gemmascope-att-16k
-  - id: layer_10/width_16k/canonical
-    path: layer_10/width_16k/average_l0_132
-    neuronpedia: gemma-2-9b/10-gemmascope-att-16k
-  - id: layer_11/width_16k/canonical
-    path: layer_11/width_16k/average_l0_67
-    neuronpedia: gemma-2-9b/11-gemmascope-att-16k
-  - id: layer_12/width_16k/canonical
-    path: layer_12/width_16k/average_l0_68
-    neuronpedia: gemma-2-9b/12-gemmascope-att-16k
-  - id: layer_13/width_16k/canonical
-    path: layer_13/width_16k/average_l0_77
-    neuronpedia: gemma-2-9b/13-gemmascope-att-16k
-  - id: layer_14/width_16k/canonical
-    path: layer_14/width_16k/average_l0_81
-    neuronpedia: gemma-2-9b/14-gemmascope-att-16k
-  - id: layer_15/width_16k/canonical
-    path: layer_15/width_16k/average_l0_79
-    neuronpedia: gemma-2-9b/15-gemmascope-att-16k
-  - id: layer_16/width_16k/canonical
-    path: layer_16/width_16k/average_l0_81
-    neuronpedia: gemma-2-9b/16-gemmascope-att-16k
-  - id: layer_17/width_16k/canonical
-    path: layer_17/width_16k/average_l0_110
-    neuronpedia: gemma-2-9b/17-gemmascope-att-16k
-  - id: layer_18/width_16k/canonical
-    path: layer_18/width_16k/average_l0_80
-    neuronpedia: gemma-2-9b/18-gemmascope-att-16k
-  - id: layer_19/width_16k/canonical
-    path: layer_19/width_16k/average_l0_86
-    neuronpedia: gemma-2-9b/19-gemmascope-att-16k
-  - id: layer_20/width_16k/canonical
-    path: layer_20/width_16k/average_l0_76
-    neuronpedia: gemma-2-9b/20-gemmascope-att-16k
-  - id: layer_21/width_16k/canonical
-    path: layer_21/width_16k/average_l0_86
-    neuronpedia: gemma-2-9b/21-gemmascope-att-16k
-  - id: layer_22/width_16k/canonical
-    path: layer_22/width_16k/average_l0_70
-    neuronpedia: gemma-2-9b/22-gemmascope-att-16k
-  - id: layer_23/width_16k/canonical
-    path: layer_23/width_16k/average_l0_80
-    neuronpedia: gemma-2-9b/23-gemmascope-att-16k
-  - id: layer_24/width_16k/canonical
-    path: layer_24/width_16k/average_l0_79
-    neuronpedia: gemma-2-9b/24-gemmascope-att-16k
-  - id: layer_25/width_16k/canonical
-    path: layer_25/width_16k/average_l0_73
-    neuronpedia: gemma-2-9b/25-gemmascope-att-16k
-  - id: layer_26/width_16k/canonical
-    path: layer_26/width_16k/average_l0_75
-    neuronpedia: gemma-2-9b/26-gemmascope-att-16k
-  - id: layer_27/width_16k/canonical
-    path: layer_27/width_16k/average_l0_136
-    neuronpedia: gemma-2-9b/27-gemmascope-att-16k
-  - id: layer_28/width_16k/canonical
-    path: layer_28/width_16k/average_l0_71
-    neuronpedia: gemma-2-9b/28-gemmascope-att-16k
-  - id: layer_29/width_16k/canonical
-    path: layer_29/width_16k/average_l0_76
-    neuronpedia: gemma-2-9b/29-gemmascope-att-16k
-  - id: layer_30/width_16k/canonical
-    path: layer_30/width_16k/average_l0_73
-    neuronpedia: gemma-2-9b/30-gemmascope-att-16k
-  - id: layer_31/width_16k/canonical
-    path: layer_31/width_16k/average_l0_73
-    neuronpedia: gemma-2-9b/31-gemmascope-att-16k
-  - id: layer_32/width_16k/canonical
-    path: layer_32/width_16k/average_l0_74
-    neuronpedia: gemma-2-9b/32-gemmascope-att-16k
-  - id: layer_33/width_16k/canonical
-    path: layer_33/width_16k/average_l0_78
-    neuronpedia: gemma-2-9b/33-gemmascope-att-16k
-  - id: layer_34/width_16k/canonical
-    path: layer_34/width_16k/average_l0_91
-    neuronpedia: gemma-2-9b/34-gemmascope-att-16k
-  - id: layer_35/width_16k/canonical
-    path: layer_35/width_16k/average_l0_77
-    neuronpedia: gemma-2-9b/35-gemmascope-att-16k
-  - id: layer_36/width_16k/canonical
-    path: layer_36/width_16k/average_l0_69
-    neuronpedia: gemma-2-9b/36-gemmascope-att-16k
-  - id: layer_37/width_16k/canonical
-    path: layer_37/width_16k/average_l0_82
-    neuronpedia: gemma-2-9b/37-gemmascope-att-16k
-  - id: layer_38/width_16k/canonical
-    path: layer_38/width_16k/average_l0_81
-    neuronpedia: gemma-2-9b/38-gemmascope-att-16k
-  - id: layer_39/width_16k/canonical
-    path: layer_39/width_16k/average_l0_77
-    neuronpedia: gemma-2-9b/39-gemmascope-att-16k
-  - id: layer_40/width_16k/canonical
-    path: layer_40/width_16k/average_l0_91
-    neuronpedia: gemma-2-9b/40-gemmascope-att-16k
-  - id: layer_41/width_16k/canonical
-    path: layer_41/width_16k/average_l0_129
-    neuronpedia: gemma-2-9b/41-gemmascope-att-16k
-  - id: layer_0/width_131k/canonical
-    path: layer_0/width_131k/average_l0_55
-    neuronpedia: gemma-2-9b/0-gemmascope-att-131k
-  - id: layer_1/width_131k/canonical
-    path: layer_1/width_131k/average_l0_116
-    neuronpedia: gemma-2-9b/1-gemmascope-att-131k
-  - id: layer_2/width_131k/canonical
-    path: layer_2/width_131k/average_l0_135
-    neuronpedia: gemma-2-9b/2-gemmascope-att-131k
-  - id: layer_3/width_131k/canonical
-    path: layer_3/width_131k/average_l0_119
-    neuronpedia: gemma-2-9b/3-gemmascope-att-131k
-  - id: layer_4/width_131k/canonical
-    path: layer_4/width_131k/average_l0_75
-    neuronpedia: gemma-2-9b/4-gemmascope-att-131k
-  - id: layer_5/width_131k/canonical
-    path: layer_5/width_131k/average_l0_78
-    neuronpedia: gemma-2-9b/5-gemmascope-att-131k
-  - id: layer_6/width_131k/canonical
-    path: layer_6/width_131k/average_l0_73
-    neuronpedia: gemma-2-9b/6-gemmascope-att-131k
-  - id: layer_7/width_131k/canonical
-    path: layer_7/width_131k/average_l0_106
-    neuronpedia: gemma-2-9b/7-gemmascope-att-131k
-  - id: layer_8/width_131k/canonical
-    path: layer_8/width_131k/average_l0_98
-    neuronpedia: gemma-2-9b/8-gemmascope-att-131k
-  - id: layer_9/width_131k/canonical
-    path: layer_9/width_131k/average_l0_111
-    neuronpedia: gemma-2-9b/9-gemmascope-att-131k
-  - id: layer_10/width_131k/canonical
-    path: layer_10/width_131k/average_l0_97
-    neuronpedia: gemma-2-9b/10-gemmascope-att-131k
-  - id: layer_11/width_131k/canonical
-    path: layer_11/width_131k/average_l0_104
-    neuronpedia: gemma-2-9b/11-gemmascope-att-131k
-  - id: layer_12/width_131k/canonical
-    path: layer_12/width_131k/average_l0_110
-    neuronpedia: gemma-2-9b/12-gemmascope-att-131k
-  - id: layer_13/width_131k/canonical
-    path: layer_13/width_131k/average_l0_126
-    neuronpedia: gemma-2-9b/13-gemmascope-att-131k
-  - id: layer_14/width_131k/canonical
-    path: layer_14/width_131k/average_l0_131
-    neuronpedia: gemma-2-9b/14-gemmascope-att-131k
-  - id: layer_15/width_131k/canonical
-    path: layer_15/width_131k/average_l0_130
-    neuronpedia: gemma-2-9b/15-gemmascope-att-131k
-  - id: layer_16/width_131k/canonical
-    path: layer_16/width_131k/average_l0_71
-    neuronpedia: gemma-2-9b/16-gemmascope-att-131k
-  - id: layer_17/width_131k/canonical
-    path: layer_17/width_131k/average_l0_90
-    neuronpedia: gemma-2-9b/17-gemmascope-att-131k
-  - id: layer_18/width_131k/canonical
-    path: layer_18/width_131k/average_l0_69
-    neuronpedia: gemma-2-9b/18-gemmascope-att-131k
-  - id: layer_19/width_131k/canonical
-    path: layer_19/width_131k/average_l0_71
-    neuronpedia: gemma-2-9b/19-gemmascope-att-131k
-  - id: layer_20/width_131k/canonical
-    path: layer_20/width_131k/average_l0_125
-    neuronpedia: gemma-2-9b/20-gemmascope-att-131k
-  - id: layer_21/width_131k/canonical
-    path: layer_21/width_131k/average_l0_71
-    neuronpedia: gemma-2-9b/21-gemmascope-att-131k
-  - id: layer_22/width_131k/canonical
-    path: layer_22/width_131k/average_l0_115
-    neuronpedia: gemma-2-9b/22-gemmascope-att-131k
-  - id: layer_23/width_131k/canonical
-    path: layer_23/width_131k/average_l0_66
-    neuronpedia: gemma-2-9b/23-gemmascope-att-131k
-  - id: layer_24/width_131k/canonical
-    path: layer_24/width_131k/average_l0_130
-    neuronpedia: gemma-2-9b/24-gemmascope-att-131k
-  - id: layer_25/width_131k/canonical
-    path: layer_25/width_131k/average_l0_115
-    neuronpedia: gemma-2-9b/25-gemmascope-att-131k
-  - id: layer_26/width_131k/canonical
-    path: layer_26/width_131k/average_l0_120
-    neuronpedia: gemma-2-9b/26-gemmascope-att-131k
-  - id: layer_27/width_131k/canonical
-    path: layer_27/width_131k/average_l0_102
-    neuronpedia: gemma-2-9b/27-gemmascope-att-131k
-  - id: layer_28/width_131k/canonical
-    path: layer_28/width_131k/average_l0_115
-    neuronpedia: gemma-2-9b/28-gemmascope-att-131k
-  - id: layer_29/width_131k/canonical
-    path: layer_29/width_131k/average_l0_128
-    neuronpedia: gemma-2-9b/29-gemmascope-att-131k
-  - id: layer_30/width_131k/canonical
-    path: layer_30/width_131k/average_l0_109
-    neuronpedia: gemma-2-9b/30-gemmascope-att-131k
-  - id: layer_31/width_131k/canonical
-    path: layer_31/width_131k/average_l0_117
-    neuronpedia: gemma-2-9b/31-gemmascope-att-131k
-  - id: layer_32/width_131k/canonical
-    path: layer_32/width_131k/average_l0_117
-    neuronpedia: gemma-2-9b/32-gemmascope-att-131k
-  - id: layer_33/width_131k/canonical
-    path: layer_33/width_131k/average_l0_128
-    neuronpedia: gemma-2-9b/33-gemmascope-att-131k
-  - id: layer_34/width_131k/canonical
-    path: layer_34/width_131k/average_l0_63
-    neuronpedia: gemma-2-9b/34-gemmascope-att-131k
-  - id: layer_35/width_131k/canonical
-    path: layer_35/width_131k/average_l0_124
-    neuronpedia: gemma-2-9b/35-gemmascope-att-131k
-  - id: layer_36/width_131k/canonical
-    path: layer_36/width_131k/average_l0_105
-    neuronpedia: gemma-2-9b/36-gemmascope-att-131k
-  - id: layer_37/width_131k/canonical
-    path: layer_37/width_131k/average_l0_124
-    neuronpedia: gemma-2-9b/37-gemmascope-att-131k
-  - id: layer_38/width_131k/canonical
-    path: layer_38/width_131k/average_l0_135
-    neuronpedia: gemma-2-9b/38-gemmascope-att-131k
-  - id: layer_39/width_131k/canonical
-    path: layer_39/width_131k/average_l0_120
-    neuronpedia: gemma-2-9b/39-gemmascope-att-131k
-  - id: layer_40/width_131k/canonical
-    path: layer_40/width_131k/average_l0_64
-    neuronpedia: gemma-2-9b/40-gemmascope-att-131k
-  - id: layer_41/width_131k/canonical
-    path: layer_41/width_131k/average_l0_92
-    neuronpedia: gemma-2-9b/41-gemmascope-att-131k
-gemma-scope-9b-pt-mlp:
-  repo_id: google/gemma-scope-9b-pt-mlp
-  model: gemma-2-9b
-  conversion_func: gemma_2
-  saes:
-  - id: layer_0/width_16k/average_l0_6
-    path: layer_0/width_16k/average_l0_6
-    l0: 6
-  - id: layer_0/width_16k/average_l0_10
-    path: layer_0/width_16k/average_l0_10
-    l0: 10
-  - id: layer_0/width_16k/average_l0_16
-    path: layer_0/width_16k/average_l0_16
-    l0: 16
-  - id: layer_0/width_16k/average_l0_28
-    path: layer_0/width_16k/average_l0_28
-    l0: 28
-  - id: layer_0/width_16k/average_l0_50
-    path: layer_0/width_16k/average_l0_50
-    l0: 50
-    neuronpedia: gemma-2-9b/0-gemmascope-mlp-16k__l0-50
-  - id: layer_0/width_131k/average_l0_3
-    path: layer_0/width_131k/average_l0_3
-    l0: 3
-  - id: layer_0/width_131k/average_l0_5
-    path: layer_0/width_131k/average_l0_5
-    l0: 5
-  - id: layer_0/width_131k/average_l0_7
-    path: layer_0/width_131k/average_l0_7
-    l0: 7
-  - id: layer_0/width_131k/average_l0_11
-    path: layer_0/width_131k/average_l0_11
-    l0: 11
-  - id: layer_0/width_131k/average_l0_18
-    path: layer_0/width_131k/average_l0_18
-    l0: 18
-  - id: layer_0/width_131k/average_l0_30
-    path: layer_0/width_131k/average_l0_30
-    l0: 30
-  - id: layer_1/width_16k/average_l0_12
-    path: layer_1/width_16k/average_l0_12
-    l0: 12
-  - id: layer_1/width_16k/average_l0_26
-    path: layer_1/width_16k/average_l0_26
-    l0: 26
-  - id: layer_1/width_16k/average_l0_56
-    path: layer_1/width_16k/average_l0_56
-    l0: 56
-    neuronpedia: gemma-2-9b/1-gemmascope-mlp-16k__l0-56
-  - id: layer_1/width_16k/average_l0_128
-    path: layer_1/width_16k/average_l0_128
-    l0: 128
-  - id: layer_1/width_16k/average_l0_278
-    path: layer_1/width_16k/average_l0_278
-    l0: 278
-  - id: layer_1/width_131k/average_l0_6
-    path: layer_1/width_131k/average_l0_6
-    l0: 6
-  - id: layer_1/width_131k/average_l0_10
-    path: layer_1/width_131k/average_l0_10
-    l0: 10
-  - id: layer_1/width_131k/average_l0_18
-    path: layer_1/width_131k/average_l0_18
-    l0: 18
-  - id: layer_1/width_131k/average_l0_32
-    path: layer_1/width_131k/average_l0_32
-    l0: 32
-  - id: layer_1/width_131k/average_l0_59
-    path: layer_1/width_131k/average_l0_59
-    l0: 59
-  - id: layer_1/width_131k/average_l0_106
-    path: layer_1/width_131k/average_l0_106
-    l0: 106
-  - id: layer_10/width_16k/average_l0_13
-    path: layer_10/width_16k/average_l0_13
-    l0: 13
-  - id: layer_10/width_16k/average_l0_24
-    path: layer_10/width_16k/average_l0_24
-    l0: 24
-  - id: layer_10/width_16k/average_l0_49
-    path: layer_10/width_16k/average_l0_49
-    l0: 49
-    neuronpedia: gemma-2-9b/10-gemmascope-mlp-16k__l0-49
-  - id: layer_10/width_16k/average_l0_114
-    path: layer_10/width_16k/average_l0_114
-    l0: 114
-  - id: layer_10/width_16k/average_l0_276
-    path: layer_10/width_16k/average_l0_276
-    l0: 276
-  - id: layer_10/width_131k/average_l0_12
-    path: layer_10/width_131k/average_l0_12
-    l0: 12
-  - id: layer_10/width_131k/average_l0_22
-    path: layer_10/width_131k/average_l0_22
-    l0: 22
-  - id: layer_10/width_131k/average_l0_42
-    path: layer_10/width_131k/average_l0_42
-    l0: 42
-  - id: layer_10/width_131k/average_l0_83
-    path: layer_10/width_131k/average_l0_83
-    l0: 83
-  - id: layer_10/width_131k/average_l0_167
-    path: layer_10/width_131k/average_l0_167
-    l0: 167
-  - id: layer_10/width_131k/average_l0_362
-    path: layer_10/width_131k/average_l0_362
-    l0: 362
-  - id: layer_11/width_16k/average_l0_17
-    path: layer_11/width_16k/average_l0_17
-    l0: 17
-  - id: layer_11/width_16k/average_l0_34
-    path: layer_11/width_16k/average_l0_34
-    l0: 34
-    neuronpedia: gemma-2-9b/11-gemmascope-mlp-16k__l0-34
-  - id: layer_11/width_16k/average_l0_76
-    path: layer_11/width_16k/average_l0_76
-    l0: 76
-  - id: layer_11/width_16k/average_l0_180
-    path: layer_11/width_16k/average_l0_180
-    l0: 180
-  - id: layer_11/width_16k/average_l0_421
-    path: layer_11/width_16k/average_l0_421
-    l0: 421
-  - id: layer_11/width_131k/average_l0_17
-    path: layer_11/width_131k/average_l0_17
-    l0: 17
-  - id: layer_11/width_131k/average_l0_31
-    path: layer_11/width_131k/average_l0_31
-    l0: 31
-  - id: layer_11/width_131k/average_l0_60
-    path: layer_11/width_131k/average_l0_60
-    l0: 60
-  - id: layer_11/width_131k/average_l0_120
-    path: layer_11/width_131k/average_l0_120
-    l0: 120
-  - id: layer_11/width_131k/average_l0_259
-    path: layer_11/width_131k/average_l0_259
-    l0: 259
-  - id: layer_11/width_131k/average_l0_569
-    path: layer_11/width_131k/average_l0_569
-    l0: 569
-  - id: layer_12/width_16k/average_l0_20
-    path: layer_12/width_16k/average_l0_20
-    l0: 20
-  - id: layer_12/width_16k/average_l0_42
-    path: layer_12/width_16k/average_l0_42
-    l0: 42
-    neuronpedia: gemma-2-9b/12-gemmascope-mlp-16k__l0-42
-  - id: layer_12/width_16k/average_l0_96
-    path: layer_12/width_16k/average_l0_96
-    l0: 96
-  - id: layer_12/width_16k/average_l0_237
-    path: layer_12/width_16k/average_l0_237
-    l0: 237
-  - id: layer_12/width_16k/average_l0_543
-    path: layer_12/width_16k/average_l0_543
-    l0: 543
-  - id: layer_12/width_16k/average_l0_1033
-    path: layer_12/width_16k/average_l0_1033
-    l0: 1033
-  - id: layer_12/width_131k/average_l0_19
-    path: layer_12/width_131k/average_l0_19
-    l0: 19
-  - id: layer_12/width_131k/average_l0_38
-    path: layer_12/width_131k/average_l0_38
-    l0: 38
-  - id: layer_12/width_131k/average_l0_77
-    path: layer_12/width_131k/average_l0_77
-    l0: 77
-  - id: layer_12/width_131k/average_l0_159
-    path: layer_12/width_131k/average_l0_159
-    l0: 159
-  - id: layer_12/width_131k/average_l0_338
-    path: layer_12/width_131k/average_l0_338
-    l0: 338
-  - id: layer_12/width_131k/average_l0_745
-    path: layer_12/width_131k/average_l0_745
-    l0: 745
-  - id: layer_13/width_16k/average_l0_19
-    path: layer_13/width_16k/average_l0_19
-    l0: 19
-  - id: layer_13/width_16k/average_l0_40
-    path: layer_13/width_16k/average_l0_40
-    l0: 40
-    neuronpedia: gemma-2-9b/13-gemmascope-mlp-16k__l0-40
-  - id: layer_13/width_16k/average_l0_94
-    path: layer_13/width_16k/average_l0_94
-    l0: 94
-  - id: layer_13/width_16k/average_l0_225
-    path: layer_13/width_16k/average_l0_225
-    l0: 225
-  - id: layer_13/width_16k/average_l0_512
-    path: layer_13/width_16k/average_l0_512
-    l0: 512
-  - id: layer_13/width_16k/average_l0_992
-    path: layer_13/width_16k/average_l0_992
-    l0: 992
-  - id: layer_13/width_131k/average_l0_20
-    path: layer_13/width_131k/average_l0_20
-    l0: 20
-  - id: layer_13/width_131k/average_l0_38
-    path: layer_13/width_131k/average_l0_38
-    l0: 38
-  - id: layer_13/width_131k/average_l0_75
-    path: layer_13/width_131k/average_l0_75
-    l0: 75
-  - id: layer_13/width_131k/average_l0_160
-    path: layer_13/width_131k/average_l0_160
-    l0: 160
-  - id: layer_13/width_131k/average_l0_351
-    path: layer_13/width_131k/average_l0_351
-    l0: 351
-  - id: layer_13/width_131k/average_l0_703
-    path: layer_13/width_131k/average_l0_703
-    l0: 703
-  - id: layer_14/width_16k/average_l0_19
-    path: layer_14/width_16k/average_l0_19
-    l0: 19
-  - id: layer_14/width_16k/average_l0_41
-    path: layer_14/width_16k/average_l0_41
-    l0: 41
-    neuronpedia: gemma-2-9b/14-gemmascope-mlp-16k__l0-41
-  - id: layer_14/width_16k/average_l0_97
-    path: layer_14/width_16k/average_l0_97
-    l0: 97
-  - id: layer_14/width_16k/average_l0_236
-    path: layer_14/width_16k/average_l0_236
-    l0: 236
-  - id: layer_14/width_16k/average_l0_538
-    path: layer_14/width_16k/average_l0_538
-    l0: 538
-  - id: layer_14/width_16k/average_l0_1023
-    path: layer_14/width_16k/average_l0_1023
-    l0: 1023
-  - id: layer_14/width_131k/average_l0_20
-    path: layer_14/width_131k/average_l0_20
-    l0: 20
-  - id: layer_14/width_131k/average_l0_40
-    path: layer_14/width_131k/average_l0_40
-    l0: 40
-  - id: layer_14/width_131k/average_l0_80
-    path: layer_14/width_131k/average_l0_80
-    l0: 80
-  - id: layer_14/width_131k/average_l0_174
-    path: layer_14/width_131k/average_l0_174
-    l0: 174
-  - id: layer_14/width_131k/average_l0_374
-    path: layer_14/width_131k/average_l0_374
-    l0: 374
-  - id: layer_14/width_131k/average_l0_743
-    path: layer_14/width_131k/average_l0_743
-    l0: 743
-  - id: layer_15/width_16k/average_l0_20
-    path: layer_15/width_16k/average_l0_20
-    l0: 20
-  - id: layer_15/width_16k/average_l0_45
-    path: layer_15/width_16k/average_l0_45
-    l0: 45
-    neuronpedia: gemma-2-9b/15-gemmascope-mlp-16k__l0-45
-  - id: layer_15/width_16k/average_l0_107
-    path: layer_15/width_16k/average_l0_107
-    l0: 107
-  - id: layer_15/width_16k/average_l0_260
-    path: layer_15/width_16k/average_l0_260
-    l0: 260
-  - id: layer_15/width_16k/average_l0_572
-    path: layer_15/width_16k/average_l0_572
-    l0: 572
-  - id: layer_15/width_16k/average_l0_1053
-    path: layer_15/width_16k/average_l0_1053
-    l0: 1053
-  - id: layer_15/width_131k/average_l0_21
-    path: layer_15/width_131k/average_l0_21
-    l0: 21
-  - id: layer_15/width_131k/average_l0_43
-    path: layer_15/width_131k/average_l0_43
-    l0: 43
-  - id: layer_15/width_131k/average_l0_89
-    path: layer_15/width_131k/average_l0_89
-    l0: 89
-  - id: layer_15/width_131k/average_l0_194
-    path: layer_15/width_131k/average_l0_194
-    l0: 194
-  - id: layer_15/width_131k/average_l0_421
-    path: layer_15/width_131k/average_l0_421
-    l0: 421
-  - id: layer_15/width_131k/average_l0_828
-    path: layer_15/width_131k/average_l0_828
-    l0: 828
-  - id: layer_16/width_16k/average_l0_16
-    path: layer_16/width_16k/average_l0_16
-    l0: 16
-  - id: layer_16/width_16k/average_l0_37
-    path: layer_16/width_16k/average_l0_37
-    l0: 37
-    neuronpedia: gemma-2-9b/16-gemmascope-mlp-16k__l0-37
-  - id: layer_16/width_16k/average_l0_91
-    path: layer_16/width_16k/average_l0_91
-    l0: 91
-  - id: layer_16/width_16k/average_l0_221
-    path: layer_16/width_16k/average_l0_221
-    l0: 221
-  - id: layer_16/width_16k/average_l0_489
-    path: layer_16/width_16k/average_l0_489
-    l0: 489
-  - id: layer_16/width_16k/average_l0_916
-    path: layer_16/width_16k/average_l0_916
-    l0: 916
-  - id: layer_16/width_131k/average_l0_17
-    path: layer_16/width_131k/average_l0_17
-    l0: 17
-  - id: layer_16/width_131k/average_l0_38
-    path: layer_16/width_131k/average_l0_38
-    l0: 38
-  - id: layer_16/width_131k/average_l0_81
-    path: layer_16/width_131k/average_l0_81
-    l0: 81
-  - id: layer_16/width_131k/average_l0_175
-    path: layer_16/width_131k/average_l0_175
-    l0: 175
-  - id: layer_16/width_131k/average_l0_384
-    path: layer_16/width_131k/average_l0_384
-    l0: 384
-  - id: layer_16/width_131k/average_l0_744
-    path: layer_16/width_131k/average_l0_744
-    l0: 744
-  - id: layer_17/width_16k/average_l0_18
-    path: layer_17/width_16k/average_l0_18
-    l0: 18
-  - id: layer_17/width_16k/average_l0_41
-    path: layer_17/width_16k/average_l0_41
-    l0: 41
-    neuronpedia: gemma-2-9b/17-gemmascope-mlp-16k__l0-41
-  - id: layer_17/width_16k/average_l0_104
-    path: layer_17/width_16k/average_l0_104
-    l0: 104
-  - id: layer_17/width_16k/average_l0_274
-    path: layer_17/width_16k/average_l0_274
-    l0: 274
-  - id: layer_17/width_16k/average_l0_624
-    path: layer_17/width_16k/average_l0_624
-    l0: 624
-  - id: layer_17/width_16k/average_l0_1137
-    path: layer_17/width_16k/average_l0_1137
-    l0: 1137
-  - id: layer_17/width_131k/average_l0_22
-    path: layer_17/width_131k/average_l0_22
-    l0: 22
-  - id: layer_17/width_131k/average_l0_43
-    path: layer_17/width_131k/average_l0_43
-    l0: 43
-  - id: layer_17/width_131k/average_l0_91
-    path: layer_17/width_131k/average_l0_91
-    l0: 91
-  - id: layer_17/width_131k/average_l0_207
-    path: layer_17/width_131k/average_l0_207
-    l0: 207
-  - id: layer_17/width_131k/average_l0_483
-    path: layer_17/width_131k/average_l0_483
-    l0: 483
-  - id: layer_17/width_131k/average_l0_950
-    path: layer_17/width_131k/average_l0_950
-    l0: 950
-  - id: layer_18/width_16k/average_l0_16
-    path: layer_18/width_16k/average_l0_16
-    l0: 16
-  - id: layer_18/width_16k/average_l0_36
-    path: layer_18/width_16k/average_l0_36
-    l0: 36
-    neuronpedia: gemma-2-9b/18-gemmascope-mlp-16k__l0-36
-  - id: layer_18/width_16k/average_l0_89
-    path: layer_18/width_16k/average_l0_89
-    l0: 89
-  - id: layer_18/width_16k/average_l0_235
-    path: layer_18/width_16k/average_l0_235
-    l0: 235
-  - id: layer_18/width_16k/average_l0_564
-    path: layer_18/width_16k/average_l0_564
-    l0: 564
-  - id: layer_18/width_16k/average_l0_1052
-    path: layer_18/width_16k/average_l0_1052
-    l0: 1052
-  - id: layer_18/width_131k/average_l0_19
-    path: layer_18/width_131k/average_l0_19
-    l0: 19
-  - id: layer_18/width_131k/average_l0_37
-    path: layer_18/width_131k/average_l0_37
-    l0: 37
-  - id: layer_18/width_131k/average_l0_82
-    path: layer_18/width_131k/average_l0_82
-    l0: 82
-  - id: layer_18/width_131k/average_l0_174
-    path: layer_18/width_131k/average_l0_174
-    l0: 174
-  - id: layer_18/width_131k/average_l0_420
-    path: layer_18/width_131k/average_l0_420
-    l0: 420
-  - id: layer_18/width_131k/average_l0_865
-    path: layer_18/width_131k/average_l0_865
-    l0: 865
-  - id: layer_19/width_16k/average_l0_16
-    path: layer_19/width_16k/average_l0_16
-    l0: 16
-  - id: layer_19/width_16k/average_l0_38
-    path: layer_19/width_16k/average_l0_38
-    l0: 38
-    neuronpedia: gemma-2-9b/19-gemmascope-mlp-16k__l0-38
-  - id: layer_19/width_16k/average_l0_98
-    path: layer_19/width_16k/average_l0_98
-    l0: 98
-  - id: layer_19/width_16k/average_l0_255
-    path: layer_19/width_16k/average_l0_255
-    l0: 255
-  - id: layer_19/width_16k/average_l0_599
-    path: layer_19/width_16k/average_l0_599
-    l0: 599
-  - id: layer_19/width_16k/average_l0_1097
-    path: layer_19/width_16k/average_l0_1097
-    l0: 1097
-  - id: layer_19/width_131k/average_l0_19
-    path: layer_19/width_131k/average_l0_19
-    l0: 19
-  - id: layer_19/width_131k/average_l0_40
-    path: layer_19/width_131k/average_l0_40
-    l0: 40
-  - id: layer_19/width_131k/average_l0_85
-    path: layer_19/width_131k/average_l0_85
-    l0: 85
-  - id: layer_19/width_131k/average_l0_189
-    path: layer_19/width_131k/average_l0_189
-    l0: 189
-  - id: layer_19/width_131k/average_l0_440
-    path: layer_19/width_131k/average_l0_440
-    l0: 440
-  - id: layer_19/width_131k/average_l0_899
-    path: layer_19/width_131k/average_l0_899
-    l0: 899
-  - id: layer_2/width_16k/average_l0_8
-    path: layer_2/width_16k/average_l0_8
-    l0: 8
-  - id: layer_2/width_16k/average_l0_16
-    path: layer_2/width_16k/average_l0_16
-    l0: 16
-  - id: layer_2/width_16k/average_l0_33
-    path: layer_2/width_16k/average_l0_33
-    l0: 33
-    neuronpedia: gemma-2-9b/2-gemmascope-mlp-16k__l0-33
-  - id: layer_2/width_16k/average_l0_81
-    path: layer_2/width_16k/average_l0_81
-    l0: 81
-  - id: layer_2/width_16k/average_l0_163
-    path: layer_2/width_16k/average_l0_163
-    l0: 163
-  - id: layer_2/width_131k/average_l0_4
-    path: layer_2/width_131k/average_l0_4
-    l0: 4
-  - id: layer_2/width_131k/average_l0_7
-    path: layer_2/width_131k/average_l0_7
-    l0: 7
-  - id: layer_2/width_131k/average_l0_12
-    path: layer_2/width_131k/average_l0_12
-    l0: 12
-  - id: layer_2/width_131k/average_l0_20
-    path: layer_2/width_131k/average_l0_20
-    l0: 20
-  - id: layer_2/width_131k/average_l0_35
-    path: layer_2/width_131k/average_l0_35
-    l0: 35
-  - id: layer_2/width_131k/average_l0_61
-    path: layer_2/width_131k/average_l0_61
-    l0: 61
-  - id: layer_20/width_16k/average_l0_17
-    path: layer_20/width_16k/average_l0_17
-    l0: 17
-  - id: layer_20/width_16k/average_l0_41
-    path: layer_20/width_16k/average_l0_41
-    l0: 41
-    neuronpedia: gemma-2-9b/20-gemmascope-mlp-16k__l0-41
-  - id: layer_20/width_16k/average_l0_108
-    path: layer_20/width_16k/average_l0_108
-    l0: 108
-  - id: layer_20/width_16k/average_l0_284
-    path: layer_20/width_16k/average_l0_284
-    l0: 284
-  - id: layer_20/width_16k/average_l0_643
-    path: layer_20/width_16k/average_l0_643
-    l0: 643
-  - id: layer_20/width_16k/average_l0_1127
-    path: layer_20/width_16k/average_l0_1127
-    l0: 1127
-  - id: layer_20/width_131k/average_l0_20
-    path: layer_20/width_131k/average_l0_20
-    l0: 20
-  - id: layer_20/width_131k/average_l0_41
-    path: layer_20/width_131k/average_l0_41
-    l0: 41
-  - id: layer_20/width_131k/average_l0_93
-    path: layer_20/width_131k/average_l0_93
-    l0: 93
-  - id: layer_20/width_131k/average_l0_212
-    path: layer_20/width_131k/average_l0_212
-    l0: 212
-  - id: layer_20/width_131k/average_l0_477
-    path: layer_20/width_131k/average_l0_477
-    l0: 477
-  - id: layer_20/width_131k/average_l0_992
-    path: layer_20/width_131k/average_l0_992
-    l0: 992
-  - id: layer_21/width_16k/average_l0_15
-    path: layer_21/width_16k/average_l0_15
-    l0: 15
-  - id: layer_21/width_16k/average_l0_34
-    path: layer_21/width_16k/average_l0_34
-    l0: 34
-    neuronpedia: gemma-2-9b/21-gemmascope-mlp-16k__l0-34
-  - id: layer_21/width_16k/average_l0_88
-    path: layer_21/width_16k/average_l0_88
-    l0: 88
-  - id: layer_21/width_16k/average_l0_241
-    path: layer_21/width_16k/average_l0_241
-    l0: 241
-  - id: layer_21/width_16k/average_l0_571
-    path: layer_21/width_16k/average_l0_571
-    l0: 571
-  - id: layer_21/width_16k/average_l0_1063
-    path: layer_21/width_16k/average_l0_1063
-    l0: 1063
-  - id: layer_21/width_131k/average_l0_16
-    path: layer_21/width_131k/average_l0_16
-    l0: 16
-  - id: layer_21/width_131k/average_l0_35
-    path: layer_21/width_131k/average_l0_35
-    l0: 35
-  - id: layer_21/width_131k/average_l0_79
-    path: layer_21/width_131k/average_l0_79
-    l0: 79
-  - id: layer_21/width_131k/average_l0_179
-    path: layer_21/width_131k/average_l0_179
-    l0: 179
-  - id: layer_21/width_131k/average_l0_417
-    path: layer_21/width_131k/average_l0_417
-    l0: 417
-  - id: layer_21/width_131k/average_l0_884
-    path: layer_21/width_131k/average_l0_884
-    l0: 884
-  - id: layer_22/width_16k/average_l0_15
-    path: layer_22/width_16k/average_l0_15
-    l0: 15
-  - id: layer_22/width_16k/average_l0_34
-    path: layer_22/width_16k/average_l0_34
-    l0: 34
-    neuronpedia: gemma-2-9b/22-gemmascope-mlp-16k__l0-34
-  - id: layer_22/width_16k/average_l0_85
-    path: layer_22/width_16k/average_l0_85
-    l0: 85
-  - id: layer_22/width_16k/average_l0_226
-    path: layer_22/width_16k/average_l0_226
-    l0: 226
-  - id: layer_22/width_16k/average_l0_566
-    path: layer_22/width_16k/average_l0_566
-    l0: 566
-  - id: layer_22/width_16k/average_l0_1065
-    path: layer_22/width_16k/average_l0_1065
-    l0: 1065
-  - id: layer_22/width_131k/average_l0_17
-    path: layer_22/width_131k/average_l0_17
-    l0: 17
-  - id: layer_22/width_131k/average_l0_35
-    path: layer_22/width_131k/average_l0_35
-    l0: 35
-  - id: layer_22/width_131k/average_l0_77
-    path: layer_22/width_131k/average_l0_77
-    l0: 77
-  - id: layer_22/width_131k/average_l0_172
-    path: layer_22/width_131k/average_l0_172
-    l0: 172
-  - id: layer_22/width_131k/average_l0_404
-    path: layer_22/width_131k/average_l0_404
-    l0: 404
-  - id: layer_22/width_131k/average_l0_861
-    path: layer_22/width_131k/average_l0_861
-    l0: 861
-  - id: layer_23/width_16k/average_l0_15
-    path: layer_23/width_16k/average_l0_15
-    l0: 15
-  - id: layer_23/width_16k/average_l0_31
-    path: layer_23/width_16k/average_l0_31
-    l0: 31
-  - id: layer_23/width_16k/average_l0_73
-    path: layer_23/width_16k/average_l0_73
-    l0: 73
-    neuronpedia: gemma-2-9b/23-gemmascope-mlp-16k__l0-73
-  - id: layer_23/width_16k/average_l0_190
-    path: layer_23/width_16k/average_l0_190
-    l0: 190
-  - id: layer_23/width_16k/average_l0_492
-    path: layer_23/width_16k/average_l0_492
-    l0: 492
-  - id: layer_23/width_16k/average_l0_990
-    path: layer_23/width_16k/average_l0_990
-    l0: 990
-  - id: layer_23/width_131k/average_l0_17
-    path: layer_23/width_131k/average_l0_17
-    l0: 17
-  - id: layer_23/width_131k/average_l0_32
-    path: layer_23/width_131k/average_l0_32
-    l0: 32
-  - id: layer_23/width_131k/average_l0_67
-    path: layer_23/width_131k/average_l0_67
-    l0: 67
-  - id: layer_23/width_131k/average_l0_146
-    path: layer_23/width_131k/average_l0_146
-    l0: 146
-  - id: layer_23/width_131k/average_l0_354
-    path: layer_23/width_131k/average_l0_354
-    l0: 354
-  - id: layer_23/width_131k/average_l0_754
-    path: layer_23/width_131k/average_l0_754
-    l0: 754
-  - id: layer_24/width_16k/average_l0_15
-    path: layer_24/width_16k/average_l0_15
-    l0: 15
-  - id: layer_24/width_16k/average_l0_32
-    path: layer_24/width_16k/average_l0_32
-    l0: 32
-    neuronpedia: gemma-2-9b/24-gemmascope-mlp-16k__l0-32
-  - id: layer_24/width_16k/average_l0_73
-    path: layer_24/width_16k/average_l0_73
-    l0: 73
-  - id: layer_24/width_16k/average_l0_192
-    path: layer_24/width_16k/average_l0_192
-    l0: 192
-  - id: layer_24/width_16k/average_l0_494
-    path: layer_24/width_16k/average_l0_494
-    l0: 494
-  - id: layer_24/width_16k/average_l0_999
-    path: layer_24/width_16k/average_l0_999
-    l0: 999
-  - id: layer_24/width_131k/average_l0_17
-    path: layer_24/width_131k/average_l0_17
-    l0: 17
-  - id: layer_24/width_131k/average_l0_33
-    path: layer_24/width_131k/average_l0_33
-    l0: 33
-  - id: layer_24/width_131k/average_l0_67
-    path: layer_24/width_131k/average_l0_67
-    l0: 67
-  - id: layer_24/width_131k/average_l0_147
-    path: layer_24/width_131k/average_l0_147
-    l0: 147
-  - id: layer_24/width_131k/average_l0_351
-    path: layer_24/width_131k/average_l0_351
-    l0: 351
-  - id: layer_24/width_131k/average_l0_709
-    path: layer_24/width_131k/average_l0_709
-    l0: 709
-  - id: layer_25/width_16k/average_l0_15
-    path: layer_25/width_16k/average_l0_15
-    l0: 15
-  - id: layer_25/width_16k/average_l0_31
-    path: layer_25/width_16k/average_l0_31
-    l0: 31
-  - id: layer_25/width_16k/average_l0_72
-    path: layer_25/width_16k/average_l0_72
-    l0: 72
-    neuronpedia: gemma-2-9b/25-gemmascope-mlp-16k__l0-72
-  - id: layer_25/width_16k/average_l0_184
-    path: layer_25/width_16k/average_l0_184
-    l0: 184
-  - id: layer_25/width_16k/average_l0_494
-    path: layer_25/width_16k/average_l0_494
-    l0: 494
-  - id: layer_25/width_16k/average_l0_1013
-    path: layer_25/width_16k/average_l0_1013
-    l0: 1013
-  - id: layer_25/width_131k/average_l0_16
-    path: layer_25/width_131k/average_l0_16
-    l0: 16
-  - id: layer_25/width_131k/average_l0_32
-    path: layer_25/width_131k/average_l0_32
-    l0: 32
-  - id: layer_25/width_131k/average_l0_65
-    path: layer_25/width_131k/average_l0_65
-    l0: 65
-  - id: layer_25/width_131k/average_l0_139
-    path: layer_25/width_131k/average_l0_139
-    l0: 139
-  - id: layer_25/width_131k/average_l0_326
-    path: layer_25/width_131k/average_l0_326
-    l0: 326
-  - id: layer_25/width_131k/average_l0_691
-    path: layer_25/width_131k/average_l0_691
-    l0: 691
-  - id: layer_26/width_16k/average_l0_14
-    path: layer_26/width_16k/average_l0_14
-    l0: 14
-  - id: layer_26/width_16k/average_l0_26
-    path: layer_26/width_16k/average_l0_26
-    l0: 26
-  - id: layer_26/width_16k/average_l0_57
-    path: layer_26/width_16k/average_l0_57
-    l0: 57
-    neuronpedia: gemma-2-9b/26-gemmascope-mlp-16k__l0-57
-  - id: layer_26/width_16k/average_l0_142
-    path: layer_26/width_16k/average_l0_142
-    l0: 142
-  - id: layer_26/width_16k/average_l0_394
-    path: layer_26/width_16k/average_l0_394
-    l0: 394
-  - id: layer_26/width_16k/average_l0_887
-    path: layer_26/width_16k/average_l0_887
-    l0: 887
-  - id: layer_26/width_131k/average_l0_14
-    path: layer_26/width_131k/average_l0_14
-    l0: 14
-  - id: layer_26/width_131k/average_l0_27
-    path: layer_26/width_131k/average_l0_27
-    l0: 27
-  - id: layer_26/width_131k/average_l0_53
-    path: layer_26/width_131k/average_l0_53
-    l0: 53
-  - id: layer_26/width_131k/average_l0_110
-    path: layer_26/width_131k/average_l0_110
-    l0: 110
-  - id: layer_26/width_131k/average_l0_249
-    path: layer_26/width_131k/average_l0_249
-    l0: 249
-  - id: layer_26/width_131k/average_l0_568
-    path: layer_26/width_131k/average_l0_568
-    l0: 568
-  - id: layer_27/width_16k/average_l0_14
-    path: layer_27/width_16k/average_l0_14
-    l0: 14
-  - id: layer_27/width_16k/average_l0_25
-    path: layer_27/width_16k/average_l0_25
-    l0: 25
-  - id: layer_27/width_16k/average_l0_52
-    path: layer_27/width_16k/average_l0_52
-    l0: 52
-    neuronpedia: gemma-2-9b/27-gemmascope-mlp-16k__l0-52
-  - id: layer_27/width_16k/average_l0_126
-    path: layer_27/width_16k/average_l0_126
-    l0: 126
-  - id: layer_27/width_16k/average_l0_352
-    path: layer_27/width_16k/average_l0_352
-    l0: 352
-  - id: layer_27/width_16k/average_l0_813
-    path: layer_27/width_16k/average_l0_813
-    l0: 813
-  - id: layer_27/width_131k/average_l0_14
-    path: layer_27/width_131k/average_l0_14
-    l0: 14
-  - id: layer_27/width_131k/average_l0_26
-    path: layer_27/width_131k/average_l0_26
-    l0: 26
-  - id: layer_27/width_131k/average_l0_49
-    path: layer_27/width_131k/average_l0_49
-    l0: 49
-  - id: layer_27/width_131k/average_l0_99
-    path: layer_27/width_131k/average_l0_99
-    l0: 99
-  - id: layer_27/width_131k/average_l0_211
-    path: layer_27/width_131k/average_l0_211
-    l0: 211
-  - id: layer_27/width_131k/average_l0_487
-    path: layer_27/width_131k/average_l0_487
-    l0: 487
-  - id: layer_28/width_16k/average_l0_14
-    path: layer_28/width_16k/average_l0_14
-    l0: 14
-  - id: layer_28/width_16k/average_l0_26
-    path: layer_28/width_16k/average_l0_26
-    l0: 26
-  - id: layer_28/width_16k/average_l0_50
-    path: layer_28/width_16k/average_l0_50
-    l0: 50
-    neuronpedia: gemma-2-9b/28-gemmascope-mlp-16k__l0-50
-  - id: layer_28/width_16k/average_l0_115
-    path: layer_28/width_16k/average_l0_115
-    l0: 115
-  - id: layer_28/width_16k/average_l0_324
-    path: layer_28/width_16k/average_l0_324
-    l0: 324
-  - id: layer_28/width_16k/average_l0_773
-    path: layer_28/width_16k/average_l0_773
-    l0: 773
-  - id: layer_28/width_131k/average_l0_15
-    path: layer_28/width_131k/average_l0_15
-    l0: 15
-  - id: layer_28/width_131k/average_l0_26
-    path: layer_28/width_131k/average_l0_26
-    l0: 26
-  - id: layer_28/width_131k/average_l0_47
-    path: layer_28/width_131k/average_l0_47
-    l0: 47
-  - id: layer_28/width_131k/average_l0_91
-    path: layer_28/width_131k/average_l0_91
-    l0: 91
-  - id: layer_28/width_131k/average_l0_189
-    path: layer_28/width_131k/average_l0_189
-    l0: 189
-  - id: layer_28/width_131k/average_l0_425
-    path: layer_28/width_131k/average_l0_425
-    l0: 425
-  - id: layer_29/width_16k/average_l0_15
-    path: layer_29/width_16k/average_l0_15
-    l0: 15
-  - id: layer_29/width_16k/average_l0_26
-    path: layer_29/width_16k/average_l0_26
-    l0: 26
-  - id: layer_29/width_16k/average_l0_49
-    path: layer_29/width_16k/average_l0_49
-    l0: 49
-    neuronpedia: gemma-2-9b/29-gemmascope-mlp-16k__l0-49
-  - id: layer_29/width_16k/average_l0_111
-    path: layer_29/width_16k/average_l0_111
-    l0: 111
-  - id: layer_29/width_16k/average_l0_311
-    path: layer_29/width_16k/average_l0_311
-    l0: 311
-  - id: layer_29/width_16k/average_l0_725
-    path: layer_29/width_16k/average_l0_725
-    l0: 725
-  - id: layer_29/width_131k/average_l0_15
-    path: layer_29/width_131k/average_l0_15
-    l0: 15
-  - id: layer_29/width_131k/average_l0_26
-    path: layer_29/width_131k/average_l0_26
-    l0: 26
-  - id: layer_29/width_131k/average_l0_47
-    path: layer_29/width_131k/average_l0_47
-    l0: 47
-  - id: layer_29/width_131k/average_l0_87
-    path: layer_29/width_131k/average_l0_87
-    l0: 87
-  - id: layer_29/width_131k/average_l0_174
-    path: layer_29/width_131k/average_l0_174
-    l0: 174
-  - id: layer_29/width_131k/average_l0_386
-    path: layer_29/width_131k/average_l0_386
-    l0: 386
-  - id: layer_3/width_16k/average_l0_13
-    path: layer_3/width_16k/average_l0_13
-    l0: 13
-  - id: layer_3/width_16k/average_l0_25
-    path: layer_3/width_16k/average_l0_25
-    l0: 25
-  - id: layer_3/width_16k/average_l0_55
-    path: layer_3/width_16k/average_l0_55
-    l0: 55
-    neuronpedia: gemma-2-9b/3-gemmascope-mlp-16k__l0-55
-  - id: layer_3/width_16k/average_l0_126
-    path: layer_3/width_16k/average_l0_126
-    l0: 126
-  - id: layer_3/width_16k/average_l0_234
-    path: layer_3/width_16k/average_l0_234
-    l0: 234
-  - id: layer_3/width_131k/average_l0_6
-    path: layer_3/width_131k/average_l0_6
-    l0: 6
-  - id: layer_3/width_131k/average_l0_11
-    path: layer_3/width_131k/average_l0_11
-    l0: 11
-  - id: layer_3/width_131k/average_l0_19
-    path: layer_3/width_131k/average_l0_19
-    l0: 19
-  - id: layer_3/width_131k/average_l0_33
-    path: layer_3/width_131k/average_l0_33
-    l0: 33
-  - id: layer_3/width_131k/average_l0_58
-    path: layer_3/width_131k/average_l0_58
-    l0: 58
-  - id: layer_3/width_131k/average_l0_109
-    path: layer_3/width_131k/average_l0_109
-    l0: 109
-  - id: layer_30/width_16k/average_l0_14
-    path: layer_30/width_16k/average_l0_14
-    l0: 14
-  - id: layer_30/width_16k/average_l0_26
-    path: layer_30/width_16k/average_l0_26
-    l0: 26
-  - id: layer_30/width_16k/average_l0_51
-    path: layer_30/width_16k/average_l0_51
-    l0: 51
-    neuronpedia: gemma-2-9b/30-gemmascope-mlp-16k__l0-51
-  - id: layer_30/width_16k/average_l0_116
-    path: layer_30/width_16k/average_l0_116
-    l0: 116
-  - id: layer_30/width_16k/average_l0_333
-    path: layer_30/width_16k/average_l0_333
-    l0: 333
-  - id: layer_30/width_16k/average_l0_806
-    path: layer_30/width_16k/average_l0_806
-    l0: 806
-  - id: layer_30/width_131k/average_l0_14
-    path: layer_30/width_131k/average_l0_14
-    l0: 14
-  - id: layer_30/width_131k/average_l0_26
-    path: layer_30/width_131k/average_l0_26
-    l0: 26
-  - id: layer_30/width_131k/average_l0_47
-    path: layer_30/width_131k/average_l0_47
-    l0: 47
-  - id: layer_30/width_131k/average_l0_89
-    path: layer_30/width_131k/average_l0_89
-    l0: 89
-  - id: layer_30/width_131k/average_l0_179
-    path: layer_30/width_131k/average_l0_179
-    l0: 179
-  - id: layer_30/width_131k/average_l0_391
-    path: layer_30/width_131k/average_l0_391
-    l0: 391
-  - id: layer_31/width_16k/average_l0_12
-    path: layer_31/width_16k/average_l0_12
-    l0: 12
-  - id: layer_31/width_16k/average_l0_22
-    path: layer_31/width_16k/average_l0_22
-    l0: 22
-  - id: layer_31/width_16k/average_l0_43
-    path: layer_31/width_16k/average_l0_43
-    l0: 43
-    neuronpedia: gemma-2-9b/31-gemmascope-mlp-16k__l0-43
-  - id: layer_31/width_16k/average_l0_94
-    path: layer_31/width_16k/average_l0_94
-    l0: 94
-  - id: layer_31/width_16k/average_l0_263
-    path: layer_31/width_16k/average_l0_263
-    l0: 263
-  - id: layer_31/width_16k/average_l0_671
-    path: layer_31/width_16k/average_l0_671
-    l0: 671
-  - id: layer_31/width_131k/average_l0_12
-    path: layer_31/width_131k/average_l0_12
-    l0: 12
-  - id: layer_31/width_131k/average_l0_22
-    path: layer_31/width_131k/average_l0_22
-    l0: 22
-  - id: layer_31/width_131k/average_l0_40
-    path: layer_31/width_131k/average_l0_40
-    l0: 40
-  - id: layer_31/width_131k/average_l0_77
-    path: layer_31/width_131k/average_l0_77
-    l0: 77
-  - id: layer_31/width_131k/average_l0_153
-    path: layer_31/width_131k/average_l0_153
-    l0: 153
-  - id: layer_31/width_131k/average_l0_326
-    path: layer_31/width_131k/average_l0_326
-    l0: 326
-  - id: layer_32/width_16k/average_l0_11
-    path: layer_32/width_16k/average_l0_11
-    l0: 11
-  - id: layer_32/width_16k/average_l0_21
-    path: layer_32/width_16k/average_l0_21
-    l0: 21
-  - id: layer_32/width_16k/average_l0_44
-    path: layer_32/width_16k/average_l0_44
-    l0: 44
-    neuronpedia: gemma-2-9b/32-gemmascope-mlp-16k__l0-44
-  - id: layer_32/width_16k/average_l0_98
-    path: layer_32/width_16k/average_l0_98
-    l0: 98
-  - id: layer_32/width_16k/average_l0_267
-    path: layer_32/width_16k/average_l0_267
-    l0: 267
-  - id: layer_32/width_16k/average_l0_623
-    path: layer_32/width_16k/average_l0_623
-    l0: 623
-  - id: layer_32/width_131k/average_l0_12
-    path: layer_32/width_131k/average_l0_12
-    l0: 12
-  - id: layer_32/width_131k/average_l0_21
-    path: layer_32/width_131k/average_l0_21
-    l0: 21
-  - id: layer_32/width_131k/average_l0_40
-    path: layer_32/width_131k/average_l0_40
-    l0: 40
-  - id: layer_32/width_131k/average_l0_76
-    path: layer_32/width_131k/average_l0_76
-    l0: 76
-  - id: layer_32/width_131k/average_l0_155
-    path: layer_32/width_131k/average_l0_155
-    l0: 155
-  - id: layer_32/width_131k/average_l0_336
-    path: layer_32/width_131k/average_l0_336
-    l0: 336
-  - id: layer_33/width_16k/average_l0_12
-    path: layer_33/width_16k/average_l0_12
-    l0: 12
-  - id: layer_33/width_16k/average_l0_23
-    path: layer_33/width_16k/average_l0_23
-    l0: 23
-  - id: layer_33/width_16k/average_l0_48
-    path: layer_33/width_16k/average_l0_48
-    l0: 48
-    neuronpedia: gemma-2-9b/33-gemmascope-mlp-16k__l0-48
-  - id: layer_33/width_16k/average_l0_107
-    path: layer_33/width_16k/average_l0_107
-    l0: 107
-  - id: layer_33/width_16k/average_l0_282
-    path: layer_33/width_16k/average_l0_282
-    l0: 282
-  - id: layer_33/width_16k/average_l0_628
-    path: layer_33/width_16k/average_l0_628
-    l0: 628
-  - id: layer_33/width_131k/average_l0_12
-    path: layer_33/width_131k/average_l0_12
-    l0: 12
-  - id: layer_33/width_131k/average_l0_22
-    path: layer_33/width_131k/average_l0_22
-    l0: 22
-  - id: layer_33/width_131k/average_l0_42
-    path: layer_33/width_131k/average_l0_42
-    l0: 42
-  - id: layer_33/width_131k/average_l0_83
-    path: layer_33/width_131k/average_l0_83
-    l0: 83
-  - id: layer_33/width_131k/average_l0_168
-    path: layer_33/width_131k/average_l0_168
-    l0: 168
-  - id: layer_33/width_131k/average_l0_394
-    path: layer_33/width_131k/average_l0_394
-    l0: 394
-  - id: layer_34/width_16k/average_l0_11
-    path: layer_34/width_16k/average_l0_11
-    l0: 11
-  - id: layer_34/width_16k/average_l0_22
-    path: layer_34/width_16k/average_l0_22
-    l0: 22
-  - id: layer_34/width_16k/average_l0_47
-    path: layer_34/width_16k/average_l0_47
-    l0: 47
-    neuronpedia: gemma-2-9b/34-gemmascope-mlp-16k__l0-47
-  - id: layer_34/width_16k/average_l0_107
-    path: layer_34/width_16k/average_l0_107
-    l0: 107
-  - id: layer_34/width_16k/average_l0_268
-    path: layer_34/width_16k/average_l0_268
-    l0: 268
-  - id: layer_34/width_16k/average_l0_559
-    path: layer_34/width_16k/average_l0_559
-    l0: 559
-  - id: layer_34/width_131k/average_l0_10
-    path: layer_34/width_131k/average_l0_10
-    l0: 10
-  - id: layer_34/width_131k/average_l0_20
-    path: layer_34/width_131k/average_l0_20
-    l0: 20
-  - id: layer_34/width_131k/average_l0_40
-    path: layer_34/width_131k/average_l0_40
-    l0: 40
-  - id: layer_34/width_131k/average_l0_82
-    path: layer_34/width_131k/average_l0_82
-    l0: 82
-  - id: layer_34/width_131k/average_l0_167
-    path: layer_34/width_131k/average_l0_167
-    l0: 167
-  - id: layer_34/width_131k/average_l0_390
-    path: layer_34/width_131k/average_l0_390
-    l0: 390
-  - id: layer_35/width_16k/average_l0_10
-    path: layer_35/width_16k/average_l0_10
-    l0: 10
-  - id: layer_35/width_16k/average_l0_21
-    path: layer_35/width_16k/average_l0_21
-    l0: 21
-  - id: layer_35/width_16k/average_l0_46
-    path: layer_35/width_16k/average_l0_46
-    l0: 46
-    neuronpedia: gemma-2-9b/35-gemmascope-mlp-16k__l0-46
-  - id: layer_35/width_16k/average_l0_108
-    path: layer_35/width_16k/average_l0_108
-    l0: 108
-  - id: layer_35/width_16k/average_l0_254
-    path: layer_35/width_16k/average_l0_254
-    l0: 254
-  - id: layer_35/width_16k/average_l0_538
-    path: layer_35/width_16k/average_l0_538
-    l0: 538
-  - id: layer_35/width_131k/average_l0_10
-    path: layer_35/width_131k/average_l0_10
-    l0: 10
-  - id: layer_35/width_131k/average_l0_19
-    path: layer_35/width_131k/average_l0_19
-    l0: 19
-  - id: layer_35/width_131k/average_l0_39
-    path: layer_35/width_131k/average_l0_39
-    l0: 39
-  - id: layer_35/width_131k/average_l0_80
-    path: layer_35/width_131k/average_l0_80
-    l0: 80
-  - id: layer_35/width_131k/average_l0_176
-    path: layer_35/width_131k/average_l0_176
-    l0: 176
-  - id: layer_35/width_131k/average_l0_389
-    path: layer_35/width_131k/average_l0_389
-    l0: 389
-  - id: layer_36/width_16k/average_l0_11
-    path: layer_36/width_16k/average_l0_11
-    l0: 11
-  - id: layer_36/width_16k/average_l0_22
-    path: layer_36/width_16k/average_l0_22
-    l0: 22
-  - id: layer_36/width_16k/average_l0_47
-    path: layer_36/width_16k/average_l0_47
-    l0: 47
-    neuronpedia: gemma-2-9b/36-gemmascope-mlp-16k__l0-47
-  - id: layer_36/width_16k/average_l0_109
-    path: layer_36/width_16k/average_l0_109
-    l0: 109
-  - id: layer_36/width_16k/average_l0_256
-    path: layer_36/width_16k/average_l0_256
-    l0: 256
-  - id: layer_36/width_16k/average_l0_523
-    path: layer_36/width_16k/average_l0_523
-    l0: 523
-  - id: layer_36/width_131k/average_l0_11
-    path: layer_36/width_131k/average_l0_11
-    l0: 11
-  - id: layer_36/width_131k/average_l0_20
-    path: layer_36/width_131k/average_l0_20
-    l0: 20
-  - id: layer_36/width_131k/average_l0_40
-    path: layer_36/width_131k/average_l0_40
-    l0: 40
-  - id: layer_36/width_131k/average_l0_81
-    path: layer_36/width_131k/average_l0_81
-    l0: 81
-  - id: layer_36/width_131k/average_l0_174
-    path: layer_36/width_131k/average_l0_174
-    l0: 174
-  - id: layer_36/width_131k/average_l0_389
-    path: layer_36/width_131k/average_l0_389
-    l0: 389
-  - id: layer_37/width_16k/average_l0_12
-    path: layer_37/width_16k/average_l0_12
-    l0: 12
-  - id: layer_37/width_16k/average_l0_24
-    path: layer_37/width_16k/average_l0_24
-    l0: 24
-  - id: layer_37/width_16k/average_l0_53
-    path: layer_37/width_16k/average_l0_53
-    l0: 53
-    neuronpedia: gemma-2-9b/37-gemmascope-mlp-16k__l0-53
-  - id: layer_37/width_16k/average_l0_119
-    path: layer_37/width_16k/average_l0_119
-    l0: 119
-  - id: layer_37/width_16k/average_l0_267
-    path: layer_37/width_16k/average_l0_267
-    l0: 267
-  - id: layer_37/width_16k/average_l0_549
-    path: layer_37/width_16k/average_l0_549
-    l0: 549
-  - id: layer_37/width_131k/average_l0_12
-    path: layer_37/width_131k/average_l0_12
-    l0: 12
-  - id: layer_37/width_131k/average_l0_23
-    path: layer_37/width_131k/average_l0_23
-    l0: 23
-  - id: layer_37/width_131k/average_l0_44
-    path: layer_37/width_131k/average_l0_44
-    l0: 44
-  - id: layer_37/width_131k/average_l0_90
-    path: layer_37/width_131k/average_l0_90
-    l0: 90
-  - id: layer_37/width_131k/average_l0_203
-    path: layer_37/width_131k/average_l0_203
-    l0: 203
-  - id: layer_37/width_131k/average_l0_403
-    path: layer_37/width_131k/average_l0_403
-    l0: 403
-  - id: layer_38/width_16k/average_l0_11
-    path: layer_38/width_16k/average_l0_11
-    l0: 11
-  - id: layer_38/width_16k/average_l0_22
-    path: layer_38/width_16k/average_l0_22
-    l0: 22
-  - id: layer_38/width_16k/average_l0_45
-    path: layer_38/width_16k/average_l0_45
-    l0: 45
-    neuronpedia: gemma-2-9b/38-gemmascope-mlp-16k__l0-45
-  - id: layer_38/width_16k/average_l0_98
-    path: layer_38/width_16k/average_l0_98
-    l0: 98
-  - id: layer_38/width_16k/average_l0_225
-    path: layer_38/width_16k/average_l0_225
-    l0: 225
-  - id: layer_38/width_16k/average_l0_491
-    path: layer_38/width_16k/average_l0_491
-    l0: 491
-  - id: layer_38/width_131k/average_l0_11
-    path: layer_38/width_131k/average_l0_11
-    l0: 11
-  - id: layer_38/width_131k/average_l0_21
-    path: layer_38/width_131k/average_l0_21
-    l0: 21
-  - id: layer_38/width_131k/average_l0_40
-    path: layer_38/width_131k/average_l0_40
-    l0: 40
-  - id: layer_38/width_131k/average_l0_79
-    path: layer_38/width_131k/average_l0_79
-    l0: 79
-  - id: layer_38/width_131k/average_l0_161
-    path: layer_38/width_131k/average_l0_161
-    l0: 161
-  - id: layer_38/width_131k/average_l0_347
-    path: layer_38/width_131k/average_l0_347
-    l0: 347
-  - id: layer_39/width_16k/average_l0_12
-    path: layer_39/width_16k/average_l0_12
-    l0: 12
-  - id: layer_39/width_16k/average_l0_22
-    path: layer_39/width_16k/average_l0_22
-    l0: 22
-  - id: layer_39/width_16k/average_l0_43
-    path: layer_39/width_16k/average_l0_43
-    l0: 43
-    neuronpedia: gemma-2-9b/39-gemmascope-mlp-16k__l0-43
-  - id: layer_39/width_16k/average_l0_90
-    path: layer_39/width_16k/average_l0_90
-    l0: 90
-  - id: layer_39/width_16k/average_l0_207
-    path: layer_39/width_16k/average_l0_207
-    l0: 207
-  - id: layer_39/width_16k/average_l0_458
-    path: layer_39/width_16k/average_l0_458
-    l0: 458
-  - id: layer_39/width_131k/average_l0_11
-    path: layer_39/width_131k/average_l0_11
-    l0: 11
-  - id: layer_39/width_131k/average_l0_21
-    path: layer_39/width_131k/average_l0_21
-    l0: 21
-  - id: layer_39/width_131k/average_l0_38
-    path: layer_39/width_131k/average_l0_38
-    l0: 38
-  - id: layer_39/width_131k/average_l0_75
-    path: layer_39/width_131k/average_l0_75
-    l0: 75
-  - id: layer_39/width_131k/average_l0_150
-    path: layer_39/width_131k/average_l0_150
-    l0: 150
-  - id: layer_39/width_131k/average_l0_319
-    path: layer_39/width_131k/average_l0_319
-    l0: 319
-  - id: layer_4/width_16k/average_l0_15
-    path: layer_4/width_16k/average_l0_15
-    l0: 15
-  - id: layer_4/width_16k/average_l0_30
-    path: layer_4/width_16k/average_l0_30
-    l0: 30
-  - id: layer_4/width_16k/average_l0_66
-    path: layer_4/width_16k/average_l0_66
-    l0: 66
-    neuronpedia: gemma-2-9b/4-gemmascope-mlp-16k__l0-66
-  - id: layer_4/width_16k/average_l0_151
-    path: layer_4/width_16k/average_l0_151
-    l0: 151
-  - id: layer_4/width_16k/average_l0_343
-    path: layer_4/width_16k/average_l0_343
-    l0: 343
-  - id: layer_4/width_131k/average_l0_8
-    path: layer_4/width_131k/average_l0_8
-    l0: 8
-  - id: layer_4/width_131k/average_l0_14
-    path: layer_4/width_131k/average_l0_14
-    l0: 14
-  - id: layer_4/width_131k/average_l0_24
-    path: layer_4/width_131k/average_l0_24
-    l0: 24
-  - id: layer_4/width_131k/average_l0_45
-    path: layer_4/width_131k/average_l0_45
-    l0: 45
-  - id: layer_4/width_131k/average_l0_84
-    path: layer_4/width_131k/average_l0_84
-    l0: 84
-  - id: layer_4/width_131k/average_l0_157
-    path: layer_4/width_131k/average_l0_157
-    l0: 157
-  - id: layer_40/width_16k/average_l0_11
-    path: layer_40/width_16k/average_l0_11
-    l0: 11
-  - id: layer_40/width_16k/average_l0_19
-    path: layer_40/width_16k/average_l0_19
-    l0: 19
-  - id: layer_40/width_16k/average_l0_37
-    path: layer_40/width_16k/average_l0_37
-    l0: 37
-    neuronpedia: gemma-2-9b/40-gemmascope-mlp-16k__l0-37
-  - id: layer_40/width_16k/average_l0_74
-    path: layer_40/width_16k/average_l0_74
-    l0: 74
-  - id: layer_40/width_16k/average_l0_162
-    path: layer_40/width_16k/average_l0_162
-    l0: 162
-  - id: layer_40/width_16k/average_l0_371
-    path: layer_40/width_16k/average_l0_371
-    l0: 371
-  - id: layer_40/width_131k/average_l0_11
-    path: layer_40/width_131k/average_l0_11
-    l0: 11
-  - id: layer_40/width_131k/average_l0_18
-    path: layer_40/width_131k/average_l0_18
-    l0: 18
-  - id: layer_40/width_131k/average_l0_33
-    path: layer_40/width_131k/average_l0_33
-    l0: 33
-  - id: layer_40/width_131k/average_l0_63
-    path: layer_40/width_131k/average_l0_63
-    l0: 63
-  - id: layer_40/width_131k/average_l0_125
-    path: layer_40/width_131k/average_l0_125
-    l0: 125
-  - id: layer_40/width_131k/average_l0_267
-    path: layer_40/width_131k/average_l0_267
-    l0: 267
-  - id: layer_41/width_16k/average_l0_8
-    path: layer_41/width_16k/average_l0_8
-    l0: 8
-  - id: layer_41/width_16k/average_l0_15
-    path: layer_41/width_16k/average_l0_15
-    l0: 15
-  - id: layer_41/width_16k/average_l0_28
-    path: layer_41/width_16k/average_l0_28
-    l0: 28
-  - id: layer_41/width_16k/average_l0_58
-    path: layer_41/width_16k/average_l0_58
-    l0: 58
-    neuronpedia: gemma-2-9b/41-gemmascope-mlp-16k__l0-58
-  - id: layer_41/width_16k/average_l0_126
-    path: layer_41/width_16k/average_l0_126
-    l0: 126
-  - id: layer_41/width_16k/average_l0_288
-    path: layer_41/width_16k/average_l0_288
-    l0: 288
-  - id: layer_41/width_131k/average_l0_8
-    path: layer_41/width_131k/average_l0_8
-    l0: 8
-  - id: layer_41/width_131k/average_l0_14
-    path: layer_41/width_131k/average_l0_14
-    l0: 14
-  - id: layer_41/width_131k/average_l0_25
-    path: layer_41/width_131k/average_l0_25
-    l0: 25
-  - id: layer_41/width_131k/average_l0_49
-    path: layer_41/width_131k/average_l0_49
-    l0: 49
-  - id: layer_41/width_131k/average_l0_99
-    path: layer_41/width_131k/average_l0_99
-    l0: 99
-  - id: layer_41/width_131k/average_l0_208
-    path: layer_41/width_131k/average_l0_208
-    l0: 208
-  - id: layer_5/width_16k/average_l0_14
-    path: layer_5/width_16k/average_l0_14
-    l0: 14
-  - id: layer_5/width_16k/average_l0_24
-    path: layer_5/width_16k/average_l0_24
-    l0: 24
-  - id: layer_5/width_16k/average_l0_46
-    path: layer_5/width_16k/average_l0_46
-    l0: 46
-    neuronpedia: gemma-2-9b/5-gemmascope-mlp-16k__l0-46
-  - id: layer_5/width_16k/average_l0_93
-    path: layer_5/width_16k/average_l0_93
-    l0: 93
-  - id: layer_5/width_16k/average_l0_194
-    path: layer_5/width_16k/average_l0_194
-    l0: 194
-  - id: layer_5/width_131k/average_l0_7
-    path: layer_5/width_131k/average_l0_7
-    l0: 7
-  - id: layer_5/width_131k/average_l0_12
-    path: layer_5/width_131k/average_l0_12
-    l0: 12
-  - id: layer_5/width_131k/average_l0_21
-    path: layer_5/width_131k/average_l0_21
-    l0: 21
-  - id: layer_5/width_131k/average_l0_37
-    path: layer_5/width_131k/average_l0_37
-    l0: 37
-  - id: layer_5/width_131k/average_l0_68
-    path: layer_5/width_131k/average_l0_68
-    l0: 68
-  - id: layer_5/width_131k/average_l0_131
-    path: layer_5/width_131k/average_l0_131
-    l0: 131
-  - id: layer_6/width_16k/average_l0_12
-    path: layer_6/width_16k/average_l0_12
-    l0: 12
-  - id: layer_6/width_16k/average_l0_23
-    path: layer_6/width_16k/average_l0_23
-    l0: 23
-  - id: layer_6/width_16k/average_l0_46
-    path: layer_6/width_16k/average_l0_46
-    l0: 46
-    neuronpedia: gemma-2-9b/6-gemmascope-mlp-16k__l0-46
-  - id: layer_6/width_16k/average_l0_96
-    path: layer_6/width_16k/average_l0_96
-    l0: 96
-  - id: layer_6/width_16k/average_l0_206
-    path: layer_6/width_16k/average_l0_206
-    l0: 206
-  - id: layer_6/width_131k/average_l0_12
-    path: layer_6/width_131k/average_l0_12
-    l0: 12
-  - id: layer_6/width_131k/average_l0_22
-    path: layer_6/width_131k/average_l0_22
-    l0: 22
-  - id: layer_6/width_131k/average_l0_40
-    path: layer_6/width_131k/average_l0_40
-    l0: 40
-  - id: layer_6/width_131k/average_l0_72
-    path: layer_6/width_131k/average_l0_72
-    l0: 72
-  - id: layer_6/width_131k/average_l0_135
-    path: layer_6/width_131k/average_l0_135
-    l0: 135
-  - id: layer_6/width_131k/average_l0_271
-    path: layer_6/width_131k/average_l0_271
-    l0: 271
-  - id: layer_7/width_16k/average_l0_14
-    path: layer_7/width_16k/average_l0_14
-    l0: 14
-  - id: layer_7/width_16k/average_l0_25
-    path: layer_7/width_16k/average_l0_25
-    l0: 25
-  - id: layer_7/width_16k/average_l0_47
-    path: layer_7/width_16k/average_l0_47
-    l0: 47
-    neuronpedia: gemma-2-9b/7-gemmascope-mlp-16k__l0-47
-  - id: layer_7/width_16k/average_l0_101
-    path: layer_7/width_16k/average_l0_101
-    l0: 101
-  - id: layer_7/width_16k/average_l0_231
-    path: layer_7/width_16k/average_l0_231
-    l0: 231
-  - id: layer_7/width_131k/average_l0_13
-    path: layer_7/width_131k/average_l0_13
-    l0: 13
-  - id: layer_7/width_131k/average_l0_23
-    path: layer_7/width_131k/average_l0_23
-    l0: 23
-  - id: layer_7/width_131k/average_l0_41
-    path: layer_7/width_131k/average_l0_41
-    l0: 41
-  - id: layer_7/width_131k/average_l0_75
-    path: layer_7/width_131k/average_l0_75
-    l0: 75
-  - id: layer_7/width_131k/average_l0_143
-    path: layer_7/width_131k/average_l0_143
-    l0: 143
-  - id: layer_7/width_131k/average_l0_309
-    path: layer_7/width_131k/average_l0_309
-    l0: 309
-  - id: layer_8/width_16k/average_l0_15
-    path: layer_8/width_16k/average_l0_15
-    l0: 15
-  - id: layer_8/width_16k/average_l0_27
-    path: layer_8/width_16k/average_l0_27
-    l0: 27
-  - id: layer_8/width_16k/average_l0_55
-    path: layer_8/width_16k/average_l0_55
-    l0: 55
-    neuronpedia: gemma-2-9b/8-gemmascope-mlp-16k__l0-55
-  - id: layer_8/width_16k/average_l0_124
-    path: layer_8/width_16k/average_l0_124
-    l0: 124
-  - id: layer_8/width_16k/average_l0_309
-    path: layer_8/width_16k/average_l0_309
-    l0: 309
-  - id: layer_8/width_131k/average_l0_15
-    path: layer_8/width_131k/average_l0_15
-    l0: 15
-  - id: layer_8/width_131k/average_l0_26
-    path: layer_8/width_131k/average_l0_26
-    l0: 26
-  - id: layer_8/width_131k/average_l0_48
-    path: layer_8/width_131k/average_l0_48
-    l0: 48
-  - id: layer_8/width_131k/average_l0_89
-    path: layer_8/width_131k/average_l0_89
-    l0: 89
-  - id: layer_8/width_131k/average_l0_184
-    path: layer_8/width_131k/average_l0_184
-    l0: 184
-  - id: layer_8/width_131k/average_l0_423
-    path: layer_8/width_131k/average_l0_423
-    l0: 423
-  - id: layer_9/width_16k/average_l0_12
-    path: layer_9/width_16k/average_l0_12
-    l0: 12
-  - id: layer_9/width_16k/average_l0_21
-    path: layer_9/width_16k/average_l0_21
-    l0: 21
-  - id: layer_9/width_16k/average_l0_40
-    path: layer_9/width_16k/average_l0_40
-    l0: 40
-  - id: layer_9/width_16k/average_l0_83
-    path: layer_9/width_16k/average_l0_83
-    l0: 83
-    neuronpedia: gemma-2-9b/9-gemmascope-mlp-16k__l0-83
-  - id: layer_9/width_16k/average_l0_200
-    path: layer_9/width_16k/average_l0_200
-    l0: 200
-  - id: layer_9/width_131k/average_l0_12
-    path: layer_9/width_131k/average_l0_12
-    l0: 12
-  - id: layer_9/width_131k/average_l0_21
-    path: layer_9/width_131k/average_l0_21
-    l0: 21
-  - id: layer_9/width_131k/average_l0_38
-    path: layer_9/width_131k/average_l0_38
-    l0: 38
-  - id: layer_9/width_131k/average_l0_67
-    path: layer_9/width_131k/average_l0_67
-    l0: 67
-  - id: layer_9/width_131k/average_l0_129
-    path: layer_9/width_131k/average_l0_129
-    l0: 129
-  - id: layer_9/width_131k/average_l0_269
-    path: layer_9/width_131k/average_l0_269
-    l0: 269
-gemma-scope-9b-pt-mlp-canonical:
-  repo_id: google/gemma-scope-9b-pt-mlp
-  model: gemma-2-9b
-  conversion_func: gemma_2
-  saes:
-  - id: layer_0/width_16k/canonical
-    path: layer_0/width_16k/average_l0_50
-    neuronpedia: gemma-2-9b/0-gemmascope-mlp-16k
-  - id: layer_1/width_16k/canonical
-    path: layer_1/width_16k/average_l0_128
-    neuronpedia: gemma-2-9b/1-gemmascope-mlp-16k
-  - id: layer_2/width_16k/canonical
-    path: layer_2/width_16k/average_l0_81
-    neuronpedia: gemma-2-9b/2-gemmascope-mlp-16k
-  - id: layer_3/width_16k/canonical
-    path: layer_3/width_16k/average_l0_126
-    neuronpedia: gemma-2-9b/3-gemmascope-mlp-16k
-  - id: layer_4/width_16k/canonical
-    path: layer_4/width_16k/average_l0_66
-    neuronpedia: gemma-2-9b/4-gemmascope-mlp-16k
-  - id: layer_5/width_16k/canonical
-    path: layer_5/width_16k/average_l0_93
-    neuronpedia: gemma-2-9b/5-gemmascope-mlp-16k
-  - id: layer_6/width_16k/canonical
-    path: layer_6/width_16k/average_l0_96
-    neuronpedia: gemma-2-9b/6-gemmascope-mlp-16k
-  - id: layer_7/width_16k/canonical
-    path: layer_7/width_16k/average_l0_101
-    neuronpedia: gemma-2-9b/7-gemmascope-mlp-16k
-  - id: layer_8/width_16k/canonical
-    path: layer_8/width_16k/average_l0_124
-    neuronpedia: gemma-2-9b/8-gemmascope-mlp-16k
-  - id: layer_9/width_16k/canonical
-    path: layer_9/width_16k/average_l0_83
-    neuronpedia: gemma-2-9b/9-gemmascope-mlp-16k
-  - id: layer_10/width_16k/canonical
-    path: layer_10/width_16k/average_l0_114
-    neuronpedia: gemma-2-9b/10-gemmascope-mlp-16k
-  - id: layer_11/width_16k/canonical
-    path: layer_11/width_16k/average_l0_76
-    neuronpedia: gemma-2-9b/11-gemmascope-mlp-16k
-  - id: layer_12/width_16k/canonical
-    path: layer_12/width_16k/average_l0_96
-    neuronpedia: gemma-2-9b/12-gemmascope-mlp-16k
-  - id: layer_13/width_16k/canonical
-    path: layer_13/width_16k/average_l0_94
-    neuronpedia: gemma-2-9b/13-gemmascope-mlp-16k
-  - id: layer_14/width_16k/canonical
-    path: layer_14/width_16k/average_l0_97
-    neuronpedia: gemma-2-9b/14-gemmascope-mlp-16k
-  - id: layer_15/width_16k/canonical
-    path: layer_15/width_16k/average_l0_107
-    neuronpedia: gemma-2-9b/15-gemmascope-mlp-16k
-  - id: layer_16/width_16k/canonical
-    path: layer_16/width_16k/average_l0_91
-    neuronpedia: gemma-2-9b/16-gemmascope-mlp-16k
-  - id: layer_17/width_16k/canonical
-    path: layer_17/width_16k/average_l0_104
-    neuronpedia: gemma-2-9b/17-gemmascope-mlp-16k
-  - id: layer_18/width_16k/canonical
-    path: layer_18/width_16k/average_l0_89
-    neuronpedia: gemma-2-9b/18-gemmascope-mlp-16k
-  - id: layer_19/width_16k/canonical
-    path: layer_19/width_16k/average_l0_98
-    neuronpedia: gemma-2-9b/19-gemmascope-mlp-16k
-  - id: layer_20/width_16k/canonical
-    path: layer_20/width_16k/average_l0_108
-    neuronpedia: gemma-2-9b/20-gemmascope-mlp-16k
-  - id: layer_21/width_16k/canonical
-    path: layer_21/width_16k/average_l0_88
-    neuronpedia: gemma-2-9b/21-gemmascope-mlp-16k
-  - id: layer_22/width_16k/canonical
-    path: layer_22/width_16k/average_l0_85
-    neuronpedia: gemma-2-9b/22-gemmascope-mlp-16k
-  - id: layer_23/width_16k/canonical
-    path: layer_23/width_16k/average_l0_73
-    neuronpedia: gemma-2-9b/23-gemmascope-mlp-16k
-  - id: layer_24/width_16k/canonical
-    path: layer_24/width_16k/average_l0_73
-    neuronpedia: gemma-2-9b/24-gemmascope-mlp-16k
-  - id: layer_25/width_16k/canonical
-    path: layer_25/width_16k/average_l0_72
-    neuronpedia: gemma-2-9b/25-gemmascope-mlp-16k
-  - id: layer_26/width_16k/canonical
-    path: layer_26/width_16k/average_l0_142
-    neuronpedia: gemma-2-9b/26-gemmascope-mlp-16k
-  - id: layer_27/width_16k/canonical
-    path: layer_27/width_16k/average_l0_126
-    neuronpedia: gemma-2-9b/27-gemmascope-mlp-16k
-  - id: layer_28/width_16k/canonical
-    path: layer_28/width_16k/average_l0_115
-    neuronpedia: gemma-2-9b/28-gemmascope-mlp-16k
-  - id: layer_29/width_16k/canonical
-    path: layer_29/width_16k/average_l0_111
-    neuronpedia: gemma-2-9b/29-gemmascope-mlp-16k
-  - id: layer_30/width_16k/canonical
-    path: layer_30/width_16k/average_l0_116
-    neuronpedia: gemma-2-9b/30-gemmascope-mlp-16k
-  - id: layer_31/width_16k/canonical
-    path: layer_31/width_16k/average_l0_94
-    neuronpedia: gemma-2-9b/31-gemmascope-mlp-16k
-  - id: layer_32/width_16k/canonical
-    path: layer_32/width_16k/average_l0_98
-    neuronpedia: gemma-2-9b/32-gemmascope-mlp-16k
-  - id: layer_33/width_16k/canonical
-    path: layer_33/width_16k/average_l0_107
-    neuronpedia: gemma-2-9b/33-gemmascope-mlp-16k
-  - id: layer_34/width_16k/canonical
-    path: layer_34/width_16k/average_l0_107
-    neuronpedia: gemma-2-9b/34-gemmascope-mlp-16k
-  - id: layer_35/width_16k/canonical
-    path: layer_35/width_16k/average_l0_108
-    neuronpedia: gemma-2-9b/35-gemmascope-mlp-16k
-  - id: layer_36/width_16k/canonical
-    path: layer_36/width_16k/average_l0_109
-    neuronpedia: gemma-2-9b/36-gemmascope-mlp-16k
-  - id: layer_37/width_16k/canonical
-    path: layer_37/width_16k/average_l0_119
-    neuronpedia: gemma-2-9b/37-gemmascope-mlp-16k
-  - id: layer_38/width_16k/canonical
-    path: layer_38/width_16k/average_l0_98
-    neuronpedia: gemma-2-9b/38-gemmascope-mlp-16k
-  - id: layer_39/width_16k/canonical
-    path: layer_39/width_16k/average_l0_90
-    neuronpedia: gemma-2-9b/39-gemmascope-mlp-16k
-  - id: layer_40/width_16k/canonical
-    path: layer_40/width_16k/average_l0_74
-    neuronpedia: gemma-2-9b/40-gemmascope-mlp-16k
-  - id: layer_41/width_16k/canonical
-    path: layer_41/width_16k/average_l0_126
-    neuronpedia: gemma-2-9b/41-gemmascope-mlp-16k
-  - id: layer_0/width_131k/canonical
-    path: layer_0/width_131k/average_l0_30
-    neuronpedia: gemma-2-9b/0-gemmascope-mlp-131k
-  - id: layer_1/width_131k/canonical
-    path: layer_1/width_131k/average_l0_106
-    neuronpedia: gemma-2-9b/1-gemmascope-mlp-131k
-  - id: layer_2/width_131k/canonical
-    path: layer_2/width_131k/average_l0_61
-    neuronpedia: gemma-2-9b/2-gemmascope-mlp-131k
-  - id: layer_3/width_131k/canonical
-    path: layer_3/width_131k/average_l0_109
-    neuronpedia: gemma-2-9b/3-gemmascope-mlp-131k
-  - id: layer_4/width_131k/canonical
-    path: layer_4/width_131k/average_l0_84
-    neuronpedia: gemma-2-9b/4-gemmascope-mlp-131k
-  - id: layer_5/width_131k/canonical
-    path: layer_5/width_131k/average_l0_131
-    neuronpedia: gemma-2-9b/5-gemmascope-mlp-131k
-  - id: layer_6/width_131k/canonical
-    path: layer_6/width_131k/average_l0_72
-    neuronpedia: gemma-2-9b/6-gemmascope-mlp-131k
-  - id: layer_7/width_131k/canonical
-    path: layer_7/width_131k/average_l0_75
-    neuronpedia: gemma-2-9b/7-gemmascope-mlp-131k
-  - id: layer_8/width_131k/canonical
-    path: layer_8/width_131k/average_l0_89
-    neuronpedia: gemma-2-9b/8-gemmascope-mlp-131k
-  - id: layer_9/width_131k/canonical
-    path: layer_9/width_131k/average_l0_129
-    neuronpedia: gemma-2-9b/9-gemmascope-mlp-131k
-  - id: layer_10/width_131k/canonical
-    path: layer_10/width_131k/average_l0_83
-    neuronpedia: gemma-2-9b/10-gemmascope-mlp-131k
-  - id: layer_11/width_131k/canonical
-    path: layer_11/width_131k/average_l0_120
-    neuronpedia: gemma-2-9b/11-gemmascope-mlp-131k
-  - id: layer_12/width_131k/canonical
-    path: layer_12/width_131k/average_l0_77
-    neuronpedia: gemma-2-9b/12-gemmascope-mlp-131k
-  - id: layer_13/width_131k/canonical
-    path: layer_13/width_131k/average_l0_75
-    neuronpedia: gemma-2-9b/13-gemmascope-mlp-131k
-  - id: layer_14/width_131k/canonical
-    path: layer_14/width_131k/average_l0_80
-    neuronpedia: gemma-2-9b/14-gemmascope-mlp-131k
-  - id: layer_15/width_131k/canonical
-    path: layer_15/width_131k/average_l0_89
-    neuronpedia: gemma-2-9b/15-gemmascope-mlp-131k
-  - id: layer_16/width_131k/canonical
-    path: layer_16/width_131k/average_l0_81
-    neuronpedia: gemma-2-9b/16-gemmascope-mlp-131k
-  - id: layer_17/width_131k/canonical
-    path: layer_17/width_131k/average_l0_91
-    neuronpedia: gemma-2-9b/17-gemmascope-mlp-131k
-  - id: layer_18/width_131k/canonical
-    path: layer_18/width_131k/average_l0_82
-    neuronpedia: gemma-2-9b/18-gemmascope-mlp-131k
-  - id: layer_19/width_131k/canonical
-    path: layer_19/width_131k/average_l0_85
-    neuronpedia: gemma-2-9b/19-gemmascope-mlp-131k
-  - id: layer_20/width_131k/canonical
-    path: layer_20/width_131k/average_l0_93
-    neuronpedia: gemma-2-9b/20-gemmascope-mlp-131k
-  - id: layer_21/width_131k/canonical
-    path: layer_21/width_131k/average_l0_79
-    neuronpedia: gemma-2-9b/21-gemmascope-mlp-131k
-  - id: layer_22/width_131k/canonical
-    path: layer_22/width_131k/average_l0_77
-    neuronpedia: gemma-2-9b/22-gemmascope-mlp-131k
-  - id: layer_23/width_131k/canonical
-    path: layer_23/width_131k/average_l0_67
-    neuronpedia: gemma-2-9b/23-gemmascope-mlp-131k
-  - id: layer_24/width_131k/canonical
-    path: layer_24/width_131k/average_l0_67
-    neuronpedia: gemma-2-9b/24-gemmascope-mlp-131k
-  - id: layer_25/width_131k/canonical
-    path: layer_25/width_131k/average_l0_65
-    neuronpedia: gemma-2-9b/25-gemmascope-mlp-131k
-  - id: layer_26/width_131k/canonical
-    path: layer_26/width_131k/average_l0_110
-    neuronpedia: gemma-2-9b/26-gemmascope-mlp-131k
-  - id: layer_27/width_131k/canonical
-    path: layer_27/width_131k/average_l0_99
-    neuronpedia: gemma-2-9b/27-gemmascope-mlp-131k
-  - id: layer_28/width_131k/canonical
-    path: layer_28/width_131k/average_l0_91
-    neuronpedia: gemma-2-9b/28-gemmascope-mlp-131k
-  - id: layer_29/width_131k/canonical
-    path: layer_29/width_131k/average_l0_87
-    neuronpedia: gemma-2-9b/29-gemmascope-mlp-131k
-  - id: layer_30/width_131k/canonical
-    path: layer_30/width_131k/average_l0_89
-    neuronpedia: gemma-2-9b/30-gemmascope-mlp-131k
-  - id: layer_31/width_131k/canonical
-    path: layer_31/width_131k/average_l0_77
-    neuronpedia: gemma-2-9b/31-gemmascope-mlp-131k
-  - id: layer_32/width_131k/canonical
-    path: layer_32/width_131k/average_l0_76
-    neuronpedia: gemma-2-9b/32-gemmascope-mlp-131k
-  - id: layer_33/width_131k/canonical
-    path: layer_33/width_131k/average_l0_83
-    neuronpedia: gemma-2-9b/33-gemmascope-mlp-131k
-  - id: layer_34/width_131k/canonical
-    path: layer_34/width_131k/average_l0_82
-    neuronpedia: gemma-2-9b/34-gemmascope-mlp-131k
-  - id: layer_35/width_131k/canonical
-    path: layer_35/width_131k/average_l0_80
-    neuronpedia: gemma-2-9b/35-gemmascope-mlp-131k
-  - id: layer_36/width_131k/canonical
-    path: layer_36/width_131k/average_l0_81
-    neuronpedia: gemma-2-9b/36-gemmascope-mlp-131k
-  - id: layer_37/width_131k/canonical
-    path: layer_37/width_131k/average_l0_90
-    neuronpedia: gemma-2-9b/37-gemmascope-mlp-131k
-  - id: layer_38/width_131k/canonical
-    path: layer_38/width_131k/average_l0_79
-    neuronpedia: gemma-2-9b/38-gemmascope-mlp-131k
-  - id: layer_39/width_131k/canonical
-    path: layer_39/width_131k/average_l0_75
-    neuronpedia: gemma-2-9b/39-gemmascope-mlp-131k
-  - id: layer_40/width_131k/canonical
-    path: layer_40/width_131k/average_l0_125
-    neuronpedia: gemma-2-9b/40-gemmascope-mlp-131k
-  - id: layer_41/width_131k/canonical
-    path: layer_41/width_131k/average_l0_99
-    neuronpedia: gemma-2-9b/41-gemmascope-mlp-131k
-gemma-scope-9b-it-res:
-  repo_id: google/gemma-scope-9b-it-res
-  model: gemma-2-9b
-  conversion_func: gemma_2
-  saes:
-  - id: layer_20/width_131k/average_l0_13
-    path: layer_20/width_131k/average_l0_13
-    l0: 13
-  - id: layer_20/width_131k/average_l0_153
-    path: layer_20/width_131k/average_l0_153
-    l0: 153
-  - id: layer_20/width_131k/average_l0_24
-    path: layer_20/width_131k/average_l0_24
-    l0: 24
-  - id: layer_20/width_131k/average_l0_43
-    path: layer_20/width_131k/average_l0_43
-    l0: 43
-  - id: layer_20/width_131k/average_l0_81
-    path: layer_20/width_131k/average_l0_81
-    l0: 81
-  - id: layer_20/width_16k/average_l0_14
-    path: layer_20/width_16k/average_l0_14
-    l0: 14
-  - id: layer_20/width_16k/average_l0_189
-    path: layer_20/width_16k/average_l0_189
-    l0: 189
-  - id: layer_20/width_16k/average_l0_25
-    path: layer_20/width_16k/average_l0_25
-    l0: 25
-  - id: layer_20/width_16k/average_l0_47
-    path: layer_20/width_16k/average_l0_47
-    l0: 47
-  - id: layer_20/width_16k/average_l0_91
-    path: layer_20/width_16k/average_l0_91
-    l0: 91
-  - id: layer_31/width_131k/average_l0_109
-    path: layer_31/width_131k/average_l0_109
-    l0: 109
-  - id: layer_31/width_131k/average_l0_13
-    path: layer_31/width_131k/average_l0_13
-    l0: 13
-  - id: layer_31/width_131k/average_l0_22
-    path: layer_31/width_131k/average_l0_22
-    l0: 22
-  - id: layer_31/width_131k/average_l0_37
-    path: layer_31/width_131k/average_l0_37
-    l0: 37
-  - id: layer_31/width_131k/average_l0_63
-    path: layer_31/width_131k/average_l0_63
-    l0: 63
-  - id: layer_31/width_16k/average_l0_14
-    path: layer_31/width_16k/average_l0_14
-    l0: 14
-  - id: layer_31/width_16k/average_l0_142
-    path: layer_31/width_16k/average_l0_142
-    l0: 142
-  - id: layer_31/width_16k/average_l0_24
-    path: layer_31/width_16k/average_l0_24
-    l0: 24
-  - id: layer_31/width_16k/average_l0_43
-    path: layer_31/width_16k/average_l0_43
-    l0: 43
-  - id: layer_31/width_16k/average_l0_76
-    path: layer_31/width_16k/average_l0_76
-    l0: 76
-  - id: layer_9/width_131k/average_l0_121
-    path: layer_9/width_131k/average_l0_121
-    l0: 121
-  - id: layer_9/width_131k/average_l0_13
-    path: layer_9/width_131k/average_l0_13
-    l0: 13
-  - id: layer_9/width_131k/average_l0_22
-    path: layer_9/width_131k/average_l0_22
-    l0: 22
-  - id: layer_9/width_131k/average_l0_39
-    path: layer_9/width_131k/average_l0_39
-    l0: 39
-  - id: layer_9/width_131k/average_l0_67
-    path: layer_9/width_131k/average_l0_67
-    l0: 67
-  - id: layer_9/width_16k/average_l0_14
-    path: layer_9/width_16k/average_l0_14
-    l0: 14
-  - id: layer_9/width_16k/average_l0_186
-    path: layer_9/width_16k/average_l0_186
-    l0: 186
-  - id: layer_9/width_16k/average_l0_26
-    path: layer_9/width_16k/average_l0_26
-    l0: 26
-  - id: layer_9/width_16k/average_l0_47
-    path: layer_9/width_16k/average_l0_47
-    l0: 47
-  - id: layer_9/width_16k/average_l0_88
-    path: layer_9/width_16k/average_l0_88
-    l0: 88
-gemma-scope-9b-it-res-canonical:
-  repo_id: google/gemma-scope-9b-it-res
-  model: gemma-2-9b-it
-  conversion_func: gemma_2
-  saes:
-  - id: layer_9/width_16k/canonical
-    path: layer_9/width_16k/average_l0_88
-    neuronpedia: gemma-2-9b-it/9-gemmascope-res-16k
-  - id: layer_20/width_16k/canonical
-    path: layer_20/width_16k/average_l0_91
-    neuronpedia: gemma-2-9b-it/20-gemmascope-res-16k
-  - id: layer_31/width_16k/canonical
-    path: layer_31/width_16k/average_l0_76
-    neuronpedia: gemma-2-9b-it/31-gemmascope-res-16k
-  - id: layer_9/width_131k/canonical
-    path: layer_9/width_131k/average_l0_121
-    neuronpedia: gemma-2-9b-it/9-gemmascope-res-131k
-  - id: layer_20/width_131k/canonical
-    path: layer_20/width_131k/average_l0_81
-    neuronpedia: gemma-2-9b-it/20-gemmascope-res-131k
-  - id: layer_31/width_131k/canonical
-    path: layer_31/width_131k/average_l0_109
-    neuronpedia: gemma-2-9b-it/31-gemmascope-res-131k
-gemma-scope-27b-pt-res:
-  repo_id: google/gemma-scope-27b-pt-res
-  model: gemma-2-27b
-  conversion_func: gemma_2
-  saes:
-  - id: layer_10/width_131k/average_l0_106
-    path: layer_10/width_131k/average_l0_106
-    l0: 106
-  - id: layer_10/width_131k/average_l0_15
-    path: layer_10/width_131k/average_l0_15
-    l0: 15
-  - id: layer_10/width_131k/average_l0_200
-    path: layer_10/width_131k/average_l0_200
-    l0: 200
-  - id: layer_10/width_131k/average_l0_24
-    path: layer_10/width_131k/average_l0_24
-    l0: 24
-  - id: layer_10/width_131k/average_l0_37
-    path: layer_10/width_131k/average_l0_37
-    l0: 37
-  - id: layer_10/width_131k/average_l0_64
-    path: layer_10/width_131k/average_l0_64
-    l0: 64
-  - id: layer_22/width_131k/average_l0_150
-    path: layer_22/width_131k/average_l0_150
-    l0: 150
-  - id: layer_22/width_131k/average_l0_20
-    path: layer_22/width_131k/average_l0_20
-    l0: 20
-  - id: layer_22/width_131k/average_l0_290
-    path: layer_22/width_131k/average_l0_290
-    l0: 290
-  - id: layer_22/width_131k/average_l0_31
-    path: layer_22/width_131k/average_l0_31
-    l0: 31
-  - id: layer_22/width_131k/average_l0_48
-    path: layer_22/width_131k/average_l0_48
-    l0: 48
-  - id: layer_22/width_131k/average_l0_82
-    path: layer_22/width_131k/average_l0_82
-    l0: 82
-  - id: layer_34/width_131k/average_l0_155
-    path: layer_34/width_131k/average_l0_155
-    l0: 155
-  - id: layer_34/width_131k/average_l0_21
-    path: layer_34/width_131k/average_l0_21
-    l0: 21
-  - id: layer_34/width_131k/average_l0_333
-    path: layer_34/width_131k/average_l0_333
-    l0: 333
-  - id: layer_34/width_131k/average_l0_38
-    path: layer_34/width_131k/average_l0_38
-    l0: 38
-  - id: layer_34/width_131k/average_l0_72
-    path: layer_34/width_131k/average_l0_72
-    l0: 72
-  - id: layer_34/width_131k/average_l0_785
-    path: layer_34/width_131k/average_l0_785
-    l0: 785
-gemma-scope-27b-pt-res-canonical:
-  repo_id: google/gemma-scope-27b-pt-res
-  model: gemma-2-27b
-  conversion_func: gemma_2
-  saes:
-  - id: layer_10/width_131k/canonical
-    path: layer_10/width_131k/average_l0_106
-    neuronpedia: gemma-2-27b/10-gemmascope-res-131k
-  - id: layer_22/width_131k/canonical
-    path: layer_22/width_131k/average_l0_82
-    neuronpedia: gemma-2-27b/22-gemmascope-res-131k
-  - id: layer_34/width_131k/canonical
-    path: layer_34/width_131k/average_l0_72
-    neuronpedia: gemma-2-27b/34-gemmascope-res-131k
-pythia-70m-deduped-res-sm:
-  repo_id: ctigges/pythia-70m-deduped__res-sm_processed
-  model: pythia-70m-deduped
+    path: layer_20/width_65k/average_l0_55
+gpt2-small-attn-out-v5-128k:
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
   conversion_func: null
-  links:
-    model: https://huggingface.co/EleutherAI/pythia-70m-deduped
-    dashboards: https://www.neuronpedia.org/pythia-70m-deduped
-  saes:
-  - id: blocks.0.hook_resid_pre
-    path: e-res-sm
-    neuronpedia: pythia-70m-deduped/e-att-sm
-  - id: blocks.0.hook_resid_post
-    path: 0-res-sm
-    neuronpedia: pythia-70m-deduped/0-res-sm
-  - id: blocks.1.hook_resid_post
-    path: 1-res-sm
-    neuronpedia: pythia-70m-deduped/1-res-sm
-  - id: blocks.2.hook_resid_post
-    path: 2-res-sm
-    neuronpedia: pythia-70m-deduped/2-res-sm
-  - id: blocks.3.hook_resid_post
-    path: 3-res-sm
-    neuronpedia: pythia-70m-deduped/3-res-sm
-  - id: blocks.4.hook_resid_post
-    path: 4-res-sm
-    neuronpedia: pythia-70m-deduped/4-res-sm
-  - id: blocks.5.hook_resid_post
-    path: 5-res-sm
-    neuronpedia: pythia-70m-deduped/5-res-sm
-pythia-70m-deduped-mlp-sm:
-  repo_id: ctigges/pythia-70m-deduped__mlp-sm_processed
-  model: pythia-70m-deduped
-  conversion_func: null
-  links:
-    model: https://huggingface.co/EleutherAI/pythia-70m-deduped
-    dashboards: https://www.neuronpedia.org/pythia-70m-deduped
-  saes:
-  - id: blocks.0.hook_mlp_out
-    path: 0-mlp-sm
-    neuronpedia: pythia-70m-deduped/0-mlp-sm
-  - id: blocks.1.hook_mlp_out
-    path: 1-mlp-sm
-    neuronpedia: pythia-70m-deduped/1-mlp-sm
-  - id: blocks.2.hook_mlp_out
-    path: 2-mlp-sm
-    neuronpedia: pythia-70m-deduped/2-mlp-sm
-  - id: blocks.3.hook_mlp_out
-    path: 3-mlp-sm
-    neuronpedia: pythia-70m-deduped/3-mlp-sm
-  - id: blocks.4.hook_mlp_out
-    path: 4-mlp-sm
-    neuronpedia: pythia-70m-deduped/4-mlp-sm
-  - id: blocks.5.hook_mlp_out
-    path: 5-mlp-sm
-    neuronpedia: pythia-70m-deduped/5-mlp-sm
-pythia-70m-deduped-att-sm:
-  repo_id: ctigges/pythia-70m-deduped__att-sm_processed
-  model: pythia-70m-deduped
-  conversion_func: null
-  links:
-    model: https://huggingface.co/EleutherAI/pythia-70m-deduped
-    dashboards: https://www.neuronpedia.org/pythia-70m-deduped
+  model: gpt2-small
+  repo_id: jbloom/GPT2-Small-OAI-v5-128k-attn-out-SAEs
   saes:
   - id: blocks.0.hook_attn_out
-    path: 0-att-sm
-    neuronpedia: pythia-70m-deduped/0-att-sm
+    neuronpedia: gpt2-small/0-att_128k-oai
+    path: v5_128k_layer_0
   - id: blocks.1.hook_attn_out
-    path: 1-att-sm
-    neuronpedia: pythia-70m-deduped/1-att-sm
+    neuronpedia: gpt2-small/1-att_128k-oai
+    path: v5_128k_layer_1
   - id: blocks.2.hook_attn_out
-    path: 2-att-sm
-    neuronpedia: pythia-70m-deduped/2-att-sm
+    neuronpedia: gpt2-small/2-att_128k-oai
+    path: v5_128k_layer_2
   - id: blocks.3.hook_attn_out
-    path: 3-att-sm
-    neuronpedia: pythia-70m-deduped/3-att-sm
+    neuronpedia: gpt2-small/3-att_128k-oai
+    path: v5_128k_layer_3
   - id: blocks.4.hook_attn_out
-    path: 4-att-sm
-    neuronpedia: pythia-70m-deduped/4-att-sm
+    neuronpedia: gpt2-small/4-att_128k-oai
+    path: v5_128k_layer_4
   - id: blocks.5.hook_attn_out
-    path: 5-att-sm
-    neuronpedia: pythia-70m-deduped/5-att-sm
-gpt2-small-res_sll-ajt:
-  repo_id: neuronpedia/gpt2-small__res_sll-ajt
+    neuronpedia: gpt2-small/5-att_128k-oai
+    path: v5_128k_layer_5
+  - id: blocks.6.hook_attn_out
+    neuronpedia: gpt2-small/6-att_128k-oai
+    path: v5_128k_layer_6
+  - id: blocks.7.hook_attn_out
+    neuronpedia: gpt2-small/7-att_128k-oai
+    path: v5_128k_layer_7
+  - id: blocks.8.hook_attn_out
+    neuronpedia: gpt2-small/8-att_128k-oai
+    path: v5_128k_layer_8
+  - id: blocks.9.hook_attn_out
+    neuronpedia: gpt2-small/9-att_128k-oai
+    path: v5_128k_layer_9
+  - id: blocks.10.hook_attn_out
+    neuronpedia: gpt2-small/10-att_128k-oai
+    path: v5_128k_layer_10
+  - id: blocks.11.hook_attn_out
+    neuronpedia: gpt2-small/11-att_128k-oai
+    path: v5_128k_layer_11
+gpt2-small-attn-out-v5-32k:
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+  conversion_func: null
   model: gpt2-small
+  repo_id: jbloom/GPT2-Small-OAI-v5-32k-attn-out-SAEs
+  saes:
+  - id: blocks.0.hook_attn_out
+    neuronpedia: gpt2-small/0-att_32k-oai
+    path: v5_32k_layer_0
+  - id: blocks.1.hook_attn_out
+    neuronpedia: gpt2-small/1-att_32k-oai
+    path: v5_32k_layer_1
+  - id: blocks.2.hook_attn_out
+    neuronpedia: gpt2-small/2-att_32k-oai
+    path: v5_32k_layer_2
+  - id: blocks.3.hook_attn_out
+    neuronpedia: gpt2-small/3-att_32k-oai
+    path: v5_32k_layer_3
+  - id: blocks.4.hook_attn_out
+    neuronpedia: gpt2-small/4-att_32k-oai
+    path: v5_32k_layer_4
+  - id: blocks.5.hook_attn_out
+    neuronpedia: gpt2-small/5-att_32k-oai
+    path: v5_32k_layer_5
+  - id: blocks.6.hook_attn_out
+    neuronpedia: gpt2-small/6-att_32k-oai
+    path: v5_32k_layer_6
+  - id: blocks.7.hook_attn_out
+    neuronpedia: gpt2-small/7-att_32k-oai
+    path: v5_32k_layer_7
+  - id: blocks.8.hook_attn_out
+    neuronpedia: gpt2-small/8-att_32k-oai
+    path: v5_32k_layer_8
+  - id: blocks.9.hook_attn_out
+    neuronpedia: gpt2-small/9-att_32k-oai
+    path: v5_32k_layer_9
+  - id: blocks.10.hook_attn_out
+    neuronpedia: gpt2-small/10-att_32k-oai
+    path: v5_32k_layer_10
+  - id: blocks.11.hook_attn_out
+    neuronpedia: gpt2-small/11-att_32k-oai
+    path: v5_32k_layer_11
+gpt2-small-hook-z-kk:
+  conversion_func: connor_rob_hook_z
+  links:
+    dashboards: https://www.neuronpedia.org/gpt2sm-kk
+    model: https://huggingface.co/gpt2
+    publication: https://www.lesswrong.com/posts/FSTRedtjuHa4Gfdbr/attention-saes-scale-to-gpt-2-small
+  model: gpt2-small
+  repo_id: ckkissane/attn-saes-gpt2-small-all-layers
+  saes:
+  - id: blocks.0.hook_z
+    l0: 3.0
+    neuronpedia: gpt2-small/0-att-kk
+    path: gpt2-small_L0_Hcat_z_lr1.20e-03_l11.80e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
+    variance_explained: 0.13
+  - id: blocks.1.hook_z
+    l0: 23.0
+    neuronpedia: gpt2-small/1-att-kk
+    path: gpt2-small_L1_Hcat_z_lr1.20e-03_l18.00e-01_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v5.pt
+    variance_explained: 0.42
+  - id: blocks.2.hook_z
+    l0: 16.0
+    neuronpedia: gpt2-small/2-att-kk
+    path: gpt2-small_L2_Hcat_z_lr1.20e-03_l11.00e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v4.pt
+    variance_explained: 0.4
+  - id: blocks.3.hook_z
+    l0: 15.0
+    neuronpedia: gpt2-small/3-att-kk
+    path: gpt2-small_L3_Hcat_z_lr1.20e-03_l19.00e-01_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
+    variance_explained: 0.43
+  - id: blocks.4.hook_z
+    l0: 14.0
+    neuronpedia: gpt2-small/4-att-kk
+    path: gpt2-small_L4_Hcat_z_lr1.20e-03_l11.10e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v7.pt
+    variance_explained: 0.27
+  - id: blocks.5.hook_z
+    l0: 17.0
+    neuronpedia: gpt2-small/5-att-kk
+    path: gpt2-small_L5_Hcat_z_lr1.20e-03_l11.00e+00_ds49152_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
+    variance_explained: 0.13
+  - id: blocks.6.hook_z
+    l0: 17.0
+    neuronpedia: gpt2-small/6-att-kk
+    path: gpt2-small_L6_Hcat_z_lr1.20e-03_l11.10e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
+    variance_explained: 0.0
+  - id: blocks.7.hook_z
+    l0: 19.0
+    neuronpedia: gpt2-small/7-att-kk
+    path: gpt2-small_L7_Hcat_z_lr1.20e-03_l11.10e+00_ds49152_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
+    variance_explained: -7.55
+  - id: blocks.8.hook_z
+    l0: 23.0
+    neuronpedia: gpt2-small/8-att-kk
+    path: gpt2-small_L8_Hcat_z_lr1.20e-03_l11.30e+00_ds24576_bs4096_dc1.00e-05_rsanthropic_rie25000_nr4_v6.pt
+    variance_explained: -0.22
+  - id: blocks.9.hook_z
+    l0: 23.0
+    neuronpedia: gpt2-small/9-att-kk
+    path: gpt2-small_L9_Hcat_z_lr1.20e-03_l11.20e+00_ds24576_bs4096_dc1.00e-06_rsanthropic_rie25000_nr4_v9.pt
+    variance_explained: -0.54
+  - id: blocks.10.hook_z
+    l0: 14.0
+    neuronpedia: gpt2-small/10-att-kk
+    path: gpt2-small_L10_Hcat_z_lr1.20e-03_l11.30e+00_ds24576_bs4096_dc1.00e-05_rsanthropic_rie25000_nr4_v9.pt
+    variance_explained: -0.27
+  - id: blocks.11.hook_z
+    l0: 9.4
+    neuronpedia: gpt2-small/11-att-kk
+    path: gpt2-small_L11_Hcat_z_lr1.20e-03_l13.00e+00_ds24576_bs4096_dc3.16e-06_rsanthropic_rie25000_nr4_v9.pt
+    variance_explained: -0.7
+gpt2-small-mlp-out-v5-128k:
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+  conversion_func: null
+  model: gpt2-small
+  repo_id: jbloom/GPT2-Small-OAI-v5-128k-mlp-out-SAEs
+  saes:
+  - id: blocks.0.hook_mlp_out
+    neuronpedia: gpt2-small/0-mlp_128k-oai
+    path: v5_128k_layer_0
+  - id: blocks.1.hook_mlp_out
+    neuronpedia: gpt2-small/1-mlp_128k-oai
+    path: v5_128k_layer_1
+  - id: blocks.2.hook_mlp_out
+    neuronpedia: gpt2-small/2-mlp_128k-oai
+    path: v5_128k_layer_2
+  - id: blocks.3.hook_mlp_out
+    neuronpedia: gpt2-small/3-mlp_128k-oai
+    path: v5_128k_layer_3
+  - id: blocks.4.hook_mlp_out
+    neuronpedia: gpt2-small/4-mlp_128k-oai
+    path: v5_128k_layer_4
+  - id: blocks.5.hook_mlp_out
+    neuronpedia: gpt2-small/5-mlp_128k-oai
+    path: v5_128k_layer_5
+  - id: blocks.6.hook_mlp_out
+    neuronpedia: gpt2-small/6-mlp_128k-oai
+    path: v5_128k_layer_6
+  - id: blocks.7.hook_mlp_out
+    neuronpedia: gpt2-small/7-mlp_128k-oai
+    path: v5_128k_layer_7
+  - id: blocks.8.hook_mlp_out
+    neuronpedia: gpt2-small/8-mlp_128k-oai
+    path: v5_128k_layer_8
+  - id: blocks.9.hook_mlp_out
+    neuronpedia: gpt2-small/9-mlp_128k-oai
+    path: v5_128k_layer_9
+  - id: blocks.10.hook_mlp_out
+    neuronpedia: gpt2-small/10-mlp_128k-oai
+    path: v5_128k_layer_10
+  - id: blocks.11.hook_mlp_out
+    neuronpedia: gpt2-small/11-mlp_128k-oai
+    path: v5_128k_layer_11
+gpt2-small-mlp-out-v5-32k:
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+  conversion_func: null
+  model: gpt2-small
+  repo_id: jbloom/GPT2-Small-OAI-v5-32k-mlp-out-SAEs
+  saes:
+  - id: blocks.0.hook_mlp_out
+    neuronpedia: gpt2-small/0-mlp_32k-oai
+    path: v5_32k_layer_0
+  - id: blocks.1.hook_mlp_out
+    neuronpedia: gpt2-small/1-mlp_32k-oai
+    path: v5_32k_layer_1
+  - id: blocks.2.hook_mlp_out
+    neuronpedia: gpt2-small/2-mlp_32k-oai
+    path: v5_32k_layer_2
+  - id: blocks.3.hook_mlp_out
+    neuronpedia: gpt2-small/3-mlp_32k-oai
+    path: v5_32k_layer_3
+  - id: blocks.4.hook_mlp_out
+    neuronpedia: gpt2-small/4-mlp_32k-oai
+    path: v5_32k_layer_4
+  - id: blocks.5.hook_mlp_out
+    neuronpedia: gpt2-small/5-mlp_32k-oai
+    path: v5_32k_layer_5
+  - id: blocks.6.hook_mlp_out
+    neuronpedia: gpt2-small/6-mlp_32k-oai
+    path: v5_32k_layer_6
+  - id: blocks.7.hook_mlp_out
+    neuronpedia: gpt2-small/7-mlp_32k-oai
+    path: v5_32k_layer_7
+  - id: blocks.8.hook_mlp_out
+    neuronpedia: gpt2-small/8-mlp_32k-oai
+    path: v5_32k_layer_8
+  - id: blocks.9.hook_mlp_out
+    neuronpedia: gpt2-small/9-mlp_32k-oai
+    path: v5_32k_layer_9
+  - id: blocks.10.hook_mlp_out
+    neuronpedia: gpt2-small/10-mlp_32k-oai
+    path: v5_32k_layer_10
+  - id: blocks.11.hook_mlp_out
+    neuronpedia: gpt2-small/11-mlp_32k-oai
+    path: v5_32k_layer_11
+gpt2-small-mlp-tm:
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+    model_from_pretrained_kwargs:
+      center_writing_weights: true
   conversion_func: null
   links:
     model: https://huggingface.co/gpt2
-    dashboards: https://www.neuronpedia.org/gpt2-small/res_sll-ajt
-  saes:
-  - id: blocks.2.hook_resid_pre
-    path: 2-res_sll-ajt
-    neuronpedia: gpt2-small/2-res_sll-ajt
-  - id: blocks.6.hook_resid_pre
-    path: 6-res_sll-ajt
-    neuronpedia: gpt2-small/6-res_sll-ajt
-  - id: blocks.10.hook_resid_pre
-    path: 10-res_sll-ajt
-    neuronpedia: gpt2-small/10-res_sll-ajt
-gpt2-small-res_slefr-ajt:
-  repo_id: neuronpedia/gpt2-small__res_slefr-ajt
   model: gpt2-small
+  repo_id: tommmcgrath/gpt2-small-mlp-out-saes
+  saes:
+  - id: blocks.0.hook_mlp_out
+    l0: 15.0
+    norm_scaling_factor: 1.049317316132615
+    path: sae_group_gpt2_blocks.0.hook_mlp_out_24576:v1
+    variance_explained: 0.999
+  - id: blocks.1.hook_mlp_out
+    l0: 21.0
+    norm_scaling_factor: 2.3693984005104283
+    path: sae_group_gpt2_blocks.1.hook_mlp_out_24576:v0
+    variance_explained: 0.57
+  - id: blocks.2.hook_mlp_out
+    l0: 137.0
+    norm_scaling_factor: 1.6411934982190302
+    path: sae_group_gpt2_blocks.2.hook_mlp_out_24576:v0
+    variance_explained: 0.55
+  - id: blocks.3.hook_mlp_out
+    l0: 54.0
+    norm_scaling_factor: 1.8958522157897557
+    path: sae_group_gpt2_blocks.3.hook_mlp_out_24576:v0
+    variance_explained: 0.57
+  - id: blocks.4.hook_mlp_out
+    l0: 74.0
+    norm_scaling_factor: 1.81673478700627
+    path: sae_group_gpt2_blocks.4.hook_mlp_out_24576:v0
+    variance_explained: 0.44
+  - id: blocks.5.hook_mlp_out
+    l0: 76.0
+    norm_scaling_factor: 1.550234472245924
+    path: sae_group_gpt2_blocks.5.hook_mlp_out_24576:v0
+    variance_explained: 0.52
+  - id: blocks.6.hook_mlp_out
+    l0: 40.0
+    norm_scaling_factor: 1.3237742807210804
+    path: sae_group_gpt2_blocks.6.hook_mlp_out_24576:v0
+    variance_explained: 0.508
+  - id: blocks.7.hook_mlp_out
+    l0: 52.0
+    norm_scaling_factor: 1.1042905114723296
+    path: sae_group_gpt2_blocks.7.hook_mlp_out_24576:v0
+    variance_explained: 0.53
+  - id: blocks.8.hook_mlp_out
+    l0: 36.0
+    norm_scaling_factor: 0.9123762783479742
+    path: sae_group_gpt2_blocks.8.hook_mlp_out_24576:v1
+    variance_explained: 0.46
+  - id: blocks.9.hook_mlp_out
+    l0: 49.0
+    norm_scaling_factor: 0.6955335635232373
+    path: sae_group_gpt2_blocks.9.hook_mlp_out_24576:v0
+    variance_explained: 0.49
+  - id: blocks.10.hook_mlp_out
+    l0: 167.0
+    norm_scaling_factor: 0.3619728926727644
+    path: sae_group_gpt2_blocks.10.hook_mlp_out_24576:v0
+    variance_explained: 0.22
+  - id: blocks.11.hook_mlp_out
+    l0: 170.0
+    norm_scaling_factor: 0.2851548652550073
+    path: sae_group_gpt2_blocks.11.hook_mlp_out_24576:v2
+    variance_explained: 0.59
+gpt2-small-res-jb:
+  config_overrides:
+    model_from_pretrained_kwargs:
+      center_writing_weights: true
   conversion_func: null
   links:
+    dashboards: https://www.neuronpedia.org/gpt2sm-res-jb
     model: https://huggingface.co/gpt2
-    dashboards: https://www.neuronpedia.org/gpt2-small/res_slefr-ajt
-  saes:
-  - id: blocks.2.hook_resid_pre
-    path: 2-res_slefr-ajt
-    neuronpedia: gpt2-small/2-res_slefr-ajt
-  - id: blocks.6.hook_resid_pre
-    path: 6-res_slefr-ajt
-    neuronpedia: gpt2-small/6-res_slefr-ajt
-  - id: blocks.10.hook_resid_pre
-    path: 10-res_slefr-ajt
-    neuronpedia: gpt2-small/10-res_slefr-ajt
-gpt2-small-res_scl-ajt:
-  repo_id: neuronpedia/gpt2-small__res_scl-ajt
+    publication: https://www.lesswrong.com/posts/f9EgfLSurAiqRJySD/open-source-sparse-autoencoders-for-all-residual-stream
   model: gpt2-small
+  repo_id: jbloom/GPT2-Small-SAEs-Reformatted
+  saes:
+  - id: blocks.0.hook_resid_pre
+    l0: 10.0
+    neuronpedia: gpt2-small/0-res-jb
+    path: blocks.0.hook_resid_pre
+    variance_explained: 0.999
+  - id: blocks.1.hook_resid_pre
+    l0: 10.0
+    neuronpedia: gpt2-small/1-res-jb
+    path: blocks.1.hook_resid_pre
+    variance_explained: 0.999
+  - id: blocks.2.hook_resid_pre
+    l0: 18.0
+    neuronpedia: gpt2-small/2-res-jb
+    path: blocks.2.hook_resid_pre
+    variance_explained: 0.999
+  - id: blocks.3.hook_resid_pre
+    l0: 23.0
+    neuronpedia: gpt2-small/3-res-jb
+    path: blocks.3.hook_resid_pre
+    variance_explained: 0.999
+  - id: blocks.4.hook_resid_pre
+    l0: 31.0
+    neuronpedia: gpt2-small/4-res-jb
+    path: blocks.4.hook_resid_pre
+    variance_explained: 0.9
+  - id: blocks.5.hook_resid_pre
+    l0: 41.0
+    neuronpedia: gpt2-small/5-res-jb
+    path: blocks.5.hook_resid_pre
+    variance_explained: 0.9
+  - id: blocks.6.hook_resid_pre
+    l0: 51.0
+    neuronpedia: gpt2-small/6-res-jb
+    path: blocks.6.hook_resid_pre
+    variance_explained: 0.9
+  - id: blocks.7.hook_resid_pre
+    l0: 54.0
+    neuronpedia: gpt2-small/7-res-jb
+    path: blocks.7.hook_resid_pre
+    variance_explained: 0.9
+  - id: blocks.8.hook_resid_pre
+    l0: 60.0
+    neuronpedia: gpt2-small/8-res-jb
+    path: blocks.8.hook_resid_pre
+    variance_explained: 0.9
+  - id: blocks.9.hook_resid_pre
+    l0: 70.0
+    neuronpedia: gpt2-small/9-res-jb
+    path: blocks.9.hook_resid_pre
+    variance_explained: 0.77
+  - id: blocks.10.hook_resid_pre
+    l0: 52.0
+    neuronpedia: gpt2-small/10-res-jb
+    path: blocks.10.hook_resid_pre
+    variance_explained: 0.77
+  - id: blocks.11.hook_resid_pre
+    l0: 56.0
+    neuronpedia: gpt2-small/11-res-jb
+    path: blocks.11.hook_resid_pre
+    variance_explained: 0.77
+  - id: blocks.11.hook_resid_post
+    l0: 70.0
+    neuronpedia: gpt2-small/12-res-jb
+    path: blocks.11.hook_resid_post
+    variance_explained: 0.77
+gpt2-small-res-jb-feature-splitting:
+  config_overrides:
+    model_from_pretrained_kwargs:
+      center_writing_weights: true
   conversion_func: null
   links:
+    dashboards: https://www.neuronpedia.org/gpt2sm-rfs-jb
     model: https://huggingface.co/gpt2
-    dashboards: https://www.neuronpedia.org/gpt2-small/res_scl-ajt
-  saes:
-  - id: blocks.2.hook_resid_pre
-    path: 2-res_scl-ajt
-    neuronpedia: gpt2-small/2-res_scl-ajt
-  - id: blocks.6.hook_resid_pre
-    path: 6-res_scl-ajt
-    neuronpedia: gpt2-small/6-res_scl-ajt
-  - id: blocks.10.hook_resid_pre
-    path: 10-res_scl-ajt
-    neuronpedia: gpt2-small/10-res_scl-ajt
-gpt2-small-res_sle-ajt:
-  repo_id: neuronpedia/gpt2-small__res_sle-ajt
   model: gpt2-small
-  conversion_func: null
-  links:
-    model: https://huggingface.co/gpt2
-    dashboards: https://www.neuronpedia.org/gpt2-small/res_sle-ajt
+  repo_id: jbloom/GPT2-Small-Feature-Splitting-Experiment-Layer-8
   saes:
-  - id: blocks.2.hook_resid_pre
-    path: 2-res_sle-ajt
-    neuronpedia: gpt2-small/2-res_sle-ajt
-  - id: blocks.6.hook_resid_pre
-    path: 6-res_sle-ajt
-    neuronpedia: gpt2-small/6-res_sle-ajt
-  - id: blocks.10.hook_resid_pre
-    path: 10-res_sle-ajt
-    neuronpedia: gpt2-small/10-res_sle-ajt
+  - id: blocks.8.hook_resid_pre_768
+    l0: 36.0
+    neuronpedia: gpt2-small/8-res_fs768-jb
+    path: blocks.8.hook_resid_pre_768
+    variance_explained: 0.61
+  - id: blocks.8.hook_resid_pre_1536
+    l0: 39.0
+    neuronpedia: gpt2-small/8-res_fs1536-jb
+    path: blocks.8.hook_resid_pre_1536
+    variance_explained: 0.67
+  - id: blocks.8.hook_resid_pre_3072
+    l0: 41.0
+    neuronpedia: gpt2-small/8-res_fs3072-jb
+    path: blocks.8.hook_resid_pre_3072
+    variance_explained: 0.72
+  - id: blocks.8.hook_resid_pre_6144
+    l0: 43.0
+    neuronpedia: gpt2-small/8-res_fs6144-jb
+    path: blocks.8.hook_resid_pre_6144
+    variance_explained: 0.76
+  - id: blocks.8.hook_resid_pre_12288
+    l0: 43.0
+    neuronpedia: gpt2-small/8-res_fs12288-jb
+    path: blocks.8.hook_resid_pre_12288
+    variance_explained: 0.77
+  - id: blocks.8.hook_resid_pre_24576
+    l0: 40.0
+    neuronpedia: gpt2-small/8-res_fs24576-jb
+    path: blocks.8.hook_resid_pre_24576
+    variance_explained: 0.79
+  - id: blocks.8.hook_resid_pre_49152
+    l0: 40.0
+    neuronpedia: gpt2-small/8-res_fs49152-jb
+    path: blocks.8.hook_resid_pre_49152
+    variance_explained: 0.81
+  - id: blocks.8.hook_resid_pre_98304
+    l0: 43.0
+    neuronpedia: gpt2-small/8-res_fs98304-jb
+    path: blocks.8.hook_resid_pre_98304
+    variance_explained: 0.82
 gpt2-small-res_sce-ajt:
-  repo_id: neuronpedia/gpt2-small__res_sce-ajt
-  model: gpt2-small
   conversion_func: null
   links:
-    model: https://huggingface.co/gpt2
     dashboards: https://www.neuronpedia.org/gpt2-small/res_sce-ajt
+    model: https://huggingface.co/gpt2
+  model: gpt2-small
+  repo_id: neuronpedia/gpt2-small__res_sce-ajt
   saes:
   - id: blocks.2.hook_resid_pre
-    path: 2-res_sce-ajt
     neuronpedia: gpt2-small/2-res_sce-ajt
+    path: 2-res_sce-ajt
   - id: blocks.6.hook_resid_pre
-    path: 6-res_sce-ajt
     neuronpedia: gpt2-small/6-res_sce-ajt
+    path: 6-res_sce-ajt
   - id: blocks.10.hook_resid_pre
-    path: 10-res_sce-ajt
     neuronpedia: gpt2-small/10-res_sce-ajt
+    path: 10-res_sce-ajt
 gpt2-small-res_scefr-ajt:
-  repo_id: neuronpedia/gpt2-small__res_scefr-ajt
-  model: gpt2-small
   conversion_func: null
   links:
-    model: https://huggingface.co/gpt2
     dashboards: https://www.neuronpedia.org/gpt2-small/res_scefr-ajt
+    model: https://huggingface.co/gpt2
+  model: gpt2-small
+  repo_id: neuronpedia/gpt2-small__res_scefr-ajt
   saes:
   - id: blocks.2.hook_resid_pre
-    path: 2-res_scefr-ajt
     neuronpedia: gpt2-small/2-res_scefr-ajt
+    path: 2-res_scefr-ajt
   - id: blocks.6.hook_resid_pre
-    path: 6-res_scefr-ajt
     neuronpedia: gpt2-small/6-res_scefr-ajt
-  - id: blocks.10.hook_resid_pre
-    path: 10-res_scefr-ajt
-    neuronpedia: gpt2-small/10-res_scefr-ajt
-    repo_id: neuronpedia/gpt2-small__res_scefr-ajt
-    model: gpt2-small
-    conversion_func: null
+    path: 6-res_scefr-ajt
+  - conversion_func: null
+    id: blocks.10.hook_resid_pre
     links:
-      model: https://huggingface.co/gpt2
       dashboards: https://www.neuronpedia.org/gpt2-small/res_scefr-ajt
+      model: https://huggingface.co/gpt2
+    model: gpt2-small
+    neuronpedia: gpt2-small/10-res_scefr-ajt
+    path: 10-res_scefr-ajt
+    repo_id: neuronpedia/gpt2-small__res_scefr-ajt
     saes:
     - id: blocks.2.hook_resid_pre
-      path: 2-res_scefr-ajt
       neuronpedia: gpt2-small/2-res_scefr-ajt
+      path: 2-res_scefr-ajt
     - id: blocks.6.hook_resid_pre
-      path: 6-res_scefr-ajt
       neuronpedia: gpt2-small/6-res_scefr-ajt
+      path: 6-res_scefr-ajt
     - id: blocks.10.hook_resid_pre
-      path: 10-res_scefr-ajt
       neuronpedia: gpt2-small/10-res_scefr-ajt
+      path: 10-res_scefr-ajt
+gpt2-small-res_scl-ajt:
+  conversion_func: null
+  links:
+    dashboards: https://www.neuronpedia.org/gpt2-small/res_scl-ajt
+    model: https://huggingface.co/gpt2
+  model: gpt2-small
+  repo_id: neuronpedia/gpt2-small__res_scl-ajt
+  saes:
+  - id: blocks.2.hook_resid_pre
+    neuronpedia: gpt2-small/2-res_scl-ajt
+    path: 2-res_scl-ajt
+  - id: blocks.6.hook_resid_pre
+    neuronpedia: gpt2-small/6-res_scl-ajt
+    path: 6-res_scl-ajt
+  - id: blocks.10.hook_resid_pre
+    neuronpedia: gpt2-small/10-res_scl-ajt
+    path: 10-res_scl-ajt
+gpt2-small-res_sle-ajt:
+  conversion_func: null
+  links:
+    dashboards: https://www.neuronpedia.org/gpt2-small/res_sle-ajt
+    model: https://huggingface.co/gpt2
+  model: gpt2-small
+  repo_id: neuronpedia/gpt2-small__res_sle-ajt
+  saes:
+  - id: blocks.2.hook_resid_pre
+    neuronpedia: gpt2-small/2-res_sle-ajt
+    path: 2-res_sle-ajt
+  - id: blocks.6.hook_resid_pre
+    neuronpedia: gpt2-small/6-res_sle-ajt
+    path: 6-res_sle-ajt
+  - id: blocks.10.hook_resid_pre
+    neuronpedia: gpt2-small/10-res_sle-ajt
+    path: 10-res_sle-ajt
+gpt2-small-res_slefr-ajt:
+  conversion_func: null
+  links:
+    dashboards: https://www.neuronpedia.org/gpt2-small/res_slefr-ajt
+    model: https://huggingface.co/gpt2
+  model: gpt2-small
+  repo_id: neuronpedia/gpt2-small__res_slefr-ajt
+  saes:
+  - id: blocks.2.hook_resid_pre
+    neuronpedia: gpt2-small/2-res_slefr-ajt
+    path: 2-res_slefr-ajt
+  - id: blocks.6.hook_resid_pre
+    neuronpedia: gpt2-small/6-res_slefr-ajt
+    path: 6-res_slefr-ajt
+  - id: blocks.10.hook_resid_pre
+    neuronpedia: gpt2-small/10-res_slefr-ajt
+    path: 10-res_slefr-ajt
+gpt2-small-res_sll-ajt:
+  conversion_func: null
+  links:
+    dashboards: https://www.neuronpedia.org/gpt2-small/res_sll-ajt
+    model: https://huggingface.co/gpt2
+  model: gpt2-small
+  repo_id: neuronpedia/gpt2-small__res_sll-ajt
+  saes:
+  - id: blocks.2.hook_resid_pre
+    neuronpedia: gpt2-small/2-res_sll-ajt
+    path: 2-res_sll-ajt
+  - id: blocks.6.hook_resid_pre
+    neuronpedia: gpt2-small/6-res_sll-ajt
+    path: 6-res_sll-ajt
+  - id: blocks.10.hook_resid_pre
+    neuronpedia: gpt2-small/10-res_sll-ajt
+    path: 10-res_sll-ajt
+gpt2-small-resid-mid-v5-128k:
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+  conversion_func: null
+  model: gpt2-small
+  repo_id: jbloom/GPT2-Small-OAI-v5-128k-resid-mid-SAEs
+  saes:
+  - id: blocks.0.hook_resid_mid
+    neuronpedia: gpt2-small/0-res_mid_128k-oai
+    path: v5_128k_layer_0
+  - id: blocks.1.hook_resid_mid
+    neuronpedia: gpt2-small/1-res_mid_128k-oai
+    path: v5_128k_layer_1
+  - id: blocks.2.hook_resid_mid
+    neuronpedia: gpt2-small/2-res_mid_128k-oai
+    path: v5_128k_layer_2
+  - id: blocks.3.hook_resid_mid
+    neuronpedia: gpt2-small/3-res_mid_128k-oai
+    path: v5_128k_layer_3
+  - id: blocks.4.hook_resid_mid
+    neuronpedia: gpt2-small/4-res_mid_128k-oai
+    path: v5_128k_layer_4
+  - id: blocks.5.hook_resid_mid
+    neuronpedia: gpt2-small/5-res_mid_128k-oai
+    path: v5_128k_layer_5
+  - id: blocks.6.hook_resid_mid
+    neuronpedia: gpt2-small/6-res_mid_128k-oai
+    path: v5_128k_layer_6
+  - id: blocks.7.hook_resid_mid
+    neuronpedia: gpt2-small/7-res_mid_128k-oai
+    path: v5_128k_layer_7
+  - id: blocks.8.hook_resid_mid
+    neuronpedia: gpt2-small/8-res_mid_128k-oai
+    path: v5_128k_layer_8
+  - id: blocks.9.hook_resid_mid
+    neuronpedia: gpt2-small/9-res_mid_128k-oai
+    path: v5_128k_layer_9
+  - id: blocks.10.hook_resid_mid
+    neuronpedia: gpt2-small/10-res_mid_128k-oai
+    path: v5_128k_layer_10
+  - id: blocks.11.hook_resid_mid
+    neuronpedia: gpt2-small/11-res_mid_128k-oai
+    path: v5_128k_layer_11
+gpt2-small-resid-mid-v5-32k:
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+  conversion_func: null
+  model: gpt2-small
+  repo_id: jbloom/GPT2-Small-OAI-v5-32k-resid-mid-SAEs
+  saes:
+  - id: blocks.0.hook_resid_mid
+    neuronpedia: gpt2-small/0-res_mid_32k-oai
+    path: v5_32k_layer_0
+  - id: blocks.1.hook_resid_mid
+    neuronpedia: gpt2-small/1-res_mid_32k-oai
+    path: v5_32k_layer_1
+  - id: blocks.2.hook_resid_mid
+    neuronpedia: gpt2-small/2-res_mid_32k-oai
+    path: v5_32k_layer_2
+  - id: blocks.3.hook_resid_mid
+    neuronpedia: gpt2-small/3-res_mid_32k-oai
+    path: v5_32k_layer_3
+  - id: blocks.4.hook_resid_mid
+    neuronpedia: gpt2-small/4-res_mid_32k-oai
+    path: v5_32k_layer_4
+  - id: blocks.5.hook_resid_mid
+    neuronpedia: gpt2-small/5-res_mid_32k-oai
+    path: v5_32k_layer_5
+  - id: blocks.6.hook_resid_mid
+    neuronpedia: gpt2-small/6-res_mid_32k-oai
+    path: v5_32k_layer_6
+  - id: blocks.7.hook_resid_mid
+    neuronpedia: gpt2-small/7-res_mid_32k-oai
+    path: v5_32k_layer_7
+  - id: blocks.8.hook_resid_mid
+    neuronpedia: gpt2-small/8-res_mid_32k-oai
+    path: v5_32k_layer_8
+  - id: blocks.9.hook_resid_mid
+    neuronpedia: gpt2-small/9-res_mid_32k-oai
+    path: v5_32k_layer_9
+  - id: blocks.10.hook_resid_mid
+    neuronpedia: gpt2-small/10-res_mid_32k-oai
+    path: v5_32k_layer_10
+  - id: blocks.11.hook_resid_mid
+    neuronpedia: gpt2-small/11-res_mid_32k-oai
+    path: v5_32k_layer_11
+gpt2-small-resid-post-v5-128k:
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+  conversion_func: null
+  model: gpt2-small
+  repo_id: jbloom/GPT2-Small-OAI-v5-128k-resid-post-SAEs
+  saes:
+  - id: blocks.0.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/0-res_post_128k-oai
+    path: v5_128k_layer_0
+    variance_explained: 0.9
+  - id: blocks.1.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/1-res_post_128k-oai
+    path: v5_128k_layer_1
+    variance_explained: 0.9
+  - id: blocks.2.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/2-res_post_128k-oai
+    path: v5_128k_layer_2
+    variance_explained: 0.9
+  - id: blocks.3.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/3-res_post_128k-oai
+    path: v5_128k_layer_3
+    variance_explained: 0.9
+  - id: blocks.4.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/4-res_post_128k-oai
+    path: v5_128k_layer_4
+    variance_explained: 0.9
+  - id: blocks.5.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/5-res_post_128k-oai
+    path: v5_128k_layer_5
+    variance_explained: 0.9
+  - id: blocks.6.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/6-res_post_128k-oai
+    path: v5_128k_layer_6
+    variance_explained: 0.9
+  - id: blocks.7.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/7-res_post_128k-oai
+    path: v5_128k_layer_7
+    variance_explained: 0.9
+  - id: blocks.8.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/8-res_post_128k-oai
+    path: v5_128k_layer_8
+    variance_explained: 0.9
+  - id: blocks.9.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/9-res_post_128k-oai
+    path: v5_128k_layer_9
+    variance_explained: 0.9
+  - id: blocks.10.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/10-res_post_128k-oai
+    path: v5_128k_layer_10
+    variance_explained: 0.9
+  - id: blocks.11.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/11-res_post_128k-oai
+    path: v5_128k_layer_11
+    variance_explained: 0.9
+gpt2-small-resid-post-v5-32k:
+  config_overrides:
+    dataset_path: Skylion007/openwebtext
+  conversion_func: null
+  model: gpt2-small
+  repo_id: jbloom/GPT2-Small-OAI-v5-32k-resid-post-SAEs
+  saes:
+  - id: blocks.0.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/0-res_post_32k-oai
+    path: v5_32k_layer_0.pt
+    variance_explained: 0.9
+  - id: blocks.1.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/1-res_post_32k-oai
+    path: v5_32k_layer_1.pt
+    variance_explained: 0.9
+  - id: blocks.2.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/2-res_post_32k-oai
+    path: v5_32k_layer_2.pt
+    variance_explained: 0.9
+  - id: blocks.3.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/3-res_post_32k-oai
+    path: v5_32k_layer_3.pt
+    variance_explained: 0.9
+  - id: blocks.4.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/4-res_post_32k-oai
+    path: v5_32k_layer_4.pt
+    variance_explained: 0.9
+  - id: blocks.5.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/5-res_post_32k-oai
+    path: v5_32k_layer_5.pt
+    variance_explained: 0.9
+  - id: blocks.6.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/6-res_post_32k-oai
+    path: v5_32k_layer_6.pt
+    variance_explained: 0.9
+  - id: blocks.7.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/7-res_post_32k-oai
+    path: v5_32k_layer_7.pt
+    variance_explained: 0.9
+  - id: blocks.8.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/8-res_post_32k-oai
+    path: v5_32k_layer_8.pt
+    variance_explained: 0.74
+  - id: blocks.9.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/9-res_post_32k-oai
+    path: v5_32k_layer_9.pt
+    variance_explained: 0.9
+  - id: blocks.10.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/10-res_post_32k-oai
+    path: v5_32k_layer_10.pt
+    variance_explained: 0.9
+  - id: blocks.11.hook_resid_post
+    l0: 32.0
+    neuronpedia: gpt2-small/11-res_post_32k-oai
+    path: v5_32k_layer_11.pt
+    variance_explained: 0.9
+llama-3-8b-it-res-jh:
+  conversion_func: null
+  links:
+    dashboards: https://www.neuronpedia.org/llama3-8b-it-res-jh
+  model: meta-llama/Meta-Llama-3-8B-Instruct
+  repo_id: Juliushanhanhan/llama-3-8b-it-res
+  saes:
+  - id: blocks.25.hook_resid_post
+    neuronpedia: llama3-8b-it/25-res-jh
+    path: blocks.25.hook_resid_post
+llama_scope_lxa_32x:
+  conversion_func: llama_scope
+  model: meta-llama/Llama-3.1-8B
+  repo_id: fnlp/Llama3_1-8B-Base-LXA-32x
+  saes:
+  - id: l0a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/0-llamascope-att-131k
+    norm_scaling_factor: 112.21917808219177
+    path: Llama3_1-8B-Base-L0A-32x
+  - id: l1a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/1-llamascope-att-131k
+    norm_scaling_factor: 94.70520231213872
+    path: Llama3_1-8B-Base-L1A-32x
+  - id: l2a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/2-llamascope-att-131k
+    norm_scaling_factor: 73.14285714285714
+    path: Llama3_1-8B-Base-L2A-32x
+  - id: l3a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/3-llamascope-att-131k
+    norm_scaling_factor: 55.72789115646258
+    path: Llama3_1-8B-Base-L3A-32x
+  - id: l4a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/4-llamascope-att-131k
+    norm_scaling_factor: 45.76536312849162
+    path: Llama3_1-8B-Base-L4A-32x
+  - id: l5a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/5-llamascope-att-131k
+    norm_scaling_factor: 39.9609756097561
+    path: Llama3_1-8B-Base-L5A-32x
+  - id: l6a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/6-llamascope-att-131k
+    norm_scaling_factor: 33.436734693877554
+    path: Llama3_1-8B-Base-L6A-32x
+  - id: l7a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/7-llamascope-att-131k
+    norm_scaling_factor: 27.30666666666667
+    path: Llama3_1-8B-Base-L7A-32x
+  - id: l8a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/8-llamascope-att-131k
+    norm_scaling_factor: 27.675675675675677
+    path: Llama3_1-8B-Base-L8A-32x
+  - id: l9a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/9-llamascope-att-131k
+    norm_scaling_factor: 25.440993788819874
+    path: Llama3_1-8B-Base-L9A-32x
+  - id: l10a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/10-llamascope-att-131k
+    norm_scaling_factor: 26.5974025974026
+    path: Llama3_1-8B-Base-L10A-32x
+  - id: l11a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/11-llamascope-att-131k
+    norm_scaling_factor: 25.761006289308177
+    path: Llama3_1-8B-Base-L11A-32x
+  - id: l12a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/12-llamascope-att-131k
+    norm_scaling_factor: 22.14054054054054
+    path: Llama3_1-8B-Base-L12A-32x
+  - id: l13a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/13-llamascope-att-131k
+    norm_scaling_factor: 20.582914572864322
+    path: Llama3_1-8B-Base-L13A-32x
+  - id: l14a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/14-llamascope-att-131k
+    norm_scaling_factor: 20.177339901477833
+    path: Llama3_1-8B-Base-L14A-32x
+  - id: l15a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/15-llamascope-att-131k
+    norm_scaling_factor: 20.582914572864322
+    path: Llama3_1-8B-Base-L15A-32x
+  - id: l16a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/16-llamascope-att-131k
+    norm_scaling_factor: 19.32075471698113
+    path: Llama3_1-8B-Base-L16A-32x
+  - id: l17a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/17-llamascope-att-131k
+    norm_scaling_factor: 21.005128205128205
+    path: Llama3_1-8B-Base-L17A-32x
+  - id: l18a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/18-llamascope-att-131k
+    norm_scaling_factor: 24.674698795180724
+    path: Llama3_1-8B-Base-L18A-32x
+  - id: l19a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/19-llamascope-att-131k
+    norm_scaling_factor: 28.248275862068965
+    path: Llama3_1-8B-Base-L19A-32x
+  - id: l20a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/20-llamascope-att-131k
+    norm_scaling_factor: 27.30666666666667
+    path: Llama3_1-8B-Base-L20A-32x
+  - id: l21a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/21-llamascope-att-131k
+    norm_scaling_factor: 19.14018691588785
+    path: Llama3_1-8B-Base-L21A-32x
+  - id: l22a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/22-llamascope-att-131k
+    norm_scaling_factor: 24.38095238095238
+    path: Llama3_1-8B-Base-L22A-32x
+  - id: l23a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/23-llamascope-att-131k
+    norm_scaling_factor: 22.14054054054054
+    path: Llama3_1-8B-Base-L23A-32x
+  - id: l24a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/24-llamascope-att-131k
+    norm_scaling_factor: 21.67195767195767
+    path: Llama3_1-8B-Base-L24A-32x
+  - id: l25a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/25-llamascope-att-131k
+    norm_scaling_factor: 18.367713004484305
+    path: Llama3_1-8B-Base-L25A-32x
+  - id: l26a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/26-llamascope-att-131k
+    norm_scaling_factor: 13.837837837837839
+    path: Llama3_1-8B-Base-L26A-32x
+  - id: l27a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/27-llamascope-att-131k
+    norm_scaling_factor: 13.931972789115646
+    path: Llama3_1-8B-Base-L27A-32x
+  - id: l28a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/28-llamascope-att-131k
+    norm_scaling_factor: 10.95187165775401
+    path: Llama3_1-8B-Base-L28A-32x
+  - id: l29a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/29-llamascope-att-131k
+    norm_scaling_factor: 8.569037656903765
+    path: Llama3_1-8B-Base-L29A-32x
+  - id: l30a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/30-llamascope-att-131k
+    norm_scaling_factor: 5.953488372093023
+    path: Llama3_1-8B-Base-L30A-32x
+  - id: l31a_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/31-llamascope-att-131k
+    norm_scaling_factor: 3.5310344827586206
+    path: Llama3_1-8B-Base-L31A-32x
+llama_scope_lxa_8x:
+  conversion_func: llama_scope
+  model: meta-llama/Llama-3.1-8B
+  repo_id: fnlp/Llama3_1-8B-Base-LXA-8x
+  saes:
+  - id: l0a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/0-llamascope-att-32k
+    norm_scaling_factor: 112.21917808219177
+    path: Llama3_1-8B-Base-L0A-8x
+  - id: l1a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/1-llamascope-att-32k
+    norm_scaling_factor: 94.70520231213872
+    path: Llama3_1-8B-Base-L1A-8x
+  - id: l2a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/2-llamascope-att-32k
+    norm_scaling_factor: 72.81777777777778
+    path: Llama3_1-8B-Base-L2A-8x
+  - id: l3a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/3-llamascope-att-32k
+    norm_scaling_factor: 55.72789115646258
+    path: Llama3_1-8B-Base-L3A-8x
+  - id: l4a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/4-llamascope-att-32k
+    norm_scaling_factor: 45.76536312849162
+    path: Llama3_1-8B-Base-L4A-8x
+  - id: l5a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/5-llamascope-att-32k
+    norm_scaling_factor: 39.9609756097561
+    path: Llama3_1-8B-Base-L5A-8x
+  - id: l6a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/6-llamascope-att-32k
+    norm_scaling_factor: 33.436734693877554
+    path: Llama3_1-8B-Base-L6A-8x
+  - id: l7a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/7-llamascope-att-32k
+    norm_scaling_factor: 27.30666666666667
+    path: Llama3_1-8B-Base-L7A-8x
+  - id: l8a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/8-llamascope-att-32k
+    norm_scaling_factor: 27.675675675675677
+    path: Llama3_1-8B-Base-L8A-8x
+  - id: l9a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/9-llamascope-att-32k
+    norm_scaling_factor: 25.28395061728395
+    path: Llama3_1-8B-Base-L9A-8x
+  - id: l10a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/10-llamascope-att-32k
+    norm_scaling_factor: 26.5974025974026
+    path: Llama3_1-8B-Base-L10A-8x
+  - id: l11a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/11-llamascope-att-32k
+    norm_scaling_factor: 25.761006289308177
+    path: Llama3_1-8B-Base-L11A-8x
+  - id: l12a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/12-llamascope-att-32k
+    norm_scaling_factor: 22.14054054054054
+    path: Llama3_1-8B-Base-L12A-8x
+  - id: l13a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/13-llamascope-att-32k
+    norm_scaling_factor: 20.48
+    path: Llama3_1-8B-Base-L13A-8x
+  - id: l14a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/14-llamascope-att-32k
+    norm_scaling_factor: 20.177339901477833
+    path: Llama3_1-8B-Base-L14A-8x
+  - id: l15a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/15-llamascope-att-32k
+    norm_scaling_factor: 20.582914572864322
+    path: Llama3_1-8B-Base-L15A-8x
+  - id: l16a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/16-llamascope-att-32k
+    norm_scaling_factor: 19.32075471698113
+    path: Llama3_1-8B-Base-L16A-8x
+  - id: l17a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/17-llamascope-att-32k
+    norm_scaling_factor: 20.897959183673468
+    path: Llama3_1-8B-Base-L17A-8x
+  - id: l18a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/18-llamascope-att-32k
+    norm_scaling_factor: 24.674698795180724
+    path: Llama3_1-8B-Base-L18A-8x
+  - id: l19a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/19-llamascope-att-32k
+    norm_scaling_factor: 28.248275862068965
+    path: Llama3_1-8B-Base-L19A-8x
+  - id: l20a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/20-llamascope-att-32k
+    norm_scaling_factor: 27.125827814569536
+    path: Llama3_1-8B-Base-L20A-8x
+  - id: l21a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/21-llamascope-att-32k
+    norm_scaling_factor: 19.14018691588785
+    path: Llama3_1-8B-Base-L21A-8x
+  - id: l22a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/22-llamascope-att-32k
+    norm_scaling_factor: 24.38095238095238
+    path: Llama3_1-8B-Base-L22A-8x
+  - id: l23a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/23-llamascope-att-32k
+    norm_scaling_factor: 22.14054054054054
+    path: Llama3_1-8B-Base-L23A-8x
+  - id: l24a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/24-llamascope-att-32k
+    norm_scaling_factor: 21.557894736842105
+    path: Llama3_1-8B-Base-L24A-8x
+  - id: l25a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/25-llamascope-att-32k
+    norm_scaling_factor: 18.533936651583712
+    path: Llama3_1-8B-Base-L25A-8x
+  - id: l26a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/26-llamascope-att-32k
+    norm_scaling_factor: 13.837837837837839
+    path: Llama3_1-8B-Base-L26A-8x
+  - id: l27a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/27-llamascope-att-32k
+    norm_scaling_factor: 13.931972789115646
+    path: Llama3_1-8B-Base-L27A-8x
+  - id: l28a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/28-llamascope-att-32k
+    norm_scaling_factor: 10.95187165775401
+    path: Llama3_1-8B-Base-L28A-8x
+  - id: l29a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/29-llamascope-att-32k
+    norm_scaling_factor: 8.569037656903765
+    path: Llama3_1-8B-Base-L29A-8x
+  - id: l30a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/30-llamascope-att-32k
+    norm_scaling_factor: 5.953488372093023
+    path: Llama3_1-8B-Base-L30A-8x
+  - id: l31a_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/31-llamascope-att-32k
+    norm_scaling_factor: 3.5555555555555554
+    path: Llama3_1-8B-Base-L31A-8x
+llama_scope_lxm_32x:
+  conversion_func: llama_scope
+  model: meta-llama/Llama-3.1-8B
+  repo_id: fnlp/Llama3_1-8B-Base-LXM-32x
+  saes:
+  - id: l0m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/0-llamascope-mlp-131k
+    norm_scaling_factor: 80.31372549019608
+    path: Llama3_1-8B-Base-L0M-32x
+  - id: l1m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/1-llamascope-mlp-131k
+    norm_scaling_factor: 71.85964912280701
+    path: Llama3_1-8B-Base-L1M-32x
+  - id: l2m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/2-llamascope-mlp-131k
+    norm_scaling_factor: 47.90643274853801
+    path: Llama3_1-8B-Base-L2M-32x
+  - id: l3m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/3-llamascope-mlp-131k
+    norm_scaling_factor: 35.46320346320346
+    path: Llama3_1-8B-Base-L3M-32x
+  - id: l4m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/4-llamascope-mlp-131k
+    norm_scaling_factor: 27.86394557823129
+    path: Llama3_1-8B-Base-L4M-32x
+  - id: l5m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/5-llamascope-mlp-131k
+    norm_scaling_factor: 23.01123595505618
+    path: Llama3_1-8B-Base-L5M-32x
+  - id: l6m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/6-llamascope-mlp-131k
+    norm_scaling_factor: 20.48
+    path: Llama3_1-8B-Base-L6M-32x
+  - id: l7m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/7-llamascope-mlp-131k
+    norm_scaling_factor: 19.692307692307693
+    path: Llama3_1-8B-Base-L7M-32x
+  - id: l8m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/8-llamascope-mlp-131k
+    norm_scaling_factor: 18.87557603686636
+    path: Llama3_1-8B-Base-L8M-32x
+  - id: l9m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/9-llamascope-mlp-131k
+    norm_scaling_factor: 17.88646288209607
+    path: Llama3_1-8B-Base-L9M-32x
+  - id: l10m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/10-llamascope-mlp-131k
+    norm_scaling_factor: 17.5793991416309
+    path: Llama3_1-8B-Base-L10M-32x
+  - id: l11m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/11-llamascope-mlp-131k
+    norm_scaling_factor: 16.855967078189302
+    path: Llama3_1-8B-Base-L11M-32x
+  - id: l12m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/12-llamascope-mlp-131k
+    norm_scaling_factor: 16.125984251968504
+    path: Llama3_1-8B-Base-L12M-32x
+  - id: l13m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/13-llamascope-mlp-131k
+    norm_scaling_factor: 14.840579710144928
+    path: Llama3_1-8B-Base-L13M-32x
+  - id: l14m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/14-llamascope-mlp-131k
+    norm_scaling_factor: 13.74496644295302
+    path: Llama3_1-8B-Base-L14M-32x
+  - id: l15m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/15-llamascope-mlp-131k
+    norm_scaling_factor: 12.118343195266272
+    path: Llama3_1-8B-Base-L15M-32x
+  - id: l16m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/16-llamascope-mlp-131k
+    norm_scaling_factor: 11.702857142857143
+    path: Llama3_1-8B-Base-L16M-32x
+  - id: l17m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/17-llamascope-mlp-131k
+    norm_scaling_factor: 10.666666666666666
+    path: Llama3_1-8B-Base-L17M-32x
+  - id: l18m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/18-llamascope-mlp-131k
+    norm_scaling_factor: 10.778947368421052
+    path: Llama3_1-8B-Base-L18M-32x
+  - id: l19m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/19-llamascope-mlp-131k
+    norm_scaling_factor: 10.502564102564103
+    path: Llama3_1-8B-Base-L19M-32x
+  - id: l20m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/20-llamascope-mlp-131k
+    norm_scaling_factor: 10.088669950738916
+    path: Llama3_1-8B-Base-L20M-32x
+  - id: l21m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/21-llamascope-mlp-131k
+    norm_scaling_factor: 9.102222222222222
+    path: Llama3_1-8B-Base-L21M-32x
+  - id: l22m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/22-llamascope-mlp-131k
+    norm_scaling_factor: 8.865800865800866
+    path: Llama3_1-8B-Base-L22M-32x
+  - id: l23m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/23-llamascope-mlp-131k
+    norm_scaling_factor: 8.677966101694915
+    path: Llama3_1-8B-Base-L23M-32x
+  - id: l24m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/24-llamascope-mlp-131k
+    norm_scaling_factor: 8.39344262295082
+    path: Llama3_1-8B-Base-L24M-32x
+  - id: l25m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/25-llamascope-mlp-131k
+    norm_scaling_factor: 8.126984126984127
+    path: Llama3_1-8B-Base-L25M-32x
+  - id: l26m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/26-llamascope-mlp-131k
+    norm_scaling_factor: 7.5851851851851855
+    path: Llama3_1-8B-Base-L26M-32x
+  - id: l27m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/27-llamascope-mlp-131k
+    norm_scaling_factor: 6.4
+    path: Llama3_1-8B-Base-L27M-32x
+  - id: l28m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/28-llamascope-mlp-131k
+    norm_scaling_factor: 5.505376344086022
+    path: Llama3_1-8B-Base-L28M-32x
+  - id: l29m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/29-llamascope-mlp-131k
+    norm_scaling_factor: 4.413793103448276
+    path: Llama3_1-8B-Base-L29M-32x
+  - id: l30m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/30-llamascope-mlp-131k
+    norm_scaling_factor: 2.5472636815920398
+    path: Llama3_1-8B-Base-L30M-32x
+  - id: l31m_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/31-llamascope-mlp-131k
+    norm_scaling_factor: 1.0534979423868314
+    path: Llama3_1-8B-Base-L31M-32x
+llama_scope_lxm_8x:
+  conversion_func: llama_scope
+  model: meta-llama/Llama-3.1-8B
+  repo_id: fnlp/Llama3_1-8B-Base-LXM-8x
+  saes:
+  - id: l0m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/0-llamascope-mlp-32k
+    norm_scaling_factor: 80.31372549019608
+    path: Llama3_1-8B-Base-L0M-8x
+  - id: l1m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/1-llamascope-mlp-32k
+    norm_scaling_factor: 72.1762114537445
+    path: Llama3_1-8B-Base-L1M-8x
+  - id: l2m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/2-llamascope-mlp-32k
+    norm_scaling_factor: 47.90643274853801
+    path: Llama3_1-8B-Base-L2M-8x
+  - id: l3m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/3-llamascope-mlp-32k
+    norm_scaling_factor: 35.46320346320346
+    path: Llama3_1-8B-Base-L3M-8x
+  - id: l4m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/4-llamascope-mlp-32k
+    norm_scaling_factor: 27.86394557823129
+    path: Llama3_1-8B-Base-L4M-8x
+  - id: l5m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/5-llamascope-mlp-32k
+    norm_scaling_factor: 23.01123595505618
+    path: Llama3_1-8B-Base-L5M-8x
+  - id: l6m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/6-llamascope-mlp-32k
+    norm_scaling_factor: 20.48
+    path: Llama3_1-8B-Base-L6M-8x
+  - id: l7m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/7-llamascope-mlp-32k
+    norm_scaling_factor: 19.692307692307693
+    path: Llama3_1-8B-Base-L7M-8x
+  - id: l8m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/8-llamascope-mlp-32k
+    norm_scaling_factor: 18.87557603686636
+    path: Llama3_1-8B-Base-L8M-8x
+  - id: l9m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/9-llamascope-mlp-32k
+    norm_scaling_factor: 17.88646288209607
+    path: Llama3_1-8B-Base-L9M-8x
+  - id: l10m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/10-llamascope-mlp-32k
+    norm_scaling_factor: 17.5793991416309
+    path: Llama3_1-8B-Base-L10M-8x
+  - id: l11m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/11-llamascope-mlp-32k
+    norm_scaling_factor: 16.855967078189302
+    path: Llama3_1-8B-Base-L11M-8x
+  - id: l12m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/12-llamascope-mlp-32k
+    norm_scaling_factor: 16.125984251968504
+    path: Llama3_1-8B-Base-L12M-8x
+  - id: l13m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/13-llamascope-mlp-32k
+    norm_scaling_factor: 14.733812949640289
+    path: Llama3_1-8B-Base-L13M-8x
+  - id: l14m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/14-llamascope-mlp-32k
+    norm_scaling_factor: 13.74496644295302
+    path: Llama3_1-8B-Base-L14M-8x
+  - id: l15m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/15-llamascope-mlp-32k
+    norm_scaling_factor: 12.118343195266272
+    path: Llama3_1-8B-Base-L15M-8x
+  - id: l16m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/16-llamascope-mlp-32k
+    norm_scaling_factor: 11.702857142857143
+    path: Llama3_1-8B-Base-L16M-8x
+  - id: l17m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/17-llamascope-mlp-32k
+    norm_scaling_factor: 10.666666666666666
+    path: Llama3_1-8B-Base-L17M-8x
+  - id: l18m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/18-llamascope-mlp-32k
+    norm_scaling_factor: 10.778947368421052
+    path: Llama3_1-8B-Base-L18M-8x
+  - id: l19m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/19-llamascope-mlp-32k
+    norm_scaling_factor: 10.502564102564103
+    path: Llama3_1-8B-Base-L19M-8x
+  - id: l20m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/20-llamascope-mlp-32k
+    norm_scaling_factor: 10.138613861386139
+    path: Llama3_1-8B-Base-L20M-8x
+  - id: l21m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/21-llamascope-mlp-32k
+    norm_scaling_factor: 9.142857142857142
+    path: Llama3_1-8B-Base-L21M-8x
+  - id: l22m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/22-llamascope-mlp-32k
+    norm_scaling_factor: 8.904347826086957
+    path: Llama3_1-8B-Base-L22M-8x
+  - id: l23m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/23-llamascope-mlp-32k
+    norm_scaling_factor: 8.641350210970463
+    path: Llama3_1-8B-Base-L23M-8x
+  - id: l24m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/24-llamascope-mlp-32k
+    norm_scaling_factor: 8.39344262295082
+    path: Llama3_1-8B-Base-L24M-8x
+  - id: l25m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/25-llamascope-mlp-32k
+    norm_scaling_factor: 8.126984126984127
+    path: Llama3_1-8B-Base-L25M-8x
+  - id: l26m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/26-llamascope-mlp-32k
+    norm_scaling_factor: 7.5851851851851855
+    path: Llama3_1-8B-Base-L26M-8x
+  - id: l27m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/27-llamascope-mlp-32k
+    norm_scaling_factor: 6.4
+    path: Llama3_1-8B-Base-L27M-8x
+  - id: l28m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/28-llamascope-mlp-32k
+    norm_scaling_factor: 5.505376344086022
+    path: Llama3_1-8B-Base-L28M-8x
+  - id: l29m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/29-llamascope-mlp-32k
+    norm_scaling_factor: 4.432900432900433
+    path: Llama3_1-8B-Base-L29M-8x
+  - id: l30m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/30-llamascope-mlp-32k
+    norm_scaling_factor: 2.5472636815920398
+    path: Llama3_1-8B-Base-L30M-8x
+  - id: l31m_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/31-llamascope-mlp-32k
+    norm_scaling_factor: 1.0534979423868314
+    path: Llama3_1-8B-Base-L31M-8x
+llama_scope_lxr_32x:
+  conversion_func: llama_scope
+  model: meta-llama/Llama-3.1-8B
+  repo_id: fnlp/Llama3_1-8B-Base-LXR-32x
+  saes:
+  - id: l0r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/0-llamascope-res-131k
+    norm_scaling_factor: 58.935251798561154
+    path: Llama3_1-8B-Base-L0R-32x
+  - id: l1r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/1-llamascope-res-131k
+    norm_scaling_factor: 39.9609756097561
+    path: Llama3_1-8B-Base-L1R-32x
+  - id: l2r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/2-llamascope-res-131k
+    norm_scaling_factor: 27.30666666666667
+    path: Llama3_1-8B-Base-L2R-32x
+  - id: l3r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/3-llamascope-res-131k
+    norm_scaling_factor: 20.177339901477833
+    path: Llama3_1-8B-Base-L3R-32x
+  - id: l4r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/4-llamascope-res-131k
+    norm_scaling_factor: 16.125984251968504
+    path: Llama3_1-8B-Base-L4R-32x
+  - id: l5r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/5-llamascope-res-131k
+    norm_scaling_factor: 13.653333333333334
+    path: Llama3_1-8B-Base-L5R-32x
+  - id: l6r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/6-llamascope-res-131k
+    norm_scaling_factor: 11.976608187134502
+    path: Llama3_1-8B-Base-L6R-32x
+  - id: l7r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/7-llamascope-res-131k
+    norm_scaling_factor: 10.835978835978835
+    path: Llama3_1-8B-Base-L7R-32x
+  - id: l8r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/8-llamascope-res-131k
+    norm_scaling_factor: 10.138613861386139
+    path: Llama3_1-8B-Base-L8R-32x
+  - id: l9r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/9-llamascope-res-131k
+    norm_scaling_factor: 9.266968325791856
+    path: Llama3_1-8B-Base-L9R-32x
+  - id: l10r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/10-llamascope-res-131k
+    norm_scaling_factor: 8.827586206896552
+    path: Llama3_1-8B-Base-L10R-32x
+  - id: l11r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/11-llamascope-res-131k
+    norm_scaling_factor: 8.427983539094651
+    path: Llama3_1-8B-Base-L11R-32x
+  - id: l12r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/12-llamascope-res-131k
+    norm_scaling_factor: 7.937984496124031
+    path: Llama3_1-8B-Base-L12R-32x
+  - id: l13r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/13-llamascope-res-131k
+    norm_scaling_factor: 7.26241134751773
+    path: Llama3_1-8B-Base-L13R-32x
+  - id: l14r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/14-llamascope-res-131k
+    norm_scaling_factor: 6.69281045751634
+    path: Llama3_1-8B-Base-L14R-32x
+  - id: l15r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/15-llamascope-res-131k
+    norm_scaling_factor: 5.91907514450867
+    path: Llama3_1-8B-Base-L15R-32x
+  - id: l16r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/16-llamascope-res-131k
+    norm_scaling_factor: 5.278350515463917
+    path: Llama3_1-8B-Base-L16R-32x
+  - id: l17r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/17-llamascope-res-131k
+    norm_scaling_factor: 4.633484162895928
+    path: Llama3_1-8B-Base-L17R-32x
+  - id: l18r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/18-llamascope-res-131k
+    norm_scaling_factor: 4.129032258064516
+    path: Llama3_1-8B-Base-L18R-32x
+  - id: l19r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/19-llamascope-res-131k
+    norm_scaling_factor: 3.7372262773722627
+    path: Llama3_1-8B-Base-L19R-32x
+  - id: l20r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/20-llamascope-res-131k
+    norm_scaling_factor: 3.4133333333333336
+    path: Llama3_1-8B-Base-L20R-32x
+  - id: l21r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/21-llamascope-res-131k
+    norm_scaling_factor: 2.9767441860465116
+    path: Llama3_1-8B-Base-L21R-32x
+  - id: l22r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/22-llamascope-res-131k
+    norm_scaling_factor: 2.680628272251309
+    path: Llama3_1-8B-Base-L22R-32x
+  - id: l23r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/23-llamascope-res-131k
+    norm_scaling_factor: 2.4150943396226414
+    path: Llama3_1-8B-Base-L23R-32x
+  - id: l24r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/24-llamascope-res-131k
+    norm_scaling_factor: 2.1974248927038627
+    path: Llama3_1-8B-Base-L24R-32x
+  - id: l25r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/25-llamascope-res-131k
+    norm_scaling_factor: 2.0237154150197627
+    path: Llama3_1-8B-Base-L25R-32x
+  - id: l26r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/26-llamascope-res-131k
+    norm_scaling_factor: 1.8156028368794326
+    path: Llama3_1-8B-Base-L26R-32x
+  - id: l27r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/27-llamascope-res-131k
+    norm_scaling_factor: 1.6623376623376624
+    path: Llama3_1-8B-Base-L27R-32x
+  - id: l28r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/28-llamascope-res-131k
+    norm_scaling_factor: 1.5058823529411764
+    path: Llama3_1-8B-Base-L28R-32x
+  - id: l29r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/29-llamascope-res-131k
+    norm_scaling_factor: 1.3763440860215055
+    path: Llama3_1-8B-Base-L29R-32x
+  - id: l30r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/30-llamascope-res-131k
+    norm_scaling_factor: 1.2075471698113207
+    path: Llama3_1-8B-Base-L30R-32x
+  - id: l31r_32x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/31-llamascope-res-131k
+    norm_scaling_factor: 0.8648648648648649
+    path: Llama3_1-8B-Base-L31R-32x
+llama_scope_lxr_8x:
+  conversion_func: llama_scope
+  model: meta-llama/Llama-3.1-8B
+  repo_id: fnlp/Llama3_1-8B-Base-LXR-8x
+  saes:
+  - id: l0r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/0-llamascope-res-32k
+    norm_scaling_factor: 58.935251798561154
+    path: Llama3_1-8B-Base-L0R-8x
+  - id: l1r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/1-llamascope-res-32k
+    norm_scaling_factor: 39.76699029126213
+    path: Llama3_1-8B-Base-L1R-8x
+  - id: l2r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/2-llamascope-res-32k
+    norm_scaling_factor: 27.30666666666667
+    path: Llama3_1-8B-Base-L2R-8x
+  - id: l3r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/3-llamascope-res-32k
+    norm_scaling_factor: 20.177339901477833
+    path: Llama3_1-8B-Base-L3R-8x
+  - id: l4r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/4-llamascope-res-32k
+    norm_scaling_factor: 16.125984251968504
+    path: Llama3_1-8B-Base-L4R-8x
+  - id: l5r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/5-llamascope-res-32k
+    norm_scaling_factor: 13.653333333333334
+    path: Llama3_1-8B-Base-L5R-8x
+  - id: l6r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/6-llamascope-res-32k
+    norm_scaling_factor: 11.976608187134502
+    path: Llama3_1-8B-Base-L6R-8x
+  - id: l7r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/7-llamascope-res-32k
+    norm_scaling_factor: 10.835978835978835
+    path: Llama3_1-8B-Base-L7R-8x
+  - id: l8r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/8-llamascope-res-32k
+    norm_scaling_factor: 10.138613861386139
+    path: Llama3_1-8B-Base-L8R-8x
+  - id: l9r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/9-llamascope-res-32k
+    norm_scaling_factor: 9.266968325791856
+    path: Llama3_1-8B-Base-L9R-8x
+  - id: l10r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/10-llamascope-res-32k
+    norm_scaling_factor: 8.827586206896552
+    path: Llama3_1-8B-Base-L10R-8x
+  - id: l11r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/11-llamascope-res-32k
+    norm_scaling_factor: 8.462809917355372
+    path: Llama3_1-8B-Base-L11R-8x
+  - id: l12r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/12-llamascope-res-32k
+    norm_scaling_factor: 7.937984496124031
+    path: Llama3_1-8B-Base-L12R-8x
+  - id: l13r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/13-llamascope-res-32k
+    norm_scaling_factor: 7.26241134751773
+    path: Llama3_1-8B-Base-L13R-8x
+  - id: l14r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/14-llamascope-res-32k
+    norm_scaling_factor: 6.69281045751634
+    path: Llama3_1-8B-Base-L14R-8x
+  - id: l15r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/15-llamascope-res-32k
+    norm_scaling_factor: 5.91907514450867
+    path: Llama3_1-8B-Base-L15R-8x
+  - id: l16r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/16-llamascope-res-32k
+    norm_scaling_factor: 5.278350515463917
+    path: Llama3_1-8B-Base-L16R-8x
+  - id: l17r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/17-llamascope-res-32k
+    norm_scaling_factor: 4.633484162895928
+    path: Llama3_1-8B-Base-L17R-8x
+  - id: l18r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/18-llamascope-res-32k
+    norm_scaling_factor: 4.129032258064516
+    path: Llama3_1-8B-Base-L18R-8x
+  - id: l19r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/19-llamascope-res-32k
+    norm_scaling_factor: 3.7372262773722627
+    path: Llama3_1-8B-Base-L19R-8x
+  - id: l20r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/20-llamascope-res-32k
+    norm_scaling_factor: 3.4133333333333336
+    path: Llama3_1-8B-Base-L20R-8x
+  - id: l21r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/21-llamascope-res-32k
+    norm_scaling_factor: 2.9767441860465116
+    path: Llama3_1-8B-Base-L21R-8x
+  - id: l22r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/22-llamascope-res-32k
+    norm_scaling_factor: 2.680628272251309
+    path: Llama3_1-8B-Base-L22R-8x
+  - id: l23r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/23-llamascope-res-32k
+    norm_scaling_factor: 2.4150943396226414
+    path: Llama3_1-8B-Base-L23R-8x
+  - id: l24r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/24-llamascope-res-32k
+    norm_scaling_factor: 2.1880341880341883
+    path: Llama3_1-8B-Base-L24R-8x
+  - id: l25r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/25-llamascope-res-32k
+    norm_scaling_factor: 2.0237154150197627
+    path: Llama3_1-8B-Base-L25R-8x
+  - id: l26r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/26-llamascope-res-32k
+    norm_scaling_factor: 1.8156028368794326
+    path: Llama3_1-8B-Base-L26R-8x
+  - id: l27r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/27-llamascope-res-32k
+    norm_scaling_factor: 1.673202614379085
+    path: Llama3_1-8B-Base-L27R-8x
+  - id: l28r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/28-llamascope-res-32k
+    norm_scaling_factor: 1.5058823529411764
+    path: Llama3_1-8B-Base-L28R-8x
+  - id: l29r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/29-llamascope-res-32k
+    norm_scaling_factor: 1.3763440860215055
+    path: Llama3_1-8B-Base-L29R-8x
+  - id: l30r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/30-llamascope-res-32k
+    norm_scaling_factor: 1.2018779342723005
+    path: Llama3_1-8B-Base-L30R-8x
+  - id: l31r_8x
+    l0: 50.0
+    neuronpedia: llama3.1-8b/31-llamascope-res-32k
+    norm_scaling_factor: 0.8590604026845637
+    path: Llama3_1-8B-Base-L31R-8x
+llama_scope_r1_distill:
+  conversion_func: llama_scope_r1_distill
+  model: deepseek-ai/DeepSeek-R1-Distill-Llama-8B
+  repo_id: fnlp/Llama-Scope-R1-Distill
+  saes:
+  - id: l0r_800m_slimpajama
+    norm_scaling_factor: 53.52995401997436
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L0R
+  - id: l1r_800m_slimpajama
+    norm_scaling_factor: 37.07457226753229
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L1R
+  - id: l2r_800m_slimpajama
+    norm_scaling_factor: 26.801271953747353
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L2R
+  - id: l3r_800m_slimpajama
+    norm_scaling_factor: 20.258785842428143
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L3R
+  - id: l4r_800m_slimpajama
+    norm_scaling_factor: 16.35620323956284
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L4R
+  - id: l5r_800m_slimpajama
+    norm_scaling_factor: 13.77273090622553
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L5R
+  - id: l6r_800m_slimpajama
+    norm_scaling_factor: 11.802642616140206
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L6R
+  - id: l7r_800m_slimpajama
+    norm_scaling_factor: 10.345622082873675
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L7R
+  - id: l8r_800m_slimpajama
+    norm_scaling_factor: 9.52711219837399
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L8R
+  - id: l9r_800m_slimpajama
+    norm_scaling_factor: 8.722802553532865
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L9R
+  - id: l10r_800m_slimpajama
+    norm_scaling_factor: 8.187374613072596
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L10R
+  - id: l11r_800m_slimpajama
+    norm_scaling_factor: 7.681409438301019
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L11R
+  - id: l12r_800m_slimpajama
+    norm_scaling_factor: 7.011470964851573
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L12R
+  - id: l13r_800m_slimpajama
+    norm_scaling_factor: 6.507851835301529
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L13R
+  - id: l14r_800m_slimpajama
+    norm_scaling_factor: 6.075830839342571
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L14R
+  - id: l15r_800m_slimpajama
+    norm_scaling_factor: 5.529329506982431
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L15R
+  - id: l16r_800m_slimpajama
+    norm_scaling_factor: 5.04125765694814
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L16R
+  - id: l17r_800m_slimpajama
+    norm_scaling_factor: 4.543060254752811
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L17R
+  - id: l18r_800m_slimpajama
+    norm_scaling_factor: 4.136073768441771
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L18R
+  - id: l19r_800m_slimpajama
+    norm_scaling_factor: 3.8186778444880143
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L19R
+  - id: l20r_800m_slimpajama
+    norm_scaling_factor: 3.4997662089479755
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L20R
+  - id: l21r_800m_slimpajama
+    norm_scaling_factor: 3.114875161525094
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L21R
+  - id: l22r_800m_slimpajama
+    norm_scaling_factor: 2.858677637086371
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L22R
+  - id: l23r_800m_slimpajama
+    norm_scaling_factor: 2.6143620233159384
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L23R
+  - id: l24r_800m_slimpajama
+    norm_scaling_factor: 2.406593266301888
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L24R
+  - id: l25r_800m_slimpajama
+    norm_scaling_factor: 2.2185540508553694
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L25R
+  - id: l26r_800m_slimpajama
+    norm_scaling_factor: 2.038628827422577
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L26R
+  - id: l27r_800m_slimpajama
+    norm_scaling_factor: 1.8664054897001374
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L27R
+  - id: l28r_800m_slimpajama
+    norm_scaling_factor: 1.6914743009513147
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L28R
+  - id: l29r_800m_slimpajama
+    norm_scaling_factor: 1.530389056066687
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L29R
+  - id: l30r_800m_slimpajama
+    norm_scaling_factor: 1.3378642198135962
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L30R
+  - id: l31r_800m_slimpajama
+    norm_scaling_factor: 1.0963025732622191
+    path: 800M-Slimpajama-0-OpenR1-Math-220k/L31R
+mistral-7b-res-wg:
+  config_overrides:
+    normalize_activations: constant_norm_rescale
+  conversion_func: null
+  model: mistral-7b
+  repo_id: JoshEngels/Mistral-7B-Residual-Stream-SAEs
+  saes:
+  - id: blocks.8.hook_resid_pre
+    l0: 92
+    path: mistral_7b_layer_8
+    variance_explained: 0.94
+  - id: blocks.16.hook_resid_pre
+    l0: 74
+    path: mistral_7b_layer_16
+    variance_explained: 0.85
+  - id: blocks.24.hook_resid_pre
+    l0: 75
+    path: mistral_7b_layer_24
+    variance_explained: 0.72
+pythia-70m-deduped-att-sm:
+  conversion_func: null
+  links:
+    dashboards: https://www.neuronpedia.org/pythia-70m-deduped
+    model: https://huggingface.co/EleutherAI/pythia-70m-deduped
+  model: pythia-70m-deduped
+  repo_id: ctigges/pythia-70m-deduped__att-sm_processed
+  saes:
+  - id: blocks.0.hook_attn_out
+    neuronpedia: pythia-70m-deduped/0-att-sm
+    path: 0-att-sm
+  - id: blocks.1.hook_attn_out
+    neuronpedia: pythia-70m-deduped/1-att-sm
+    path: 1-att-sm
+  - id: blocks.2.hook_attn_out
+    neuronpedia: pythia-70m-deduped/2-att-sm
+    path: 2-att-sm
+  - id: blocks.3.hook_attn_out
+    neuronpedia: pythia-70m-deduped/3-att-sm
+    path: 3-att-sm
+  - id: blocks.4.hook_attn_out
+    neuronpedia: pythia-70m-deduped/4-att-sm
+    path: 4-att-sm
+  - id: blocks.5.hook_attn_out
+    neuronpedia: pythia-70m-deduped/5-att-sm
+    path: 5-att-sm
+pythia-70m-deduped-mlp-sm:
+  conversion_func: null
+  links:
+    dashboards: https://www.neuronpedia.org/pythia-70m-deduped
+    model: https://huggingface.co/EleutherAI/pythia-70m-deduped
+  model: pythia-70m-deduped
+  repo_id: ctigges/pythia-70m-deduped__mlp-sm_processed
+  saes:
+  - id: blocks.0.hook_mlp_out
+    neuronpedia: pythia-70m-deduped/0-mlp-sm
+    path: 0-mlp-sm
+  - id: blocks.1.hook_mlp_out
+    neuronpedia: pythia-70m-deduped/1-mlp-sm
+    path: 1-mlp-sm
+  - id: blocks.2.hook_mlp_out
+    neuronpedia: pythia-70m-deduped/2-mlp-sm
+    path: 2-mlp-sm
+  - id: blocks.3.hook_mlp_out
+    neuronpedia: pythia-70m-deduped/3-mlp-sm
+    path: 3-mlp-sm
+  - id: blocks.4.hook_mlp_out
+    neuronpedia: pythia-70m-deduped/4-mlp-sm
+    path: 4-mlp-sm
+  - id: blocks.5.hook_mlp_out
+    neuronpedia: pythia-70m-deduped/5-mlp-sm
+    path: 5-mlp-sm
+pythia-70m-deduped-res-sm:
+  conversion_func: null
+  links:
+    dashboards: https://www.neuronpedia.org/pythia-70m-deduped
+    model: https://huggingface.co/EleutherAI/pythia-70m-deduped
+  model: pythia-70m-deduped
+  repo_id: ctigges/pythia-70m-deduped__res-sm_processed
+  saes:
+  - id: blocks.0.hook_resid_pre
+    neuronpedia: pythia-70m-deduped/e-att-sm
+    path: e-res-sm
+  - id: blocks.0.hook_resid_post
+    neuronpedia: pythia-70m-deduped/0-res-sm
+    path: 0-res-sm
+  - id: blocks.1.hook_resid_post
+    neuronpedia: pythia-70m-deduped/1-res-sm
+    path: 1-res-sm
+  - id: blocks.2.hook_resid_post
+    neuronpedia: pythia-70m-deduped/2-res-sm
+    path: 2-res-sm
+  - id: blocks.3.hook_resid_post
+    neuronpedia: pythia-70m-deduped/3-res-sm
+    path: 3-res-sm
+  - id: blocks.4.hook_resid_post
+    neuronpedia: pythia-70m-deduped/4-res-sm
+    path: 4-res-sm
+  - id: blocks.5.hook_resid_post
+    neuronpedia: pythia-70m-deduped/5-res-sm
+    path: 5-res-sm
+sae_bench_gemma-2-2b_topk_width-2pow12_date-1109:
+  conversion_func: dictionary_learning_1
+  links:
+    model: https://huggingface.co/google/gemma-2-2b
+  model: gemma-2-2b
+  repo_id: canrager/saebench_gemma-2-2b_width-2pow12_date-1109
+  saes:
+  - id: blocks.12.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_0_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12/trainer_0
+  - id: blocks.12.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_0_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_0
+  - id: blocks.12.hook_resid_post__trainer_0_step_308
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_0_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_308
+  - id: blocks.12.hook_resid_post__trainer_0_step_3088
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_0_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_3088
+  - id: blocks.12.hook_resid_post__trainer_0_step_30881
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_0_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_30881
+  - id: blocks.12.hook_resid_post__trainer_0_step_97
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_0_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_97
+  - id: blocks.12.hook_resid_post__trainer_0_step_976
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_0_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_976
+  - id: blocks.12.hook_resid_post__trainer_0_step_9765
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_0_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_9765
+  - id: blocks.12.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_1_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12/trainer_1
+  - id: blocks.12.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_1_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_0
+  - id: blocks.12.hook_resid_post__trainer_1_step_308
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_1_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_308
+  - id: blocks.12.hook_resid_post__trainer_1_step_3088
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_1_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_3088
+  - id: blocks.12.hook_resid_post__trainer_1_step_30881
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_1_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_30881
+  - id: blocks.12.hook_resid_post__trainer_1_step_97
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_1_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_97
+  - id: blocks.12.hook_resid_post__trainer_1_step_976
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_1_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_976
+  - id: blocks.12.hook_resid_post__trainer_1_step_9765
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_1_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_9765
+  - id: blocks.12.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_2_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12/trainer_2
+  - id: blocks.12.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_2_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_0
+  - id: blocks.12.hook_resid_post__trainer_2_step_308
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_2_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_308
+  - id: blocks.12.hook_resid_post__trainer_2_step_3088
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_2_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_3088
+  - id: blocks.12.hook_resid_post__trainer_2_step_30881
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_2_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_30881
+  - id: blocks.12.hook_resid_post__trainer_2_step_97
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_2_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_97
+  - id: blocks.12.hook_resid_post__trainer_2_step_976
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_2_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_976
+  - id: blocks.12.hook_resid_post__trainer_2_step_9765
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_2_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_9765
+  - id: blocks.12.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_3_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12/trainer_3
+  - id: blocks.12.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_3_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_0
+  - id: blocks.12.hook_resid_post__trainer_3_step_308
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_3_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_308
+  - id: blocks.12.hook_resid_post__trainer_3_step_3088
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_3_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_3088
+  - id: blocks.12.hook_resid_post__trainer_3_step_30881
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_3_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_30881
+  - id: blocks.12.hook_resid_post__trainer_3_step_97
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_3_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_97
+  - id: blocks.12.hook_resid_post__trainer_3_step_976
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_3_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_976
+  - id: blocks.12.hook_resid_post__trainer_3_step_9765
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_3_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_9765
+  - id: blocks.12.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_4_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12/trainer_4
+  - id: blocks.12.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_4_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_0
+  - id: blocks.12.hook_resid_post__trainer_4_step_308
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_4_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_308
+  - id: blocks.12.hook_resid_post__trainer_4_step_3088
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_4_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_3088
+  - id: blocks.12.hook_resid_post__trainer_4_step_30881
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_4_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_30881
+  - id: blocks.12.hook_resid_post__trainer_4_step_97
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_4_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_97
+  - id: blocks.12.hook_resid_post__trainer_4_step_976
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_4_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_976
+  - id: blocks.12.hook_resid_post__trainer_4_step_9765
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_4_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_9765
+  - id: blocks.12.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_5_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12/trainer_5
+  - id: blocks.12.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_5_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_0
+  - id: blocks.12.hook_resid_post__trainer_5_step_308
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_5_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_308
+  - id: blocks.12.hook_resid_post__trainer_5_step_3088
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_5_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_3088
+  - id: blocks.12.hook_resid_post__trainer_5_step_30881
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_5_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_30881
+  - id: blocks.12.hook_resid_post__trainer_5_step_97
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_5_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_97
+  - id: blocks.12.hook_resid_post__trainer_5_step_976
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_5_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_976
+  - id: blocks.12.hook_resid_post__trainer_5_step_9765
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_5_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_9765
+  - id: blocks.19.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_0_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19/trainer_0
+  - id: blocks.19.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_0_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_0
+  - id: blocks.19.hook_resid_post__trainer_0_step_308
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_0_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_308
+  - id: blocks.19.hook_resid_post__trainer_0_step_3088
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_0_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_3088
+  - id: blocks.19.hook_resid_post__trainer_0_step_30881
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_0_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_30881
+  - id: blocks.19.hook_resid_post__trainer_0_step_97
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_0_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_97
+  - id: blocks.19.hook_resid_post__trainer_0_step_976
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_0_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_976
+  - id: blocks.19.hook_resid_post__trainer_0_step_9765
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_0_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_9765
+  - id: blocks.19.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_1_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19/trainer_1
+  - id: blocks.19.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_1_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_0
+  - id: blocks.19.hook_resid_post__trainer_1_step_308
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_1_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_308
+  - id: blocks.19.hook_resid_post__trainer_1_step_3088
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_1_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_3088
+  - id: blocks.19.hook_resid_post__trainer_1_step_30881
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_1_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_30881
+  - id: blocks.19.hook_resid_post__trainer_1_step_97
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_1_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_97
+  - id: blocks.19.hook_resid_post__trainer_1_step_976
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_1_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_976
+  - id: blocks.19.hook_resid_post__trainer_1_step_9765
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_1_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_9765
+  - id: blocks.19.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_2_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19/trainer_2
+  - id: blocks.19.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_2_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_0
+  - id: blocks.19.hook_resid_post__trainer_2_step_308
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_2_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_308
+  - id: blocks.19.hook_resid_post__trainer_2_step_3088
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_2_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_3088
+  - id: blocks.19.hook_resid_post__trainer_2_step_30881
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_2_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_30881
+  - id: blocks.19.hook_resid_post__trainer_2_step_97
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_2_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_97
+  - id: blocks.19.hook_resid_post__trainer_2_step_976
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_2_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_976
+  - id: blocks.19.hook_resid_post__trainer_2_step_9765
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_2_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_9765
+  - id: blocks.19.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_3_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19/trainer_3
+  - id: blocks.19.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_3_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_0
+  - id: blocks.19.hook_resid_post__trainer_3_step_308
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_3_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_308
+  - id: blocks.19.hook_resid_post__trainer_3_step_3088
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_3_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_3088
+  - id: blocks.19.hook_resid_post__trainer_3_step_30881
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_3_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_30881
+  - id: blocks.19.hook_resid_post__trainer_3_step_97
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_3_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_97
+  - id: blocks.19.hook_resid_post__trainer_3_step_976
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_3_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_976
+  - id: blocks.19.hook_resid_post__trainer_3_step_9765
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_3_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_9765
+  - id: blocks.19.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_4_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19/trainer_4
+  - id: blocks.19.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_4_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_0
+  - id: blocks.19.hook_resid_post__trainer_4_step_308
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_4_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_308
+  - id: blocks.19.hook_resid_post__trainer_4_step_3088
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_4_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_3088
+  - id: blocks.19.hook_resid_post__trainer_4_step_30881
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_4_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_30881
+  - id: blocks.19.hook_resid_post__trainer_4_step_97
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_4_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_97
+  - id: blocks.19.hook_resid_post__trainer_4_step_976
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_4_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_976
+  - id: blocks.19.hook_resid_post__trainer_4_step_9765
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_4_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_9765
+  - id: blocks.19.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_5_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19/trainer_5
+  - id: blocks.19.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_5_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_0
+  - id: blocks.19.hook_resid_post__trainer_5_step_308
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_5_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_308
+  - id: blocks.19.hook_resid_post__trainer_5_step_3088
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_5_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_3088
+  - id: blocks.19.hook_resid_post__trainer_5_step_30881
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_5_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_30881
+  - id: blocks.19.hook_resid_post__trainer_5_step_97
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_5_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_97
+  - id: blocks.19.hook_resid_post__trainer_5_step_976
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_5_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_976
+  - id: blocks.19.hook_resid_post__trainer_5_step_9765
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_5_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_9765
+  - id: blocks.5.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_0_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5/trainer_0
+  - id: blocks.5.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_0_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_0
+  - id: blocks.5.hook_resid_post__trainer_0_step_308
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_0_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_308
+  - id: blocks.5.hook_resid_post__trainer_0_step_3088
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_0_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_3088
+  - id: blocks.5.hook_resid_post__trainer_0_step_30881
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_0_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_30881
+  - id: blocks.5.hook_resid_post__trainer_0_step_97
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_0_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_97
+  - id: blocks.5.hook_resid_post__trainer_0_step_976
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_0_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_976
+  - id: blocks.5.hook_resid_post__trainer_0_step_9765
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_0_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_9765
+  - id: blocks.5.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_1_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5/trainer_1
+  - id: blocks.5.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_1_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_0
+  - id: blocks.5.hook_resid_post__trainer_1_step_308
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_1_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_308
+  - id: blocks.5.hook_resid_post__trainer_1_step_3088
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_1_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_3088
+  - id: blocks.5.hook_resid_post__trainer_1_step_30881
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_1_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_30881
+  - id: blocks.5.hook_resid_post__trainer_1_step_97
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_1_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_97
+  - id: blocks.5.hook_resid_post__trainer_1_step_976
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_1_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_976
+  - id: blocks.5.hook_resid_post__trainer_1_step_9765
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_1_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_9765
+  - id: blocks.5.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_2_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5/trainer_2
+  - id: blocks.5.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_2_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_0
+  - id: blocks.5.hook_resid_post__trainer_2_step_308
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_2_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_308
+  - id: blocks.5.hook_resid_post__trainer_2_step_3088
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_2_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_3088
+  - id: blocks.5.hook_resid_post__trainer_2_step_30881
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_2_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_30881
+  - id: blocks.5.hook_resid_post__trainer_2_step_97
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_2_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_97
+  - id: blocks.5.hook_resid_post__trainer_2_step_976
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_2_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_976
+  - id: blocks.5.hook_resid_post__trainer_2_step_9765
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_2_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_9765
+  - id: blocks.5.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_3_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5/trainer_3
+  - id: blocks.5.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_3_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_0
+  - id: blocks.5.hook_resid_post__trainer_3_step_308
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_3_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_308
+  - id: blocks.5.hook_resid_post__trainer_3_step_3088
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_3_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_3088
+  - id: blocks.5.hook_resid_post__trainer_3_step_30881
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_3_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_30881
+  - id: blocks.5.hook_resid_post__trainer_3_step_97
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_3_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_97
+  - id: blocks.5.hook_resid_post__trainer_3_step_976
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_3_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_976
+  - id: blocks.5.hook_resid_post__trainer_3_step_9765
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_3_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_9765
+  - id: blocks.5.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_4_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5/trainer_4
+  - id: blocks.5.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_4_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_0
+  - id: blocks.5.hook_resid_post__trainer_4_step_308
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_4_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_308
+  - id: blocks.5.hook_resid_post__trainer_4_step_3088
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_4_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_3088
+  - id: blocks.5.hook_resid_post__trainer_4_step_30881
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_4_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_30881
+  - id: blocks.5.hook_resid_post__trainer_4_step_97
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_4_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_97
+  - id: blocks.5.hook_resid_post__trainer_4_step_976
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_4_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_976
+  - id: blocks.5.hook_resid_post__trainer_4_step_9765
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_4_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_9765
+  - id: blocks.5.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_5_step_final
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5/trainer_5
+  - id: blocks.5.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_5_step_0
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_0
+  - id: blocks.5.hook_resid_post__trainer_5_step_308
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_5_step_308
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_308
+  - id: blocks.5.hook_resid_post__trainer_5_step_3088
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_5_step_3088
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_3088
+  - id: blocks.5.hook_resid_post__trainer_5_step_30881
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_5_step_30881
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_30881
+  - id: blocks.5.hook_resid_post__trainer_5_step_97
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_5_step_97
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_97
+  - id: blocks.5.hook_resid_post__trainer_5_step_976
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_5_step_976
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_976
+  - id: blocks.5.hook_resid_post__trainer_5_step_9765
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_5_step_9765
+    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_9765
+sae_bench_gemma-2-2b_topk_width-2pow14_date-1109:
+  conversion_func: dictionary_learning_1
+  links:
+    model: https://huggingface.co/google/gemma-2-2b
+  model: gemma-2-2b
+  repo_id: canrager/saebench_gemma-2-2b_width-2pow14_date-1109
+  saes:
+  - id: blocks.12.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_0_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12/trainer_0
+  - id: blocks.12.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_0_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_0
+  - id: blocks.12.hook_resid_post__trainer_0_step_146
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_0_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_146
+  - id: blocks.12.hook_resid_post__trainer_0_step_1464
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_0_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_1464
+  - id: blocks.12.hook_resid_post__trainer_0_step_14648
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_0_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_14648
+  - id: blocks.12.hook_resid_post__trainer_0_step_463
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_0_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_463
+  - id: blocks.12.hook_resid_post__trainer_0_step_4632
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_0_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_4632
+  - id: blocks.12.hook_resid_post__trainer_0_step_46322
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_0_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_46322
+  - id: blocks.12.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_1_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12/trainer_1
+  - id: blocks.12.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_1_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_0
+  - id: blocks.12.hook_resid_post__trainer_1_step_146
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_1_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_146
+  - id: blocks.12.hook_resid_post__trainer_1_step_1464
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_1_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_1464
+  - id: blocks.12.hook_resid_post__trainer_1_step_14648
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_1_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_14648
+  - id: blocks.12.hook_resid_post__trainer_1_step_463
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_1_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_463
+  - id: blocks.12.hook_resid_post__trainer_1_step_4632
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_1_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_4632
+  - id: blocks.12.hook_resid_post__trainer_1_step_46322
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_1_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_46322
+  - id: blocks.12.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_2_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12/trainer_2
+  - id: blocks.12.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_2_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_0
+  - id: blocks.12.hook_resid_post__trainer_2_step_146
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_2_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_146
+  - id: blocks.12.hook_resid_post__trainer_2_step_1464
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_2_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_1464
+  - id: blocks.12.hook_resid_post__trainer_2_step_14648
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_2_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_14648
+  - id: blocks.12.hook_resid_post__trainer_2_step_463
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_2_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_463
+  - id: blocks.12.hook_resid_post__trainer_2_step_4632
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_2_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_4632
+  - id: blocks.12.hook_resid_post__trainer_2_step_46322
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_2_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_46322
+  - id: blocks.12.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_3_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12/trainer_3
+  - id: blocks.12.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_3_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_0
+  - id: blocks.12.hook_resid_post__trainer_3_step_146
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_3_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_146
+  - id: blocks.12.hook_resid_post__trainer_3_step_1464
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_3_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_1464
+  - id: blocks.12.hook_resid_post__trainer_3_step_14648
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_3_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_14648
+  - id: blocks.12.hook_resid_post__trainer_3_step_463
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_3_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_463
+  - id: blocks.12.hook_resid_post__trainer_3_step_4632
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_3_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_4632
+  - id: blocks.12.hook_resid_post__trainer_3_step_46322
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_3_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_46322
+  - id: blocks.12.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_4_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12/trainer_4
+  - id: blocks.12.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_4_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_0
+  - id: blocks.12.hook_resid_post__trainer_4_step_146
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_4_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_146
+  - id: blocks.12.hook_resid_post__trainer_4_step_1464
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_4_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_1464
+  - id: blocks.12.hook_resid_post__trainer_4_step_14648
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_4_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_14648
+  - id: blocks.12.hook_resid_post__trainer_4_step_463
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_4_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_463
+  - id: blocks.12.hook_resid_post__trainer_4_step_4632
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_4_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_4632
+  - id: blocks.12.hook_resid_post__trainer_4_step_46322
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_4_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_46322
+  - id: blocks.12.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_5_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12/trainer_5
+  - id: blocks.12.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_5_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_0
+  - id: blocks.12.hook_resid_post__trainer_5_step_146
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_5_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_146
+  - id: blocks.12.hook_resid_post__trainer_5_step_1464
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_5_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_1464
+  - id: blocks.12.hook_resid_post__trainer_5_step_14648
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_5_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_14648
+  - id: blocks.12.hook_resid_post__trainer_5_step_463
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_5_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_463
+  - id: blocks.12.hook_resid_post__trainer_5_step_4632
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_5_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_4632
+  - id: blocks.12.hook_resid_post__trainer_5_step_46322
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_5_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_46322
+  - id: blocks.19.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_0_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19/trainer_0
+  - id: blocks.19.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_0_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_0
+  - id: blocks.19.hook_resid_post__trainer_0_step_146
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_0_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_146
+  - id: blocks.19.hook_resid_post__trainer_0_step_1464
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_0_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_1464
+  - id: blocks.19.hook_resid_post__trainer_0_step_14648
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_0_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_14648
+  - id: blocks.19.hook_resid_post__trainer_0_step_463
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_0_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_463
+  - id: blocks.19.hook_resid_post__trainer_0_step_4632
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_0_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_4632
+  - id: blocks.19.hook_resid_post__trainer_0_step_46322
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_0_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_46322
+  - id: blocks.19.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_1_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19/trainer_1
+  - id: blocks.19.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_1_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_0
+  - id: blocks.19.hook_resid_post__trainer_1_step_146
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_1_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_146
+  - id: blocks.19.hook_resid_post__trainer_1_step_1464
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_1_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_1464
+  - id: blocks.19.hook_resid_post__trainer_1_step_14648
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_1_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_14648
+  - id: blocks.19.hook_resid_post__trainer_1_step_463
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_1_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_463
+  - id: blocks.19.hook_resid_post__trainer_1_step_4632
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_1_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_4632
+  - id: blocks.19.hook_resid_post__trainer_1_step_46322
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_1_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_46322
+  - id: blocks.19.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_2_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19/trainer_2
+  - id: blocks.19.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_2_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_0
+  - id: blocks.19.hook_resid_post__trainer_2_step_146
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_2_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_146
+  - id: blocks.19.hook_resid_post__trainer_2_step_1464
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_2_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_1464
+  - id: blocks.19.hook_resid_post__trainer_2_step_14648
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_2_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_14648
+  - id: blocks.19.hook_resid_post__trainer_2_step_463
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_2_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_463
+  - id: blocks.19.hook_resid_post__trainer_2_step_4632
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_2_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_4632
+  - id: blocks.19.hook_resid_post__trainer_2_step_46322
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_2_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_46322
+  - id: blocks.19.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_3_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19/trainer_3
+  - id: blocks.19.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_3_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_0
+  - id: blocks.19.hook_resid_post__trainer_3_step_146
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_3_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_146
+  - id: blocks.19.hook_resid_post__trainer_3_step_1464
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_3_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_1464
+  - id: blocks.19.hook_resid_post__trainer_3_step_14648
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_3_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_14648
+  - id: blocks.19.hook_resid_post__trainer_3_step_463
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_3_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_463
+  - id: blocks.19.hook_resid_post__trainer_3_step_4632
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_3_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_4632
+  - id: blocks.19.hook_resid_post__trainer_3_step_46322
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_3_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_46322
+  - id: blocks.19.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_4_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19/trainer_4
+  - id: blocks.19.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_4_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_0
+  - id: blocks.19.hook_resid_post__trainer_4_step_146
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_4_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_146
+  - id: blocks.19.hook_resid_post__trainer_4_step_1464
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_4_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_1464
+  - id: blocks.19.hook_resid_post__trainer_4_step_14648
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_4_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_14648
+  - id: blocks.19.hook_resid_post__trainer_4_step_463
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_4_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_463
+  - id: blocks.19.hook_resid_post__trainer_4_step_4632
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_4_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_4632
+  - id: blocks.19.hook_resid_post__trainer_4_step_46322
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_4_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_46322
+  - id: blocks.19.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_5_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19/trainer_5
+  - id: blocks.19.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_5_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_0
+  - id: blocks.19.hook_resid_post__trainer_5_step_146
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_5_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_146
+  - id: blocks.19.hook_resid_post__trainer_5_step_1464
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_5_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_1464
+  - id: blocks.19.hook_resid_post__trainer_5_step_14648
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_5_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_14648
+  - id: blocks.19.hook_resid_post__trainer_5_step_463
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_5_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_463
+  - id: blocks.19.hook_resid_post__trainer_5_step_4632
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_5_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_4632
+  - id: blocks.19.hook_resid_post__trainer_5_step_46322
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_5_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_46322
+  - id: blocks.5.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_0_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5/trainer_0
+  - id: blocks.5.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_0_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_0
+  - id: blocks.5.hook_resid_post__trainer_0_step_146
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_0_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_146
+  - id: blocks.5.hook_resid_post__trainer_0_step_1464
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_0_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_1464
+  - id: blocks.5.hook_resid_post__trainer_0_step_14648
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_0_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_14648
+  - id: blocks.5.hook_resid_post__trainer_0_step_463
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_0_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_463
+  - id: blocks.5.hook_resid_post__trainer_0_step_4632
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_0_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_4632
+  - id: blocks.5.hook_resid_post__trainer_0_step_46322
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_0_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_46322
+  - id: blocks.5.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_1_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5/trainer_1
+  - id: blocks.5.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_1_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_0
+  - id: blocks.5.hook_resid_post__trainer_1_step_146
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_1_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_146
+  - id: blocks.5.hook_resid_post__trainer_1_step_1464
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_1_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_1464
+  - id: blocks.5.hook_resid_post__trainer_1_step_14648
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_1_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_14648
+  - id: blocks.5.hook_resid_post__trainer_1_step_463
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_1_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_463
+  - id: blocks.5.hook_resid_post__trainer_1_step_4632
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_1_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_4632
+  - id: blocks.5.hook_resid_post__trainer_1_step_46322
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_1_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_46322
+  - id: blocks.5.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_2_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5/trainer_2
+  - id: blocks.5.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_2_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_0
+  - id: blocks.5.hook_resid_post__trainer_2_step_146
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_2_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_146
+  - id: blocks.5.hook_resid_post__trainer_2_step_1464
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_2_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_1464
+  - id: blocks.5.hook_resid_post__trainer_2_step_14648
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_2_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_14648
+  - id: blocks.5.hook_resid_post__trainer_2_step_463
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_2_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_463
+  - id: blocks.5.hook_resid_post__trainer_2_step_4632
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_2_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_4632
+  - id: blocks.5.hook_resid_post__trainer_2_step_46322
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_2_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_46322
+  - id: blocks.5.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_3_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5/trainer_3
+  - id: blocks.5.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_3_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_0
+  - id: blocks.5.hook_resid_post__trainer_3_step_146
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_3_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_146
+  - id: blocks.5.hook_resid_post__trainer_3_step_1464
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_3_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_1464
+  - id: blocks.5.hook_resid_post__trainer_3_step_14648
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_3_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_14648
+  - id: blocks.5.hook_resid_post__trainer_3_step_463
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_3_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_463
+  - id: blocks.5.hook_resid_post__trainer_3_step_4632
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_3_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_4632
+  - id: blocks.5.hook_resid_post__trainer_3_step_46322
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_3_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_46322
+  - id: blocks.5.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_4_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5/trainer_4
+  - id: blocks.5.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_4_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_0
+  - id: blocks.5.hook_resid_post__trainer_4_step_146
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_4_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_146
+  - id: blocks.5.hook_resid_post__trainer_4_step_1464
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_4_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_1464
+  - id: blocks.5.hook_resid_post__trainer_4_step_14648
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_4_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_14648
+  - id: blocks.5.hook_resid_post__trainer_4_step_463
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_4_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_463
+  - id: blocks.5.hook_resid_post__trainer_4_step_4632
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_4_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_4632
+  - id: blocks.5.hook_resid_post__trainer_4_step_46322
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_4_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_46322
+  - id: blocks.5.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_5_step_final
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5/trainer_5
+  - id: blocks.5.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_5_step_0
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_0
+  - id: blocks.5.hook_resid_post__trainer_5_step_146
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_5_step_146
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_146
+  - id: blocks.5.hook_resid_post__trainer_5_step_1464
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_5_step_1464
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_1464
+  - id: blocks.5.hook_resid_post__trainer_5_step_14648
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_5_step_14648
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_14648
+  - id: blocks.5.hook_resid_post__trainer_5_step_463
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_5_step_463
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_463
+  - id: blocks.5.hook_resid_post__trainer_5_step_4632
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_5_step_4632
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_4632
+  - id: blocks.5.hook_resid_post__trainer_5_step_46322
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_5_step_46322
+    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_46322
+sae_bench_gemma-2-2b_topk_width-2pow16_date-1109:
+  conversion_func: dictionary_learning_1
+  links:
+    model: https://huggingface.co/google/gemma-2-2b
+  model: gemma-2-2b
+  repo_id: canrager/saebench_gemma-2-2b_width-2pow16_date-1109
+  saes:
+  - id: blocks.12.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-65k__trainer_0_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_12/trainer_0
+  - id: blocks.12.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-65k__trainer_1_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_12/trainer_1
+  - id: blocks.12.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-65k__trainer_2_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_12/trainer_2
+  - id: blocks.12.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-65k__trainer_3_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_12/trainer_3
+  - id: blocks.12.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-65k__trainer_4_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_12/trainer_4
+  - id: blocks.12.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-65k__trainer_5_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_12/trainer_5
+  - id: blocks.19.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-65k__trainer_0_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_19/trainer_0
+  - id: blocks.19.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-65k__trainer_1_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_19/trainer_1
+  - id: blocks.19.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-65k__trainer_2_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_19/trainer_2
+  - id: blocks.19.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-65k__trainer_3_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_19/trainer_3
+  - id: blocks.19.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-65k__trainer_4_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_19/trainer_4
+  - id: blocks.19.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-65k__trainer_5_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_19/trainer_5
+  - id: blocks.5.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-65k__trainer_0_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_5/trainer_0
+  - id: blocks.5.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-65k__trainer_1_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_5/trainer_1
+  - id: blocks.5.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-65k__trainer_2_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_5/trainer_2
+  - id: blocks.5.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-65k__trainer_3_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_5/trainer_3
+  - id: blocks.5.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-65k__trainer_4_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_5/trainer_4
+  - id: blocks.5.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-65k__trainer_5_step_final
+    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_5/trainer_5
+sae_bench_gemma-2-2b_vanilla_width-2pow12_date-1109:
+  conversion_func: dictionary_learning_1
+  links:
+    model: https://huggingface.co/google/gemma-2-2b
+  model: gemma-2-2b
+  repo_id: canrager/saebench_gemma-2-2b_width-2pow12_date-1109
+  saes:
+  - id: blocks.12.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_0_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12/trainer_0
+  - id: blocks.12.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_0_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_0
+  - id: blocks.12.hook_resid_post__trainer_0_step_308
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_0_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_308
+  - id: blocks.12.hook_resid_post__trainer_0_step_3088
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_0_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_3088
+  - id: blocks.12.hook_resid_post__trainer_0_step_30881
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_0_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_30881
+  - id: blocks.12.hook_resid_post__trainer_0_step_97
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_0_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_97
+  - id: blocks.12.hook_resid_post__trainer_0_step_976
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_0_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_976
+  - id: blocks.12.hook_resid_post__trainer_0_step_9765
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_0_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_9765
+  - id: blocks.12.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_1_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12/trainer_1
+  - id: blocks.12.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_1_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_0
+  - id: blocks.12.hook_resid_post__trainer_1_step_308
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_1_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_308
+  - id: blocks.12.hook_resid_post__trainer_1_step_3088
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_1_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_3088
+  - id: blocks.12.hook_resid_post__trainer_1_step_30881
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_1_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_30881
+  - id: blocks.12.hook_resid_post__trainer_1_step_97
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_1_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_97
+  - id: blocks.12.hook_resid_post__trainer_1_step_976
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_1_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_976
+  - id: blocks.12.hook_resid_post__trainer_1_step_9765
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_1_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_9765
+  - id: blocks.12.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_2_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12/trainer_2
+  - id: blocks.12.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_2_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_0
+  - id: blocks.12.hook_resid_post__trainer_2_step_308
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_2_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_308
+  - id: blocks.12.hook_resid_post__trainer_2_step_3088
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_2_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_3088
+  - id: blocks.12.hook_resid_post__trainer_2_step_30881
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_2_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_30881
+  - id: blocks.12.hook_resid_post__trainer_2_step_97
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_2_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_97
+  - id: blocks.12.hook_resid_post__trainer_2_step_976
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_2_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_976
+  - id: blocks.12.hook_resid_post__trainer_2_step_9765
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_2_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_9765
+  - id: blocks.12.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_3_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12/trainer_3
+  - id: blocks.12.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_3_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_0
+  - id: blocks.12.hook_resid_post__trainer_3_step_308
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_3_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_308
+  - id: blocks.12.hook_resid_post__trainer_3_step_3088
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_3_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_3088
+  - id: blocks.12.hook_resid_post__trainer_3_step_30881
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_3_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_30881
+  - id: blocks.12.hook_resid_post__trainer_3_step_97
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_3_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_97
+  - id: blocks.12.hook_resid_post__trainer_3_step_976
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_3_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_976
+  - id: blocks.12.hook_resid_post__trainer_3_step_9765
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_3_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_9765
+  - id: blocks.12.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_4_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12/trainer_4
+  - id: blocks.12.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_4_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_0
+  - id: blocks.12.hook_resid_post__trainer_4_step_308
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_4_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_308
+  - id: blocks.12.hook_resid_post__trainer_4_step_3088
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_4_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_3088
+  - id: blocks.12.hook_resid_post__trainer_4_step_30881
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_4_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_30881
+  - id: blocks.12.hook_resid_post__trainer_4_step_97
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_4_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_97
+  - id: blocks.12.hook_resid_post__trainer_4_step_976
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_4_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_976
+  - id: blocks.12.hook_resid_post__trainer_4_step_9765
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_4_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_9765
+  - id: blocks.12.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_5_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12/trainer_5
+  - id: blocks.12.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_5_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_0
+  - id: blocks.12.hook_resid_post__trainer_5_step_308
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_5_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_308
+  - id: blocks.12.hook_resid_post__trainer_5_step_3088
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_5_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_3088
+  - id: blocks.12.hook_resid_post__trainer_5_step_30881
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_5_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_30881
+  - id: blocks.12.hook_resid_post__trainer_5_step_97
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_5_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_97
+  - id: blocks.12.hook_resid_post__trainer_5_step_976
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_5_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_976
+  - id: blocks.12.hook_resid_post__trainer_5_step_9765
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_5_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_9765
+  - id: blocks.19.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_0_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19/trainer_0
+  - id: blocks.19.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_0_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_0
+  - id: blocks.19.hook_resid_post__trainer_0_step_308
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_0_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_308
+  - id: blocks.19.hook_resid_post__trainer_0_step_3088
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_0_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_3088
+  - id: blocks.19.hook_resid_post__trainer_0_step_30881
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_0_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_30881
+  - id: blocks.19.hook_resid_post__trainer_0_step_97
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_0_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_97
+  - id: blocks.19.hook_resid_post__trainer_0_step_976
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_0_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_976
+  - id: blocks.19.hook_resid_post__trainer_0_step_9765
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_0_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_9765
+  - id: blocks.19.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_1_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19/trainer_1
+  - id: blocks.19.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_1_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_0
+  - id: blocks.19.hook_resid_post__trainer_1_step_308
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_1_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_308
+  - id: blocks.19.hook_resid_post__trainer_1_step_3088
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_1_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_3088
+  - id: blocks.19.hook_resid_post__trainer_1_step_30881
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_1_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_30881
+  - id: blocks.19.hook_resid_post__trainer_1_step_97
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_1_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_97
+  - id: blocks.19.hook_resid_post__trainer_1_step_976
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_1_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_976
+  - id: blocks.19.hook_resid_post__trainer_1_step_9765
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_1_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_9765
+  - id: blocks.19.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_2_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19/trainer_2
+  - id: blocks.19.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_2_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_0
+  - id: blocks.19.hook_resid_post__trainer_2_step_308
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_2_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_308
+  - id: blocks.19.hook_resid_post__trainer_2_step_3088
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_2_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_3088
+  - id: blocks.19.hook_resid_post__trainer_2_step_30881
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_2_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_30881
+  - id: blocks.19.hook_resid_post__trainer_2_step_97
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_2_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_97
+  - id: blocks.19.hook_resid_post__trainer_2_step_976
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_2_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_976
+  - id: blocks.19.hook_resid_post__trainer_2_step_9765
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_2_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_9765
+  - id: blocks.19.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_3_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19/trainer_3
+  - id: blocks.19.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_3_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_0
+  - id: blocks.19.hook_resid_post__trainer_3_step_308
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_3_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_308
+  - id: blocks.19.hook_resid_post__trainer_3_step_3088
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_3_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_3088
+  - id: blocks.19.hook_resid_post__trainer_3_step_30881
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_3_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_30881
+  - id: blocks.19.hook_resid_post__trainer_3_step_97
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_3_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_97
+  - id: blocks.19.hook_resid_post__trainer_3_step_976
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_3_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_976
+  - id: blocks.19.hook_resid_post__trainer_3_step_9765
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_3_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_9765
+  - id: blocks.19.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_4_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19/trainer_4
+  - id: blocks.19.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_4_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_0
+  - id: blocks.19.hook_resid_post__trainer_4_step_308
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_4_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_308
+  - id: blocks.19.hook_resid_post__trainer_4_step_3088
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_4_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_3088
+  - id: blocks.19.hook_resid_post__trainer_4_step_30881
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_4_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_30881
+  - id: blocks.19.hook_resid_post__trainer_4_step_97
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_4_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_97
+  - id: blocks.19.hook_resid_post__trainer_4_step_976
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_4_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_976
+  - id: blocks.19.hook_resid_post__trainer_4_step_9765
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_4_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_9765
+  - id: blocks.19.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_5_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19/trainer_5
+  - id: blocks.19.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_5_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_0
+  - id: blocks.19.hook_resid_post__trainer_5_step_308
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_5_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_308
+  - id: blocks.19.hook_resid_post__trainer_5_step_3088
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_5_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_3088
+  - id: blocks.19.hook_resid_post__trainer_5_step_30881
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_5_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_30881
+  - id: blocks.19.hook_resid_post__trainer_5_step_97
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_5_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_97
+  - id: blocks.19.hook_resid_post__trainer_5_step_976
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_5_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_976
+  - id: blocks.19.hook_resid_post__trainer_5_step_9765
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_5_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_9765
+  - id: blocks.5.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_0_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5/trainer_0
+  - id: blocks.5.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_0_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_0
+  - id: blocks.5.hook_resid_post__trainer_0_step_308
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_0_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_308
+  - id: blocks.5.hook_resid_post__trainer_0_step_3088
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_0_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_3088
+  - id: blocks.5.hook_resid_post__trainer_0_step_30881
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_0_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_30881
+  - id: blocks.5.hook_resid_post__trainer_0_step_97
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_0_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_97
+  - id: blocks.5.hook_resid_post__trainer_0_step_976
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_0_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_976
+  - id: blocks.5.hook_resid_post__trainer_0_step_9765
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_0_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_9765
+  - id: blocks.5.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_1_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5/trainer_1
+  - id: blocks.5.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_1_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_0
+  - id: blocks.5.hook_resid_post__trainer_1_step_308
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_1_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_308
+  - id: blocks.5.hook_resid_post__trainer_1_step_3088
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_1_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_3088
+  - id: blocks.5.hook_resid_post__trainer_1_step_30881
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_1_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_30881
+  - id: blocks.5.hook_resid_post__trainer_1_step_97
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_1_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_97
+  - id: blocks.5.hook_resid_post__trainer_1_step_976
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_1_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_976
+  - id: blocks.5.hook_resid_post__trainer_1_step_9765
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_1_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_9765
+  - id: blocks.5.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_2_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5/trainer_2
+  - id: blocks.5.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_2_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_0
+  - id: blocks.5.hook_resid_post__trainer_2_step_308
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_2_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_308
+  - id: blocks.5.hook_resid_post__trainer_2_step_3088
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_2_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_3088
+  - id: blocks.5.hook_resid_post__trainer_2_step_30881
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_2_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_30881
+  - id: blocks.5.hook_resid_post__trainer_2_step_97
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_2_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_97
+  - id: blocks.5.hook_resid_post__trainer_2_step_976
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_2_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_976
+  - id: blocks.5.hook_resid_post__trainer_2_step_9765
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_2_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_9765
+  - id: blocks.5.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_3_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5/trainer_3
+  - id: blocks.5.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_3_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_0
+  - id: blocks.5.hook_resid_post__trainer_3_step_308
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_3_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_308
+  - id: blocks.5.hook_resid_post__trainer_3_step_3088
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_3_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_3088
+  - id: blocks.5.hook_resid_post__trainer_3_step_30881
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_3_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_30881
+  - id: blocks.5.hook_resid_post__trainer_3_step_97
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_3_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_97
+  - id: blocks.5.hook_resid_post__trainer_3_step_976
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_3_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_976
+  - id: blocks.5.hook_resid_post__trainer_3_step_9765
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_3_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_9765
+  - id: blocks.5.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_4_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5/trainer_4
+  - id: blocks.5.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_4_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_0
+  - id: blocks.5.hook_resid_post__trainer_4_step_308
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_4_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_308
+  - id: blocks.5.hook_resid_post__trainer_4_step_3088
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_4_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_3088
+  - id: blocks.5.hook_resid_post__trainer_4_step_30881
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_4_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_30881
+  - id: blocks.5.hook_resid_post__trainer_4_step_97
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_4_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_97
+  - id: blocks.5.hook_resid_post__trainer_4_step_976
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_4_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_976
+  - id: blocks.5.hook_resid_post__trainer_4_step_9765
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_4_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_9765
+  - id: blocks.5.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_5_step_final
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5/trainer_5
+  - id: blocks.5.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_5_step_0
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_0
+  - id: blocks.5.hook_resid_post__trainer_5_step_308
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_5_step_308
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_308
+  - id: blocks.5.hook_resid_post__trainer_5_step_3088
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_5_step_3088
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_3088
+  - id: blocks.5.hook_resid_post__trainer_5_step_30881
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_5_step_30881
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_30881
+  - id: blocks.5.hook_resid_post__trainer_5_step_97
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_5_step_97
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_97
+  - id: blocks.5.hook_resid_post__trainer_5_step_976
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_5_step_976
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_976
+  - id: blocks.5.hook_resid_post__trainer_5_step_9765
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_5_step_9765
+    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_9765
+sae_bench_gemma-2-2b_vanilla_width-2pow14_date-1109:
+  conversion_func: dictionary_learning_1
+  links:
+    model: https://huggingface.co/google/gemma-2-2b
+  model: gemma-2-2b
+  repo_id: canrager/saebench_gemma-2-2b_width-2pow14_date-1109
+  saes:
+  - id: blocks.12.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_0_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12/trainer_0
+  - id: blocks.12.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_0_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_0
+  - id: blocks.12.hook_resid_post__trainer_0_step_146
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_0_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_146
+  - id: blocks.12.hook_resid_post__trainer_0_step_1464
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_0_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_1464
+  - id: blocks.12.hook_resid_post__trainer_0_step_14648
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_0_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_14648
+  - id: blocks.12.hook_resid_post__trainer_0_step_463
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_0_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_463
+  - id: blocks.12.hook_resid_post__trainer_0_step_4632
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_0_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_4632
+  - id: blocks.12.hook_resid_post__trainer_0_step_46322
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_0_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_46322
+  - id: blocks.12.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_1_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12/trainer_1
+  - id: blocks.12.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_1_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_0
+  - id: blocks.12.hook_resid_post__trainer_1_step_146
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_1_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_146
+  - id: blocks.12.hook_resid_post__trainer_1_step_1464
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_1_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_1464
+  - id: blocks.12.hook_resid_post__trainer_1_step_14648
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_1_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_14648
+  - id: blocks.12.hook_resid_post__trainer_1_step_463
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_1_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_463
+  - id: blocks.12.hook_resid_post__trainer_1_step_4632
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_1_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_4632
+  - id: blocks.12.hook_resid_post__trainer_1_step_46322
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_1_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_46322
+  - id: blocks.12.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_2_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12/trainer_2
+  - id: blocks.12.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_2_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_0
+  - id: blocks.12.hook_resid_post__trainer_2_step_146
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_2_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_146
+  - id: blocks.12.hook_resid_post__trainer_2_step_1464
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_2_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_1464
+  - id: blocks.12.hook_resid_post__trainer_2_step_14648
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_2_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_14648
+  - id: blocks.12.hook_resid_post__trainer_2_step_463
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_2_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_463
+  - id: blocks.12.hook_resid_post__trainer_2_step_4632
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_2_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_4632
+  - id: blocks.12.hook_resid_post__trainer_2_step_46322
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_2_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_46322
+  - id: blocks.12.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_3_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12/trainer_3
+  - id: blocks.12.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_3_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_0
+  - id: blocks.12.hook_resid_post__trainer_3_step_146
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_3_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_146
+  - id: blocks.12.hook_resid_post__trainer_3_step_1464
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_3_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_1464
+  - id: blocks.12.hook_resid_post__trainer_3_step_14648
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_3_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_14648
+  - id: blocks.12.hook_resid_post__trainer_3_step_463
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_3_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_463
+  - id: blocks.12.hook_resid_post__trainer_3_step_4632
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_3_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_4632
+  - id: blocks.12.hook_resid_post__trainer_3_step_46322
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_3_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_46322
+  - id: blocks.12.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_4_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12/trainer_4
+  - id: blocks.12.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_4_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_0
+  - id: blocks.12.hook_resid_post__trainer_4_step_146
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_4_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_146
+  - id: blocks.12.hook_resid_post__trainer_4_step_1464
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_4_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_1464
+  - id: blocks.12.hook_resid_post__trainer_4_step_14648
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_4_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_14648
+  - id: blocks.12.hook_resid_post__trainer_4_step_463
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_4_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_463
+  - id: blocks.12.hook_resid_post__trainer_4_step_4632
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_4_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_4632
+  - id: blocks.12.hook_resid_post__trainer_4_step_46322
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_4_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_46322
+  - id: blocks.12.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_5_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12/trainer_5
+  - id: blocks.12.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_5_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_0
+  - id: blocks.12.hook_resid_post__trainer_5_step_146
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_5_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_146
+  - id: blocks.12.hook_resid_post__trainer_5_step_1464
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_5_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_1464
+  - id: blocks.12.hook_resid_post__trainer_5_step_14648
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_5_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_14648
+  - id: blocks.12.hook_resid_post__trainer_5_step_463
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_5_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_463
+  - id: blocks.12.hook_resid_post__trainer_5_step_4632
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_5_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_4632
+  - id: blocks.12.hook_resid_post__trainer_5_step_46322
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_5_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_46322
+  - id: blocks.19.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_0_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19/trainer_0
+  - id: blocks.19.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_0_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_0
+  - id: blocks.19.hook_resid_post__trainer_0_step_146
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_0_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_146
+  - id: blocks.19.hook_resid_post__trainer_0_step_1464
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_0_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_1464
+  - id: blocks.19.hook_resid_post__trainer_0_step_14648
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_0_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_14648
+  - id: blocks.19.hook_resid_post__trainer_0_step_463
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_0_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_463
+  - id: blocks.19.hook_resid_post__trainer_0_step_4632
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_0_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_4632
+  - id: blocks.19.hook_resid_post__trainer_0_step_46322
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_0_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_46322
+  - id: blocks.19.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_1_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19/trainer_1
+  - id: blocks.19.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_1_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_0
+  - id: blocks.19.hook_resid_post__trainer_1_step_146
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_1_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_146
+  - id: blocks.19.hook_resid_post__trainer_1_step_1464
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_1_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_1464
+  - id: blocks.19.hook_resid_post__trainer_1_step_14648
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_1_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_14648
+  - id: blocks.19.hook_resid_post__trainer_1_step_463
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_1_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_463
+  - id: blocks.19.hook_resid_post__trainer_1_step_4632
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_1_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_4632
+  - id: blocks.19.hook_resid_post__trainer_1_step_46322
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_1_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_46322
+  - id: blocks.19.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_2_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19/trainer_2
+  - id: blocks.19.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_2_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_0
+  - id: blocks.19.hook_resid_post__trainer_2_step_146
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_2_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_146
+  - id: blocks.19.hook_resid_post__trainer_2_step_1464
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_2_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_1464
+  - id: blocks.19.hook_resid_post__trainer_2_step_14648
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_2_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_14648
+  - id: blocks.19.hook_resid_post__trainer_2_step_463
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_2_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_463
+  - id: blocks.19.hook_resid_post__trainer_2_step_4632
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_2_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_4632
+  - id: blocks.19.hook_resid_post__trainer_2_step_46322
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_2_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_46322
+  - id: blocks.19.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_3_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19/trainer_3
+  - id: blocks.19.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_3_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_0
+  - id: blocks.19.hook_resid_post__trainer_3_step_146
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_3_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_146
+  - id: blocks.19.hook_resid_post__trainer_3_step_1464
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_3_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_1464
+  - id: blocks.19.hook_resid_post__trainer_3_step_14648
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_3_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_14648
+  - id: blocks.19.hook_resid_post__trainer_3_step_463
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_3_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_463
+  - id: blocks.19.hook_resid_post__trainer_3_step_4632
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_3_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_4632
+  - id: blocks.19.hook_resid_post__trainer_3_step_46322
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_3_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_46322
+  - id: blocks.19.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_4_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19/trainer_4
+  - id: blocks.19.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_4_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_0
+  - id: blocks.19.hook_resid_post__trainer_4_step_146
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_4_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_146
+  - id: blocks.19.hook_resid_post__trainer_4_step_1464
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_4_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_1464
+  - id: blocks.19.hook_resid_post__trainer_4_step_14648
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_4_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_14648
+  - id: blocks.19.hook_resid_post__trainer_4_step_463
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_4_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_463
+  - id: blocks.19.hook_resid_post__trainer_4_step_4632
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_4_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_4632
+  - id: blocks.19.hook_resid_post__trainer_4_step_46322
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_4_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_46322
+  - id: blocks.19.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_5_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19/trainer_5
+  - id: blocks.19.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_5_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_0
+  - id: blocks.19.hook_resid_post__trainer_5_step_146
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_5_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_146
+  - id: blocks.19.hook_resid_post__trainer_5_step_1464
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_5_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_1464
+  - id: blocks.19.hook_resid_post__trainer_5_step_14648
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_5_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_14648
+  - id: blocks.19.hook_resid_post__trainer_5_step_463
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_5_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_463
+  - id: blocks.19.hook_resid_post__trainer_5_step_4632
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_5_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_4632
+  - id: blocks.19.hook_resid_post__trainer_5_step_46322
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_5_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_46322
+  - id: blocks.5.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_0_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5/trainer_0
+  - id: blocks.5.hook_resid_post__trainer_0_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_0_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_0
+  - id: blocks.5.hook_resid_post__trainer_0_step_146
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_0_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_146
+  - id: blocks.5.hook_resid_post__trainer_0_step_1464
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_0_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_1464
+  - id: blocks.5.hook_resid_post__trainer_0_step_14648
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_0_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_14648
+  - id: blocks.5.hook_resid_post__trainer_0_step_463
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_0_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_463
+  - id: blocks.5.hook_resid_post__trainer_0_step_4632
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_0_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_4632
+  - id: blocks.5.hook_resid_post__trainer_0_step_46322
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_0_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_46322
+  - id: blocks.5.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_1_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5/trainer_1
+  - id: blocks.5.hook_resid_post__trainer_1_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_1_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_0
+  - id: blocks.5.hook_resid_post__trainer_1_step_146
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_1_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_146
+  - id: blocks.5.hook_resid_post__trainer_1_step_1464
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_1_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_1464
+  - id: blocks.5.hook_resid_post__trainer_1_step_14648
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_1_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_14648
+  - id: blocks.5.hook_resid_post__trainer_1_step_463
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_1_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_463
+  - id: blocks.5.hook_resid_post__trainer_1_step_4632
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_1_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_4632
+  - id: blocks.5.hook_resid_post__trainer_1_step_46322
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_1_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_46322
+  - id: blocks.5.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_2_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5/trainer_2
+  - id: blocks.5.hook_resid_post__trainer_2_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_2_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_0
+  - id: blocks.5.hook_resid_post__trainer_2_step_146
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_2_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_146
+  - id: blocks.5.hook_resid_post__trainer_2_step_1464
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_2_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_1464
+  - id: blocks.5.hook_resid_post__trainer_2_step_14648
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_2_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_14648
+  - id: blocks.5.hook_resid_post__trainer_2_step_463
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_2_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_463
+  - id: blocks.5.hook_resid_post__trainer_2_step_4632
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_2_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_4632
+  - id: blocks.5.hook_resid_post__trainer_2_step_46322
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_2_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_46322
+  - id: blocks.5.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_3_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5/trainer_3
+  - id: blocks.5.hook_resid_post__trainer_3_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_3_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_0
+  - id: blocks.5.hook_resid_post__trainer_3_step_146
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_3_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_146
+  - id: blocks.5.hook_resid_post__trainer_3_step_1464
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_3_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_1464
+  - id: blocks.5.hook_resid_post__trainer_3_step_14648
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_3_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_14648
+  - id: blocks.5.hook_resid_post__trainer_3_step_463
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_3_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_463
+  - id: blocks.5.hook_resid_post__trainer_3_step_4632
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_3_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_4632
+  - id: blocks.5.hook_resid_post__trainer_3_step_46322
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_3_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_46322
+  - id: blocks.5.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_4_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5/trainer_4
+  - id: blocks.5.hook_resid_post__trainer_4_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_4_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_0
+  - id: blocks.5.hook_resid_post__trainer_4_step_146
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_4_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_146
+  - id: blocks.5.hook_resid_post__trainer_4_step_1464
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_4_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_1464
+  - id: blocks.5.hook_resid_post__trainer_4_step_14648
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_4_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_14648
+  - id: blocks.5.hook_resid_post__trainer_4_step_463
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_4_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_463
+  - id: blocks.5.hook_resid_post__trainer_4_step_4632
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_4_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_4632
+  - id: blocks.5.hook_resid_post__trainer_4_step_46322
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_4_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_46322
+  - id: blocks.5.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_5_step_final
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5/trainer_5
+  - id: blocks.5.hook_resid_post__trainer_5_step_0
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_5_step_0
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_0
+  - id: blocks.5.hook_resid_post__trainer_5_step_146
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_5_step_146
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_146
+  - id: blocks.5.hook_resid_post__trainer_5_step_1464
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_5_step_1464
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_1464
+  - id: blocks.5.hook_resid_post__trainer_5_step_14648
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_5_step_14648
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_14648
+  - id: blocks.5.hook_resid_post__trainer_5_step_463
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_5_step_463
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_463
+  - id: blocks.5.hook_resid_post__trainer_5_step_4632
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_5_step_4632
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_4632
+  - id: blocks.5.hook_resid_post__trainer_5_step_46322
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_5_step_46322
+    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_46322
+sae_bench_gemma-2-2b_vanilla_width-2pow16_date-1109:
+  conversion_func: dictionary_learning_1
+  links:
+    model: https://huggingface.co/google/gemma-2-2b
+  model: gemma-2-2b
+  repo_id: canrager/saebench_gemma-2-2b_width-2pow16_date-1109
+  saes:
+  - id: blocks.12.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-65k__trainer_0_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_12/trainer_0
+  - id: blocks.12.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-65k__trainer_1_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_12/trainer_1
+  - id: blocks.12.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-65k__trainer_2_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_12/trainer_2
+  - id: blocks.12.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-65k__trainer_3_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_12/trainer_3
+  - id: blocks.12.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-65k__trainer_4_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_12/trainer_4
+  - id: blocks.12.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-65k__trainer_5_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_12/trainer_5
+  - id: blocks.19.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-65k__trainer_0_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_19/trainer_0
+  - id: blocks.19.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-65k__trainer_1_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_19/trainer_1
+  - id: blocks.19.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-65k__trainer_2_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_19/trainer_2
+  - id: blocks.19.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-65k__trainer_3_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_19/trainer_3
+  - id: blocks.19.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-65k__trainer_4_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_19/trainer_4
+  - id: blocks.19.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-65k__trainer_5_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_19/trainer_5
+  - id: blocks.5.hook_resid_post__trainer_0
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-65k__trainer_0_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_5/trainer_0
+  - id: blocks.5.hook_resid_post__trainer_1
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-65k__trainer_1_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_5/trainer_1
+  - id: blocks.5.hook_resid_post__trainer_2
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-65k__trainer_2_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_5/trainer_2
+  - id: blocks.5.hook_resid_post__trainer_3
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-65k__trainer_3_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_5/trainer_3
+  - id: blocks.5.hook_resid_post__trainer_4
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-65k__trainer_4_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_5/trainer_4
+  - id: blocks.5.hook_resid_post__trainer_5
+    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-65k__trainer_5_step_final
+    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_5/trainer_5
 sae_bench_pythia70m_sweep_gated_ctx128_0730:
   conversion_func: dictionary_learning_1
   links:
@@ -10313,2889 +13300,3 @@ sae_bench_pythia70m_sweep_topk_ctx128_0730:
   - id: blocks.4.hook_resid_post__trainer_8
     neuronpedia: pythia-70m-deduped/4-sae_bench-topk-res-4k__trainer_8_step_final
     path: pythia70m_sweep_topk_ctx128_0730/resid_post_layer_4/trainer_8
-llama-3-8b-it-res-jh:
-  repo_id: Juliushanhanhan/llama-3-8b-it-res
-  model: meta-llama/Meta-Llama-3-8B-Instruct
-  conversion_func: null
-  links:
-    dashboards: https://www.neuronpedia.org/llama3-8b-it-res-jh
-  saes:
-  - id: blocks.25.hook_resid_post
-    path: blocks.25.hook_resid_post
-    neuronpedia: llama3-8b-it/25-res-jh
-llama_scope_lxa_32x:
-  conversion_func: llama_scope
-  model: meta-llama/Llama-3.1-8B
-  repo_id: fnlp/Llama3_1-8B-Base-LXA-32x
-  saes:
-  - id: l0a_32x
-    l0: 50.0
-    norm_scaling_factor: 112.21917808219177
-    path: Llama3_1-8B-Base-L0A-32x
-    neuronpedia: llama3.1-8b/0-llamascope-att-131k
-  - id: l1a_32x
-    l0: 50.0
-    norm_scaling_factor: 94.70520231213872
-    path: Llama3_1-8B-Base-L1A-32x
-    neuronpedia: llama3.1-8b/1-llamascope-att-131k
-  - id: l2a_32x
-    l0: 50.0
-    norm_scaling_factor: 73.14285714285714
-    path: Llama3_1-8B-Base-L2A-32x
-    neuronpedia: llama3.1-8b/2-llamascope-att-131k
-  - id: l3a_32x
-    l0: 50.0
-    norm_scaling_factor: 55.72789115646258
-    path: Llama3_1-8B-Base-L3A-32x
-    neuronpedia: llama3.1-8b/3-llamascope-att-131k
-  - id: l4a_32x
-    l0: 50.0
-    norm_scaling_factor: 45.76536312849162
-    path: Llama3_1-8B-Base-L4A-32x
-    neuronpedia: llama3.1-8b/4-llamascope-att-131k
-  - id: l5a_32x
-    l0: 50.0
-    norm_scaling_factor: 39.9609756097561
-    path: Llama3_1-8B-Base-L5A-32x
-    neuronpedia: llama3.1-8b/5-llamascope-att-131k
-  - id: l6a_32x
-    l0: 50.0
-    norm_scaling_factor: 33.436734693877554
-    path: Llama3_1-8B-Base-L6A-32x
-    neuronpedia: llama3.1-8b/6-llamascope-att-131k
-  - id: l7a_32x
-    l0: 50.0
-    norm_scaling_factor: 27.30666666666667
-    path: Llama3_1-8B-Base-L7A-32x
-    neuronpedia: llama3.1-8b/7-llamascope-att-131k
-  - id: l8a_32x
-    l0: 50.0
-    norm_scaling_factor: 27.675675675675677
-    path: Llama3_1-8B-Base-L8A-32x
-    neuronpedia: llama3.1-8b/8-llamascope-att-131k
-  - id: l9a_32x
-    l0: 50.0
-    norm_scaling_factor: 25.440993788819874
-    path: Llama3_1-8B-Base-L9A-32x
-    neuronpedia: llama3.1-8b/9-llamascope-att-131k
-  - id: l10a_32x
-    l0: 50.0
-    norm_scaling_factor: 26.5974025974026
-    path: Llama3_1-8B-Base-L10A-32x
-    neuronpedia: llama3.1-8b/10-llamascope-att-131k
-  - id: l11a_32x
-    l0: 50.0
-    norm_scaling_factor: 25.761006289308177
-    path: Llama3_1-8B-Base-L11A-32x
-    neuronpedia: llama3.1-8b/11-llamascope-att-131k
-  - id: l12a_32x
-    l0: 50.0
-    norm_scaling_factor: 22.14054054054054
-    path: Llama3_1-8B-Base-L12A-32x
-    neuronpedia: llama3.1-8b/12-llamascope-att-131k
-  - id: l13a_32x
-    l0: 50.0
-    norm_scaling_factor: 20.582914572864322
-    path: Llama3_1-8B-Base-L13A-32x
-    neuronpedia: llama3.1-8b/13-llamascope-att-131k
-  - id: l14a_32x
-    l0: 50.0
-    norm_scaling_factor: 20.177339901477833
-    path: Llama3_1-8B-Base-L14A-32x
-    neuronpedia: llama3.1-8b/14-llamascope-att-131k
-  - id: l15a_32x
-    l0: 50.0
-    norm_scaling_factor: 20.582914572864322
-    path: Llama3_1-8B-Base-L15A-32x
-    neuronpedia: llama3.1-8b/15-llamascope-att-131k
-  - id: l16a_32x
-    l0: 50.0
-    norm_scaling_factor: 19.32075471698113
-    path: Llama3_1-8B-Base-L16A-32x
-    neuronpedia: llama3.1-8b/16-llamascope-att-131k
-  - id: l17a_32x
-    l0: 50.0
-    norm_scaling_factor: 21.005128205128205
-    path: Llama3_1-8B-Base-L17A-32x
-    neuronpedia: llama3.1-8b/17-llamascope-att-131k
-  - id: l18a_32x
-    l0: 50.0
-    norm_scaling_factor: 24.674698795180724
-    path: Llama3_1-8B-Base-L18A-32x
-    neuronpedia: llama3.1-8b/18-llamascope-att-131k
-  - id: l19a_32x
-    l0: 50.0
-    norm_scaling_factor: 28.248275862068965
-    path: Llama3_1-8B-Base-L19A-32x
-    neuronpedia: llama3.1-8b/19-llamascope-att-131k
-  - id: l20a_32x
-    l0: 50.0
-    norm_scaling_factor: 27.30666666666667
-    path: Llama3_1-8B-Base-L20A-32x
-    neuronpedia: llama3.1-8b/20-llamascope-att-131k
-  - id: l21a_32x
-    l0: 50.0
-    norm_scaling_factor: 19.14018691588785
-    path: Llama3_1-8B-Base-L21A-32x
-    neuronpedia: llama3.1-8b/21-llamascope-att-131k
-  - id: l22a_32x
-    l0: 50.0
-    norm_scaling_factor: 24.38095238095238
-    path: Llama3_1-8B-Base-L22A-32x
-    neuronpedia: llama3.1-8b/22-llamascope-att-131k
-  - id: l23a_32x
-    l0: 50.0
-    norm_scaling_factor: 22.14054054054054
-    path: Llama3_1-8B-Base-L23A-32x
-    neuronpedia: llama3.1-8b/23-llamascope-att-131k
-  - id: l24a_32x
-    l0: 50.0
-    norm_scaling_factor: 21.67195767195767
-    path: Llama3_1-8B-Base-L24A-32x
-    neuronpedia: llama3.1-8b/24-llamascope-att-131k
-  - id: l25a_32x
-    l0: 50.0
-    norm_scaling_factor: 18.367713004484305
-    path: Llama3_1-8B-Base-L25A-32x
-    neuronpedia: llama3.1-8b/25-llamascope-att-131k
-  - id: l26a_32x
-    l0: 50.0
-    norm_scaling_factor: 13.837837837837839
-    path: Llama3_1-8B-Base-L26A-32x
-    neuronpedia: llama3.1-8b/26-llamascope-att-131k
-  - id: l27a_32x
-    l0: 50.0
-    norm_scaling_factor: 13.931972789115646
-    path: Llama3_1-8B-Base-L27A-32x
-    neuronpedia: llama3.1-8b/27-llamascope-att-131k
-  - id: l28a_32x
-    l0: 50.0
-    norm_scaling_factor: 10.95187165775401
-    path: Llama3_1-8B-Base-L28A-32x
-    neuronpedia: llama3.1-8b/28-llamascope-att-131k
-  - id: l29a_32x
-    l0: 50.0
-    norm_scaling_factor: 8.569037656903765
-    path: Llama3_1-8B-Base-L29A-32x
-    neuronpedia: llama3.1-8b/29-llamascope-att-131k
-  - id: l30a_32x
-    l0: 50.0
-    norm_scaling_factor: 5.953488372093023
-    path: Llama3_1-8B-Base-L30A-32x
-    neuronpedia: llama3.1-8b/30-llamascope-att-131k
-  - id: l31a_32x
-    l0: 50.0
-    norm_scaling_factor: 3.5310344827586206
-    path: Llama3_1-8B-Base-L31A-32x
-    neuronpedia: llama3.1-8b/31-llamascope-att-131k
-llama_scope_lxa_8x:
-  conversion_func: llama_scope
-  model: meta-llama/Llama-3.1-8B
-  repo_id: fnlp/Llama3_1-8B-Base-LXA-8x
-  saes:
-  - id: l0a_8x
-    l0: 50.0
-    norm_scaling_factor: 112.21917808219177
-    path: Llama3_1-8B-Base-L0A-8x
-    neuronpedia: llama3.1-8b/0-llamascope-att-32k
-  - id: l1a_8x
-    l0: 50.0
-    norm_scaling_factor: 94.70520231213872
-    path: Llama3_1-8B-Base-L1A-8x
-    neuronpedia: llama3.1-8b/1-llamascope-att-32k
-  - id: l2a_8x
-    l0: 50.0
-    norm_scaling_factor: 72.81777777777778
-    path: Llama3_1-8B-Base-L2A-8x
-    neuronpedia: llama3.1-8b/2-llamascope-att-32k
-  - id: l3a_8x
-    l0: 50.0
-    norm_scaling_factor: 55.72789115646258
-    path: Llama3_1-8B-Base-L3A-8x
-    neuronpedia: llama3.1-8b/3-llamascope-att-32k
-  - id: l4a_8x
-    l0: 50.0
-    norm_scaling_factor: 45.76536312849162
-    path: Llama3_1-8B-Base-L4A-8x
-    neuronpedia: llama3.1-8b/4-llamascope-att-32k
-  - id: l5a_8x
-    l0: 50.0
-    norm_scaling_factor: 39.9609756097561
-    path: Llama3_1-8B-Base-L5A-8x
-    neuronpedia: llama3.1-8b/5-llamascope-att-32k
-  - id: l6a_8x
-    l0: 50.0
-    norm_scaling_factor: 33.436734693877554
-    path: Llama3_1-8B-Base-L6A-8x
-    neuronpedia: llama3.1-8b/6-llamascope-att-32k
-  - id: l7a_8x
-    l0: 50.0
-    norm_scaling_factor: 27.30666666666667
-    path: Llama3_1-8B-Base-L7A-8x
-    neuronpedia: llama3.1-8b/7-llamascope-att-32k
-  - id: l8a_8x
-    l0: 50.0
-    norm_scaling_factor: 27.675675675675677
-    path: Llama3_1-8B-Base-L8A-8x
-    neuronpedia: llama3.1-8b/8-llamascope-att-32k
-  - id: l9a_8x
-    l0: 50.0
-    norm_scaling_factor: 25.28395061728395
-    path: Llama3_1-8B-Base-L9A-8x
-    neuronpedia: llama3.1-8b/9-llamascope-att-32k
-  - id: l10a_8x
-    l0: 50.0
-    norm_scaling_factor: 26.5974025974026
-    path: Llama3_1-8B-Base-L10A-8x
-    neuronpedia: llama3.1-8b/10-llamascope-att-32k
-  - id: l11a_8x
-    l0: 50.0
-    norm_scaling_factor: 25.761006289308177
-    path: Llama3_1-8B-Base-L11A-8x
-    neuronpedia: llama3.1-8b/11-llamascope-att-32k
-  - id: l12a_8x
-    l0: 50.0
-    norm_scaling_factor: 22.14054054054054
-    path: Llama3_1-8B-Base-L12A-8x
-    neuronpedia: llama3.1-8b/12-llamascope-att-32k
-  - id: l13a_8x
-    l0: 50.0
-    norm_scaling_factor: 20.48
-    path: Llama3_1-8B-Base-L13A-8x
-    neuronpedia: llama3.1-8b/13-llamascope-att-32k
-  - id: l14a_8x
-    l0: 50.0
-    norm_scaling_factor: 20.177339901477833
-    path: Llama3_1-8B-Base-L14A-8x
-    neuronpedia: llama3.1-8b/14-llamascope-att-32k
-  - id: l15a_8x
-    l0: 50.0
-    norm_scaling_factor: 20.582914572864322
-    path: Llama3_1-8B-Base-L15A-8x
-    neuronpedia: llama3.1-8b/15-llamascope-att-32k
-  - id: l16a_8x
-    l0: 50.0
-    norm_scaling_factor: 19.32075471698113
-    path: Llama3_1-8B-Base-L16A-8x
-    neuronpedia: llama3.1-8b/16-llamascope-att-32k
-  - id: l17a_8x
-    l0: 50.0
-    norm_scaling_factor: 20.897959183673468
-    path: Llama3_1-8B-Base-L17A-8x
-    neuronpedia: llama3.1-8b/17-llamascope-att-32k
-  - id: l18a_8x
-    l0: 50.0
-    norm_scaling_factor: 24.674698795180724
-    path: Llama3_1-8B-Base-L18A-8x
-    neuronpedia: llama3.1-8b/18-llamascope-att-32k
-  - id: l19a_8x
-    l0: 50.0
-    norm_scaling_factor: 28.248275862068965
-    path: Llama3_1-8B-Base-L19A-8x
-    neuronpedia: llama3.1-8b/19-llamascope-att-32k
-  - id: l20a_8x
-    l0: 50.0
-    norm_scaling_factor: 27.125827814569536
-    path: Llama3_1-8B-Base-L20A-8x
-    neuronpedia: llama3.1-8b/20-llamascope-att-32k
-  - id: l21a_8x
-    l0: 50.0
-    norm_scaling_factor: 19.14018691588785
-    path: Llama3_1-8B-Base-L21A-8x
-    neuronpedia: llama3.1-8b/21-llamascope-att-32k
-  - id: l22a_8x
-    l0: 50.0
-    norm_scaling_factor: 24.38095238095238
-    path: Llama3_1-8B-Base-L22A-8x
-    neuronpedia: llama3.1-8b/22-llamascope-att-32k
-  - id: l23a_8x
-    l0: 50.0
-    norm_scaling_factor: 22.14054054054054
-    path: Llama3_1-8B-Base-L23A-8x
-    neuronpedia: llama3.1-8b/23-llamascope-att-32k
-  - id: l24a_8x
-    l0: 50.0
-    norm_scaling_factor: 21.557894736842105
-    path: Llama3_1-8B-Base-L24A-8x
-    neuronpedia: llama3.1-8b/24-llamascope-att-32k
-  - id: l25a_8x
-    l0: 50.0
-    norm_scaling_factor: 18.533936651583712
-    path: Llama3_1-8B-Base-L25A-8x
-    neuronpedia: llama3.1-8b/25-llamascope-att-32k
-  - id: l26a_8x
-    l0: 50.0
-    norm_scaling_factor: 13.837837837837839
-    path: Llama3_1-8B-Base-L26A-8x
-    neuronpedia: llama3.1-8b/26-llamascope-att-32k
-  - id: l27a_8x
-    l0: 50.0
-    norm_scaling_factor: 13.931972789115646
-    path: Llama3_1-8B-Base-L27A-8x
-    neuronpedia: llama3.1-8b/27-llamascope-att-32k
-  - id: l28a_8x
-    l0: 50.0
-    norm_scaling_factor: 10.95187165775401
-    path: Llama3_1-8B-Base-L28A-8x
-    neuronpedia: llama3.1-8b/28-llamascope-att-32k
-  - id: l29a_8x
-    l0: 50.0
-    norm_scaling_factor: 8.569037656903765
-    path: Llama3_1-8B-Base-L29A-8x
-    neuronpedia: llama3.1-8b/29-llamascope-att-32k
-  - id: l30a_8x
-    l0: 50.0
-    norm_scaling_factor: 5.953488372093023
-    path: Llama3_1-8B-Base-L30A-8x
-    neuronpedia: llama3.1-8b/30-llamascope-att-32k
-  - id: l31a_8x
-    l0: 50.0
-    norm_scaling_factor: 3.5555555555555554
-    path: Llama3_1-8B-Base-L31A-8x
-    neuronpedia: llama3.1-8b/31-llamascope-att-32k
-llama_scope_lxm_32x:
-  conversion_func: llama_scope
-  model: meta-llama/Llama-3.1-8B
-  repo_id: fnlp/Llama3_1-8B-Base-LXM-32x
-  saes:
-  - id: l0m_32x
-    l0: 50.0
-    norm_scaling_factor: 80.31372549019608
-    path: Llama3_1-8B-Base-L0M-32x
-    neuronpedia: llama3.1-8b/0-llamascope-mlp-131k
-  - id: l1m_32x
-    l0: 50.0
-    norm_scaling_factor: 71.85964912280701
-    path: Llama3_1-8B-Base-L1M-32x
-    neuronpedia: llama3.1-8b/1-llamascope-mlp-131k
-  - id: l2m_32x
-    l0: 50.0
-    norm_scaling_factor: 47.90643274853801
-    path: Llama3_1-8B-Base-L2M-32x
-    neuronpedia: llama3.1-8b/2-llamascope-mlp-131k
-  - id: l3m_32x
-    l0: 50.0
-    norm_scaling_factor: 35.46320346320346
-    path: Llama3_1-8B-Base-L3M-32x
-    neuronpedia: llama3.1-8b/3-llamascope-mlp-131k
-  - id: l4m_32x
-    l0: 50.0
-    norm_scaling_factor: 27.86394557823129
-    path: Llama3_1-8B-Base-L4M-32x
-    neuronpedia: llama3.1-8b/4-llamascope-mlp-131k
-  - id: l5m_32x
-    l0: 50.0
-    norm_scaling_factor: 23.01123595505618
-    path: Llama3_1-8B-Base-L5M-32x
-    neuronpedia: llama3.1-8b/5-llamascope-mlp-131k
-  - id: l6m_32x
-    l0: 50.0
-    norm_scaling_factor: 20.48
-    path: Llama3_1-8B-Base-L6M-32x
-    neuronpedia: llama3.1-8b/6-llamascope-mlp-131k
-  - id: l7m_32x
-    l0: 50.0
-    norm_scaling_factor: 19.692307692307693
-    path: Llama3_1-8B-Base-L7M-32x
-    neuronpedia: llama3.1-8b/7-llamascope-mlp-131k
-  - id: l8m_32x
-    l0: 50.0
-    norm_scaling_factor: 18.87557603686636
-    path: Llama3_1-8B-Base-L8M-32x
-    neuronpedia: llama3.1-8b/8-llamascope-mlp-131k
-  - id: l9m_32x
-    l0: 50.0
-    norm_scaling_factor: 17.88646288209607
-    path: Llama3_1-8B-Base-L9M-32x
-    neuronpedia: llama3.1-8b/9-llamascope-mlp-131k
-  - id: l10m_32x
-    l0: 50.0
-    norm_scaling_factor: 17.5793991416309
-    path: Llama3_1-8B-Base-L10M-32x
-    neuronpedia: llama3.1-8b/10-llamascope-mlp-131k
-  - id: l11m_32x
-    l0: 50.0
-    norm_scaling_factor: 16.855967078189302
-    path: Llama3_1-8B-Base-L11M-32x
-    neuronpedia: llama3.1-8b/11-llamascope-mlp-131k
-  - id: l12m_32x
-    l0: 50.0
-    norm_scaling_factor: 16.125984251968504
-    path: Llama3_1-8B-Base-L12M-32x
-    neuronpedia: llama3.1-8b/12-llamascope-mlp-131k
-  - id: l13m_32x
-    l0: 50.0
-    norm_scaling_factor: 14.840579710144928
-    path: Llama3_1-8B-Base-L13M-32x
-    neuronpedia: llama3.1-8b/13-llamascope-mlp-131k
-  - id: l14m_32x
-    l0: 50.0
-    norm_scaling_factor: 13.74496644295302
-    path: Llama3_1-8B-Base-L14M-32x
-    neuronpedia: llama3.1-8b/14-llamascope-mlp-131k
-  - id: l15m_32x
-    l0: 50.0
-    norm_scaling_factor: 12.118343195266272
-    path: Llama3_1-8B-Base-L15M-32x
-    neuronpedia: llama3.1-8b/15-llamascope-mlp-131k
-  - id: l16m_32x
-    l0: 50.0
-    norm_scaling_factor: 11.702857142857143
-    path: Llama3_1-8B-Base-L16M-32x
-    neuronpedia: llama3.1-8b/16-llamascope-mlp-131k
-  - id: l17m_32x
-    l0: 50.0
-    norm_scaling_factor: 10.666666666666666
-    path: Llama3_1-8B-Base-L17M-32x
-    neuronpedia: llama3.1-8b/17-llamascope-mlp-131k
-  - id: l18m_32x
-    l0: 50.0
-    norm_scaling_factor: 10.778947368421052
-    path: Llama3_1-8B-Base-L18M-32x
-    neuronpedia: llama3.1-8b/18-llamascope-mlp-131k
-  - id: l19m_32x
-    l0: 50.0
-    norm_scaling_factor: 10.502564102564103
-    path: Llama3_1-8B-Base-L19M-32x
-    neuronpedia: llama3.1-8b/19-llamascope-mlp-131k
-  - id: l20m_32x
-    l0: 50.0
-    norm_scaling_factor: 10.088669950738916
-    path: Llama3_1-8B-Base-L20M-32x
-    neuronpedia: llama3.1-8b/20-llamascope-mlp-131k
-  - id: l21m_32x
-    l0: 50.0
-    norm_scaling_factor: 9.102222222222222
-    path: Llama3_1-8B-Base-L21M-32x
-    neuronpedia: llama3.1-8b/21-llamascope-mlp-131k
-  - id: l22m_32x
-    l0: 50.0
-    norm_scaling_factor: 8.865800865800866
-    path: Llama3_1-8B-Base-L22M-32x
-    neuronpedia: llama3.1-8b/22-llamascope-mlp-131k
-  - id: l23m_32x
-    l0: 50.0
-    norm_scaling_factor: 8.677966101694915
-    path: Llama3_1-8B-Base-L23M-32x
-    neuronpedia: llama3.1-8b/23-llamascope-mlp-131k
-  - id: l24m_32x
-    l0: 50.0
-    norm_scaling_factor: 8.39344262295082
-    path: Llama3_1-8B-Base-L24M-32x
-    neuronpedia: llama3.1-8b/24-llamascope-mlp-131k
-  - id: l25m_32x
-    l0: 50.0
-    norm_scaling_factor: 8.126984126984127
-    path: Llama3_1-8B-Base-L25M-32x
-    neuronpedia: llama3.1-8b/25-llamascope-mlp-131k
-  - id: l26m_32x
-    l0: 50.0
-    norm_scaling_factor: 7.5851851851851855
-    path: Llama3_1-8B-Base-L26M-32x
-    neuronpedia: llama3.1-8b/26-llamascope-mlp-131k
-  - id: l27m_32x
-    l0: 50.0
-    norm_scaling_factor: 6.4
-    path: Llama3_1-8B-Base-L27M-32x
-    neuronpedia: llama3.1-8b/27-llamascope-mlp-131k
-  - id: l28m_32x
-    l0: 50.0
-    norm_scaling_factor: 5.505376344086022
-    path: Llama3_1-8B-Base-L28M-32x
-    neuronpedia: llama3.1-8b/28-llamascope-mlp-131k
-  - id: l29m_32x
-    l0: 50.0
-    norm_scaling_factor: 4.413793103448276
-    path: Llama3_1-8B-Base-L29M-32x
-    neuronpedia: llama3.1-8b/29-llamascope-mlp-131k
-  - id: l30m_32x
-    l0: 50.0
-    norm_scaling_factor: 2.5472636815920398
-    path: Llama3_1-8B-Base-L30M-32x
-    neuronpedia: llama3.1-8b/30-llamascope-mlp-131k
-  - id: l31m_32x
-    l0: 50.0
-    norm_scaling_factor: 1.0534979423868314
-    path: Llama3_1-8B-Base-L31M-32x
-    neuronpedia: llama3.1-8b/31-llamascope-mlp-131k
-llama_scope_lxm_8x:
-  conversion_func: llama_scope
-  model: meta-llama/Llama-3.1-8B
-  repo_id: fnlp/Llama3_1-8B-Base-LXM-8x
-  saes:
-  - id: l0m_8x
-    l0: 50.0
-    norm_scaling_factor: 80.31372549019608
-    path: Llama3_1-8B-Base-L0M-8x
-    neuronpedia: llama3.1-8b/0-llamascope-mlp-32k
-  - id: l1m_8x
-    l0: 50.0
-    norm_scaling_factor: 72.1762114537445
-    path: Llama3_1-8B-Base-L1M-8x
-    neuronpedia: llama3.1-8b/1-llamascope-mlp-32k
-  - id: l2m_8x
-    l0: 50.0
-    norm_scaling_factor: 47.90643274853801
-    path: Llama3_1-8B-Base-L2M-8x
-    neuronpedia: llama3.1-8b/2-llamascope-mlp-32k
-  - id: l3m_8x
-    l0: 50.0
-    norm_scaling_factor: 35.46320346320346
-    path: Llama3_1-8B-Base-L3M-8x
-    neuronpedia: llama3.1-8b/3-llamascope-mlp-32k
-  - id: l4m_8x
-    l0: 50.0
-    norm_scaling_factor: 27.86394557823129
-    path: Llama3_1-8B-Base-L4M-8x
-    neuronpedia: llama3.1-8b/4-llamascope-mlp-32k
-  - id: l5m_8x
-    l0: 50.0
-    norm_scaling_factor: 23.01123595505618
-    path: Llama3_1-8B-Base-L5M-8x
-    neuronpedia: llama3.1-8b/5-llamascope-mlp-32k
-  - id: l6m_8x
-    l0: 50.0
-    norm_scaling_factor: 20.48
-    path: Llama3_1-8B-Base-L6M-8x
-    neuronpedia: llama3.1-8b/6-llamascope-mlp-32k
-  - id: l7m_8x
-    l0: 50.0
-    norm_scaling_factor: 19.692307692307693
-    path: Llama3_1-8B-Base-L7M-8x
-    neuronpedia: llama3.1-8b/7-llamascope-mlp-32k
-  - id: l8m_8x
-    l0: 50.0
-    norm_scaling_factor: 18.87557603686636
-    path: Llama3_1-8B-Base-L8M-8x
-    neuronpedia: llama3.1-8b/8-llamascope-mlp-32k
-  - id: l9m_8x
-    l0: 50.0
-    norm_scaling_factor: 17.88646288209607
-    path: Llama3_1-8B-Base-L9M-8x
-    neuronpedia: llama3.1-8b/9-llamascope-mlp-32k
-  - id: l10m_8x
-    l0: 50.0
-    norm_scaling_factor: 17.5793991416309
-    path: Llama3_1-8B-Base-L10M-8x
-    neuronpedia: llama3.1-8b/10-llamascope-mlp-32k
-  - id: l11m_8x
-    l0: 50.0
-    norm_scaling_factor: 16.855967078189302
-    path: Llama3_1-8B-Base-L11M-8x
-    neuronpedia: llama3.1-8b/11-llamascope-mlp-32k
-  - id: l12m_8x
-    l0: 50.0
-    norm_scaling_factor: 16.125984251968504
-    path: Llama3_1-8B-Base-L12M-8x
-    neuronpedia: llama3.1-8b/12-llamascope-mlp-32k
-  - id: l13m_8x
-    l0: 50.0
-    norm_scaling_factor: 14.733812949640289
-    path: Llama3_1-8B-Base-L13M-8x
-    neuronpedia: llama3.1-8b/13-llamascope-mlp-32k
-  - id: l14m_8x
-    l0: 50.0
-    norm_scaling_factor: 13.74496644295302
-    path: Llama3_1-8B-Base-L14M-8x
-    neuronpedia: llama3.1-8b/14-llamascope-mlp-32k
-  - id: l15m_8x
-    l0: 50.0
-    norm_scaling_factor: 12.118343195266272
-    path: Llama3_1-8B-Base-L15M-8x
-    neuronpedia: llama3.1-8b/15-llamascope-mlp-32k
-  - id: l16m_8x
-    l0: 50.0
-    norm_scaling_factor: 11.702857142857143
-    path: Llama3_1-8B-Base-L16M-8x
-    neuronpedia: llama3.1-8b/16-llamascope-mlp-32k
-  - id: l17m_8x
-    l0: 50.0
-    norm_scaling_factor: 10.666666666666666
-    path: Llama3_1-8B-Base-L17M-8x
-    neuronpedia: llama3.1-8b/17-llamascope-mlp-32k
-  - id: l18m_8x
-    l0: 50.0
-    norm_scaling_factor: 10.778947368421052
-    path: Llama3_1-8B-Base-L18M-8x
-    neuronpedia: llama3.1-8b/18-llamascope-mlp-32k
-  - id: l19m_8x
-    l0: 50.0
-    norm_scaling_factor: 10.502564102564103
-    path: Llama3_1-8B-Base-L19M-8x
-    neuronpedia: llama3.1-8b/19-llamascope-mlp-32k
-  - id: l20m_8x
-    l0: 50.0
-    norm_scaling_factor: 10.138613861386139
-    path: Llama3_1-8B-Base-L20M-8x
-    neuronpedia: llama3.1-8b/20-llamascope-mlp-32k
-  - id: l21m_8x
-    l0: 50.0
-    norm_scaling_factor: 9.142857142857142
-    path: Llama3_1-8B-Base-L21M-8x
-    neuronpedia: llama3.1-8b/21-llamascope-mlp-32k
-  - id: l22m_8x
-    l0: 50.0
-    norm_scaling_factor: 8.904347826086957
-    path: Llama3_1-8B-Base-L22M-8x
-    neuronpedia: llama3.1-8b/22-llamascope-mlp-32k
-  - id: l23m_8x
-    l0: 50.0
-    norm_scaling_factor: 8.641350210970463
-    path: Llama3_1-8B-Base-L23M-8x
-    neuronpedia: llama3.1-8b/23-llamascope-mlp-32k
-  - id: l24m_8x
-    l0: 50.0
-    norm_scaling_factor: 8.39344262295082
-    path: Llama3_1-8B-Base-L24M-8x
-    neuronpedia: llama3.1-8b/24-llamascope-mlp-32k
-  - id: l25m_8x
-    l0: 50.0
-    norm_scaling_factor: 8.126984126984127
-    path: Llama3_1-8B-Base-L25M-8x
-    neuronpedia: llama3.1-8b/25-llamascope-mlp-32k
-  - id: l26m_8x
-    l0: 50.0
-    norm_scaling_factor: 7.5851851851851855
-    path: Llama3_1-8B-Base-L26M-8x
-    neuronpedia: llama3.1-8b/26-llamascope-mlp-32k
-  - id: l27m_8x
-    l0: 50.0
-    norm_scaling_factor: 6.4
-    path: Llama3_1-8B-Base-L27M-8x
-    neuronpedia: llama3.1-8b/27-llamascope-mlp-32k
-  - id: l28m_8x
-    l0: 50.0
-    norm_scaling_factor: 5.505376344086022
-    path: Llama3_1-8B-Base-L28M-8x
-    neuronpedia: llama3.1-8b/28-llamascope-mlp-32k
-  - id: l29m_8x
-    l0: 50.0
-    norm_scaling_factor: 4.432900432900433
-    path: Llama3_1-8B-Base-L29M-8x
-    neuronpedia: llama3.1-8b/29-llamascope-mlp-32k
-  - id: l30m_8x
-    l0: 50.0
-    norm_scaling_factor: 2.5472636815920398
-    path: Llama3_1-8B-Base-L30M-8x
-    neuronpedia: llama3.1-8b/30-llamascope-mlp-32k
-  - id: l31m_8x
-    l0: 50.0
-    norm_scaling_factor: 1.0534979423868314
-    path: Llama3_1-8B-Base-L31M-8x
-    neuronpedia: llama3.1-8b/31-llamascope-mlp-32k
-llama_scope_lxr_32x:
-  conversion_func: llama_scope
-  model: meta-llama/Llama-3.1-8B
-  repo_id: fnlp/Llama3_1-8B-Base-LXR-32x
-  saes:
-  - id: l0r_32x
-    l0: 50.0
-    norm_scaling_factor: 58.935251798561154
-    path: Llama3_1-8B-Base-L0R-32x
-    neuronpedia: llama3.1-8b/0-llamascope-res-131k
-  - id: l1r_32x
-    l0: 50.0
-    norm_scaling_factor: 39.9609756097561
-    path: Llama3_1-8B-Base-L1R-32x
-    neuronpedia: llama3.1-8b/1-llamascope-res-131k
-  - id: l2r_32x
-    l0: 50.0
-    norm_scaling_factor: 27.30666666666667
-    path: Llama3_1-8B-Base-L2R-32x
-    neuronpedia: llama3.1-8b/2-llamascope-res-131k
-  - id: l3r_32x
-    l0: 50.0
-    norm_scaling_factor: 20.177339901477833
-    path: Llama3_1-8B-Base-L3R-32x
-    neuronpedia: llama3.1-8b/3-llamascope-res-131k
-  - id: l4r_32x
-    l0: 50.0
-    norm_scaling_factor: 16.125984251968504
-    path: Llama3_1-8B-Base-L4R-32x
-    neuronpedia: llama3.1-8b/4-llamascope-res-131k
-  - id: l5r_32x
-    l0: 50.0
-    norm_scaling_factor: 13.653333333333334
-    path: Llama3_1-8B-Base-L5R-32x
-    neuronpedia: llama3.1-8b/5-llamascope-res-131k
-  - id: l6r_32x
-    l0: 50.0
-    norm_scaling_factor: 11.976608187134502
-    path: Llama3_1-8B-Base-L6R-32x
-    neuronpedia: llama3.1-8b/6-llamascope-res-131k
-  - id: l7r_32x
-    l0: 50.0
-    norm_scaling_factor: 10.835978835978835
-    path: Llama3_1-8B-Base-L7R-32x
-    neuronpedia: llama3.1-8b/7-llamascope-res-131k
-  - id: l8r_32x
-    l0: 50.0
-    norm_scaling_factor: 10.138613861386139
-    path: Llama3_1-8B-Base-L8R-32x
-    neuronpedia: llama3.1-8b/8-llamascope-res-131k
-  - id: l9r_32x
-    l0: 50.0
-    norm_scaling_factor: 9.266968325791856
-    path: Llama3_1-8B-Base-L9R-32x
-    neuronpedia: llama3.1-8b/9-llamascope-res-131k
-  - id: l10r_32x
-    l0: 50.0
-    norm_scaling_factor: 8.827586206896552
-    path: Llama3_1-8B-Base-L10R-32x
-    neuronpedia: llama3.1-8b/10-llamascope-res-131k
-  - id: l11r_32x
-    l0: 50.0
-    norm_scaling_factor: 8.427983539094651
-    path: Llama3_1-8B-Base-L11R-32x
-    neuronpedia: llama3.1-8b/11-llamascope-res-131k
-  - id: l12r_32x
-    l0: 50.0
-    norm_scaling_factor: 7.937984496124031
-    path: Llama3_1-8B-Base-L12R-32x
-    neuronpedia: llama3.1-8b/12-llamascope-res-131k
-  - id: l13r_32x
-    l0: 50.0
-    norm_scaling_factor: 7.26241134751773
-    path: Llama3_1-8B-Base-L13R-32x
-    neuronpedia: llama3.1-8b/13-llamascope-res-131k
-  - id: l14r_32x
-    l0: 50.0
-    norm_scaling_factor: 6.69281045751634
-    path: Llama3_1-8B-Base-L14R-32x
-    neuronpedia: llama3.1-8b/14-llamascope-res-131k
-  - id: l15r_32x
-    l0: 50.0
-    norm_scaling_factor: 5.91907514450867
-    path: Llama3_1-8B-Base-L15R-32x
-    neuronpedia: llama3.1-8b/15-llamascope-res-131k
-  - id: l16r_32x
-    l0: 50.0
-    norm_scaling_factor: 5.278350515463917
-    path: Llama3_1-8B-Base-L16R-32x
-    neuronpedia: llama3.1-8b/16-llamascope-res-131k
-  - id: l17r_32x
-    l0: 50.0
-    norm_scaling_factor: 4.633484162895928
-    path: Llama3_1-8B-Base-L17R-32x
-    neuronpedia: llama3.1-8b/17-llamascope-res-131k
-  - id: l18r_32x
-    l0: 50.0
-    norm_scaling_factor: 4.129032258064516
-    path: Llama3_1-8B-Base-L18R-32x
-    neuronpedia: llama3.1-8b/18-llamascope-res-131k
-  - id: l19r_32x
-    l0: 50.0
-    norm_scaling_factor: 3.7372262773722627
-    path: Llama3_1-8B-Base-L19R-32x
-    neuronpedia: llama3.1-8b/19-llamascope-res-131k
-  - id: l20r_32x
-    l0: 50.0
-    norm_scaling_factor: 3.4133333333333336
-    path: Llama3_1-8B-Base-L20R-32x
-    neuronpedia: llama3.1-8b/20-llamascope-res-131k
-  - id: l21r_32x
-    l0: 50.0
-    norm_scaling_factor: 2.9767441860465116
-    path: Llama3_1-8B-Base-L21R-32x
-    neuronpedia: llama3.1-8b/21-llamascope-res-131k
-  - id: l22r_32x
-    l0: 50.0
-    norm_scaling_factor: 2.680628272251309
-    path: Llama3_1-8B-Base-L22R-32x
-    neuronpedia: llama3.1-8b/22-llamascope-res-131k
-  - id: l23r_32x
-    l0: 50.0
-    norm_scaling_factor: 2.4150943396226414
-    path: Llama3_1-8B-Base-L23R-32x
-    neuronpedia: llama3.1-8b/23-llamascope-res-131k
-  - id: l24r_32x
-    l0: 50.0
-    norm_scaling_factor: 2.1974248927038627
-    path: Llama3_1-8B-Base-L24R-32x
-    neuronpedia: llama3.1-8b/24-llamascope-res-131k
-  - id: l25r_32x
-    l0: 50.0
-    norm_scaling_factor: 2.0237154150197627
-    path: Llama3_1-8B-Base-L25R-32x
-    neuronpedia: llama3.1-8b/25-llamascope-res-131k
-  - id: l26r_32x
-    l0: 50.0
-    norm_scaling_factor: 1.8156028368794326
-    path: Llama3_1-8B-Base-L26R-32x
-    neuronpedia: llama3.1-8b/26-llamascope-res-131k
-  - id: l27r_32x
-    l0: 50.0
-    norm_scaling_factor: 1.6623376623376624
-    path: Llama3_1-8B-Base-L27R-32x
-    neuronpedia: llama3.1-8b/27-llamascope-res-131k
-  - id: l28r_32x
-    l0: 50.0
-    norm_scaling_factor: 1.5058823529411764
-    path: Llama3_1-8B-Base-L28R-32x
-    neuronpedia: llama3.1-8b/28-llamascope-res-131k
-  - id: l29r_32x
-    l0: 50.0
-    norm_scaling_factor: 1.3763440860215055
-    path: Llama3_1-8B-Base-L29R-32x
-    neuronpedia: llama3.1-8b/29-llamascope-res-131k
-  - id: l30r_32x
-    l0: 50.0
-    norm_scaling_factor: 1.2075471698113207
-    path: Llama3_1-8B-Base-L30R-32x
-    neuronpedia: llama3.1-8b/30-llamascope-res-131k
-  - id: l31r_32x
-    l0: 50.0
-    norm_scaling_factor: 0.8648648648648649
-    path: Llama3_1-8B-Base-L31R-32x
-    neuronpedia: llama3.1-8b/31-llamascope-res-131k
-llama_scope_lxr_8x:
-  conversion_func: llama_scope
-  model: meta-llama/Llama-3.1-8B
-  repo_id: fnlp/Llama3_1-8B-Base-LXR-8x
-  saes:
-  - id: l0r_8x
-    l0: 50.0
-    norm_scaling_factor: 58.935251798561154
-    path: Llama3_1-8B-Base-L0R-8x
-    neuronpedia: llama3.1-8b/0-llamascope-res-32k
-  - id: l1r_8x
-    l0: 50.0
-    norm_scaling_factor: 39.76699029126213
-    path: Llama3_1-8B-Base-L1R-8x
-    neuronpedia: llama3.1-8b/1-llamascope-res-32k
-  - id: l2r_8x
-    l0: 50.0
-    norm_scaling_factor: 27.30666666666667
-    path: Llama3_1-8B-Base-L2R-8x
-    neuronpedia: llama3.1-8b/2-llamascope-res-32k
-  - id: l3r_8x
-    l0: 50.0
-    norm_scaling_factor: 20.177339901477833
-    path: Llama3_1-8B-Base-L3R-8x
-    neuronpedia: llama3.1-8b/3-llamascope-res-32k
-  - id: l4r_8x
-    l0: 50.0
-    norm_scaling_factor: 16.125984251968504
-    path: Llama3_1-8B-Base-L4R-8x
-    neuronpedia: llama3.1-8b/4-llamascope-res-32k
-  - id: l5r_8x
-    l0: 50.0
-    norm_scaling_factor: 13.653333333333334
-    path: Llama3_1-8B-Base-L5R-8x
-    neuronpedia: llama3.1-8b/5-llamascope-res-32k
-  - id: l6r_8x
-    l0: 50.0
-    norm_scaling_factor: 11.976608187134502
-    path: Llama3_1-8B-Base-L6R-8x
-    neuronpedia: llama3.1-8b/6-llamascope-res-32k
-  - id: l7r_8x
-    l0: 50.0
-    norm_scaling_factor: 10.835978835978835
-    path: Llama3_1-8B-Base-L7R-8x
-    neuronpedia: llama3.1-8b/7-llamascope-res-32k
-  - id: l8r_8x
-    l0: 50.0
-    norm_scaling_factor: 10.138613861386139
-    path: Llama3_1-8B-Base-L8R-8x
-    neuronpedia: llama3.1-8b/8-llamascope-res-32k
-  - id: l9r_8x
-    l0: 50.0
-    norm_scaling_factor: 9.266968325791856
-    path: Llama3_1-8B-Base-L9R-8x
-    neuronpedia: llama3.1-8b/9-llamascope-res-32k
-  - id: l10r_8x
-    l0: 50.0
-    norm_scaling_factor: 8.827586206896552
-    path: Llama3_1-8B-Base-L10R-8x
-    neuronpedia: llama3.1-8b/10-llamascope-res-32k
-  - id: l11r_8x
-    l0: 50.0
-    norm_scaling_factor: 8.462809917355372
-    path: Llama3_1-8B-Base-L11R-8x
-    neuronpedia: llama3.1-8b/11-llamascope-res-32k
-  - id: l12r_8x
-    l0: 50.0
-    norm_scaling_factor: 7.937984496124031
-    path: Llama3_1-8B-Base-L12R-8x
-    neuronpedia: llama3.1-8b/12-llamascope-res-32k
-  - id: l13r_8x
-    l0: 50.0
-    norm_scaling_factor: 7.26241134751773
-    path: Llama3_1-8B-Base-L13R-8x
-    neuronpedia: llama3.1-8b/13-llamascope-res-32k
-  - id: l14r_8x
-    l0: 50.0
-    norm_scaling_factor: 6.69281045751634
-    path: Llama3_1-8B-Base-L14R-8x
-    neuronpedia: llama3.1-8b/14-llamascope-res-32k
-  - id: l15r_8x
-    l0: 50.0
-    norm_scaling_factor: 5.91907514450867
-    path: Llama3_1-8B-Base-L15R-8x
-    neuronpedia: llama3.1-8b/15-llamascope-res-32k
-  - id: l16r_8x
-    l0: 50.0
-    norm_scaling_factor: 5.278350515463917
-    path: Llama3_1-8B-Base-L16R-8x
-    neuronpedia: llama3.1-8b/16-llamascope-res-32k
-  - id: l17r_8x
-    l0: 50.0
-    norm_scaling_factor: 4.633484162895928
-    path: Llama3_1-8B-Base-L17R-8x
-    neuronpedia: llama3.1-8b/17-llamascope-res-32k
-  - id: l18r_8x
-    l0: 50.0
-    norm_scaling_factor: 4.129032258064516
-    path: Llama3_1-8B-Base-L18R-8x
-    neuronpedia: llama3.1-8b/18-llamascope-res-32k
-  - id: l19r_8x
-    l0: 50.0
-    norm_scaling_factor: 3.7372262773722627
-    path: Llama3_1-8B-Base-L19R-8x
-    neuronpedia: llama3.1-8b/19-llamascope-res-32k
-  - id: l20r_8x
-    l0: 50.0
-    norm_scaling_factor: 3.4133333333333336
-    path: Llama3_1-8B-Base-L20R-8x
-    neuronpedia: llama3.1-8b/20-llamascope-res-32k
-  - id: l21r_8x
-    l0: 50.0
-    norm_scaling_factor: 2.9767441860465116
-    path: Llama3_1-8B-Base-L21R-8x
-    neuronpedia: llama3.1-8b/21-llamascope-res-32k
-  - id: l22r_8x
-    l0: 50.0
-    norm_scaling_factor: 2.680628272251309
-    path: Llama3_1-8B-Base-L22R-8x
-    neuronpedia: llama3.1-8b/22-llamascope-res-32k
-  - id: l23r_8x
-    l0: 50.0
-    norm_scaling_factor: 2.4150943396226414
-    path: Llama3_1-8B-Base-L23R-8x
-    neuronpedia: llama3.1-8b/23-llamascope-res-32k
-  - id: l24r_8x
-    l0: 50.0
-    norm_scaling_factor: 2.1880341880341883
-    path: Llama3_1-8B-Base-L24R-8x
-    neuronpedia: llama3.1-8b/24-llamascope-res-32k
-  - id: l25r_8x
-    l0: 50.0
-    norm_scaling_factor: 2.0237154150197627
-    path: Llama3_1-8B-Base-L25R-8x
-    neuronpedia: llama3.1-8b/25-llamascope-res-32k
-  - id: l26r_8x
-    l0: 50.0
-    norm_scaling_factor: 1.8156028368794326
-    path: Llama3_1-8B-Base-L26R-8x
-    neuronpedia: llama3.1-8b/26-llamascope-res-32k
-  - id: l27r_8x
-    l0: 50.0
-    norm_scaling_factor: 1.673202614379085
-    path: Llama3_1-8B-Base-L27R-8x
-    neuronpedia: llama3.1-8b/27-llamascope-res-32k
-  - id: l28r_8x
-    l0: 50.0
-    norm_scaling_factor: 1.5058823529411764
-    path: Llama3_1-8B-Base-L28R-8x
-    neuronpedia: llama3.1-8b/28-llamascope-res-32k
-  - id: l29r_8x
-    l0: 50.0
-    norm_scaling_factor: 1.3763440860215055
-    path: Llama3_1-8B-Base-L29R-8x
-    neuronpedia: llama3.1-8b/29-llamascope-res-32k
-  - id: l30r_8x
-    l0: 50.0
-    norm_scaling_factor: 1.2018779342723005
-    path: Llama3_1-8B-Base-L30R-8x
-    neuronpedia: llama3.1-8b/30-llamascope-res-32k
-  - id: l31r_8x
-    l0: 50.0
-    norm_scaling_factor: 0.8590604026845637
-    path: Llama3_1-8B-Base-L31R-8x
-    neuronpedia: llama3.1-8b/31-llamascope-res-32k
-sae_bench_gemma-2-2b_topk_width-2pow12_date-1109:
-  conversion_func: dictionary_learning_1
-  links:
-    model: https://huggingface.co/google/gemma-2-2b
-  model: gemma-2-2b
-  repo_id: canrager/saebench_gemma-2-2b_width-2pow12_date-1109
-  saes:
-  - id: blocks.12.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_0_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12/trainer_0
-  - id: blocks.12.hook_resid_post__trainer_0_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_0_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_0
-  - id: blocks.12.hook_resid_post__trainer_0_step_308
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_0_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_308
-  - id: blocks.12.hook_resid_post__trainer_0_step_3088
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_0_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_3088
-  - id: blocks.12.hook_resid_post__trainer_0_step_30881
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_0_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_30881
-  - id: blocks.12.hook_resid_post__trainer_0_step_97
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_0_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_97
-  - id: blocks.12.hook_resid_post__trainer_0_step_976
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_0_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_976
-  - id: blocks.12.hook_resid_post__trainer_0_step_9765
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_0_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_9765
-  - id: blocks.12.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_1_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12/trainer_1
-  - id: blocks.12.hook_resid_post__trainer_1_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_1_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_0
-  - id: blocks.12.hook_resid_post__trainer_1_step_308
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_1_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_308
-  - id: blocks.12.hook_resid_post__trainer_1_step_3088
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_1_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_3088
-  - id: blocks.12.hook_resid_post__trainer_1_step_30881
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_1_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_30881
-  - id: blocks.12.hook_resid_post__trainer_1_step_97
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_1_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_97
-  - id: blocks.12.hook_resid_post__trainer_1_step_976
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_1_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_976
-  - id: blocks.12.hook_resid_post__trainer_1_step_9765
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_1_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_9765
-  - id: blocks.12.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_2_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12/trainer_2
-  - id: blocks.12.hook_resid_post__trainer_2_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_2_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_0
-  - id: blocks.12.hook_resid_post__trainer_2_step_308
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_2_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_308
-  - id: blocks.12.hook_resid_post__trainer_2_step_3088
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_2_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_3088
-  - id: blocks.12.hook_resid_post__trainer_2_step_30881
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_2_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_30881
-  - id: blocks.12.hook_resid_post__trainer_2_step_97
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_2_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_97
-  - id: blocks.12.hook_resid_post__trainer_2_step_976
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_2_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_976
-  - id: blocks.12.hook_resid_post__trainer_2_step_9765
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_2_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_9765
-  - id: blocks.12.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_3_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12/trainer_3
-  - id: blocks.12.hook_resid_post__trainer_3_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_3_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_0
-  - id: blocks.12.hook_resid_post__trainer_3_step_308
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_3_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_308
-  - id: blocks.12.hook_resid_post__trainer_3_step_3088
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_3_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_3088
-  - id: blocks.12.hook_resid_post__trainer_3_step_30881
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_3_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_30881
-  - id: blocks.12.hook_resid_post__trainer_3_step_97
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_3_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_97
-  - id: blocks.12.hook_resid_post__trainer_3_step_976
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_3_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_976
-  - id: blocks.12.hook_resid_post__trainer_3_step_9765
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_3_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_9765
-  - id: blocks.12.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_4_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12/trainer_4
-  - id: blocks.12.hook_resid_post__trainer_4_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_4_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_0
-  - id: blocks.12.hook_resid_post__trainer_4_step_308
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_4_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_308
-  - id: blocks.12.hook_resid_post__trainer_4_step_3088
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_4_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_3088
-  - id: blocks.12.hook_resid_post__trainer_4_step_30881
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_4_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_30881
-  - id: blocks.12.hook_resid_post__trainer_4_step_97
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_4_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_97
-  - id: blocks.12.hook_resid_post__trainer_4_step_976
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_4_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_976
-  - id: blocks.12.hook_resid_post__trainer_4_step_9765
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_4_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_9765
-  - id: blocks.12.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_5_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12/trainer_5
-  - id: blocks.12.hook_resid_post__trainer_5_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_5_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_0
-  - id: blocks.12.hook_resid_post__trainer_5_step_308
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_5_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_308
-  - id: blocks.12.hook_resid_post__trainer_5_step_3088
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_5_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_3088
-  - id: blocks.12.hook_resid_post__trainer_5_step_30881
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_5_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_30881
-  - id: blocks.12.hook_resid_post__trainer_5_step_97
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_5_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_97
-  - id: blocks.12.hook_resid_post__trainer_5_step_976
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_5_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_976
-  - id: blocks.12.hook_resid_post__trainer_5_step_9765
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-4k__trainer_5_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_9765
-  - id: blocks.19.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_0_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19/trainer_0
-  - id: blocks.19.hook_resid_post__trainer_0_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_0_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_0
-  - id: blocks.19.hook_resid_post__trainer_0_step_308
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_0_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_308
-  - id: blocks.19.hook_resid_post__trainer_0_step_3088
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_0_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_3088
-  - id: blocks.19.hook_resid_post__trainer_0_step_30881
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_0_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_30881
-  - id: blocks.19.hook_resid_post__trainer_0_step_97
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_0_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_97
-  - id: blocks.19.hook_resid_post__trainer_0_step_976
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_0_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_976
-  - id: blocks.19.hook_resid_post__trainer_0_step_9765
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_0_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_9765
-  - id: blocks.19.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_1_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19/trainer_1
-  - id: blocks.19.hook_resid_post__trainer_1_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_1_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_0
-  - id: blocks.19.hook_resid_post__trainer_1_step_308
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_1_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_308
-  - id: blocks.19.hook_resid_post__trainer_1_step_3088
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_1_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_3088
-  - id: blocks.19.hook_resid_post__trainer_1_step_30881
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_1_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_30881
-  - id: blocks.19.hook_resid_post__trainer_1_step_97
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_1_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_97
-  - id: blocks.19.hook_resid_post__trainer_1_step_976
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_1_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_976
-  - id: blocks.19.hook_resid_post__trainer_1_step_9765
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_1_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_9765
-  - id: blocks.19.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_2_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19/trainer_2
-  - id: blocks.19.hook_resid_post__trainer_2_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_2_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_0
-  - id: blocks.19.hook_resid_post__trainer_2_step_308
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_2_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_308
-  - id: blocks.19.hook_resid_post__trainer_2_step_3088
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_2_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_3088
-  - id: blocks.19.hook_resid_post__trainer_2_step_30881
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_2_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_30881
-  - id: blocks.19.hook_resid_post__trainer_2_step_97
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_2_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_97
-  - id: blocks.19.hook_resid_post__trainer_2_step_976
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_2_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_976
-  - id: blocks.19.hook_resid_post__trainer_2_step_9765
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_2_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_9765
-  - id: blocks.19.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_3_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19/trainer_3
-  - id: blocks.19.hook_resid_post__trainer_3_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_3_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_0
-  - id: blocks.19.hook_resid_post__trainer_3_step_308
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_3_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_308
-  - id: blocks.19.hook_resid_post__trainer_3_step_3088
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_3_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_3088
-  - id: blocks.19.hook_resid_post__trainer_3_step_30881
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_3_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_30881
-  - id: blocks.19.hook_resid_post__trainer_3_step_97
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_3_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_97
-  - id: blocks.19.hook_resid_post__trainer_3_step_976
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_3_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_976
-  - id: blocks.19.hook_resid_post__trainer_3_step_9765
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_3_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_9765
-  - id: blocks.19.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_4_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19/trainer_4
-  - id: blocks.19.hook_resid_post__trainer_4_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_4_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_0
-  - id: blocks.19.hook_resid_post__trainer_4_step_308
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_4_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_308
-  - id: blocks.19.hook_resid_post__trainer_4_step_3088
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_4_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_3088
-  - id: blocks.19.hook_resid_post__trainer_4_step_30881
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_4_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_30881
-  - id: blocks.19.hook_resid_post__trainer_4_step_97
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_4_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_97
-  - id: blocks.19.hook_resid_post__trainer_4_step_976
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_4_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_976
-  - id: blocks.19.hook_resid_post__trainer_4_step_9765
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_4_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_9765
-  - id: blocks.19.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_5_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19/trainer_5
-  - id: blocks.19.hook_resid_post__trainer_5_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_5_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_0
-  - id: blocks.19.hook_resid_post__trainer_5_step_308
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_5_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_308
-  - id: blocks.19.hook_resid_post__trainer_5_step_3088
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_5_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_3088
-  - id: blocks.19.hook_resid_post__trainer_5_step_30881
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_5_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_30881
-  - id: blocks.19.hook_resid_post__trainer_5_step_97
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_5_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_97
-  - id: blocks.19.hook_resid_post__trainer_5_step_976
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_5_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_976
-  - id: blocks.19.hook_resid_post__trainer_5_step_9765
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-4k__trainer_5_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_9765
-  - id: blocks.5.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_0_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5/trainer_0
-  - id: blocks.5.hook_resid_post__trainer_0_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_0_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_0
-  - id: blocks.5.hook_resid_post__trainer_0_step_308
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_0_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_308
-  - id: blocks.5.hook_resid_post__trainer_0_step_3088
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_0_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_3088
-  - id: blocks.5.hook_resid_post__trainer_0_step_30881
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_0_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_30881
-  - id: blocks.5.hook_resid_post__trainer_0_step_97
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_0_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_97
-  - id: blocks.5.hook_resid_post__trainer_0_step_976
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_0_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_976
-  - id: blocks.5.hook_resid_post__trainer_0_step_9765
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_0_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_9765
-  - id: blocks.5.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_1_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5/trainer_1
-  - id: blocks.5.hook_resid_post__trainer_1_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_1_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_0
-  - id: blocks.5.hook_resid_post__trainer_1_step_308
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_1_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_308
-  - id: blocks.5.hook_resid_post__trainer_1_step_3088
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_1_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_3088
-  - id: blocks.5.hook_resid_post__trainer_1_step_30881
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_1_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_30881
-  - id: blocks.5.hook_resid_post__trainer_1_step_97
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_1_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_97
-  - id: blocks.5.hook_resid_post__trainer_1_step_976
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_1_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_976
-  - id: blocks.5.hook_resid_post__trainer_1_step_9765
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_1_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_9765
-  - id: blocks.5.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_2_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5/trainer_2
-  - id: blocks.5.hook_resid_post__trainer_2_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_2_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_0
-  - id: blocks.5.hook_resid_post__trainer_2_step_308
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_2_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_308
-  - id: blocks.5.hook_resid_post__trainer_2_step_3088
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_2_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_3088
-  - id: blocks.5.hook_resid_post__trainer_2_step_30881
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_2_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_30881
-  - id: blocks.5.hook_resid_post__trainer_2_step_97
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_2_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_97
-  - id: blocks.5.hook_resid_post__trainer_2_step_976
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_2_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_976
-  - id: blocks.5.hook_resid_post__trainer_2_step_9765
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_2_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_9765
-  - id: blocks.5.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_3_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5/trainer_3
-  - id: blocks.5.hook_resid_post__trainer_3_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_3_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_0
-  - id: blocks.5.hook_resid_post__trainer_3_step_308
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_3_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_308
-  - id: blocks.5.hook_resid_post__trainer_3_step_3088
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_3_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_3088
-  - id: blocks.5.hook_resid_post__trainer_3_step_30881
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_3_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_30881
-  - id: blocks.5.hook_resid_post__trainer_3_step_97
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_3_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_97
-  - id: blocks.5.hook_resid_post__trainer_3_step_976
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_3_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_976
-  - id: blocks.5.hook_resid_post__trainer_3_step_9765
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_3_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_9765
-  - id: blocks.5.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_4_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5/trainer_4
-  - id: blocks.5.hook_resid_post__trainer_4_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_4_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_0
-  - id: blocks.5.hook_resid_post__trainer_4_step_308
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_4_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_308
-  - id: blocks.5.hook_resid_post__trainer_4_step_3088
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_4_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_3088
-  - id: blocks.5.hook_resid_post__trainer_4_step_30881
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_4_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_30881
-  - id: blocks.5.hook_resid_post__trainer_4_step_97
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_4_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_97
-  - id: blocks.5.hook_resid_post__trainer_4_step_976
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_4_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_976
-  - id: blocks.5.hook_resid_post__trainer_4_step_9765
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_4_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_9765
-  - id: blocks.5.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_5_step_final
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5/trainer_5
-  - id: blocks.5.hook_resid_post__trainer_5_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_5_step_0
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_0
-  - id: blocks.5.hook_resid_post__trainer_5_step_308
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_5_step_308
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_308
-  - id: blocks.5.hook_resid_post__trainer_5_step_3088
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_5_step_3088
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_3088
-  - id: blocks.5.hook_resid_post__trainer_5_step_30881
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_5_step_30881
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_30881
-  - id: blocks.5.hook_resid_post__trainer_5_step_97
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_5_step_97
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_97
-  - id: blocks.5.hook_resid_post__trainer_5_step_976
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_5_step_976
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_976
-  - id: blocks.5.hook_resid_post__trainer_5_step_9765
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-4k__trainer_5_step_9765
-    path: gemma-2-2b_topk_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_9765
-sae_bench_gemma-2-2b_vanilla_width-2pow12_date-1109:
-  conversion_func: dictionary_learning_1
-  links:
-    model: https://huggingface.co/google/gemma-2-2b
-  model: gemma-2-2b
-  repo_id: canrager/saebench_gemma-2-2b_width-2pow12_date-1109
-  saes:
-  - id: blocks.12.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_0_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12/trainer_0
-  - id: blocks.12.hook_resid_post__trainer_0_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_0_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_0
-  - id: blocks.12.hook_resid_post__trainer_0_step_308
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_0_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_308
-  - id: blocks.12.hook_resid_post__trainer_0_step_3088
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_0_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_3088
-  - id: blocks.12.hook_resid_post__trainer_0_step_30881
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_0_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_30881
-  - id: blocks.12.hook_resid_post__trainer_0_step_97
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_0_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_97
-  - id: blocks.12.hook_resid_post__trainer_0_step_976
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_0_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_976
-  - id: blocks.12.hook_resid_post__trainer_0_step_9765
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_0_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_9765
-  - id: blocks.12.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_1_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12/trainer_1
-  - id: blocks.12.hook_resid_post__trainer_1_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_1_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_0
-  - id: blocks.12.hook_resid_post__trainer_1_step_308
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_1_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_308
-  - id: blocks.12.hook_resid_post__trainer_1_step_3088
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_1_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_3088
-  - id: blocks.12.hook_resid_post__trainer_1_step_30881
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_1_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_30881
-  - id: blocks.12.hook_resid_post__trainer_1_step_97
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_1_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_97
-  - id: blocks.12.hook_resid_post__trainer_1_step_976
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_1_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_976
-  - id: blocks.12.hook_resid_post__trainer_1_step_9765
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_1_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_9765
-  - id: blocks.12.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_2_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12/trainer_2
-  - id: blocks.12.hook_resid_post__trainer_2_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_2_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_0
-  - id: blocks.12.hook_resid_post__trainer_2_step_308
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_2_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_308
-  - id: blocks.12.hook_resid_post__trainer_2_step_3088
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_2_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_3088
-  - id: blocks.12.hook_resid_post__trainer_2_step_30881
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_2_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_30881
-  - id: blocks.12.hook_resid_post__trainer_2_step_97
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_2_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_97
-  - id: blocks.12.hook_resid_post__trainer_2_step_976
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_2_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_976
-  - id: blocks.12.hook_resid_post__trainer_2_step_9765
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_2_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_9765
-  - id: blocks.12.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_3_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12/trainer_3
-  - id: blocks.12.hook_resid_post__trainer_3_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_3_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_0
-  - id: blocks.12.hook_resid_post__trainer_3_step_308
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_3_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_308
-  - id: blocks.12.hook_resid_post__trainer_3_step_3088
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_3_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_3088
-  - id: blocks.12.hook_resid_post__trainer_3_step_30881
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_3_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_30881
-  - id: blocks.12.hook_resid_post__trainer_3_step_97
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_3_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_97
-  - id: blocks.12.hook_resid_post__trainer_3_step_976
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_3_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_976
-  - id: blocks.12.hook_resid_post__trainer_3_step_9765
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_3_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_9765
-  - id: blocks.12.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_4_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12/trainer_4
-  - id: blocks.12.hook_resid_post__trainer_4_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_4_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_0
-  - id: blocks.12.hook_resid_post__trainer_4_step_308
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_4_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_308
-  - id: blocks.12.hook_resid_post__trainer_4_step_3088
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_4_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_3088
-  - id: blocks.12.hook_resid_post__trainer_4_step_30881
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_4_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_30881
-  - id: blocks.12.hook_resid_post__trainer_4_step_97
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_4_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_97
-  - id: blocks.12.hook_resid_post__trainer_4_step_976
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_4_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_976
-  - id: blocks.12.hook_resid_post__trainer_4_step_9765
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_4_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_9765
-  - id: blocks.12.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_5_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12/trainer_5
-  - id: blocks.12.hook_resid_post__trainer_5_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_5_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_0
-  - id: blocks.12.hook_resid_post__trainer_5_step_308
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_5_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_308
-  - id: blocks.12.hook_resid_post__trainer_5_step_3088
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_5_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_3088
-  - id: blocks.12.hook_resid_post__trainer_5_step_30881
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_5_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_30881
-  - id: blocks.12.hook_resid_post__trainer_5_step_97
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_5_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_97
-  - id: blocks.12.hook_resid_post__trainer_5_step_976
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_5_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_976
-  - id: blocks.12.hook_resid_post__trainer_5_step_9765
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-4k__trainer_5_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_9765
-  - id: blocks.19.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_0_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19/trainer_0
-  - id: blocks.19.hook_resid_post__trainer_0_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_0_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_0
-  - id: blocks.19.hook_resid_post__trainer_0_step_308
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_0_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_308
-  - id: blocks.19.hook_resid_post__trainer_0_step_3088
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_0_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_3088
-  - id: blocks.19.hook_resid_post__trainer_0_step_30881
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_0_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_30881
-  - id: blocks.19.hook_resid_post__trainer_0_step_97
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_0_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_97
-  - id: blocks.19.hook_resid_post__trainer_0_step_976
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_0_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_976
-  - id: blocks.19.hook_resid_post__trainer_0_step_9765
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_0_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_9765
-  - id: blocks.19.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_1_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19/trainer_1
-  - id: blocks.19.hook_resid_post__trainer_1_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_1_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_0
-  - id: blocks.19.hook_resid_post__trainer_1_step_308
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_1_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_308
-  - id: blocks.19.hook_resid_post__trainer_1_step_3088
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_1_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_3088
-  - id: blocks.19.hook_resid_post__trainer_1_step_30881
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_1_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_30881
-  - id: blocks.19.hook_resid_post__trainer_1_step_97
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_1_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_97
-  - id: blocks.19.hook_resid_post__trainer_1_step_976
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_1_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_976
-  - id: blocks.19.hook_resid_post__trainer_1_step_9765
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_1_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_9765
-  - id: blocks.19.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_2_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19/trainer_2
-  - id: blocks.19.hook_resid_post__trainer_2_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_2_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_0
-  - id: blocks.19.hook_resid_post__trainer_2_step_308
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_2_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_308
-  - id: blocks.19.hook_resid_post__trainer_2_step_3088
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_2_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_3088
-  - id: blocks.19.hook_resid_post__trainer_2_step_30881
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_2_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_30881
-  - id: blocks.19.hook_resid_post__trainer_2_step_97
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_2_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_97
-  - id: blocks.19.hook_resid_post__trainer_2_step_976
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_2_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_976
-  - id: blocks.19.hook_resid_post__trainer_2_step_9765
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_2_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_9765
-  - id: blocks.19.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_3_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19/trainer_3
-  - id: blocks.19.hook_resid_post__trainer_3_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_3_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_0
-  - id: blocks.19.hook_resid_post__trainer_3_step_308
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_3_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_308
-  - id: blocks.19.hook_resid_post__trainer_3_step_3088
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_3_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_3088
-  - id: blocks.19.hook_resid_post__trainer_3_step_30881
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_3_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_30881
-  - id: blocks.19.hook_resid_post__trainer_3_step_97
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_3_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_97
-  - id: blocks.19.hook_resid_post__trainer_3_step_976
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_3_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_976
-  - id: blocks.19.hook_resid_post__trainer_3_step_9765
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_3_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_9765
-  - id: blocks.19.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_4_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19/trainer_4
-  - id: blocks.19.hook_resid_post__trainer_4_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_4_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_0
-  - id: blocks.19.hook_resid_post__trainer_4_step_308
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_4_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_308
-  - id: blocks.19.hook_resid_post__trainer_4_step_3088
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_4_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_3088
-  - id: blocks.19.hook_resid_post__trainer_4_step_30881
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_4_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_30881
-  - id: blocks.19.hook_resid_post__trainer_4_step_97
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_4_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_97
-  - id: blocks.19.hook_resid_post__trainer_4_step_976
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_4_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_976
-  - id: blocks.19.hook_resid_post__trainer_4_step_9765
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_4_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_9765
-  - id: blocks.19.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_5_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19/trainer_5
-  - id: blocks.19.hook_resid_post__trainer_5_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_5_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_0
-  - id: blocks.19.hook_resid_post__trainer_5_step_308
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_5_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_308
-  - id: blocks.19.hook_resid_post__trainer_5_step_3088
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_5_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_3088
-  - id: blocks.19.hook_resid_post__trainer_5_step_30881
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_5_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_30881
-  - id: blocks.19.hook_resid_post__trainer_5_step_97
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_5_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_97
-  - id: blocks.19.hook_resid_post__trainer_5_step_976
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_5_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_976
-  - id: blocks.19.hook_resid_post__trainer_5_step_9765
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-4k__trainer_5_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_9765
-  - id: blocks.5.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_0_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5/trainer_0
-  - id: blocks.5.hook_resid_post__trainer_0_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_0_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_0
-  - id: blocks.5.hook_resid_post__trainer_0_step_308
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_0_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_308
-  - id: blocks.5.hook_resid_post__trainer_0_step_3088
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_0_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_3088
-  - id: blocks.5.hook_resid_post__trainer_0_step_30881
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_0_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_30881
-  - id: blocks.5.hook_resid_post__trainer_0_step_97
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_0_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_97
-  - id: blocks.5.hook_resid_post__trainer_0_step_976
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_0_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_976
-  - id: blocks.5.hook_resid_post__trainer_0_step_9765
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_0_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_9765
-  - id: blocks.5.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_1_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5/trainer_1
-  - id: blocks.5.hook_resid_post__trainer_1_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_1_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_0
-  - id: blocks.5.hook_resid_post__trainer_1_step_308
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_1_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_308
-  - id: blocks.5.hook_resid_post__trainer_1_step_3088
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_1_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_3088
-  - id: blocks.5.hook_resid_post__trainer_1_step_30881
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_1_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_30881
-  - id: blocks.5.hook_resid_post__trainer_1_step_97
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_1_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_97
-  - id: blocks.5.hook_resid_post__trainer_1_step_976
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_1_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_976
-  - id: blocks.5.hook_resid_post__trainer_1_step_9765
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_1_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_9765
-  - id: blocks.5.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_2_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5/trainer_2
-  - id: blocks.5.hook_resid_post__trainer_2_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_2_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_0
-  - id: blocks.5.hook_resid_post__trainer_2_step_308
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_2_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_308
-  - id: blocks.5.hook_resid_post__trainer_2_step_3088
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_2_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_3088
-  - id: blocks.5.hook_resid_post__trainer_2_step_30881
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_2_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_30881
-  - id: blocks.5.hook_resid_post__trainer_2_step_97
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_2_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_97
-  - id: blocks.5.hook_resid_post__trainer_2_step_976
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_2_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_976
-  - id: blocks.5.hook_resid_post__trainer_2_step_9765
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_2_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_9765
-  - id: blocks.5.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_3_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5/trainer_3
-  - id: blocks.5.hook_resid_post__trainer_3_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_3_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_0
-  - id: blocks.5.hook_resid_post__trainer_3_step_308
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_3_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_308
-  - id: blocks.5.hook_resid_post__trainer_3_step_3088
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_3_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_3088
-  - id: blocks.5.hook_resid_post__trainer_3_step_30881
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_3_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_30881
-  - id: blocks.5.hook_resid_post__trainer_3_step_97
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_3_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_97
-  - id: blocks.5.hook_resid_post__trainer_3_step_976
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_3_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_976
-  - id: blocks.5.hook_resid_post__trainer_3_step_9765
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_3_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_9765
-  - id: blocks.5.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_4_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5/trainer_4
-  - id: blocks.5.hook_resid_post__trainer_4_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_4_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_0
-  - id: blocks.5.hook_resid_post__trainer_4_step_308
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_4_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_308
-  - id: blocks.5.hook_resid_post__trainer_4_step_3088
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_4_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_3088
-  - id: blocks.5.hook_resid_post__trainer_4_step_30881
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_4_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_30881
-  - id: blocks.5.hook_resid_post__trainer_4_step_97
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_4_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_97
-  - id: blocks.5.hook_resid_post__trainer_4_step_976
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_4_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_976
-  - id: blocks.5.hook_resid_post__trainer_4_step_9765
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_4_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_9765
-  - id: blocks.5.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_5_step_final
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5/trainer_5
-  - id: blocks.5.hook_resid_post__trainer_5_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_5_step_0
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_0
-  - id: blocks.5.hook_resid_post__trainer_5_step_308
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_5_step_308
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_308
-  - id: blocks.5.hook_resid_post__trainer_5_step_3088
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_5_step_3088
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_3088
-  - id: blocks.5.hook_resid_post__trainer_5_step_30881
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_5_step_30881
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_30881
-  - id: blocks.5.hook_resid_post__trainer_5_step_97
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_5_step_97
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_97
-  - id: blocks.5.hook_resid_post__trainer_5_step_976
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_5_step_976
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_976
-  - id: blocks.5.hook_resid_post__trainer_5_step_9765
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-4k__trainer_5_step_9765
-    path: gemma-2-2b_vanilla_width-2pow12_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_9765
-sae_bench_gemma-2-2b_topk_width-2pow14_date-1109:
-  conversion_func: dictionary_learning_1
-  links:
-    model: https://huggingface.co/google/gemma-2-2b
-  model: gemma-2-2b
-  repo_id: canrager/saebench_gemma-2-2b_width-2pow14_date-1109
-  saes:
-  - id: blocks.12.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_0_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12/trainer_0
-  - id: blocks.12.hook_resid_post__trainer_0_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_0_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_0
-  - id: blocks.12.hook_resid_post__trainer_0_step_146
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_0_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_146
-  - id: blocks.12.hook_resid_post__trainer_0_step_1464
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_0_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_1464
-  - id: blocks.12.hook_resid_post__trainer_0_step_14648
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_0_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_14648
-  - id: blocks.12.hook_resid_post__trainer_0_step_463
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_0_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_463
-  - id: blocks.12.hook_resid_post__trainer_0_step_4632
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_0_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_4632
-  - id: blocks.12.hook_resid_post__trainer_0_step_46322
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_0_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_46322
-  - id: blocks.12.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_1_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12/trainer_1
-  - id: blocks.12.hook_resid_post__trainer_1_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_1_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_0
-  - id: blocks.12.hook_resid_post__trainer_1_step_146
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_1_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_146
-  - id: blocks.12.hook_resid_post__trainer_1_step_1464
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_1_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_1464
-  - id: blocks.12.hook_resid_post__trainer_1_step_14648
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_1_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_14648
-  - id: blocks.12.hook_resid_post__trainer_1_step_463
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_1_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_463
-  - id: blocks.12.hook_resid_post__trainer_1_step_4632
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_1_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_4632
-  - id: blocks.12.hook_resid_post__trainer_1_step_46322
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_1_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_46322
-  - id: blocks.12.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_2_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12/trainer_2
-  - id: blocks.12.hook_resid_post__trainer_2_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_2_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_0
-  - id: blocks.12.hook_resid_post__trainer_2_step_146
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_2_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_146
-  - id: blocks.12.hook_resid_post__trainer_2_step_1464
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_2_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_1464
-  - id: blocks.12.hook_resid_post__trainer_2_step_14648
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_2_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_14648
-  - id: blocks.12.hook_resid_post__trainer_2_step_463
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_2_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_463
-  - id: blocks.12.hook_resid_post__trainer_2_step_4632
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_2_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_4632
-  - id: blocks.12.hook_resid_post__trainer_2_step_46322
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_2_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_46322
-  - id: blocks.12.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_3_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12/trainer_3
-  - id: blocks.12.hook_resid_post__trainer_3_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_3_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_0
-  - id: blocks.12.hook_resid_post__trainer_3_step_146
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_3_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_146
-  - id: blocks.12.hook_resid_post__trainer_3_step_1464
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_3_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_1464
-  - id: blocks.12.hook_resid_post__trainer_3_step_14648
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_3_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_14648
-  - id: blocks.12.hook_resid_post__trainer_3_step_463
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_3_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_463
-  - id: blocks.12.hook_resid_post__trainer_3_step_4632
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_3_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_4632
-  - id: blocks.12.hook_resid_post__trainer_3_step_46322
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_3_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_46322
-  - id: blocks.12.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_4_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12/trainer_4
-  - id: blocks.12.hook_resid_post__trainer_4_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_4_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_0
-  - id: blocks.12.hook_resid_post__trainer_4_step_146
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_4_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_146
-  - id: blocks.12.hook_resid_post__trainer_4_step_1464
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_4_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_1464
-  - id: blocks.12.hook_resid_post__trainer_4_step_14648
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_4_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_14648
-  - id: blocks.12.hook_resid_post__trainer_4_step_463
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_4_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_463
-  - id: blocks.12.hook_resid_post__trainer_4_step_4632
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_4_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_4632
-  - id: blocks.12.hook_resid_post__trainer_4_step_46322
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_4_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_46322
-  - id: blocks.12.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_5_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12/trainer_5
-  - id: blocks.12.hook_resid_post__trainer_5_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_5_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_0
-  - id: blocks.12.hook_resid_post__trainer_5_step_146
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_5_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_146
-  - id: blocks.12.hook_resid_post__trainer_5_step_1464
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_5_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_1464
-  - id: blocks.12.hook_resid_post__trainer_5_step_14648
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_5_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_14648
-  - id: blocks.12.hook_resid_post__trainer_5_step_463
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_5_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_463
-  - id: blocks.12.hook_resid_post__trainer_5_step_4632
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_5_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_4632
-  - id: blocks.12.hook_resid_post__trainer_5_step_46322
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-16k__trainer_5_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_46322
-  - id: blocks.19.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_0_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19/trainer_0
-  - id: blocks.19.hook_resid_post__trainer_0_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_0_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_0
-  - id: blocks.19.hook_resid_post__trainer_0_step_146
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_0_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_146
-  - id: blocks.19.hook_resid_post__trainer_0_step_1464
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_0_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_1464
-  - id: blocks.19.hook_resid_post__trainer_0_step_14648
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_0_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_14648
-  - id: blocks.19.hook_resid_post__trainer_0_step_463
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_0_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_463
-  - id: blocks.19.hook_resid_post__trainer_0_step_4632
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_0_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_4632
-  - id: blocks.19.hook_resid_post__trainer_0_step_46322
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_0_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_46322
-  - id: blocks.19.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_1_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19/trainer_1
-  - id: blocks.19.hook_resid_post__trainer_1_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_1_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_0
-  - id: blocks.19.hook_resid_post__trainer_1_step_146
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_1_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_146
-  - id: blocks.19.hook_resid_post__trainer_1_step_1464
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_1_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_1464
-  - id: blocks.19.hook_resid_post__trainer_1_step_14648
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_1_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_14648
-  - id: blocks.19.hook_resid_post__trainer_1_step_463
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_1_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_463
-  - id: blocks.19.hook_resid_post__trainer_1_step_4632
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_1_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_4632
-  - id: blocks.19.hook_resid_post__trainer_1_step_46322
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_1_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_46322
-  - id: blocks.19.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_2_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19/trainer_2
-  - id: blocks.19.hook_resid_post__trainer_2_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_2_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_0
-  - id: blocks.19.hook_resid_post__trainer_2_step_146
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_2_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_146
-  - id: blocks.19.hook_resid_post__trainer_2_step_1464
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_2_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_1464
-  - id: blocks.19.hook_resid_post__trainer_2_step_14648
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_2_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_14648
-  - id: blocks.19.hook_resid_post__trainer_2_step_463
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_2_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_463
-  - id: blocks.19.hook_resid_post__trainer_2_step_4632
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_2_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_4632
-  - id: blocks.19.hook_resid_post__trainer_2_step_46322
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_2_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_46322
-  - id: blocks.19.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_3_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19/trainer_3
-  - id: blocks.19.hook_resid_post__trainer_3_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_3_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_0
-  - id: blocks.19.hook_resid_post__trainer_3_step_146
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_3_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_146
-  - id: blocks.19.hook_resid_post__trainer_3_step_1464
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_3_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_1464
-  - id: blocks.19.hook_resid_post__trainer_3_step_14648
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_3_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_14648
-  - id: blocks.19.hook_resid_post__trainer_3_step_463
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_3_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_463
-  - id: blocks.19.hook_resid_post__trainer_3_step_4632
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_3_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_4632
-  - id: blocks.19.hook_resid_post__trainer_3_step_46322
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_3_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_46322
-  - id: blocks.19.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_4_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19/trainer_4
-  - id: blocks.19.hook_resid_post__trainer_4_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_4_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_0
-  - id: blocks.19.hook_resid_post__trainer_4_step_146
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_4_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_146
-  - id: blocks.19.hook_resid_post__trainer_4_step_1464
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_4_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_1464
-  - id: blocks.19.hook_resid_post__trainer_4_step_14648
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_4_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_14648
-  - id: blocks.19.hook_resid_post__trainer_4_step_463
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_4_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_463
-  - id: blocks.19.hook_resid_post__trainer_4_step_4632
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_4_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_4632
-  - id: blocks.19.hook_resid_post__trainer_4_step_46322
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_4_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_46322
-  - id: blocks.19.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_5_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19/trainer_5
-  - id: blocks.19.hook_resid_post__trainer_5_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_5_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_0
-  - id: blocks.19.hook_resid_post__trainer_5_step_146
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_5_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_146
-  - id: blocks.19.hook_resid_post__trainer_5_step_1464
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_5_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_1464
-  - id: blocks.19.hook_resid_post__trainer_5_step_14648
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_5_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_14648
-  - id: blocks.19.hook_resid_post__trainer_5_step_463
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_5_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_463
-  - id: blocks.19.hook_resid_post__trainer_5_step_4632
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_5_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_4632
-  - id: blocks.19.hook_resid_post__trainer_5_step_46322
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-16k__trainer_5_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_46322
-  - id: blocks.5.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_0_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5/trainer_0
-  - id: blocks.5.hook_resid_post__trainer_0_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_0_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_0
-  - id: blocks.5.hook_resid_post__trainer_0_step_146
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_0_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_146
-  - id: blocks.5.hook_resid_post__trainer_0_step_1464
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_0_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_1464
-  - id: blocks.5.hook_resid_post__trainer_0_step_14648
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_0_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_14648
-  - id: blocks.5.hook_resid_post__trainer_0_step_463
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_0_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_463
-  - id: blocks.5.hook_resid_post__trainer_0_step_4632
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_0_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_4632
-  - id: blocks.5.hook_resid_post__trainer_0_step_46322
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_0_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_46322
-  - id: blocks.5.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_1_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5/trainer_1
-  - id: blocks.5.hook_resid_post__trainer_1_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_1_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_0
-  - id: blocks.5.hook_resid_post__trainer_1_step_146
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_1_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_146
-  - id: blocks.5.hook_resid_post__trainer_1_step_1464
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_1_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_1464
-  - id: blocks.5.hook_resid_post__trainer_1_step_14648
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_1_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_14648
-  - id: blocks.5.hook_resid_post__trainer_1_step_463
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_1_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_463
-  - id: blocks.5.hook_resid_post__trainer_1_step_4632
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_1_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_4632
-  - id: blocks.5.hook_resid_post__trainer_1_step_46322
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_1_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_46322
-  - id: blocks.5.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_2_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5/trainer_2
-  - id: blocks.5.hook_resid_post__trainer_2_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_2_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_0
-  - id: blocks.5.hook_resid_post__trainer_2_step_146
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_2_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_146
-  - id: blocks.5.hook_resid_post__trainer_2_step_1464
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_2_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_1464
-  - id: blocks.5.hook_resid_post__trainer_2_step_14648
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_2_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_14648
-  - id: blocks.5.hook_resid_post__trainer_2_step_463
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_2_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_463
-  - id: blocks.5.hook_resid_post__trainer_2_step_4632
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_2_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_4632
-  - id: blocks.5.hook_resid_post__trainer_2_step_46322
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_2_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_46322
-  - id: blocks.5.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_3_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5/trainer_3
-  - id: blocks.5.hook_resid_post__trainer_3_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_3_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_0
-  - id: blocks.5.hook_resid_post__trainer_3_step_146
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_3_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_146
-  - id: blocks.5.hook_resid_post__trainer_3_step_1464
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_3_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_1464
-  - id: blocks.5.hook_resid_post__trainer_3_step_14648
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_3_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_14648
-  - id: blocks.5.hook_resid_post__trainer_3_step_463
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_3_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_463
-  - id: blocks.5.hook_resid_post__trainer_3_step_4632
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_3_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_4632
-  - id: blocks.5.hook_resid_post__trainer_3_step_46322
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_3_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_46322
-  - id: blocks.5.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_4_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5/trainer_4
-  - id: blocks.5.hook_resid_post__trainer_4_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_4_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_0
-  - id: blocks.5.hook_resid_post__trainer_4_step_146
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_4_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_146
-  - id: blocks.5.hook_resid_post__trainer_4_step_1464
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_4_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_1464
-  - id: blocks.5.hook_resid_post__trainer_4_step_14648
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_4_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_14648
-  - id: blocks.5.hook_resid_post__trainer_4_step_463
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_4_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_463
-  - id: blocks.5.hook_resid_post__trainer_4_step_4632
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_4_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_4632
-  - id: blocks.5.hook_resid_post__trainer_4_step_46322
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_4_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_46322
-  - id: blocks.5.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_5_step_final
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5/trainer_5
-  - id: blocks.5.hook_resid_post__trainer_5_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_5_step_0
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_0
-  - id: blocks.5.hook_resid_post__trainer_5_step_146
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_5_step_146
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_146
-  - id: blocks.5.hook_resid_post__trainer_5_step_1464
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_5_step_1464
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_1464
-  - id: blocks.5.hook_resid_post__trainer_5_step_14648
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_5_step_14648
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_14648
-  - id: blocks.5.hook_resid_post__trainer_5_step_463
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_5_step_463
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_463
-  - id: blocks.5.hook_resid_post__trainer_5_step_4632
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_5_step_4632
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_4632
-  - id: blocks.5.hook_resid_post__trainer_5_step_46322
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-16k__trainer_5_step_46322
-    path: gemma-2-2b_topk_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_46322
-sae_bench_gemma-2-2b_vanilla_width-2pow14_date-1109:
-  conversion_func: dictionary_learning_1
-  links:
-    model: https://huggingface.co/google/gemma-2-2b
-  model: gemma-2-2b
-  repo_id: canrager/saebench_gemma-2-2b_width-2pow14_date-1109
-  saes:
-  - id: blocks.12.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_0_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12/trainer_0
-  - id: blocks.12.hook_resid_post__trainer_0_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_0_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_0
-  - id: blocks.12.hook_resid_post__trainer_0_step_146
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_0_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_146
-  - id: blocks.12.hook_resid_post__trainer_0_step_1464
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_0_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_1464
-  - id: blocks.12.hook_resid_post__trainer_0_step_14648
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_0_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_14648
-  - id: blocks.12.hook_resid_post__trainer_0_step_463
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_0_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_463
-  - id: blocks.12.hook_resid_post__trainer_0_step_4632
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_0_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_4632
-  - id: blocks.12.hook_resid_post__trainer_0_step_46322
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_0_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_0_step_46322
-  - id: blocks.12.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_1_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12/trainer_1
-  - id: blocks.12.hook_resid_post__trainer_1_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_1_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_0
-  - id: blocks.12.hook_resid_post__trainer_1_step_146
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_1_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_146
-  - id: blocks.12.hook_resid_post__trainer_1_step_1464
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_1_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_1464
-  - id: blocks.12.hook_resid_post__trainer_1_step_14648
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_1_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_14648
-  - id: blocks.12.hook_resid_post__trainer_1_step_463
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_1_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_463
-  - id: blocks.12.hook_resid_post__trainer_1_step_4632
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_1_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_4632
-  - id: blocks.12.hook_resid_post__trainer_1_step_46322
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_1_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_1_step_46322
-  - id: blocks.12.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_2_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12/trainer_2
-  - id: blocks.12.hook_resid_post__trainer_2_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_2_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_0
-  - id: blocks.12.hook_resid_post__trainer_2_step_146
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_2_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_146
-  - id: blocks.12.hook_resid_post__trainer_2_step_1464
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_2_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_1464
-  - id: blocks.12.hook_resid_post__trainer_2_step_14648
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_2_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_14648
-  - id: blocks.12.hook_resid_post__trainer_2_step_463
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_2_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_463
-  - id: blocks.12.hook_resid_post__trainer_2_step_4632
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_2_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_4632
-  - id: blocks.12.hook_resid_post__trainer_2_step_46322
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_2_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_2_step_46322
-  - id: blocks.12.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_3_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12/trainer_3
-  - id: blocks.12.hook_resid_post__trainer_3_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_3_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_0
-  - id: blocks.12.hook_resid_post__trainer_3_step_146
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_3_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_146
-  - id: blocks.12.hook_resid_post__trainer_3_step_1464
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_3_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_1464
-  - id: blocks.12.hook_resid_post__trainer_3_step_14648
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_3_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_14648
-  - id: blocks.12.hook_resid_post__trainer_3_step_463
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_3_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_463
-  - id: blocks.12.hook_resid_post__trainer_3_step_4632
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_3_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_4632
-  - id: blocks.12.hook_resid_post__trainer_3_step_46322
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_3_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_3_step_46322
-  - id: blocks.12.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_4_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12/trainer_4
-  - id: blocks.12.hook_resid_post__trainer_4_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_4_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_0
-  - id: blocks.12.hook_resid_post__trainer_4_step_146
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_4_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_146
-  - id: blocks.12.hook_resid_post__trainer_4_step_1464
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_4_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_1464
-  - id: blocks.12.hook_resid_post__trainer_4_step_14648
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_4_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_14648
-  - id: blocks.12.hook_resid_post__trainer_4_step_463
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_4_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_463
-  - id: blocks.12.hook_resid_post__trainer_4_step_4632
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_4_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_4632
-  - id: blocks.12.hook_resid_post__trainer_4_step_46322
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_4_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_4_step_46322
-  - id: blocks.12.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_5_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12/trainer_5
-  - id: blocks.12.hook_resid_post__trainer_5_step_0
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_5_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_0
-  - id: blocks.12.hook_resid_post__trainer_5_step_146
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_5_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_146
-  - id: blocks.12.hook_resid_post__trainer_5_step_1464
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_5_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_1464
-  - id: blocks.12.hook_resid_post__trainer_5_step_14648
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_5_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_14648
-  - id: blocks.12.hook_resid_post__trainer_5_step_463
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_5_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_463
-  - id: blocks.12.hook_resid_post__trainer_5_step_4632
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_5_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_4632
-  - id: blocks.12.hook_resid_post__trainer_5_step_46322
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-16k__trainer_5_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_12_checkpoints/trainer_5_step_46322
-  - id: blocks.19.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_0_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19/trainer_0
-  - id: blocks.19.hook_resid_post__trainer_0_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_0_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_0
-  - id: blocks.19.hook_resid_post__trainer_0_step_146
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_0_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_146
-  - id: blocks.19.hook_resid_post__trainer_0_step_1464
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_0_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_1464
-  - id: blocks.19.hook_resid_post__trainer_0_step_14648
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_0_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_14648
-  - id: blocks.19.hook_resid_post__trainer_0_step_463
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_0_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_463
-  - id: blocks.19.hook_resid_post__trainer_0_step_4632
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_0_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_4632
-  - id: blocks.19.hook_resid_post__trainer_0_step_46322
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_0_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_0_step_46322
-  - id: blocks.19.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_1_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19/trainer_1
-  - id: blocks.19.hook_resid_post__trainer_1_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_1_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_0
-  - id: blocks.19.hook_resid_post__trainer_1_step_146
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_1_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_146
-  - id: blocks.19.hook_resid_post__trainer_1_step_1464
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_1_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_1464
-  - id: blocks.19.hook_resid_post__trainer_1_step_14648
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_1_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_14648
-  - id: blocks.19.hook_resid_post__trainer_1_step_463
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_1_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_463
-  - id: blocks.19.hook_resid_post__trainer_1_step_4632
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_1_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_4632
-  - id: blocks.19.hook_resid_post__trainer_1_step_46322
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_1_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_1_step_46322
-  - id: blocks.19.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_2_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19/trainer_2
-  - id: blocks.19.hook_resid_post__trainer_2_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_2_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_0
-  - id: blocks.19.hook_resid_post__trainer_2_step_146
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_2_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_146
-  - id: blocks.19.hook_resid_post__trainer_2_step_1464
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_2_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_1464
-  - id: blocks.19.hook_resid_post__trainer_2_step_14648
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_2_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_14648
-  - id: blocks.19.hook_resid_post__trainer_2_step_463
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_2_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_463
-  - id: blocks.19.hook_resid_post__trainer_2_step_4632
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_2_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_4632
-  - id: blocks.19.hook_resid_post__trainer_2_step_46322
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_2_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_2_step_46322
-  - id: blocks.19.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_3_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19/trainer_3
-  - id: blocks.19.hook_resid_post__trainer_3_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_3_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_0
-  - id: blocks.19.hook_resid_post__trainer_3_step_146
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_3_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_146
-  - id: blocks.19.hook_resid_post__trainer_3_step_1464
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_3_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_1464
-  - id: blocks.19.hook_resid_post__trainer_3_step_14648
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_3_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_14648
-  - id: blocks.19.hook_resid_post__trainer_3_step_463
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_3_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_463
-  - id: blocks.19.hook_resid_post__trainer_3_step_4632
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_3_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_4632
-  - id: blocks.19.hook_resid_post__trainer_3_step_46322
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_3_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_3_step_46322
-  - id: blocks.19.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_4_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19/trainer_4
-  - id: blocks.19.hook_resid_post__trainer_4_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_4_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_0
-  - id: blocks.19.hook_resid_post__trainer_4_step_146
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_4_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_146
-  - id: blocks.19.hook_resid_post__trainer_4_step_1464
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_4_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_1464
-  - id: blocks.19.hook_resid_post__trainer_4_step_14648
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_4_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_14648
-  - id: blocks.19.hook_resid_post__trainer_4_step_463
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_4_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_463
-  - id: blocks.19.hook_resid_post__trainer_4_step_4632
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_4_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_4632
-  - id: blocks.19.hook_resid_post__trainer_4_step_46322
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_4_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_4_step_46322
-  - id: blocks.19.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_5_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19/trainer_5
-  - id: blocks.19.hook_resid_post__trainer_5_step_0
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_5_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_0
-  - id: blocks.19.hook_resid_post__trainer_5_step_146
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_5_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_146
-  - id: blocks.19.hook_resid_post__trainer_5_step_1464
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_5_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_1464
-  - id: blocks.19.hook_resid_post__trainer_5_step_14648
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_5_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_14648
-  - id: blocks.19.hook_resid_post__trainer_5_step_463
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_5_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_463
-  - id: blocks.19.hook_resid_post__trainer_5_step_4632
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_5_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_4632
-  - id: blocks.19.hook_resid_post__trainer_5_step_46322
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-16k__trainer_5_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_19_checkpoints/trainer_5_step_46322
-  - id: blocks.5.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_0_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5/trainer_0
-  - id: blocks.5.hook_resid_post__trainer_0_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_0_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_0
-  - id: blocks.5.hook_resid_post__trainer_0_step_146
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_0_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_146
-  - id: blocks.5.hook_resid_post__trainer_0_step_1464
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_0_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_1464
-  - id: blocks.5.hook_resid_post__trainer_0_step_14648
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_0_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_14648
-  - id: blocks.5.hook_resid_post__trainer_0_step_463
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_0_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_463
-  - id: blocks.5.hook_resid_post__trainer_0_step_4632
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_0_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_4632
-  - id: blocks.5.hook_resid_post__trainer_0_step_46322
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_0_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_0_step_46322
-  - id: blocks.5.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_1_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5/trainer_1
-  - id: blocks.5.hook_resid_post__trainer_1_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_1_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_0
-  - id: blocks.5.hook_resid_post__trainer_1_step_146
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_1_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_146
-  - id: blocks.5.hook_resid_post__trainer_1_step_1464
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_1_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_1464
-  - id: blocks.5.hook_resid_post__trainer_1_step_14648
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_1_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_14648
-  - id: blocks.5.hook_resid_post__trainer_1_step_463
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_1_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_463
-  - id: blocks.5.hook_resid_post__trainer_1_step_4632
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_1_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_4632
-  - id: blocks.5.hook_resid_post__trainer_1_step_46322
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_1_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_1_step_46322
-  - id: blocks.5.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_2_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5/trainer_2
-  - id: blocks.5.hook_resid_post__trainer_2_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_2_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_0
-  - id: blocks.5.hook_resid_post__trainer_2_step_146
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_2_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_146
-  - id: blocks.5.hook_resid_post__trainer_2_step_1464
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_2_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_1464
-  - id: blocks.5.hook_resid_post__trainer_2_step_14648
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_2_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_14648
-  - id: blocks.5.hook_resid_post__trainer_2_step_463
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_2_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_463
-  - id: blocks.5.hook_resid_post__trainer_2_step_4632
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_2_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_4632
-  - id: blocks.5.hook_resid_post__trainer_2_step_46322
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_2_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_2_step_46322
-  - id: blocks.5.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_3_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5/trainer_3
-  - id: blocks.5.hook_resid_post__trainer_3_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_3_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_0
-  - id: blocks.5.hook_resid_post__trainer_3_step_146
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_3_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_146
-  - id: blocks.5.hook_resid_post__trainer_3_step_1464
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_3_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_1464
-  - id: blocks.5.hook_resid_post__trainer_3_step_14648
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_3_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_14648
-  - id: blocks.5.hook_resid_post__trainer_3_step_463
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_3_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_463
-  - id: blocks.5.hook_resid_post__trainer_3_step_4632
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_3_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_4632
-  - id: blocks.5.hook_resid_post__trainer_3_step_46322
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_3_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_3_step_46322
-  - id: blocks.5.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_4_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5/trainer_4
-  - id: blocks.5.hook_resid_post__trainer_4_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_4_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_0
-  - id: blocks.5.hook_resid_post__trainer_4_step_146
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_4_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_146
-  - id: blocks.5.hook_resid_post__trainer_4_step_1464
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_4_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_1464
-  - id: blocks.5.hook_resid_post__trainer_4_step_14648
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_4_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_14648
-  - id: blocks.5.hook_resid_post__trainer_4_step_463
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_4_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_463
-  - id: blocks.5.hook_resid_post__trainer_4_step_4632
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_4_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_4632
-  - id: blocks.5.hook_resid_post__trainer_4_step_46322
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_4_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_4_step_46322
-  - id: blocks.5.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_5_step_final
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5/trainer_5
-  - id: blocks.5.hook_resid_post__trainer_5_step_0
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_5_step_0
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_0
-  - id: blocks.5.hook_resid_post__trainer_5_step_146
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_5_step_146
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_146
-  - id: blocks.5.hook_resid_post__trainer_5_step_1464
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_5_step_1464
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_1464
-  - id: blocks.5.hook_resid_post__trainer_5_step_14648
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_5_step_14648
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_14648
-  - id: blocks.5.hook_resid_post__trainer_5_step_463
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_5_step_463
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_463
-  - id: blocks.5.hook_resid_post__trainer_5_step_4632
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_5_step_4632
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_4632
-  - id: blocks.5.hook_resid_post__trainer_5_step_46322
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-16k__trainer_5_step_46322
-    path: gemma-2-2b_vanilla_width-2pow14_date-1109/resid_post_layer_5_checkpoints/trainer_5_step_46322
-sae_bench_gemma-2-2b_vanilla_width-2pow16_date-1109:
-  conversion_func: dictionary_learning_1
-  links:
-    model: https://huggingface.co/google/gemma-2-2b
-  model: gemma-2-2b
-  repo_id: canrager/saebench_gemma-2-2b_width-2pow16_date-1109
-  saes:
-  - id: blocks.12.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-65k__trainer_0_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_12/trainer_0
-  - id: blocks.12.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-65k__trainer_1_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_12/trainer_1
-  - id: blocks.12.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-65k__trainer_2_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_12/trainer_2
-  - id: blocks.12.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-65k__trainer_3_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_12/trainer_3
-  - id: blocks.12.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-65k__trainer_4_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_12/trainer_4
-  - id: blocks.12.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/12-sae_bench-standard-res-65k__trainer_5_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_12/trainer_5
-  - id: blocks.19.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-65k__trainer_0_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_19/trainer_0
-  - id: blocks.19.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-65k__trainer_1_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_19/trainer_1
-  - id: blocks.19.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-65k__trainer_2_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_19/trainer_2
-  - id: blocks.19.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-65k__trainer_3_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_19/trainer_3
-  - id: blocks.19.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-65k__trainer_4_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_19/trainer_4
-  - id: blocks.19.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/19-sae_bench-standard-res-65k__trainer_5_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_19/trainer_5
-  - id: blocks.5.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-65k__trainer_0_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_5/trainer_0
-  - id: blocks.5.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-65k__trainer_1_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_5/trainer_1
-  - id: blocks.5.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-65k__trainer_2_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_5/trainer_2
-  - id: blocks.5.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-65k__trainer_3_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_5/trainer_3
-  - id: blocks.5.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-65k__trainer_4_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_5/trainer_4
-  - id: blocks.5.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/5-sae_bench-standard-res-65k__trainer_5_step_final
-    path: gemma-2-2b_vanilla_width-2pow16_date-1109/resid_post_layer_5/trainer_5
-sae_bench_gemma-2-2b_topk_width-2pow16_date-1109:
-  conversion_func: dictionary_learning_1
-  links:
-    model: https://huggingface.co/google/gemma-2-2b
-  model: gemma-2-2b
-  repo_id: canrager/saebench_gemma-2-2b_width-2pow16_date-1109
-  saes:
-  - id: blocks.12.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-65k__trainer_0_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_12/trainer_0
-  - id: blocks.12.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-65k__trainer_1_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_12/trainer_1
-  - id: blocks.12.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-65k__trainer_2_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_12/trainer_2
-  - id: blocks.12.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-65k__trainer_3_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_12/trainer_3
-  - id: blocks.12.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-65k__trainer_4_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_12/trainer_4
-  - id: blocks.12.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/12-sae_bench-topk-res-65k__trainer_5_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_12/trainer_5
-  - id: blocks.19.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-65k__trainer_0_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_19/trainer_0
-  - id: blocks.19.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-65k__trainer_1_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_19/trainer_1
-  - id: blocks.19.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-65k__trainer_2_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_19/trainer_2
-  - id: blocks.19.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-65k__trainer_3_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_19/trainer_3
-  - id: blocks.19.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-65k__trainer_4_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_19/trainer_4
-  - id: blocks.19.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/19-sae_bench-topk-res-65k__trainer_5_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_19/trainer_5
-  - id: blocks.5.hook_resid_post__trainer_0
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-65k__trainer_0_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_5/trainer_0
-  - id: blocks.5.hook_resid_post__trainer_1
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-65k__trainer_1_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_5/trainer_1
-  - id: blocks.5.hook_resid_post__trainer_2
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-65k__trainer_2_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_5/trainer_2
-  - id: blocks.5.hook_resid_post__trainer_3
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-65k__trainer_3_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_5/trainer_3
-  - id: blocks.5.hook_resid_post__trainer_4
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-65k__trainer_4_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_5/trainer_4
-  - id: blocks.5.hook_resid_post__trainer_5
-    neuronpedia: gemma-2-2b/5-sae_bench-topk-res-65k__trainer_5_step_final
-    path: gemma-2-2b_topk_width-2pow16_date-1109/resid_post_layer_5/trainer_5
-deepseek-r1-distill-llama-8b-qresearch:
-  repo_id: qresearch/DeepSeek-R1-Distill-Llama-8B-SAE-l19
-  model: deepseek-ai/DeepSeek-R1-Distill-Llama-8B
-  conversion_func: deepseek_r1
-  saes:
-    - id: blocks.19.hook_resid_post
-      neuronpedia: deepseek-r1-distill-llama-8b/19-qresearch-res-65k
-      path: DeepSeek-R1-Distill-Llama-8B-SAE-l19.pt

--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -10826,100 +10826,100 @@ llama_scope_r1_distill:
   - id: l31r_400m_slimpajama_400m_openr1_math
     norm_scaling_factor: 1.041977999933546
     path: 400M-Slimpajama-400M-OpenR1-Math-220k/L31R
-  - id: l0r_0_slimpajama_800m_openr1_math
+  - id: l0r_800m_openr1_math
     norm_scaling_factor: 54.308791085956486
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L0R
-  - id: l1r_0_slimpajama_800m_openr1_math
+  - id: l1r_800m_openr1_math
     norm_scaling_factor: 36.49473030775242
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L1R
-  - id: l2r_0_slimpajama_800m_openr1_math
+  - id: l2r_800m_openr1_math
     norm_scaling_factor: 26.96126387031055
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L2R
-  - id: l3r_0_slimpajama_800m_openr1_math
+  - id: l3r_800m_openr1_math
     norm_scaling_factor: 20.52210199911164
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L3R
-  - id: l4r_0_slimpajama_800m_openr1_math
+  - id: l4r_800m_openr1_math
     norm_scaling_factor: 16.67733543806145
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L4R
-  - id: l5r_0_slimpajama_800m_openr1_math
+  - id: l5r_800m_openr1_math
     norm_scaling_factor: 14.067505043509176
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L5R
-  - id: l6r_0_slimpajama_800m_openr1_math
+  - id: l6r_800m_openr1_math
     norm_scaling_factor: 12.034338704494331
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L6R
-  - id: l7r_0_slimpajama_800m_openr1_math
+  - id: l7r_800m_openr1_math
     norm_scaling_factor: 10.495662821867164
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L7R
-  - id: l8r_0_slimpajama_800m_openr1_math
+  - id: l8r_800m_openr1_math
     norm_scaling_factor: 9.683004157081735
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L8R
-  - id: l9r_0_slimpajama_800m_openr1_math
+  - id: l9r_800m_openr1_math
     norm_scaling_factor: 8.679730500864236
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L9R
-  - id: l10r_0_slimpajama_800m_openr1_math
+  - id: l10r_800m_openr1_math
     norm_scaling_factor: 7.988383971728427
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L10R
-  - id: l11r_0_slimpajama_800m_openr1_math
+  - id: l11r_800m_openr1_math
     norm_scaling_factor: 7.237531143695951
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L11R
-  - id: l12r_0_slimpajama_800m_openr1_math
+  - id: l12r_800m_openr1_math
     norm_scaling_factor: 6.69444885029299
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L12R
-  - id: l13r_0_slimpajama_800m_openr1_math
+  - id: l13r_800m_openr1_math
     norm_scaling_factor: 6.0489858065009265
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L13R
-  - id: l14r_0_slimpajama_800m_openr1_math
+  - id: l14r_800m_openr1_math
     norm_scaling_factor: 5.4935929917888595
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L14R
-  - id: l15r_0_slimpajama_800m_openr1_math
+  - id: l15r_800m_openr1_math
     norm_scaling_factor: 4.970860531188141
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L15R
-  - id: l16r_0_slimpajama_800m_openr1_math
+  - id: l16r_800m_openr1_math
     norm_scaling_factor: 4.541887865516153
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L16R
-  - id: l17r_0_slimpajama_800m_openr1_math
+  - id: l17r_800m_openr1_math
     norm_scaling_factor: 4.111292885351861
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L17R
-  - id: l18r_0_slimpajama_800m_openr1_math
+  - id: l18r_800m_openr1_math
     norm_scaling_factor: 3.7319009471881754
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L18R
-  - id: l19r_0_slimpajama_800m_openr1_math
+  - id: l19r_800m_openr1_math
     norm_scaling_factor: 3.4464218438335172
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L19R
-  - id: l20r_0_slimpajama_800m_openr1_math
+  - id: l20r_800m_openr1_math
     norm_scaling_factor: 3.1614163309538377
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L20R
-  - id: l21r_0_slimpajama_800m_openr1_math
+  - id: l21r_800m_openr1_math
     norm_scaling_factor: 2.8600260547627334
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L21R
-  - id: l22r_0_slimpajama_800m_openr1_math
+  - id: l22r_800m_openr1_math
     norm_scaling_factor: 2.636157171207381
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L22R
-  - id: l23r_0_slimpajama_800m_openr1_math
+  - id: l23r_800m_openr1_math
     norm_scaling_factor: 2.4287397996449367
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L23R
-  - id: l24r_0_slimpajama_800m_openr1_math
+  - id: l24r_800m_openr1_math
     norm_scaling_factor: 2.2405978768214556
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L24R
-  - id: l25r_0_slimpajama_800m_openr1_math
+  - id: l25r_800m_openr1_math
     norm_scaling_factor: 2.034659098936678
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L25R
-  - id: l26r_0_slimpajama_800m_openr1_math
+  - id: l26r_800m_openr1_math
     norm_scaling_factor: 1.8430054630341937
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L26R
-  - id: l27r_0_slimpajama_800m_openr1_math
+  - id: l27r_800m_openr1_math
     norm_scaling_factor: 1.6554423260870552
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L27R
-  - id: l28r_0_slimpajama_800m_openr1_math
+  - id: l28r_800m_openr1_math
     norm_scaling_factor: 1.477070442772071
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L28R
-  - id: l29r_0_slimpajama_800m_openr1_math
+  - id: l29r_800m_openr1_math
     norm_scaling_factor: 1.3361543238773446
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L29R
-  - id: l30r_0_slimpajama_800m_openr1_math
+  - id: l30r_800m_openr1_math
     norm_scaling_factor: 1.1387454210154435
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L30R
-  - id: l31r_0_slimpajama_800m_openr1_math
+  - id: l31r_800m_openr1_math
     norm_scaling_factor: 0.926395749048437
     path: 0-Slimpajama-800M-OpenR1-Math-220k/L31R
 mistral-7b-res-wg:

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -645,16 +645,15 @@ def llama_scope_r1_distill_sae_loader(
         "b_dec": state_dict_loaded["decoder.bias"].to(
             dtype=DTYPE_MAP[cfg_dict["dtype"]]
         ),
-        "threshold": state_dict_loaded["log_jumprelu_threshold"].to(
-            dtype=DTYPE_MAP[cfg_dict["dtype"]]
-        ).exp(),
+        "threshold": state_dict_loaded["log_jumprelu_threshold"]
+        .to(dtype=DTYPE_MAP[cfg_dict["dtype"]])
+        .exp(),
     }
 
     # No sparsity tensor for Llama Scope SAEs
     log_sparsity = None
 
     return cfg_dict, state_dict, log_sparsity
-
 
 
 def get_dictionary_learning_config_1(


### PR DESCRIPTION
**Failing tests seem to be caused by a connection error to pythia-14m config, which is irrelevant to this PR. As suggested by @hijohnnylin I ignore this.**

# Description

Supports llama scope r1 distill SAEs in https://huggingface.co/fnlp/Llama-Scope-R1-Distill/tree/main. This set includes 96 SAEs (32 layers * 3 data recipes). The 3 data recipes include
- 800M pretraining data ([Slimpajama](https://huggingface.co/datasets/Hzfinfdu/SlimPajama-3B))
- 400M pretraining data + 400M math reasoning data
- 800M math reasoning data ([OpenR1-Math-220k](https://huggingface.co/datasets/open-r1/OpenR1-Math-220k))

 No dependency is required for this change.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 