### PR TITLE
chore: updating docs for v6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ This library is maintained by [Joseph Bloom](https://www.jbloomaus.com/), [Curt 
 
 Pre-trained SAEs for various models can be imported via SAE Lens. See this [page](https://jbloomaus.github.io/SAELens/sae_table/) in the readme for a list of all SAEs.
 
+## Migrating to SAELens v6
+
+The new v6 update is a major refactor to SAELens and changes the way training code is structured. Check out the [migration guide](https://jbloomaus.github.io/SAELens/latest/migrating/) for more details.
+
 ## Tutorials
 
 - [SAE Lens + Neuronpedia](tutorials/tutorial_2_0.ipynb)[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://githubtocolab.com/jbloomAus/SAELens/blob/main/tutorials/tutorial_2_0.ipynb)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 <!-- prettier-ignore-start -->
-!!! tip "Pre-Release Available"
-    SAELens 6.0.0 pre-release is available with exciting new features. [View documentation →](https://jbloomaus.github.io/SAELens/pre-release/)
+!!! tip "SAELens v6"
+    SAELens 6.0.0 is live with changes to SAE training and loading. Check out the [migration guide →](migrating)
 <!-- prettier-ignore-end -->
 
 <img width="1308" alt="Screenshot 2024-03-21 at 3 08 28 pm" src="https://github.com/jbloomAus/mats_sae_training/assets/69127271/209012ec-a779-4036-b4be-7b7739ea87f6">
@@ -26,7 +26,7 @@ The SAELens training codebase exists to help researchers:
 ### Installation
 
 ```
-pip install --pre sae-lens
+pip install sae-lens
 ```
 
 ### Loading Sparse Autoencoders from Huggingface

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -14,7 +14,9 @@ We apologize for any inconvenience this causes! These changes should put SAELens
 
 We expect that most users will use SAELens to load SAEs rather than training SAEs, so we expect this section to be the most important for most users. Previously, `SAE.from_pretrained()` returned a tuple of SAE, a cfg dict, and a feature sparsity tensor. Now, `SAE.from_pretrained()` returns just the SAE to be consistent with how `from_pretrained()` functions in [Huggingface Transformers](https://huggingface.co/docs/transformers/en/index) and [TransformerLens](https://transformerlensorg.github.io/TransformerLens/).
 
-The old functionality still exists via `SAE.load_from_pretrained_with_cfg_and_sparsity()` - although we expect this will not be needed by most users.
+Old code of the form `sae, cfg_dict, sparsity = SAE.from_pretrained(...)` should still continue to work, but will give a deprecation warning.
+
+The old functionality also exists via `SAE.load_from_pretrained_with_cfg_and_sparsity()` - although we expect this will not be needed by most users.
 
 ## SAE Training config changes
 


### PR DESCRIPTION
# Description

This PR makes minor changes to the docs around the v6 release:

- removes the `--pre` option from `pip install sae-lens`
- adds a note that `SAE.from_pretrained()` will continue to work with a deprecation warning
- changes the docs banner to point to the mitgration guide instead of the pre-release page