### PR TITLE
chore: fixing incorrect citation format

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Please cite the package as follows:
 ```
 @misc{bloom2024saetrainingcodebase,
    title = {SAELens},
-   author = {Joseph Bloom, Curt Tigges, Anthony Duong and David Chanin},
+   author = {Bloom, Joseph and Tigges, Curt and Duong, Anthony and Chanin, David},
    year = {2024},
    howpublished = {\url{https://github.com/jbloomAus/SAELens}},
 }

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -3,7 +3,7 @@
 ```
 @misc{bloom2024saetrainingcodebase,
    title = {SAELens},
-   author = {Joseph Bloom, Curt Tigges, Anthony Duong and David Chanin},
+   author = {Bloom, Joseph and Tigges, Curt and Duong, Anthony and Chanin, David},
    year = {2024},
    howpublished = {\url{https://github.com/jbloomAus/SAELens}},
 }}

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,7 +81,7 @@ WandB Dashboards provide lots of useful insights while training SAEs. Here's a s
 ```
 @misc{bloom2024saetrainingcodebase,
    title = {SAELens},
-   author = {Joseph Bloom, Curt Tigges, Anthony Duong and David Chanin},
+   author = {Bloom, Joseph and Tigges, Curt and Duong, Anthony and Chanin, David},
    year = {2024},
    howpublished = {\url{https://github.com/jbloomAus/SAELens}},
 }}


### PR DESCRIPTION
# Description

This PR fixes the bibtex citation format in the docs/readme. Bibtex requires `and` between names, not a comma.