### PR TITLE
Fixed issue with PretokenizeRunner with streaming=True

### DIFF
--- a/sae_lens/pretokenize_runner.py
+++ b/sae_lens/pretokenize_runner.py
@@ -100,6 +100,8 @@ def pretokenize_dataset(
         }
 
     if cfg.streaming:
+        if cfg.num_proc > 1:
+            raise ValueError("num_proc must be 1 when streaming is True")
         tokenized_dataset = dataset.map(
             process_examples,
             batched=True,

--- a/sae_lens/pretokenize_runner.py
+++ b/sae_lens/pretokenize_runner.py
@@ -99,16 +99,30 @@ def pretokenize_dataset(
             )
         }
 
-    tokenized_dataset = dataset.map(
-        process_examples,
-        batched=True,
-        batch_size=cfg.pretokenize_batch_size,
-        num_proc=cfg.num_proc,
-        remove_columns=dataset.column_names,
-    )
+    if cfg.streaming:
+        tokenized_dataset = dataset.map(
+            process_examples,
+            batched=True,
+            batch_size=cfg.pretokenize_batch_size,
+            remove_columns=dataset.column_names,
+        )
+    else:
+        tokenized_dataset = dataset.map(
+            process_examples,
+            batched=True,
+            batch_size=cfg.pretokenize_batch_size,
+            num_proc=cfg.num_proc,
+            remove_columns=dataset.column_names,
+        )
+
     if cfg.shuffle:
         tokenized_dataset = tokenized_dataset.shuffle(seed=cfg.seed)
-    tokenized_dataset.set_format(type="torch", columns=["input_ids"])
+
+    if cfg.streaming:
+        tokenized_dataset = tokenized_dataset.with_format(type="torch")
+    else:
+        tokenized_dataset.set_format(type="torch", columns=["input_ids"])
+
     return tokenized_dataset
 
 

--- a/tests/training/test_pretokenize_runner.py
+++ b/tests/training/test_pretokenize_runner.py
@@ -178,7 +178,7 @@ def test_pretokenize_runner_streaming_dataset():
     cfg = PretokenizeRunnerConfig(
         tokenizer_name="gpt2",
         context_size=10,
-        num_proc=2,
+        num_proc=1,
         dataset_path="NeelNanda/c4-10k",
         split="train",
         streaming=True,
@@ -196,3 +196,16 @@ def test_pretokenize_runner_streaming_dataset():
     )
     dataset = PretokenizeRunner(cfg).run()
     assert not isinstance(dataset, IterableDataset)
+
+
+def test_pretokenize_runner_raises_error_when_num_proc_is_greater_than_1_and_streaming_is_true():
+    cfg = PretokenizeRunnerConfig(
+        tokenizer_name="gpt2",
+        context_size=10,
+        num_proc=2,
+        dataset_path="NeelNanda/c4-10k",
+        split="train",
+        streaming=True,
+    )
+    with pytest.raises(ValueError):
+        PretokenizeRunner(cfg).run()

--- a/tests/training/test_pretokenize_runner.py
+++ b/tests/training/test_pretokenize_runner.py
@@ -3,12 +3,12 @@ from pathlib import Path
 from typing import Any, cast
 
 import pytest
-from datasets import Dataset
+from datasets import Dataset, IterableDataset
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from sae_lens import __version__
 from sae_lens.config import PretokenizeRunnerConfig
-from sae_lens.pretokenize_runner import pretokenize_dataset, pretokenize_runner
+from sae_lens.pretokenize_runner import PretokenizeRunner, pretokenize_dataset
 
 
 @pytest.fixture
@@ -157,7 +157,7 @@ def test_pretokenize_runner_save_dataset_locally(tmp_path: Path):
         begin_batch_token="bos",
         sequence_separator_token="eos",
     )
-    dataset = pretokenize_runner(cfg)
+    dataset = PretokenizeRunner(cfg).run()
     assert save_path.exists()
     loaded_dataset = Dataset.load_from_disk(str(save_path))
     assert len(dataset) == len(loaded_dataset)
@@ -172,3 +172,27 @@ def test_pretokenize_runner_save_dataset_locally(tmp_path: Path):
     assert metadata_dict["begin_sequence_token"] is None
     assert metadata_dict["sequence_separator_token"] == "eos"
     assert metadata_dict["sae_lens_version"] == __version__
+
+
+def test_pretokenize_runner_streaming_dataset():
+    cfg = PretokenizeRunnerConfig(
+        tokenizer_name="gpt2",
+        context_size=10,
+        num_proc=2,
+        dataset_path="NeelNanda/c4-10k",
+        split="train",
+        streaming=True,
+    )
+    dataset = PretokenizeRunner(cfg).run()
+    assert isinstance(dataset, IterableDataset)
+
+    cfg = PretokenizeRunnerConfig(
+        tokenizer_name="gpt2",
+        context_size=10,
+        num_proc=2,
+        dataset_path="NeelNanda/c4-10k",
+        split="train",
+        streaming=False,
+    )
+    dataset = PretokenizeRunner(cfg).run()
+    assert not isinstance(dataset, IterableDataset)


### PR DESCRIPTION
# Description

Fixes bug with PretokenizerRunner when `streaming=True` due to differences in interface with `Dataset` and `IterableDataset`. Specifically, `num_proc` is an argument to the `map` method for the former but not the latter. Similarly, `Dataset` uses `set_format` and `IterableDataset` uses `with_format`. Added test.

Also replaced a usage of deprecated `pretokenize_runner ` with `PretokenizeRunner` in a separate test.

Fixes #441 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)