### PR TITLE
adds fields for sequence logic in ActivationsStore

### DIFF
--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -150,6 +150,8 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
         sae_lens_version (str): The version of the sae_lens library.
         sae_lens_training_version (str): The version of the sae_lens training library.
         exclude_special_tokens (bool | list[int]): Whether to exclude special tokens from the activations. If True, excludes all special tokens. If a list of ints, excludes those token IDs.
+        disable_concat_sequences (bool): Whether to disable concatenating sequences and ignore sequences shorter than the context size. If True, disables concatenating and ignores short sequences.
+        exclude_bos_between_sequences (bool): Whether to exclude the BOS token between concatenated sequences. If True, excludes the BOS token.
     """
 
     sae: T_TRAINING_SAE_CONFIG

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -46,6 +46,29 @@ def dict_field(default: dict[str, Any] | None, **kwargs: Any) -> Any:  # type: i
     return simple_parsing.helpers.dict_field(default, type=json_dict, **kwargs)
 
 
+def special_token(s: str) -> Any:
+    """Parse special token value from string."""
+    if s.lower() == "none":
+        return None
+    if s in ["bos", "eos", "sep"]:
+        return s
+    try:
+        return int(s)
+    except ValueError:
+        raise ValueError(
+            f"Expected 'bos', 'eos', 'sep', an integer, or 'none', got {s}"
+        )
+
+
+def special_token_field(
+    default: int | Literal["bos", "eos", "sep"] | None, **kwargs: Any
+) -> Any:  # type: ignore
+    """
+    Helper to wrap simple_parsing.helpers.field so we can load special token fields from the command line.
+    """
+    return simple_parsing.helpers.field(default=default, type=special_token, **kwargs)
+
+
 @dataclass
 class LoggingConfig:
     # WANDB
@@ -181,7 +204,9 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
     store_batch_size_prompts: int = 32
     seqpos_slice: tuple[int | None, ...] = (None,)
     disable_concat_sequences: bool = False
-    sequence_separator_token: int | Literal["bos", "eos", "sep"] | None = "bos"
+    sequence_separator_token: int | Literal["bos", "eos", "sep"] | None = (
+        special_token_field(default="bos")
+    )
 
     # Misc
     device: str = "cpu"

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -233,6 +233,8 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
     sae_lens_version: str = field(default_factory=lambda: __version__)
     sae_lens_training_version: str = field(default_factory=lambda: __version__)
     exclude_special_tokens: bool | list[int] = False
+    disable_concat_sequences: bool = False
+    exclude_bos_between_sequences: bool = False
 
     def __post_init__(self):
         if self.use_cached_activations and self.cached_activations_path is None:

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -116,6 +116,8 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
         training_tokens (int): The number of training tokens.
         store_batch_size_prompts (int): The batch size for storing activations. This controls how many prompts are in the batch of the language model when generating activations.
         seqpos_slice (tuple[int | None, ...]): Determines slicing of activations when constructing batches during training. The slice should be (start_pos, end_pos, optional[step_size]), e.g. for Othello we sometimes use (5, -5). Note, step_size > 0.
+        disable_concat_sequences (bool): Whether to disable concatenating sequences and ignore sequences shorter than the context size. If True, disables concatenating and ignores short sequences.
+        exclude_bos_between_sequences (bool): Whether to exclude the BOS token between concatenated sequences. If True, excludes the BOS token.
         device (str): The device to use. Usually "cuda".
         act_store_device (str): The device to use for the activation store. "cpu" is advised in order to save VRAM. Defaults to "with_model" which uses the same device as the main model.
         seed (int): The seed to use.
@@ -150,8 +152,6 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
         sae_lens_version (str): The version of the sae_lens library.
         sae_lens_training_version (str): The version of the sae_lens training library.
         exclude_special_tokens (bool | list[int]): Whether to exclude special tokens from the activations. If True, excludes all special tokens. If a list of ints, excludes those token IDs.
-        disable_concat_sequences (bool): Whether to disable concatenating sequences and ignore sequences shorter than the context size. If True, disables concatenating and ignores short sequences.
-        exclude_bos_between_sequences (bool): Whether to exclude the BOS token between concatenated sequences. If True, excludes the BOS token.
     """
 
     sae: T_TRAINING_SAE_CONFIG
@@ -180,6 +180,8 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
     training_tokens: int = 2_000_000
     store_batch_size_prompts: int = 32
     seqpos_slice: tuple[int | None, ...] = (None,)
+    disable_concat_sequences: bool = False
+    exclude_bos_between_sequences: bool = False
 
     # Misc
     device: str = "cpu"
@@ -235,8 +237,6 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
     sae_lens_version: str = field(default_factory=lambda: __version__)
     sae_lens_training_version: str = field(default_factory=lambda: __version__)
     exclude_special_tokens: bool | list[int] = False
-    disable_concat_sequences: bool = False
-    exclude_bos_between_sequences: bool = False
 
     def __post_init__(self):
         if self.use_cached_activations and self.cached_activations_path is None:

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -117,7 +117,7 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
         store_batch_size_prompts (int): The batch size for storing activations. This controls how many prompts are in the batch of the language model when generating activations.
         seqpos_slice (tuple[int | None, ...]): Determines slicing of activations when constructing batches during training. The slice should be (start_pos, end_pos, optional[step_size]), e.g. for Othello we sometimes use (5, -5). Note, step_size > 0.
         disable_concat_sequences (bool): Whether to disable concatenating sequences and ignore sequences shorter than the context size. If True, disables concatenating and ignores short sequences.
-        exclude_bos_between_sequences (bool): Whether to exclude the BOS token between concatenated sequences. If True, excludes the BOS token.
+        sequence_separator_token (int | Literal["bos", "eos", "sep"] | None): If not `None`, this token will be placed between sentences in a batch to act as a separator. By default, this is the `<bos>` token.
         device (str): The device to use. Usually "cuda".
         act_store_device (str): The device to use for the activation store. "cpu" is advised in order to save VRAM. Defaults to "with_model" which uses the same device as the main model.
         seed (int): The seed to use.
@@ -181,7 +181,7 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
     store_batch_size_prompts: int = 32
     seqpos_slice: tuple[int | None, ...] = (None,)
     disable_concat_sequences: bool = False
-    exclude_bos_between_sequences: bool = False
+    sequence_separator_token: int | Literal["bos", "eos", "sep"] | None = "bos"
 
     # Misc
     device: str = "cpu"

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -568,6 +568,9 @@ class PretokenizeRunnerConfig:
     begin_sequence_token: int | Literal["bos", "eos", "sep"] | None = None
     sequence_separator_token: int | Literal["bos", "eos", "sep"] | None = "bos"
 
+    # sequence processing
+    disable_concat_sequences: bool = False
+
     # if saving locally, set save_path
     save_path: str | None = None
 

--- a/sae_lens/llm_sae_training_runner.py
+++ b/sae_lens/llm_sae_training_runner.py
@@ -202,6 +202,12 @@ class LanguageModelSAETrainingRunner:
         )
         self.sae.cfg.metadata.prepend_bos = self.cfg.prepend_bos
         self.sae.cfg.metadata.exclude_special_tokens = self.cfg.exclude_special_tokens
+        self.sae.cfg.metadata.sequence_separator_token = (
+            self.cfg.sequence_separator_token
+        )
+        self.sae.cfg.metadata.disable_concat_sequences = (
+            self.cfg.disable_concat_sequences
+        )
 
     def _compile_if_needed(self):
         # Compile model and SAE

--- a/sae_lens/pretokenize_runner.py
+++ b/sae_lens/pretokenize_runner.py
@@ -35,6 +35,7 @@ class PretokenizedDatasetMetadata:
     begin_batch_token: int | Literal["bos", "eos", "sep"] | None
     begin_sequence_token: int | Literal["bos", "eos", "sep"] | None
     sequence_separator_token: int | Literal["bos", "eos", "sep"] | None
+    disable_concat_sequences: bool
 
 
 def metadata_from_config(cfg: PretokenizeRunnerConfig) -> PretokenizedDatasetMetadata:
@@ -52,6 +53,7 @@ def metadata_from_config(cfg: PretokenizeRunnerConfig) -> PretokenizedDatasetMet
         begin_batch_token=cfg.begin_batch_token,
         begin_sequence_token=cfg.begin_sequence_token,
         sequence_separator_token=cfg.sequence_separator_token,
+        disable_concat_sequences=cfg.disable_concat_sequences,
     )
 
 

--- a/sae_lens/pretokenize_runner.py
+++ b/sae_lens/pretokenize_runner.py
@@ -99,6 +99,7 @@ def pretokenize_dataset(
                     sequence_separator_token_id=get_special_token_from_cfg(
                         cfg.sequence_separator_token, tokenizer
                     ),
+                    disable_concat_sequences=cfg.disable_concat_sequences,
                 )
             )
         }

--- a/sae_lens/tokenization_and_batching.py
+++ b/sae_lens/tokenization_and_batching.py
@@ -64,6 +64,7 @@ def concat_and_batch_sequences(
     begin_batch_token_id: int | None = None,
     begin_sequence_token_id: int | None = None,
     sequence_separator_token_id: int | None = None,
+    disable_concat_sequences: bool = False,
 ) -> Generator[torch.Tensor, None, None]:
     """
     Generator to concat token sequences together from the tokens_interator, yielding
@@ -75,8 +76,15 @@ def concat_and_batch_sequences(
         begin_batch_token_id: If provided, this token will be at position 0 of each batch
         begin_sequence_token_id: If provided, this token will be the first token of each sequence
         sequence_separator_token_id: If provided, this token will be inserted between concatenated sequences
+        disable_concat_sequences: If True, disable concatenating sequences and ignore sequences shorter than context_size
         max_batches: If not provided, the iterator will be run to completion.
     """
+    if disable_concat_sequences:
+        for tokens in tokens_iterator:
+            if len(tokens) >= context_size:
+                yield tokens[:context_size]
+        return
+
     batch: torch.Tensor | None = None
     for tokens in tokens_iterator:
         if len(tokens.shape) != 1:

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -160,6 +160,8 @@ class ActivationsStore:
         train_batch_size_tokens: int = 4096,
         total_tokens: int = 10**9,
         device: str = "cpu",
+        disable_concat_sequences: bool = False,
+        sequence_separator_token: int | Literal["bos", "eos", "sep"] | None = "bos",
     ) -> ActivationsStore:
         if sae.cfg.metadata.hook_name is None:
             raise ValueError("hook_name is required")
@@ -187,6 +189,8 @@ class ActivationsStore:
             dtype=sae.cfg.dtype,
             device=torch.device(device),
             seqpos_slice=sae.cfg.metadata.seqpos_slice or (None,),
+            disable_concat_sequences=disable_concat_sequences,
+            sequence_separator_token=sequence_separator_token,
         )
 
     def __init__(

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -368,22 +368,18 @@ class ActivationsStore:
             tokenizer = getattr(self.model, "tokenizer", None)
             bos_token_id = None if tokenizer is None else tokenizer.bos_token_id
 
-            if self.disable_concat_sequences:
-                for tokens in self._iterate_raw_dataset_tokens():
-                    if len(tokens) >= self.context_size:
-                        yield tokens[: self.context_size]
-            else:
-                sequence_separator_token_id = None
-                if self.prepend_bos and not self.exclude_bos_between_sequences:
-                    sequence_separator_token_id = bos_token_id
+            sequence_separator_token_id = None
+            if self.prepend_bos and not self.exclude_bos_between_sequences:
+                sequence_separator_token_id = bos_token_id
 
-                yield from concat_and_batch_sequences(
-                    tokens_iterator=self._iterate_raw_dataset_tokens(),
-                    context_size=self.context_size,
-                    begin_batch_token_id=(bos_token_id if self.prepend_bos else None),
-                    begin_sequence_token_id=None,
-                    sequence_separator_token_id=sequence_separator_token_id,
-                )
+            yield from concat_and_batch_sequences(
+                tokens_iterator=self._iterate_raw_dataset_tokens(),
+                context_size=self.context_size,
+                begin_batch_token_id=(bos_token_id if self.prepend_bos else None),
+                begin_sequence_token_id=None,
+                sequence_separator_token_id=sequence_separator_token_id,
+                disable_concat_sequences=self.disable_concat_sequences,
+            )
 
     def load_cached_activation_dataset(self) -> Dataset | None:
         """

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Any, Sequence, TypedDict, cast
+from typing import Any, Literal, Sequence, TypedDict, cast
 
 import pytest
 import torch
@@ -43,7 +43,7 @@ class LanguageModelSAERunnerConfigDict(TypedDict, total=False):
     normalize_activations: str
     seqpos_slice: tuple[int | None, ...] | Sequence[int | None]
     disable_concat_sequences: bool
-    exclude_bos_between_sequences: bool
+    sequence_separator_token: int | Literal["bos", "eos", "sep"] | None
     device: str
     act_store_device: str
     seed: int
@@ -133,7 +133,7 @@ def _get_default_runner_config() -> LanguageModelSAERunnerConfigDict:
         "store_batch_size_prompts": 4,
         "seqpos_slice": (None,),
         "disable_concat_sequences": False,
-        "exclude_bos_between_sequences": False,
+        "sequence_separator_token": "bos",
         "device": "cpu",
         "act_store_device": "cpu",
         "seed": 24,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -76,6 +76,8 @@ class LanguageModelSAERunnerConfigDict(TypedDict, total=False):
     sae_lens_version: str
     sae_lens_training_version: str
     exclude_special_tokens: bool | list[int]
+    disable_concat_sequences: bool
+    exclude_bos_between_sequences: bool
 
 
 # Base TrainingSAEConfig fields + all architecture specific fields
@@ -169,6 +171,8 @@ def _get_default_runner_config() -> LanguageModelSAERunnerConfigDict:
         "sae_lens_version": "test_version",
         "sae_lens_training_version": "test_version",
         "exclude_special_tokens": False,
+        "disable_concat_sequences": False,
+        "exclude_bos_between_sequences": False,
     }
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -42,6 +42,8 @@ class LanguageModelSAERunnerConfigDict(TypedDict, total=False):
     store_batch_size_prompts: int
     normalize_activations: str
     seqpos_slice: tuple[int | None, ...] | Sequence[int | None]
+    disable_concat_sequences: bool
+    exclude_bos_between_sequences: bool
     device: str
     act_store_device: str
     seed: int
@@ -76,8 +78,6 @@ class LanguageModelSAERunnerConfigDict(TypedDict, total=False):
     sae_lens_version: str
     sae_lens_training_version: str
     exclude_special_tokens: bool | list[int]
-    disable_concat_sequences: bool
-    exclude_bos_between_sequences: bool
 
 
 # Base TrainingSAEConfig fields + all architecture specific fields
@@ -132,6 +132,8 @@ def _get_default_runner_config() -> LanguageModelSAERunnerConfigDict:
         "training_tokens": 1_000_000,
         "store_batch_size_prompts": 4,
         "seqpos_slice": (None,),
+        "disable_concat_sequences": False,
+        "exclude_bos_between_sequences": False,
         "device": "cpu",
         "act_store_device": "cpu",
         "seed": 24,
@@ -171,8 +173,6 @@ def _get_default_runner_config() -> LanguageModelSAERunnerConfigDict:
         "sae_lens_version": "test_version",
         "sae_lens_training_version": "test_version",
         "exclude_special_tokens": False,
-        "disable_concat_sequences": False,
-        "exclude_bos_between_sequences": False,
     }
 
 

--- a/tests/training/test_activations_store.py
+++ b/tests/training/test_activations_store.py
@@ -851,7 +851,7 @@ def test_activations_store_get_batch_tokens_disable_concat_sequences(
     assert batch_tokens[1].tolist() == expected_tokens_2
 
 
-def test_activations_store_get_batch_tokens_exclude_bos_between_sequences(
+def test_activations_store_get_batch_tokens_no_sequence_separator_token(
     ts_model: HookedTransformer,
 ):
     cfg = build_runner_cfg(

--- a/tests/training/test_activations_store.py
+++ b/tests/training/test_activations_store.py
@@ -855,7 +855,7 @@ def test_activations_store_get_batch_tokens_exclude_bos_between_sequences(
     ts_model: HookedTransformer,
 ):
     cfg = build_runner_cfg(
-        exclude_bos_between_sequences=True,
+        sequence_separator_token=None,
         context_size=8,
         store_batch_size_prompts=1,
     )

--- a/tests/training/test_tokenization_and_batching.py
+++ b/tests/training/test_tokenization_and_batching.py
@@ -351,3 +351,19 @@ def test_concat_and_batch_sequences_works_with_extremely_long_samples():
     for batch in batches_list:
         assert batch.shape == (5,)
         assert batch[0] == 999
+
+
+def test_concat_and_batch_sequences_disable_concat_sequences():
+    all_toks = torch.arange(20)
+    seqs = [all_toks[:3], all_toks[3:10], all_toks[10:17], all_toks[17:]]
+    batches_list = list(
+        concat_and_batch_sequences(
+            tokens_iterator=iter(seqs), context_size=5, disable_concat_sequences=True
+        )
+    )
+    batches = torch.stack(batches_list)
+    expected = [
+        [3, 4, 5, 6, 7],
+        [10, 11, 12, 13, 14],
+    ]
+    assert batches.tolist() == expected

--- a/tutorials/pretokenizing_datasets.ipynb
+++ b/tutorials/pretokenizing_datasets.ipynb
@@ -25,7 +25,7 @@
     "\n",
     "- `begin_batch_token`: If not `None`, this token will be prepended to the start of each batch. By default this is the `<bos>` token\n",
     "- `begin_sequence_token`: If not `None`, this token will be prepended to the start of every sentence, regardless of where in the batch the sentence starts. By default this is `None`\n",
-    "- `sequence_separator_token`: If not `None`, this tokken will be placed between sentences in a batch to act as a separator. By default, this is the `<eos>` token.\n",
+    "- `sequence_separator_token`: If not `None`, this token will be placed between sentences in a batch to act as a separator. By default, this is the `<bos>` token.\n",
     "\n",
     "For each of the above options, you can pass the string `\"bos\"`, `\"eos\"`, or `\"sep\"` for the `<bos>`, `<eos>`, or `<sep>` tokens, respectively. You can also pass in a token ID as an int if you need to customize this further.\n",
     "\n",


### PR DESCRIPTION
# Description

Adds a field, where if the value is `True`, excludes the BOS token between concatenated sequences, and a field, where if the value is `True`, disables concatenating sequences and ignores sequences shorter than the context size. Gemma 2 wasn't trained on BOS tokens and we want to match this during training. We can do this using `PretokenizeRunner`, but not without it.

Fixes #472

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 