### PR TITLE
fix: Use the whole batch when estimating norm scaling factor.

### DIFF
--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -448,7 +448,7 @@ class ActivationsStore:
         ):
             # temporalily set estimated_norm_scaling_factor to 1.0 so the dataloader works
             self.estimated_norm_scaling_factor = 1.0
-            acts = self.next_batch()[0]
+            acts = self.next_batch()[:, 0]
             self.estimated_norm_scaling_factor = None
             norms_per_batch.append(acts.norm(dim=-1).mean().item())
         mean_norm = np.mean(norms_per_batch)

--- a/tests/training/test_activations_store.py
+++ b/tests/training/test_activations_store.py
@@ -348,8 +348,39 @@ def test_activations_store_estimate_norm_scaling_factor(
     assert isinstance(factor, float)
 
     assert store._storage_buffer is not None
-    scaled_norm = store._storage_buffer[0].norm(dim=-1).mean() * factor
+    scaled_norm = store._storage_buffer[:, 0].norm(dim=-1).mean() * factor
     assert scaled_norm == pytest.approx(np.sqrt(store.d_in), abs=5)
+
+
+@torch.no_grad()
+def test_activations_store_estimate_norm_scaling_factor_uses_full_batch(
+    ts_model: HookedTransformer,
+):
+    """Simulate a model where activation norms within a batch are far
+    apart, and confirm that the norm scaling factor is estimated from
+    the entire batch.
+
+    """
+    tokenizer = ts_model.tokenizer
+    assert tokenizer is not None
+    # Set the embedding of BOS to be very large, and attach the
+    # activations store to a hook that reads it.
+    ts_model.embed.W_E[tokenizer.bos_token_id, :] = 1e4  # type: ignore
+    cfg = build_sae_cfg(prepend_bos=False, context_size=6, hook_name="hook_embed")
+    dataset = Dataset.from_list(
+        [
+            {"text": (tokenizer.bos_token + "a") * 3},  # type: ignore
+        ]
+    )
+    store = ActivationsStore.from_config(ts_model, cfg, override_dataset=dataset)
+    factor = store.estimate_norm_scaling_factor(n_batches_for_norm_estimate=1)
+    # The norm scaling factor should be greater than the factor if it
+    # were only estimated from the 'a' token, and less than if it were
+    # only estimated from bos.
+    mean_from_a = ts_model.embed(ts_model.to_single_token("a")).norm(dim=-1).item()
+    assert factor < np.sqrt(cfg.d_in) / mean_from_a
+    mean_from_bos = ts_model.embed(tokenizer.bos_token_id).norm(dim=-1).item()
+    assert factor > np.sqrt(cfg.d_in) / mean_from_bos
 
 
 def test_activations_store___iterate_tokenized_sequences__yields_concat_and_batched_sequences(


### PR DESCRIPTION
# Description

`ActivationsStore.estimate_norm_scaling_factor()` was taking the first sample from each batch, when it looks like it was meant to take the first (and only) layer. This fixes it to use the whole batch instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability