### PR TITLE
feat: Add configuration for decoder norms under decoder_heuristic_init.

### DIFF
--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -171,6 +171,7 @@ class LanguageModelSAERunnerConfig:
     apply_b_dec_to_input: bool = True
     decoder_orthogonal_init: bool = False
     decoder_heuristic_init: bool = False
+    decoder_heuristic_init_norm: float = 0.1
     init_encoder_as_decoder_transpose: bool = False
 
     # Activation Store Parameters
@@ -465,6 +466,7 @@ class LanguageModelSAERunnerConfig:
             "decoder_orthogonal_init": self.decoder_orthogonal_init,
             "mse_loss_normalization": self.mse_loss_normalization,
             "decoder_heuristic_init": self.decoder_heuristic_init,
+            "decoder_heuristic_init_norm": self.decoder_heuristic_init_norm,
             "init_encoder_as_decoder_transpose": self.init_encoder_as_decoder_transpose,
             "normalize_activations": self.normalize_activations,
             "jumprelu_init_threshold": self.jumprelu_init_threshold,

--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -118,6 +118,7 @@ class TrainingSAEConfig(SAEConfig):
     jumprelu_init_threshold: float
     jumprelu_bandwidth: float
     decoder_heuristic_init: bool
+    decoder_heuristic_init_norm: float
     init_encoder_as_decoder_transpose: bool
     scale_sparsity_penalty_by_decoder_norm: bool
 
@@ -154,6 +155,7 @@ class TrainingSAEConfig(SAEConfig):
             decoder_orthogonal_init=cfg.decoder_orthogonal_init,
             mse_loss_normalization=cfg.mse_loss_normalization,
             decoder_heuristic_init=cfg.decoder_heuristic_init,
+            decoder_heuristic_init_norm=cfg.decoder_heuristic_init_norm,
             init_encoder_as_decoder_transpose=cfg.init_encoder_as_decoder_transpose,
             scale_sparsity_penalty_by_decoder_norm=cfg.scale_sparsity_penalty_by_decoder_norm,
             normalize_activations=cfg.normalize_activations,
@@ -197,6 +199,7 @@ class TrainingSAEConfig(SAEConfig):
             "init_encoder_as_decoder_transpose": self.init_encoder_as_decoder_transpose,
             "mse_loss_normalization": self.mse_loss_normalization,
             "decoder_heuristic_init": self.decoder_heuristic_init,
+            "decoder_heuristic_init_norm": self.decoder_heuristic_init_norm,
             "scale_sparsity_penalty_by_decoder_norm": self.scale_sparsity_penalty_by_decoder_norm,
             "normalize_activations": self.normalize_activations,
             "jumprelu_init_threshold": self.jumprelu_init_threshold,
@@ -603,7 +606,9 @@ class TrainingSAE(SAE):
                     self.cfg.d_sae, self.cfg.d_in, dtype=self.dtype, device=self.device
                 )
             )
-            self.initialize_decoder_norm_constant_norm()
+            self.initialize_decoder_norm_constant_norm(
+                self.cfg.decoder_heuristic_init_norm
+            )
 
         # Then we initialize the encoder weights (either as the transpose of decoder or not)
         if self.cfg.init_encoder_as_decoder_transpose:

--- a/tests/training/test_training_sae.py
+++ b/tests/training/test_training_sae.py
@@ -316,3 +316,15 @@ def test_TrainingSAE_fold_w_dec_norm_jumprelu():
 
     # but actual outputs should be the same
     torch.testing.assert_close(sae_out_1, sae_out_2)
+
+
+def test_TrainingSAE_heuristic_init():
+    cfg = build_sae_cfg(
+        d_in=3,
+        d_sae=5,
+        normalize_sae_decoder=False,
+        decoder_heuristic_init=True,
+        decoder_heuristic_init_norm=0.2,
+    )
+    training_sae = TrainingSAE(TrainingSAEConfig.from_sae_runner_config(cfg))
+    torch.testing.assert_close(training_sae.W_dec.norm(dim=1), torch.full((5,), 0.2))


### PR DESCRIPTION
# Description

When `decoder_heuristic_init` is enabled for training, allow for configuring the decoder norms via a new config option, `decoder_heuristic_init_norm`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 