### PR TITLE
fixes alias already exists error

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -120,7 +120,7 @@ jobs:
           
           # If stable release (no pre-release identifiers), also update latest alias
           if [[ ! "$RELEASE_TAG" =~ (alpha|beta|rc) ]]; then
-            poetry run mike alias --push $RELEASE_TAG latest
+            poetry run mike alias -u --push $RELEASE_TAG latest
             poetry run mike set-default --push latest
           fi
       - name: Deploy main branch docs


### PR DESCRIPTION
# Description

Adds `-u` to move `latest` to the current version. We want to fix the build, and Deploy Docs is failing with
`error: alias 'latest' already exists for version 'v5.10.5'`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 