### PR TITLE
fix: base k_aux on d_in instead of d_sae in topk aux loss

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ mkdocstrings = "^0.25.2"
 mkdocstrings-python = "^1.10.9"
 tabulate = "^0.9.0"
 ruff = "^0.7.4"
+sparsify = {git = "https://github.com/EleutherAI/sparsify"}
 
 [tool.poetry.extras]
 mamba = ["mamba-lens"]

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -473,7 +473,7 @@ class TrainingSAE(SAE):
             dead_neuron_mask is not None
             and (num_dead := int(dead_neuron_mask.sum())) > 0
         ):
-            residual = sae_in - sae_out
+            residual = (sae_in - sae_out).detach()
 
             # Heuristic from Appendix B.1 in the paper
             k_aux = sae_in.shape[-1] // 2

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -476,7 +476,7 @@ class TrainingSAE(SAE):
             residual = sae_in - sae_out
 
             # Heuristic from Appendix B.1 in the paper
-            k_aux = hidden_pre.shape[-1] // 2
+            k_aux = sae_in.shape[-1] // 2
 
             # Reduce the scale of the loss if there are a small number of dead latents
             scale = min(num_dead / k_aux, 1.0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import random
 import shutil
 from pathlib import Path
@@ -10,6 +11,9 @@ from sae_lens.sae import SAE
 from tests.helpers import TINYSTORIES_MODEL, load_model_cached
 
 torch.set_grad_enabled(True)
+
+# sparsify's triton implementation breaks in CI, so just disable it
+os.environ["SPARSIFY_DISABLE_TRITON"] = "1"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/training/test_training_sae.py
+++ b/tests/training/test_training_sae.py
@@ -114,7 +114,7 @@ def test_TrainingSAE_topk_aux_loss_matches_unnormalized_sparsify_implementation(
     )
 
     sae = TrainingSAE(TrainingSAEConfig.from_sae_runner_config(cfg))
-    comparison_sae = SparseCoder(
+    sparse_coder_sae = SparseCoder(
         d_in=d_in, cfg=SparseCoderConfig(num_latents=d_sae, k=26)
     )
 
@@ -124,10 +124,10 @@ def test_TrainingSAE_topk_aux_loss_matches_unnormalized_sparsify_implementation(
         # this is not something we need to try to replicate.
         sae.b_enc.data = sae.b_enc + 100.0
         # make sure all params are the same
-        comparison_sae.encoder.weight.data = sae.W_enc.T
-        comparison_sae.encoder.bias.data = sae.b_enc
-        comparison_sae.b_dec.data = sae.b_dec
-        comparison_sae.W_dec.data = sae.W_dec  # type: ignore
+        sparse_coder_sae.encoder.weight.data = sae.W_enc.T
+        sparse_coder_sae.encoder.bias.data = sae.b_enc
+        sparse_coder_sae.b_dec.data = sae.b_dec
+        sparse_coder_sae.W_dec.data = sae.W_dec  # type: ignore
 
     dead_neuron_mask = torch.randn(d_sae) > 0.1
     input_acts = torch.randn(200, d_in)
@@ -138,7 +138,9 @@ def test_TrainingSAE_topk_aux_loss_matches_unnormalized_sparsify_implementation(
         current_l1_coefficient=0.0,
         dead_neuron_mask=dead_neuron_mask,
     )
-    comparison_sae_out = comparison_sae.forward(input_acts, dead_mask=dead_neuron_mask)
+    comparison_sae_out = sparse_coder_sae.forward(
+        input_acts, dead_mask=dead_neuron_mask
+    )
     comparison_aux_loss = comparison_sae_out.auxk_loss.detach().item()
 
     normalization = input_var / input_acts.shape[0]


### PR DESCRIPTION
# Description

This PR fixes a minor issue with our topk aux loss implementation, where we calculate `k_aux` using `d_sae` instead of the correct `d_in`. This likely doesn't make a huge difference in practice, but can't hurt to fix. This PR also calls `detach()` on the residual error before calculating topk aux loss, similar to [dictionary_learning's implementation](https://github.com/saprmarks/dictionary_learning/blob/main/dictionary_learning/trainers/top_k.py#L297). This should help ensure that the aux loss only pulls dead latents towards the SAE error, and doesn't accidentally pull live latents towards dead latents.

This PR also adds a test asserting that our topk aux loss matches the sparsity implementation aside from a normalization factor.

As a side note, we should probably add an optional `aux_coefficient` to the config to further customize this, but this is something that probably makes sense to hold off on until the refactor is done. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)