### PR TITLE
chore: adds Ruff rule to check for banned imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,13 @@ select = ["UP", "TID", "I", "F", "E", "ARG", "SIM", "RET", "LOG", "T20"]
 "benchmark/*" = ["T20"]
 "scripts/*" = ["T20"]
 
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"typing.Union".msg = "Use `|` instead"
+"typing.Optional".msg = "Use `| None` instead"
+"typing.Dict".msg = "Use `dict` instead"
+"typing.Tuple".msg = "Use `tuple` instead"
+"typing.List".msg = "Use `list` instead"
+
 [tool.pyright]
 typeCheckingMode = "strict"
 reportMissingTypeStubs = "none"

--- a/sae_lens/analysis/neuronpedia_integration.py
+++ b/sae_lens/analysis/neuronpedia_integration.py
@@ -4,7 +4,7 @@ import os
 import urllib.parse
 import webbrowser
 from datetime import datetime
-from typing import Any, Optional, TypeVar
+from typing import Any, TypeVar
 
 import requests
 from dotenv import load_dotenv
@@ -179,7 +179,7 @@ def make_neuronpedia_list_with_features(
     api_key: str,
     list_name: str,
     features: list[NeuronpediaFeature],
-    list_description: Optional[str] = None,
+    list_description: str | None = None,
     open_browser: bool = True,
 ):
     url = NEURONPEDIA_DOMAIN + "/api/list/new-with-features"

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -2,7 +2,7 @@ import json
 import math
 import os
 from dataclasses import dataclass, field
-from typing import Any, Literal, Optional, cast
+from typing import Any, Literal, cast
 
 import simple_parsing
 import torch
@@ -144,30 +144,30 @@ class LanguageModelSAERunnerConfig:
     hook_name: str = "blocks.0.hook_mlp_out"
     hook_eval: str = "NOT_IN_USE"
     hook_layer: int = 0
-    hook_head_index: Optional[int] = None
+    hook_head_index: int | None = None
     dataset_path: str = ""
     dataset_trust_remote_code: bool = True
     streaming: bool = True
     is_dataset_tokenized: bool = True
     context_size: int = 128
     use_cached_activations: bool = False
-    cached_activations_path: Optional[str] = (
+    cached_activations_path: str | None = (
         None  # Defaults to "activations/{dataset}/{model}/{full_hook_name}_{hook_head_index}"
     )
 
     # SAE Parameters
     architecture: Literal["standard", "gated", "jumprelu", "topk"] = "standard"
     d_in: int = 512
-    d_sae: Optional[int] = None
+    d_sae: int | None = None
     b_dec_init_method: str = "geometric_median"
-    expansion_factor: Optional[int] = (
+    expansion_factor: int | None = (
         None  # defaults to 4 if d_sae and expansion_factor is None
     )
     activation_fn: str = None  # relu, tanh-relu, topk. Default is relu. # type: ignore
     activation_fn_kwargs: dict[str, int] = dict_field(default=None)  # for topk
     normalize_sae_decoder: bool = True
     noise_scale: float = 0.0
-    from_pretrained_path: Optional[str] = None
+    from_pretrained_path: str | None = None
     apply_b_dec_to_input: bool = True
     decoder_orthogonal_init: bool = False
     decoder_heuristic_init: bool = False
@@ -210,7 +210,7 @@ class LanguageModelSAERunnerConfig:
     adam_beta2: float = 0.999
 
     ## Loss Function
-    mse_loss_normalization: Optional[str] = None
+    mse_loss_normalization: str | None = None
     l1_coefficient: float = 1e-3
     lp_norm: float = 1
     scale_sparsity_penalty_by_decoder_norm: bool = False
@@ -222,12 +222,12 @@ class LanguageModelSAERunnerConfig:
         "constant"  # constant, cosineannealing, cosineannealingwarmrestarts
     )
     lr_warm_up_steps: int = 0
-    lr_end: Optional[float] = None  # only used for cosine annealing, default is lr / 10
+    lr_end: float | None = None  # only used for cosine annealing, default is lr / 10
     lr_decay_steps: int = 0
     n_restart_cycles: int = 1  # used only for cosineannealingwarmrestarts
 
     ## FineTuning
-    finetuning_method: Optional[str] = None  # scale, decoder or unrotated_decoder
+    finetuning_method: str | None = None  # scale, decoder or unrotated_decoder
 
     # Resampling protocol args
     use_ghost_grads: bool = False  # want to change this to true on some timeline.
@@ -245,9 +245,9 @@ class LanguageModelSAERunnerConfig:
     log_activations_store_to_wandb: bool = False
     log_optimizer_state_to_wandb: bool = False
     wandb_project: str = "mats_sae_training_language_model"
-    wandb_id: Optional[str] = None
-    run_name: Optional[str] = None
-    wandb_entity: Optional[str] = None
+    wandb_id: str | None = None
+    run_name: str | None = None
+    wandb_entity: str | None = None
     wandb_log_frequency: int = 10
     eval_every_n_wandb_logs: int = 100  # logs every 1000 steps.
 

--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from functools import partial
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any
 
 import einops
 import pandas as pd
@@ -753,7 +753,7 @@ def multiple_evals(
     ctx_lens: list[int] = [128],
     output_dir: str = "eval_results",
     verbose: bool = False,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     device = "cuda" if torch.cuda.is_available() else "cpu"
 
     filtered_saes = get_saes_from_regex(sae_regex_pattern, sae_block_pattern)
@@ -836,7 +836,7 @@ def multiple_evals(
     return eval_results
 
 
-def run_evaluations(args: argparse.Namespace) -> List[Dict[str, Any]]:
+def run_evaluations(args: argparse.Namespace) -> list[dict[str, Any]]:
     # Filter SAEs based on regex patterns
     filtered_saes = get_saes_from_regex(args.sae_regex_pattern, args.sae_block_pattern)
 
@@ -871,8 +871,8 @@ def replace_nans_with_negative_one(obj: Any) -> Any:
 
 
 def process_results(
-    eval_results: List[Dict[str, Any]], output_dir: str
-) -> Dict[str, Union[List[Path], Path]]:
+    eval_results: list[dict[str, Any]], output_dir: str
+) -> dict[str, list[Path] | Path]:
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
 

--- a/sae_lens/sae.py
+++ b/sae_lens/sae.py
@@ -8,7 +8,7 @@ import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Literal, Optional, Tuple, TypeVar, Union, overload
+from typing import Any, Callable, Literal, TypeVar, overload
 
 import einops
 import torch
@@ -53,7 +53,7 @@ class SAEConfig:
     model_name: str
     hook_name: str
     hook_layer: int
-    hook_head_index: Optional[int]
+    hook_head_index: int | None
     prepend_bos: bool
     dataset_path: str
     dataset_trust_remote_code: bool
@@ -62,9 +62,9 @@ class SAEConfig:
     # misc
     dtype: str
     device: str
-    sae_lens_training_version: Optional[str]
+    sae_lens_training_version: str | None
     activation_fn_kwargs: dict[str, Any] = field(default_factory=dict)
-    neuronpedia_id: Optional[str] = None
+    neuronpedia_id: str | None = None
     model_from_pretrained_kwargs: dict[str, Any] = field(default_factory=dict)
     seqpos_slice: tuple[int | None, ...] = (None,)
 
@@ -319,8 +319,8 @@ class SAE(HookedRootModule):
     @overload
     def to(
         self: T,
-        device: Optional[Union[torch.device, str]] = ...,
-        dtype: Optional[torch.dtype] = ...,
+        device: torch.device | str | None = ...,
+        dtype: torch.dtype | None = ...,
         non_blocking: bool = ...,
     ) -> T: ...
 
@@ -489,14 +489,14 @@ class SAE(HookedRootModule):
         self.cfg.normalize_activations = "none"
 
     @overload
-    def save_model(self, path: str | Path) -> Tuple[Path, Path]: ...
+    def save_model(self, path: str | Path) -> tuple[Path, Path]: ...
 
     @overload
     def save_model(
         self, path: str | Path, sparsity: torch.Tensor
-    ) -> Tuple[Path, Path, Path]: ...
+    ) -> tuple[Path, Path, Path]: ...
 
-    def save_model(self, path: str | Path, sparsity: Optional[torch.Tensor] = None):
+    def save_model(self, path: str | Path, sparsity: torch.Tensor | None = None):
         path = Path(path)
 
         if not path.exists():
@@ -565,7 +565,7 @@ class SAE(HookedRootModule):
         release: str,
         sae_id: str,
         device: str = "cpu",
-    ) -> Tuple["SAE", dict[str, Any], Optional[torch.Tensor]]:
+    ) -> tuple["SAE", dict[str, Any], torch.Tensor | None]:
         """
 
         Load a pretrained SAE from the Hugging Face model hub.

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -1,7 +1,7 @@
 import json
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, Protocol, Tuple
+from typing import Any, Protocol
 
 import numpy as np
 import torch
@@ -28,16 +28,16 @@ class PretrainedSaeLoader(Protocol):
         device: str | torch.device | None = None,
         force_download: bool = False,
         cfg_overrides: dict[str, Any] | None = None,
-    ) -> tuple[dict[str, Any], dict[str, torch.Tensor], Optional[torch.Tensor]]: ...
+    ) -> tuple[dict[str, Any], dict[str, torch.Tensor], torch.Tensor | None]: ...
 
 
 @dataclass
 class SAEConfigLoadOptions:
-    device: Optional[str] = None
+    device: str | None = None
     force_download: bool = False
-    d_sae_override: Optional[int] = None
-    layer_override: Optional[int] = None
-    cfg_overrides: Optional[Dict[str, Any]] = field(default_factory=dict)
+    d_sae_override: int | None = None
+    layer_override: int | None = None
+    cfg_overrides: dict[str, Any] | None = field(default_factory=dict)
 
 
 def sae_lens_loader(
@@ -45,8 +45,8 @@ def sae_lens_loader(
     sae_id: str,
     device: str = "cpu",
     force_download: bool = False,
-    cfg_overrides: Optional[dict[str, Any]] = None,
-) -> tuple[dict[str, Any], dict[str, torch.Tensor], Optional[torch.Tensor]]:
+    cfg_overrides: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], dict[str, torch.Tensor], torch.Tensor | None]:
     """
     Get's SAEs from HF, loads them.
     """
@@ -92,7 +92,7 @@ def get_sae_config_from_hf(
     repo_id: str,
     folder_name: str,
     options: SAEConfigLoadOptions,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Retrieve the configuration for a Sparse Autoencoder (SAE) from a Hugging Face repository.
 
@@ -100,10 +100,10 @@ def get_sae_config_from_hf(
         repo_id (str): The repository ID on Hugging Face.
         folder_name (str): The folder name within the repository containing the config file.
         force_download (bool, optional): Whether to force download the config file. Defaults to False.
-        cfg_overrides (Optional[Dict[str, Any]], optional): Overrides for the config. Defaults to None.
+        cfg_overrides (dict[str, Any] | None, optional): Overrides for the config. Defaults to None.
 
     Returns:
-        Dict[str, Any]: The configuration dictionary for the SAE.
+        dict[str, Any]: The configuration dictionary for the SAE.
     """
     cfg_filename = f"{folder_name}/cfg.json"
     cfg_path = hf_hub_download(
@@ -181,9 +181,9 @@ def get_connor_rob_hook_z_config(
 def connor_rob_hook_z_loader(
     release: str,
     sae_id: str,
-    device: Optional[str] = None,
+    device: str | None = None,
     force_download: bool = False,
-    cfg_overrides: Optional[dict[str, Any]] = None,  # noqa: ARG001
+    cfg_overrides: dict[str, Any] | None = None,  # noqa: ARG001
 ) -> tuple[dict[str, Any], dict[str, torch.Tensor], None]:
     options = SAEConfigLoadOptions(
         device=device,
@@ -209,7 +209,7 @@ def read_sae_from_disk(
     cfg_dict: dict[str, Any],
     weight_path: str,
     device: str = "cpu",
-    dtype: Optional[torch.dtype] = None,
+    dtype: torch.dtype | None = None,
 ) -> tuple[dict[str, Any], dict[str, torch.Tensor]]:
     """
     Given a loaded dictionary and a path to a weight file, load the weights and return the state_dict.
@@ -250,7 +250,7 @@ def get_gemma_2_config(
     repo_id: str,
     folder_name: str,
     options: SAEConfigLoadOptions,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     # Detect width from folder_name
     width_map = {
         "width_4k": 4096,
@@ -342,10 +342,10 @@ def gemma_2_sae_loader(
     sae_id: str,
     device: str = "cpu",
     force_download: bool = False,
-    cfg_overrides: Optional[Dict[str, Any]] = None,
-    d_sae_override: Optional[int] = None,
-    layer_override: Optional[int] = None,
-) -> Tuple[Dict[str, Any], Dict[str, torch.Tensor], Optional[torch.Tensor]]:
+    cfg_overrides: dict[str, Any] | None = None,
+    d_sae_override: int | None = None,
+    layer_override: int | None = None,
+) -> tuple[dict[str, Any], dict[str, torch.Tensor], torch.Tensor | None]:
     """
     Custom loader for Gemma 2 SAEs.
     """
@@ -416,7 +416,7 @@ def get_llama_scope_config(
     repo_id: str,
     folder_name: str,
     options: SAEConfigLoadOptions,  # noqa: ARG001
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     # Llama Scope SAEs
     # repo_id: fnlp/Llama3_1-8B-Base-LX{sublayer}-{exp_factor}x
     # folder_name: Llama3_1-8B-Base-L{layer}{sublayer}-{exp_factor}x
@@ -458,10 +458,10 @@ def llama_scope_sae_loader(
     sae_id: str,
     device: str = "cpu",
     force_download: bool = False,
-    cfg_overrides: Optional[Dict[str, Any]] = None,
-    d_sae_override: Optional[int] = None,
-    layer_override: Optional[int] = None,
-) -> Tuple[Dict[str, Any], Dict[str, torch.Tensor], Optional[torch.Tensor]]:
+    cfg_overrides: dict[str, Any] | None = None,
+    d_sae_override: int | None = None,
+    layer_override: int | None = None,
+) -> tuple[dict[str, Any], dict[str, torch.Tensor], torch.Tensor | None]:
     """
     Custom loader for Llama Scope SAEs.
 
@@ -470,12 +470,12 @@ def llama_scope_sae_loader(
         sae_id: SAE identifier
         device: Device to load tensors to
         force_download: Whether to force download even if files exist
-        cfg_overrides: Optional configuration overrides
-        d_sae_override: Optional override for SAE dimension
-        layer_override: Optional override for layer number
+        cfg_overrides: Configuration overrides (optional)
+        d_sae_override: Override for SAE dimension (optional)
+        layer_override: Override for layer number (optional)
 
     Returns:
-        Tuple of (config dict, state dict, log sparsity tensor)
+        tuple of (config dict, state dict, log sparsity tensor)
     """
     options = SAEConfigLoadOptions(
         device=device,
@@ -538,7 +538,7 @@ def get_llama_scope_r1_distill_config(
     repo_id: str,
     folder_name: str,
     options: SAEConfigLoadOptions,  # noqa: ARG001
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     # Future Llama Scope series SAE by OpenMoss group use this config.
     # repo_id: [
     #   fnlp/Llama-Scope-R1-Distill
@@ -583,10 +583,10 @@ def llama_scope_r1_distill_sae_loader(
     sae_id: str,
     device: str = "cpu",
     force_download: bool = False,
-    cfg_overrides: Optional[Dict[str, Any]] = None,
-    d_sae_override: Optional[int] = None,
-    layer_override: Optional[int] = None,
-) -> Tuple[Dict[str, Any], Dict[str, torch.Tensor], Optional[torch.Tensor]]:
+    cfg_overrides: dict[str, Any] | None = None,
+    d_sae_override: int | None = None,
+    layer_override: int | None = None,
+) -> tuple[dict[str, Any], dict[str, torch.Tensor], torch.Tensor | None]:
     """
     Custom loader for Llama Scope SAEs.
 
@@ -595,12 +595,12 @@ def llama_scope_r1_distill_sae_loader(
         sae_id: SAE identifier
         device: Device to load tensors to
         force_download: Whether to force download even if files exist
-        cfg_overrides: Optional configuration overrides
-        d_sae_override: Optional override for SAE dimension
-        layer_override: Optional override for layer number
+        cfg_overrides: Configuration overrides (optional)
+        d_sae_override: Override for SAE dimension (optional)
+        layer_override: Override for layer number (optional)
 
     Returns:
-        Tuple of (config dict, state dict, log sparsity tensor)
+        tuple of (config dict, state dict, log sparsity tensor)
     """
     options = SAEConfigLoadOptions(
         device=device,
@@ -743,8 +743,8 @@ def deepseek_r1_sae_loader(
     sae_id: str,
     device: str = "cpu",
     force_download: bool = False,
-    cfg_overrides: Optional[dict[str, Any]] = None,
-) -> tuple[dict[str, Any], dict[str, torch.Tensor], Optional[torch.Tensor]]:
+    cfg_overrides: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], dict[str, torch.Tensor], torch.Tensor | None]:
     """Load a DeepSeek R1 SAE."""
     repo_id, filename = get_repo_id_and_folder_name(release, sae_id=sae_id)
 
@@ -777,7 +777,7 @@ def deepseek_r1_sae_loader(
     return cfg_dict, state_dict, None
 
 
-def get_conversion_loader_name(sae_info: Optional[PretrainedSAELookup]):
+def get_conversion_loader_name(sae_info: PretrainedSAELookup | None):
     conversion_loader_name = "sae_lens"
     if sae_info is not None and sae_info.conversion_func is not None:
         conversion_loader_name = sae_info.conversion_func
@@ -816,8 +816,8 @@ def dictionary_learning_sae_loader_1(
     sae_id: str,
     device: str = "cpu",
     force_download: bool = False,
-    cfg_overrides: Optional[dict[str, Any]] = None,
-) -> tuple[dict[str, Any], dict[str, torch.Tensor], Optional[torch.Tensor]]:
+    cfg_overrides: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], dict[str, torch.Tensor], torch.Tensor | None]:
     """
     Suitable for SAEs from https://huggingface.co/canrager/lm_sae.
     """

--- a/sae_lens/toolkit/pretrained_saes_directory.py
+++ b/sae_lens/toolkit/pretrained_saes_directory.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from functools import cache
 from importlib import resources
-from typing import Optional
 
 import yaml
 
@@ -56,7 +55,7 @@ def get_pretrained_saes_directory() -> dict[str, PretrainedSAELookup]:
     return directory
 
 
-def get_norm_scaling_factor(release: str, sae_id: str) -> Optional[float]:
+def get_norm_scaling_factor(release: str, sae_id: str) -> float | None:
     """
     Retrieve the norm_scaling_factor for a specific SAE if it exists.
 
@@ -65,7 +64,7 @@ def get_norm_scaling_factor(release: str, sae_id: str) -> Optional[float]:
         sae_id (str): The ID of the specific SAE.
 
     Returns:
-        Optional[float]: The norm_scaling_factor if it exists, None otherwise.
+        float | None: The norm_scaling_factor if it exists, None otherwise.
     """
     package = "sae_lens"
     with resources.open_text(package, "pretrained_saes.yaml") as file:

--- a/sae_lens/training/geometric_median.py
+++ b/sae_lens/training/geometric_median.py
@@ -1,5 +1,4 @@
 from types import SimpleNamespace
-from typing import Optional
 
 import torch
 import tqdm
@@ -21,7 +20,7 @@ def geometric_median_objective(
 
 def compute_geometric_median(
     points: torch.Tensor,
-    weights: Optional[torch.Tensor] = None,
+    weights: torch.Tensor | None = None,
     eps: float = 1e-6,
     maxiter: int = 100,
     ftol: float = 1e-20,

--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -1,6 +1,6 @@
 import contextlib
 from dataclasses import dataclass
-from typing import Any, Optional, Protocol, cast
+from typing import Any, Protocol, cast
 
 import torch
 import wandb
@@ -48,7 +48,7 @@ class SaveCheckpointFn(Protocol):
         self,
         trainer: "SAETrainer",
         checkpoint_name: str,
-        wandb_aliases: Optional[list[str]] = None,
+        wandb_aliases: list[str] | None = None,
     ) -> None: ...
 
 

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -5,7 +5,7 @@ https://github.com/ArthurConmy/sae/blob/main/sae/model.py
 import json
 import os
 from dataclasses import dataclass, fields
-from typing import Any, Optional
+from typing import Any
 
 import einops
 import numpy as np
@@ -114,7 +114,7 @@ class TrainingSAEConfig(SAEConfig):
     normalize_sae_decoder: bool
     noise_scale: float
     decoder_orthogonal_init: bool
-    mse_loss_normalization: Optional[str]
+    mse_loss_normalization: str | None
     jumprelu_init_threshold: float
     jumprelu_bandwidth: float
     decoder_heuristic_init: bool
@@ -370,7 +370,7 @@ class TrainingSAE(SAE):
         self,
         sae_in: torch.Tensor,
         current_l1_coefficient: float,
-        dead_neuron_mask: Optional[torch.Tensor] = None,
+        dead_neuron_mask: torch.Tensor | None = None,
     ) -> TrainStepOutput:
         # do a forward pass to get SAE out, but we also need the
         # hidden pre.

--- a/sae_lens/tutorial/tsea.py
+++ b/sae_lens/tutorial/tsea.py
@@ -1,7 +1,6 @@
 import os
 import re
 import string
-from typing import Optional
 
 import nltk
 import numpy as np
@@ -161,9 +160,9 @@ def plot_top_k_feature_projections_by_token_and_category(
     dec_projection_onto_W_U: torch.Tensor,
     k: int = 5,
     projection_onto: str = "W_U",
-    features: Optional[list[int]] = None,
+    features: list[int] | None = None,
     log_y: bool = True,
-    histnorm: Optional[str] = None,
+    histnorm: str | None = None,
 ):
     if not os.path.exists("es_plots"):
         os.makedirs("es_plots")

--- a/tests/analysis/test_hooked_sae_transformer.py
+++ b/tests/analysis/test_hooked_sae_transformer.py
@@ -1,5 +1,4 @@
 # type: ignore
-from typing import Tuple, Union
 
 import pytest
 import torch
@@ -15,7 +14,7 @@ MODEL = "solu-1l"
 prompt = "Hello World!"
 
 
-Output = Union[torch.Tensor, Tuple[torch.Tensor, Loss], None]
+Output = torch.Tensor | tuple[torch.Tensor, Loss] | None
 
 
 def get_logits(output: Output) -> torch.Tensor:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Any, Optional, TypedDict
+from typing import Any, TypedDict
 
 from transformer_lens import HookedTransformer
 
@@ -15,7 +15,7 @@ class LanguageModelSAERunnerConfigDict(TypedDict, total=False):
     model_name: str
     hook_name: str
     hook_layer: int
-    hook_head_index: Optional[int]
+    hook_head_index: int | None
     dataset_path: str
     dataset_trust_remote_code: bool
     is_dataset_tokenized: bool

--- a/tests/training/test_activations_store.py
+++ b/tests/training/test_activations_store.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 from collections.abc import Iterable
 from math import ceil
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import pytest
@@ -427,7 +427,7 @@ def test_activations_store___iterate_tokenized_sequences__works_with_huggingface
     [(5, RuntimeWarning), (10, None), (15, ValueError)],
 )
 def test_activations_store__errors_on_context_size_mismatch(
-    ts_model: HookedTransformer, context_size: int, expected_error: Optional[ValueError]
+    ts_model: HookedTransformer, context_size: int, expected_error: ValueError | None
 ):
     tokenizer = ts_model.tokenizer
     assert tokenizer is not None


### PR DESCRIPTION
# Description

Adds a lint rule to check for banned imports. We want to stop using `Union`, `Optional`, `Dict`, `List`, etc. since using shorthands is recommended and type aliases have been deprecated. @chanind had made a comment in https://github.com/jbloomAus/SAELens/pull/425#discussion_r1992034386 about this.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.




# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 