### PR TITLE
removes deleted gemma-scope-9b-pt-res-canonical SAE

### DIFF
--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -8835,10 +8835,6 @@ gemma-scope-9b-pt-res-canonical:
     l0: 77
     neuronpedia: gemma-2-9b/31-gemmascope-res-1m
     path: layer_31/width_1m/average_l0_77
-  - id: layer_20/width_262k/canonical
-    l0: 64
-    neuronpedia: gemma-2-9b/20-gemmascope-res-262k
-    path: layer_20/width_262k/average_l0_64
   - id: layer_20/width_32k/canonical
     l0: 57
     neuronpedia: gemma-2-9b/20-gemmascope-res-32k


### PR DESCRIPTION
# Description

Removes the `layer_20/width_262k/canonical` SAE from `pretrained_saes.yaml`. We want to ensure the accuracy of the file, and this SAE was not found in (deleted from) Hugging Face.

Fixes #456

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 