### PR TITLE
fix: Ensure activation scaling factor set before initializing b_dec

### DIFF
--- a/sae_lens/sae_training_runner.py
+++ b/sae_lens/sae_training_runner.py
@@ -168,6 +168,7 @@ class SAETrainingRunner:
         """
 
         if self.cfg.b_dec_init_method == "geometric_median":
+            self.activations_store.set_norm_scaling_factor_if_needed()
             layer_acts = self.activations_store.storage_buffer.detach()[:, 0, :]
             # get geometric median of the activations if we're using those.
             median = compute_geometric_median(
@@ -176,6 +177,7 @@ class SAETrainingRunner:
             ).median
             self.sae.initialize_b_dec_with_precalculated(median)  # type: ignore
         elif self.cfg.b_dec_init_method == "mean":
+            self.activations_store.set_norm_scaling_factor_if_needed()
             layer_acts = self.activations_store.storage_buffer.detach().cpu()[:, 0, :]
             self.sae.initialize_b_dec_with_mean(layer_acts)  # type: ignore
 

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -417,7 +417,10 @@ class ActivationsStore:
         return activations_dataset
 
     def set_norm_scaling_factor_if_needed(self):
-        if self.normalize_activations == "expected_average_only_in":
+        if (
+            self.normalize_activations == "expected_average_only_in"
+            and self.estimated_norm_scaling_factor is None
+        ):
             self.estimated_norm_scaling_factor = self.estimate_norm_scaling_factor()
 
     def apply_norm_scaling_factor(self, activations: torch.Tensor) -> torch.Tensor:

--- a/tests/training/test_sae_training_runner.py
+++ b/tests/training/test_sae_training_runner.py
@@ -290,3 +290,13 @@ def test_sae_training_runner_works_with_huggingface_models(tmp_path: Path):
 
     sae = SAE.load_from_pretrained(str(checkpoint_dirs[0]))
     assert isinstance(sae, SAE)
+
+
+def test_set_norm_scaling_factor_before_b_dec_init():
+    # Test that the activation norm scaling factor is set before b_dec is initialized
+    cfg = build_sae_cfg(
+        normalize_activations="expected_average_only_in",
+        b_dec_init_method="geometric_median",
+    )
+    # Will fail if b_dec is initialized before the norm scaling factor is set
+    SAETrainingRunner(cfg)


### PR DESCRIPTION
# Description

Fixes #439 

When `b_dec_init_method` is set to `mean` or `geometric_median` we require getting activations from the buffer, however `set_norm_scaling_factor_if_needed` was not being called prior to this, meaning if `normalize_activations` was set to `expected_average_only_in` it would throw an error.

I added a call to `set_norm_scaling_factor_if_needed` directly before accessing the activations buffer inside `_init_sae_group_b_decs` to ensure the scaling factor is set before initialization. I also added a condition to `set_norm_scaling_factor_if_needed` to check whether the scaling factor is already set to prevent it from being set twice.

An alternative solution would be to take this opportunity to resolve the TODO for `_init_sae_group_b_decs` and move that method to another class, which I'm happy to do as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)