### PR TITLE
fix: heuristic init should place latents anywhere in the space

### DIFF
--- a/sae_lens/training/training_sae.py
+++ b/sae_lens/training/training_sae.py
@@ -593,7 +593,7 @@ class TrainingSAE(SAE):
 
         elif self.cfg.decoder_heuristic_init:
             self.W_dec = nn.Parameter(
-                torch.rand(
+                torch.randn(
                     self.cfg.d_sae, self.cfg.d_in, dtype=self.dtype, device=self.device
                 )
             )

--- a/tests/training/test_sae_initialization.py
+++ b/tests/training/test_sae_initialization.py
@@ -177,11 +177,11 @@ def test_SparseAutoencoder_initialization_heuristic_init():
 
     sae = TrainingSAE.from_dict(cfg.get_training_sae_cfg_dict())
 
-    decoder_norms = sae.W_dec.norm(dim=1)
-
     # Check for both positive and negative values in the decoder weights
     assert torch.any(sae.W_dec > 0)
     assert torch.any(sae.W_dec < 0)
+
+    decoder_norms = sae.W_dec.norm(dim=1)
 
     # not unit norms
     assert not torch.allclose(

--- a/tests/training/test_sae_initialization.py
+++ b/tests/training/test_sae_initialization.py
@@ -179,6 +179,10 @@ def test_SparseAutoencoder_initialization_heuristic_init():
 
     decoder_norms = sae.W_dec.norm(dim=1)
 
+    # Check for both positive and negative values in the decoder weights
+    assert torch.any(sae.W_dec > 0)
+    assert torch.any(sae.W_dec < 0)
+
     # not unit norms
     assert not torch.allclose(
         decoder_norms, torch.ones_like(sae.W_dec.norm(dim=1)), atol=1e-6


### PR DESCRIPTION
# Description

This PR fixes a bug with the `decoder_heuristic_init` option. The decoder should be initialized to random directions (see: https://transformer-circuits.pub/2024/april-update/index.html#training-saes). However, SAELens was using `torch.rand`, which picks values at random between 0 and 1, rather than `torch.randn` which positive or negative values according to a normal distribution. As a result, the decoder had only positive values when using `decoder_heuristic_init`, which basically forces all the decoder latents into a tiny portion of the full subspace of size `1/d_in` of the full `d_in` vector space.

This PR fixes this issue and adds a test so we can't accidentally revert back to this behavior.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)