### PR TITLE
fix: removing strangely missing gemma 2 9b SAE

### DIFF
--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -13789,9 +13789,6 @@ gemma-2-9b-res-matryoshka-dc:
   - id: blocks.10.hook_resid_post
     path: blocks.10.hook_resid_post
     l0: 60.0
-  - id: blocks.11.hook_resid_post
-    path: blocks.11.hook_resid_post
-    l0: 60.0
   - id: blocks.12.hook_resid_post
     path: blocks.12.hook_resid_post
     l0: 60.0


### PR DESCRIPTION
# Description

Bizarrely, the layer 11 SAE for gemma-2-9b is missing. This PR temporarily removes it from the list of SAEs until I can get it retrained and uploaded.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update