### PR TITLE
feat: Add support for dataset name in PretokenizeRunner

### DIFF
--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -674,6 +674,7 @@ def _validate_seqpos(seqpos: tuple[int | None, ...], context_size: int) -> None:
 class PretokenizeRunnerConfig:
     tokenizer_name: str = "gpt2"
     dataset_path: str = ""
+    dataset_name: str | None = None
     dataset_trust_remote_code: bool | None = None
     split: str | None = "train"
     data_files: list[str] | None = None

--- a/sae_lens/pretokenize_runner.py
+++ b/sae_lens/pretokenize_runner.py
@@ -25,8 +25,10 @@ class PretokenizedDatasetMetadata:
     sae_lens_version: str
     tokenizer_name: str
     original_dataset: str
+    original_dataset_name: str | None
     original_split: str | None
     original_data_files: list[str] | None
+    original_column_name: str | None
     context_size: int
     shuffled: bool
     seed: int | None
@@ -40,8 +42,10 @@ def metadata_from_config(cfg: PretokenizeRunnerConfig) -> PretokenizedDatasetMet
         sae_lens_version=__version__,
         tokenizer_name=cfg.tokenizer_name,
         original_dataset=cfg.dataset_path,
+        original_dataset_name=cfg.dataset_name,
         original_split=cfg.split,
         original_data_files=cfg.data_files,
+        original_column_name=cfg.column_name,
         context_size=cfg.context_size,
         shuffled=cfg.shuffle,
         seed=cfg.seed,
@@ -164,6 +168,7 @@ class PretokenizeRunner:
         """
         dataset = load_dataset(
             self.cfg.dataset_path,
+            name=self.cfg.dataset_name,
             data_dir=self.cfg.data_dir,
             data_files=self.cfg.data_files,
             split=self.cfg.split,

--- a/tests/training/test_pretokenize_runner.py
+++ b/tests/training/test_pretokenize_runner.py
@@ -8,7 +8,7 @@ from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from sae_lens import __version__
 from sae_lens.config import PretokenizeRunnerConfig
-from sae_lens.pretokenize_runner import pretokenize_dataset, pretokenize_runner
+from sae_lens.pretokenize_runner import PretokenizeRunner, pretokenize_dataset
 
 
 @pytest.fixture
@@ -157,7 +157,7 @@ def test_pretokenize_runner_save_dataset_locally(tmp_path: Path):
         begin_batch_token="bos",
         sequence_separator_token="eos",
     )
-    dataset = pretokenize_runner(cfg)
+    dataset = PretokenizeRunner(cfg).run()
     assert save_path.exists()
     loaded_dataset = Dataset.load_from_disk(str(save_path))
     assert len(dataset) == len(loaded_dataset)
@@ -166,6 +166,41 @@ def test_pretokenize_runner_save_dataset_locally(tmp_path: Path):
         metadata_dict = json.load(f)
     assert metadata_dict["original_dataset"] == "NeelNanda/c4-10k"
     assert metadata_dict["original_split"] == "train[:20]"
+    assert metadata_dict["original_column_name"] == "text"
+    assert metadata_dict["context_size"] == 10
+    assert metadata_dict["shuffled"] is True
+    assert metadata_dict["begin_batch_token"] == "bos"
+    assert metadata_dict["begin_sequence_token"] is None
+    assert metadata_dict["sequence_separator_token"] == "eos"
+    assert metadata_dict["sae_lens_version"] == __version__
+
+
+def test_pretokenize_runner_with_dataset_name(tmp_path: Path):
+    save_path = tmp_path / "ds_with_dataset_name"
+    cfg = PretokenizeRunnerConfig(
+        tokenizer_name="gpt2",
+        context_size=10,
+        num_proc=2,
+        shuffle=True,
+        save_path=str(save_path),
+        dataset_path="nyu-mll/glue",
+        dataset_name="ax",
+        split="test[:20]",
+        column_name="premise",
+        begin_batch_token="bos",
+        sequence_separator_token="eos",
+    )
+    dataset = cast(Any, PretokenizeRunner(cfg).run())
+    assert save_path.exists()
+    loaded_dataset = Dataset.load_from_disk(str(save_path))
+    assert len(dataset) == len(loaded_dataset)
+    assert dataset["input_ids"].tolist() == loaded_dataset["input_ids"].tolist()  # type: ignore
+    with open(save_path / "sae_lens.json") as f:
+        metadata_dict = json.load(f)
+    assert metadata_dict["original_dataset"] == "nyu-mll/glue"
+    assert metadata_dict["original_dataset_name"] == "ax"
+    assert metadata_dict["original_split"] == "test[:20]"
+    assert metadata_dict["original_column_name"] == "premise"
     assert metadata_dict["context_size"] == 10
     assert metadata_dict["shuffled"] is True
     assert metadata_dict["begin_batch_token"] == "bos"


### PR DESCRIPTION
# Description

`PretokenizerRunner` doesn't support datasets `name` argument. Usually you can get around this by specifying the `data_dir`, but supporting this argument brings the interface more in line with the `datasets` interface. Additionally, the column name was previously not being tracked in the metadata, and now is. Finally, a pretokenizer test was using `pretokenize_runner` instead of `PretokenizerRunner`, which was deprecated, and has now been upgraded. 

Summary of updates:
- Added optional dataset name parameter
- Updated metadata to track dataset name and column name
- Added test for loading dataset with name argument and checking metadata
- Updated tests to use PretokenizeRunner instead of depricated pretokenizer_runner

Dependencies:
- Loads new (but small) dataset from HF for tests

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
