### PR TITLE
adds sparsify_huggingface_loader()

### DIFF
--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -33,6 +33,7 @@ HfDataset = DatasetDict | Dataset | IterableDatasetDict | IterableDataset
 
 SPARSITY_FILENAME = "sparsity.safetensors"
 SAE_WEIGHTS_FILENAME = "sae_weights.safetensors"
+SPARSIFY_WEIGHTS_FILENAME = "sae.safetensors"
 SAE_CFG_FILENAME = "cfg.json"
 
 

--- a/sae_lens/load_model.py
+++ b/sae_lens/load_model.py
@@ -159,7 +159,7 @@ class HookedProxyLM(HookedRootModule):
 
         # We don't want to prepend bos but the tokenizer does it automatically, so we remove it manually
         if hasattr(self.tokenizer, "add_bos_token") and self.tokenizer.add_bos_token:  # type: ignore
-            tokens = get_tokens_with_bos_removed(self.tokenizer, tokens)
+            tokens = get_tokens_with_bos_removed(self.tokenizer, tokens)  # type: ignore
         return tokens  # type: ignore
 
 

--- a/sae_lens/toolkit/pretrained_sae_loaders.py
+++ b/sae_lens/toolkit/pretrained_sae_loaders.py
@@ -1016,11 +1016,10 @@ def sparsify_disk_loader(
         else state_dict_loaded["encoder.weight"].T
     ).to(dtype)
 
-    W_dec = (
-        state_dict_loaded["W_dec"]
-        if "W_dec" in state_dict_loaded
-        else state_dict_loaded["decoder.weight"].T
-    ).to(dtype)
+    if "W_dec" in state_dict_loaded:
+        W_dec = state_dict_loaded["W_dec"].T.to(dtype)
+    else:
+        W_dec = state_dict_loaded["decoder.weight"].T.to(dtype)
 
     if "b_enc" in state_dict_loaded:
         b_enc = state_dict_loaded["b_enc"].to(dtype)


### PR DESCRIPTION
# Description

Adds functions to load SAEs trained with the `sparsify` library, from Hugging Face or disk. In #433, we made a change so that you can load an SAE trained using any library as long as you pass a correct arg to the `converter` param of `SAE.from_pretrained()`/`SAE.load_from_disk()`, and said we wanted to add this for SAEs trained with the `sparsify` library.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 