### PR TITLE
feat: allow old usage of SAE.from_pretrained() to continue to work

### DIFF
--- a/sae_lens/saes/sae.py
+++ b/sae_lens/saes/sae.py
@@ -732,6 +732,64 @@ class SAE(HookedRootModule, Generic[T_SAE_CONFIG], ABC):
     ) -> type[SAEConfig]:
         return SAEConfig
 
+    ### Methods to support deprecated usage of SAE.from_pretrained() ###
+
+    def __getitem__(self, index: int) -> Any:
+        """
+        Support indexing for backward compatibility with tuple unpacking.
+        DEPRECATED: SAE.from_pretrained() no longer returns a tuple.
+        Use SAE.from_pretrained_with_cfg_and_sparsity() instead.
+        """
+        warnings.warn(
+            "Indexing SAE objects is deprecated. SAE.from_pretrained() now returns "
+            "only the SAE object. Use SAE.from_pretrained_with_cfg_and_sparsity() "
+            "to get the config dict and sparsity as well.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        if index == 0:
+            return self
+        if index == 1:
+            return self.cfg.to_dict()
+        if index == 2:
+            return None
+        raise IndexError(f"SAE tuple index {index} out of range")
+
+    def __iter__(self):
+        """
+        Support unpacking for backward compatibility with tuple unpacking.
+        DEPRECATED: SAE.from_pretrained() no longer returns a tuple.
+        Use SAE.from_pretrained_with_cfg_and_sparsity() instead.
+        """
+        warnings.warn(
+            "Unpacking SAE objects is deprecated. SAE.from_pretrained() now returns "
+            "only the SAE object. Use SAE.from_pretrained_with_cfg_and_sparsity() "
+            "to get the config dict and sparsity as well.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        yield self
+        yield self.cfg.to_dict()
+        yield None
+
+    def __len__(self) -> int:
+        """
+        Support len() for backward compatibility with tuple unpacking.
+        DEPRECATED: SAE.from_pretrained() no longer returns a tuple.
+        Use SAE.from_pretrained_with_cfg_and_sparsity() instead.
+        """
+        warnings.warn(
+            "Getting length of SAE objects is deprecated. SAE.from_pretrained() now returns "
+            "only the SAE object. Use SAE.from_pretrained_with_cfg_and_sparsity() "
+            "to get the config dict and sparsity as well.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return 3
+
 
 @dataclass(kw_only=True)
 class TrainingSAEConfig(SAEConfig, ABC):

--- a/tests/saes/test_sae.py
+++ b/tests/saes/test_sae.py
@@ -5,7 +5,7 @@ import pytest
 
 from sae_lens import __version__
 from sae_lens.registry import get_sae_class, get_sae_training_class
-from sae_lens.saes.sae import SAEConfig, SAEMetadata, TrainingSAEConfig
+from sae_lens.saes.sae import SAE, SAEConfig, SAEMetadata, TrainingSAEConfig
 from tests.helpers import (
     ALL_ARCHITECTURES,
     build_sae_training_cfg_for_arch,
@@ -181,3 +181,28 @@ def test_SAEMetadata_dynamic_attribute_setting():
     assert metadata.another_field == 123
     assert "new_field" in metadata
     assert "another_field" in metadata
+
+
+def test_SAE_from_pretrained_deprecated_usage_as_tuple():
+    sae = SAE.from_pretrained("gpt2-small-hook-z-kk", "blocks.2.hook_z", device="cpu")
+
+    # Test tuple unpacking with deprecation warning
+    with pytest.warns(DeprecationWarning, match="Unpacking SAE objects is deprecated"):
+        tup_sae, tup_cfg_dict, tup_sparsity = sae
+    assert tup_sae is sae
+    assert tup_cfg_dict == sae.cfg.to_dict()
+    assert tup_sparsity is None
+
+    # Test indexing with deprecation warnings
+    with pytest.warns(DeprecationWarning, match="Indexing SAE objects is deprecated"):
+        assert sae[0] is sae
+    with pytest.warns(DeprecationWarning, match="Indexing SAE objects is deprecated"):
+        assert sae[1] == sae.cfg.to_dict()
+    with pytest.warns(DeprecationWarning, match="Indexing SAE objects is deprecated"):
+        assert sae[2] is None
+
+    # Test len with deprecation warning
+    with pytest.warns(
+        DeprecationWarning, match="Getting length of SAE objects is deprecated"
+    ):
+        assert len(sae) == 3


### PR DESCRIPTION
# Description

This PR allows the old usage of `SAE.from_pretrained()` returning a tuple to still continue to work, to make the transition to SAELens v6 more graceful. This will output a deprecation warning if the user does this.