### PR TITLE
fix: adding a link to the pre-release docs from main docs page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,8 @@
+<!-- prettier-ignore-start -->
+!!! tip "Pre-Release Available"
+    SAELens 6.0.0 pre-release is available with exciting new features. [View documentation →](https://jbloomaus.github.io/SAELens/pre-release/)
+<!-- prettier-ignore-end -->
+
 <img width="1308" alt="Screenshot 2024-03-21 at 3 08 28 pm" src="https://github.com/jbloomAus/mats_sae_training/assets/69127271/209012ec-a779-4036-b4be-7b7739ea87f6">
 
 # SAELens

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ hooks:
   - docs/generate_sae_table.py
 
 markdown_extensions:
+  - admonition
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span


### PR DESCRIPTION
# Description

This PR adds a link to the pre-release docs from the main docs page, to help make users aware of the coming refactor changes so they can try them out.

![Screenshot 2025-05-28 at 12 01 56](https://github.com/user-attachments/assets/c9f9852b-c15f-453b-a6c3-1114701e60c7)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update