### PR TITLE
feat: BatchTopK SAE training

### DIFF
--- a/docs/training_saes.md
+++ b/docs/training_saes.md
@@ -132,7 +132,30 @@ from sae_lens.saes import TopKTrainingSAEConfig # Import TopK config
 #     ),
 #     # ...
 # )
-# sparse_autoencoder = SAETrainingRunner(cfg).run() # Commented out
+# sparse_autoencoder = SAETrainingRunner(cfg).run()
+```
+
+### Training BatchTopk SAEs
+
+A more modern version of the TopK SAE is the [BatchTopK](https://arxiv.org/abs/2412.06410) architecture, which fixes the mean L0 across a training batch rather than fixing the L0 for every sample in the batch. To train a BatchTopK SAE, provide a `BatchTopKTrainingSAEConfig` instance to the `sae` field. The primary parameter for TopK SAEs is `k`, the number of features to keep active. If not set, `k` defaults to 100 in `BatchTopKTrainingSAEConfig`. Like the TopK architecture, the BatchTopK architecture does not use an `l1_coefficient` or `lp_norm` for sparsity, as sparsity is structurally enforced.
+
+Also worth noting is that `BatchTopK` SAEs will save as `JumpReLU` SAEs for use at inference. This is to avoid needing to provide a batch of inputs at inference time, allowing the SAE to work consistently on any batch size after training is complete.
+
+```python
+from sae_lens import LanguageModelSAERunnerConfig, SAETrainingRunner
+from sae_lens.saes import BatchTopKTrainingSAEConfig # Import BatchTopK config
+
+# cfg = LanguageModelSAERunnerConfig( # Full config would be defined here
+#     # ... other LanguageModelSAERunnerConfig parameters ...
+#     sae=BatchTopKTrainingSAEConfig(
+#         k=100, # Set the number of active features
+#         d_in=1024, # Example, must match your hook point
+#         d_sae=16 * 1024, # Example
+#         # ... other common SAE parameters from SAEConfig if needed ...
+#     ),
+#     # ...
+# )
+# sparse_autoencoder = SAETrainingRunner(cfg).run()
 ```
 
 ### Training JumpReLU SAEs
@@ -155,7 +178,7 @@ from sae_lens.saes import JumpReLUTrainingSAEConfig # Import JumpReLU config
 #     ),
 #     # ...
 # )
-# sparse_autoencoder = SAETrainingRunner(cfg).run() # Commented out
+# sparse_autoencoder = SAETrainingRunner(cfg).run()
 ```
 
 ### Training Gated SAEs
@@ -176,7 +199,7 @@ from sae_lens.saes import GatedTrainingSAEConfig # Import Gated config
 #     ),
 #     # ...
 # )
-# sparse_autoencoder = SAETrainingRunner(cfg).run() # Commented out
+# sparse_autoencoder = SAETrainingRunner(cfg).run()
 ```
 
 ## CLI Runner

--- a/sae_lens/__init__.py
+++ b/sae_lens/__init__.py
@@ -7,6 +7,8 @@ logger = logging.getLogger(__name__)
 
 from sae_lens.saes import (
     SAE,
+    BatchTopKTrainingSAE,
+    BatchTopKTrainingSAEConfig,
     GatedSAE,
     GatedSAEConfig,
     GatedTrainingSAE,
@@ -85,6 +87,8 @@ __all__ = [
     "JumpReLUTrainingSAEConfig",
     "SAETrainingRunner",
     "LoggingConfig",
+    "BatchTopKTrainingSAE",
+    "BatchTopKTrainingSAEConfig",
 ]
 
 
@@ -96,3 +100,6 @@ register_sae_class("topk", TopKSAE, TopKSAEConfig)
 register_sae_training_class("topk", TopKTrainingSAE, TopKTrainingSAEConfig)
 register_sae_class("jumprelu", JumpReLUSAE, JumpReLUSAEConfig)
 register_sae_training_class("jumprelu", JumpReLUTrainingSAE, JumpReLUTrainingSAEConfig)
+register_sae_training_class(
+    "batchtopk", BatchTopKTrainingSAE, BatchTopKTrainingSAEConfig
+)

--- a/sae_lens/saes/__init__.py
+++ b/sae_lens/saes/__init__.py
@@ -1,3 +1,7 @@
+from .batchtopk_sae import (
+    BatchTopKTrainingSAE,
+    BatchTopKTrainingSAEConfig,
+)
 from .gated_sae import (
     GatedSAE,
     GatedSAEConfig,
@@ -45,4 +49,6 @@ __all__ = [
     "TopKSAEConfig",
     "TopKTrainingSAE",
     "TopKTrainingSAEConfig",
+    "BatchTopKTrainingSAE",
+    "BatchTopKTrainingSAEConfig",
 ]

--- a/sae_lens/saes/batchtopk_sae.py
+++ b/sae_lens/saes/batchtopk_sae.py
@@ -1,0 +1,109 @@
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import torch
+import torch.nn as nn
+from typing_extensions import override
+
+from sae_lens.saes.jumprelu_sae import JumpReLUSAEConfig
+from sae_lens.saes.sae import TrainStepInput, TrainStepOutput
+from sae_lens.saes.topk_sae import TopKTrainingSAE, TopKTrainingSAEConfig
+from sae_lens.util import filter_valid_dataclass_fields
+
+
+class BatchTopK(nn.Module):
+    """BatchTopK activation function"""
+
+    def __init__(
+        self,
+        k: int,
+        postact_fn: Callable[[torch.Tensor], torch.Tensor] = nn.ReLU(),
+    ):
+        super().__init__()
+        self.k = k
+        self.postact_fn = postact_fn
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        acts = x.relu()
+        flat_acts = acts.flatten()
+        acts_topk_flat = torch.topk(flat_acts, self.k * acts.shape[0], dim=-1)
+        return (
+            torch.zeros_like(flat_acts)
+            .scatter(-1, acts_topk_flat.indices, acts_topk_flat.values)
+            .reshape(acts.shape)
+        )
+
+
+@dataclass
+class BatchTopKTrainingSAEConfig(TopKTrainingSAEConfig):
+    """
+    Configuration class for training a BatchTopKTrainingSAE.
+    """
+
+    topk_threshold_lr: float = 0.01
+
+    @override
+    @classmethod
+    def architecture(cls) -> str:
+        return "batchtopk"
+
+
+class BatchTopKTrainingSAE(TopKTrainingSAE):
+    """
+    Global Batch TopK Training SAE
+
+    This SAE will maintain the k on average across the batch, rather than enforcing the k per-sample as in standard TopK.
+
+    BatchTopK SAEs are saved as JumpReLU SAEs after training.
+    """
+
+    topk_threshold: torch.Tensor
+    cfg: BatchTopKTrainingSAEConfig  # type: ignore[assignment]
+
+    def __init__(self, cfg: BatchTopKTrainingSAEConfig, use_error_term: bool = False):
+        super().__init__(cfg, use_error_term)
+
+        self.register_buffer(
+            "topk_threshold",
+            # use double precision as otherwise we can run into numerical issues
+            torch.tensor(0.0, dtype=torch.double, device=self.W_dec.device),
+        )
+
+    def get_activation_fn(self) -> Callable[[torch.Tensor], torch.Tensor]:
+        return BatchTopK(self.cfg.k)
+
+    def to_inference_config_dict(self) -> dict[str, Any]:
+        """
+        BatchTopK SAEs are saved as JumpReLU SAEs after training.
+        """
+        cfg = filter_valid_dataclass_fields(self.cfg.to_dict(), JumpReLUSAEConfig)
+        cfg["architecture"] = "jumprelu"
+        return cfg
+
+    @override
+    def training_forward_pass(self, step_input: TrainStepInput) -> TrainStepOutput:
+        output = super().training_forward_pass(step_input)
+        self.update_topk_threshold(output.feature_acts)
+        output.metrics["topk_threshold"] = self.topk_threshold
+        return output
+
+    @torch.no_grad()
+    def update_topk_threshold(self, acts_topk: torch.Tensor) -> None:
+        positive_mask = acts_topk > 0
+        lr = self.cfg.topk_threshold_lr
+        # autocast can cause numerical issues with the threshold update
+        with torch.autocast(self.topk_threshold.device.type, enabled=False):
+            if positive_mask.any():
+                min_positive = (
+                    acts_topk[positive_mask].min().to(self.topk_threshold.dtype)
+                )
+                self.topk_threshold = (1 - lr) * self.topk_threshold + lr * min_positive
+
+    @override
+    def process_state_dict_for_saving_inference(
+        self, state_dict: dict[str, Any]
+    ) -> None:
+        super().process_state_dict_for_saving_inference(state_dict)
+        # turn the topk threshold into jumprelu threshold
+        topk_threshold = state_dict.pop("topk_threshold").item()
+        state_dict["threshold"] = torch.ones_like(self.b_enc) * topk_threshold

--- a/sae_lens/saes/sae.py
+++ b/sae_lens/saes/sae.py
@@ -207,6 +207,8 @@ class TrainStepOutput:
     hidden_pre: torch.Tensor
     loss: torch.Tensor  # we need to call backwards on this
     losses: dict[str, torch.Tensor]
+    # any extra metrics to log can be added here
+    metrics: dict[str, torch.Tensor | float | int] = field(default_factory=dict)
 
 
 @dataclass

--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -349,8 +349,10 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
             },
         }
         for loss_name, loss_value in output.losses.items():
-            loss_item = _unwrap_item(loss_value)
-            log_dict[f"losses/{loss_name}"] = loss_item
+            log_dict[f"losses/{loss_name}"] = _unwrap_item(loss_value)
+
+        for metric_name, metric_value in output.metrics.items():
+            log_dict[f"metrics/{metric_name}"] = _unwrap_item(metric_value)
 
         return log_dict
 

--- a/tests/saes/test_batchtopk_sae.py
+++ b/tests/saes/test_batchtopk_sae.py
@@ -1,0 +1,254 @@
+import os
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+
+from sae_lens.saes.batchtopk_sae import BatchTopK, BatchTopKTrainingSAE
+from sae_lens.saes.jumprelu_sae import JumpReLUSAE
+from sae_lens.saes.sae import SAE, TrainStepInput
+from tests.helpers import build_batchtopk_sae_training_cfg
+
+
+def test_BatchTopK_with_same_number_of_top_features_per_batch():
+    batch_topk = BatchTopK(k=2)
+    x = torch.tensor([[1.0, -2.0, 3.0, -4.0], [-5.0, 6.0, -7.0, 8.0]])
+
+    # Expected output after:
+    # 1. ReLU: [[1, 0, 3, 0], [0, 6, 0, 8]]
+    # 2. Flatten: [1, 0, 3, 0, 0, 6, 0, 8]
+    # 3. Top 4 values (k=2 * batch_size=2): [8, 6, 3, 1]
+    # 4. Reshape back to original shape
+    expected = torch.tensor([[1.0, 0.0, 3.0, 0.0], [0.0, 6.0, 0.0, 8.0]])
+
+    output = batch_topk(x)
+
+    assert output.shape == x.shape
+    torch.testing.assert_close(output, expected)
+
+    # Check that exactly k*batch_size values are non-zero
+    assert (output != 0).sum() == batch_topk.k * x.shape[0]
+
+
+def test_BatchTopK_with_imbalanced_top_features_per_batch():
+    batch_topk = BatchTopK(k=2)
+    x = torch.tensor(
+        [
+            [1.0, 2.0, 3.0, 4.0],  # All positive values
+            [-5.0, -6.0, 0.5, -8.0],  # Only one small positive value
+        ]
+    )
+
+    # Expected output after:
+    # 1. ReLU: [[1, 2, 3, 4], [0, 0, 0.5, 0]]
+    # 2. Flatten: [1, 2, 3, 4, 0, 0, 0.5, 0]
+    # 3. Top 4 values (k=2 * batch_size=2): [4, 3, 2, 1]
+    # 4. Reshape back to original shape
+    expected = torch.tensor(
+        [
+            [1.0, 2.0, 3.0, 4.0],  # Gets 4 non-zero values
+            [0.0, 0.0, 0.0, 0.0],  # Gets 0 non-zero values
+        ]
+    )
+
+    output = batch_topk(x)
+    torch.testing.assert_close(output, expected)
+
+    # Check that exactly k*batch_size values are non-zero across all batches
+    assert (output != 0).sum() == batch_topk.k * x.shape[0]
+
+
+def test_BatchTopK_output_must_be_positive():
+    batch_topk = BatchTopK(k=2)
+    x = torch.tensor(
+        [
+            [-1.0, 2.0, -3.0, -4.0],  # Only 1 positive value
+            [5.0, -6.0, -7.0, -8.0],  # Only 1 positive value
+        ]
+    )
+    # Total positive values (2) < k*batch_size (4)
+
+    # Expected output after:
+    # 1. ReLU: [[0, 2, 0, 0], [5, 0, 0, 0]]
+    # 2. Flatten: [0, 2, 0, 0, 5, 0, 0, 0]
+    # 3. Top 4 values (k=2 * batch_size=2): [5, 2, 0, 0]
+    # 4. Reshape back to original shape
+    expected = torch.tensor(
+        [
+            [0.0, 2.0, 0.0, 0.0],
+            [5.0, 0.0, 0.0, 0.0],
+        ]
+    )
+
+    output = batch_topk(x)
+
+    torch.testing.assert_close(output, expected)
+    assert (output >= 0).all()
+
+    # Check that number of non-zero values equals number of positive inputs
+    # (which is less than k*batch_size)
+    assert (output != 0).sum() == (x > 0).sum()
+
+
+def test_BatchTopKTrainingSAE_initialization():
+    cfg = build_batchtopk_sae_training_cfg(device="cpu")
+    sae = BatchTopKTrainingSAE.from_dict(cfg.to_dict())
+    assert isinstance(sae.W_enc, nn.Parameter)
+    assert isinstance(sae.W_dec, nn.Parameter)
+    assert isinstance(sae.b_enc, nn.Parameter)
+    assert isinstance(sae.b_dec, nn.Parameter)
+    assert isinstance(sae.topk_threshold, torch.Tensor)
+
+    assert sae.W_enc.shape == (cfg.d_in, cfg.d_sae)
+    assert sae.W_dec.shape == (cfg.d_sae, cfg.d_in)
+    assert sae.b_enc.shape == (cfg.d_sae,)
+    assert sae.b_dec.shape == (cfg.d_in,)
+    assert sae.topk_threshold.shape == ()
+
+    # encoder/decoder should be initialized, everything else should be 0s
+    assert not torch.allclose(sae.W_enc, torch.zeros_like(sae.W_enc))
+    assert not torch.allclose(sae.W_dec, torch.zeros_like(sae.W_dec))
+    assert torch.allclose(sae.b_dec, torch.zeros_like(sae.b_dec))
+    assert torch.allclose(sae.b_enc, torch.zeros_like(sae.b_enc))
+    assert sae.topk_threshold.item() == 0.0
+
+
+def test_BatchTopKTrainingSAE_save_and_load_inference_sae(tmp_path: Path) -> None:
+    # Create a training SAE with specific parameter values
+    cfg = build_batchtopk_sae_training_cfg(device="cpu")
+    training_sae = BatchTopKTrainingSAE(cfg)
+
+    # Set some known values for testing
+    training_sae.W_enc.data = torch.randn_like(training_sae.W_enc.data)
+    training_sae.W_dec.data = torch.randn_like(training_sae.W_dec.data)
+    training_sae.b_enc.data = torch.randn_like(training_sae.b_enc.data)
+    training_sae.b_dec.data = torch.randn_like(training_sae.b_dec.data)
+
+    sae_in = torch.randn(30, training_sae.cfg.d_in)
+    train_step_input = TrainStepInput(
+        sae_in=sae_in,
+        coefficients={},
+        dead_neuron_mask=None,
+    )
+
+    # run some test data through to learn the correct threshold
+    for _ in range(1000):
+        training_sae.training_forward_pass(train_step_input)
+
+    # Save original state for comparison
+    original_W_enc = training_sae.W_enc.data.clone()
+    original_W_dec = training_sae.W_dec.data.clone()
+    original_b_enc = training_sae.b_enc.data.clone()
+    original_b_dec = training_sae.b_dec.data.clone()
+    original_threshold = training_sae.topk_threshold.item()
+
+    # Save as inference model
+    model_path = str(tmp_path)
+    training_sae.save_inference_model(model_path)
+
+    assert os.path.exists(model_path)
+
+    # Load as inference SAE
+    inference_sae = SAE.load_from_disk(model_path, device="cpu")
+
+    # Should be loaded as JumpReLUSAE
+    assert isinstance(inference_sae, JumpReLUSAE)
+
+    # Check that all parameters match
+    assert torch.allclose(inference_sae.W_enc, original_W_enc)
+    assert torch.allclose(inference_sae.W_dec, original_W_dec)
+    assert torch.allclose(inference_sae.b_enc, original_b_enc)
+    assert torch.allclose(inference_sae.b_dec, original_b_dec)
+
+    # Check that topk_threshold was converted to threshold
+    assert torch.allclose(
+        inference_sae.threshold,
+        original_threshold * torch.ones_like(inference_sae.b_enc),
+    )
+
+    # Get output from training SAE
+    training_feature_acts, _ = training_sae.encode_with_hidden_pre(sae_in)
+    training_sae_out = training_sae.decode(training_feature_acts)
+
+    # Get output from inference SAE
+    inference_feature_acts = inference_sae.encode(sae_in)
+    inference_sae_out = inference_sae.decode(inference_feature_acts)
+
+    # Should produce identical outputs
+    assert torch.allclose(training_feature_acts, inference_feature_acts)
+    assert torch.allclose(training_sae_out, inference_sae_out)
+
+    # Test the full forward pass
+    training_full_out = training_sae(sae_in)
+    inference_full_out = inference_sae(sae_in)
+    assert torch.allclose(training_full_out, inference_full_out)
+
+
+def test_BatchTopKTrainingSAE_training_step_updates_threshold() -> None:
+    # Create BatchTopKTrainingSAE
+    cfg = build_batchtopk_sae_training_cfg(device="cpu")
+    sae = BatchTopKTrainingSAE(cfg)
+
+    # Set initial threshold
+    initial_threshold = 0.0
+    sae.topk_threshold = torch.tensor(initial_threshold)
+    sae.b_enc.data = torch.randn(sae.cfg.d_sae) + 10
+
+    # Create input that will produce non-zero activations
+    sae_in = torch.randn(4, sae.cfg.d_in)
+    train_step_input = TrainStepInput(
+        sae_in=sae_in,
+        coefficients={},
+        dead_neuron_mask=None,
+    )
+
+    # Do training step
+    with torch.no_grad():
+        output = sae.training_forward_pass(train_step_input)
+
+    # Verify threshold changed
+    assert sae.topk_threshold != initial_threshold
+
+    # Verify threshold is included in metrics dict
+    assert "topk_threshold" in output.metrics
+    assert output.metrics["topk_threshold"] == sae.topk_threshold
+
+
+def test_BatchTopKTrainingSAE_to_inference_config_dict() -> None:
+    cfg = build_batchtopk_sae_training_cfg(device="cpu")
+    sae = BatchTopKTrainingSAE(cfg)
+
+    inference_config = sae.to_inference_config_dict()
+
+    # Should convert to JumpReLU architecture
+    assert inference_config["architecture"] == "jumprelu"
+
+    # Should preserve key config fields
+    assert inference_config["d_in"] == cfg.d_in
+    assert inference_config["d_sae"] == cfg.d_sae
+    assert inference_config["dtype"] == cfg.dtype
+    assert inference_config["device"] == cfg.device
+
+    # Should not have BatchTopK-specific fields
+    assert "topk_threshold_lr" not in inference_config
+
+
+def test_BatchTopKTrainingSAE_process_state_dict_for_saving_inference() -> None:
+    cfg = build_batchtopk_sae_training_cfg(device="cpu")
+    sae = BatchTopKTrainingSAE(cfg)
+
+    # Set a known threshold value
+    threshold_value = 0.5
+    sae.topk_threshold = torch.tensor(threshold_value)
+
+    # Get state dict and process it
+    state_dict = sae.state_dict()
+    sae.process_state_dict_for_saving_inference(state_dict)
+
+    # topk_threshold should be removed
+    assert "topk_threshold" not in state_dict
+
+    # threshold should be added with correct shape and value
+    assert "threshold" in state_dict
+    expected_threshold = torch.ones_like(sae.b_enc) * threshold_value
+    torch.testing.assert_close(state_dict["threshold"], expected_threshold)

--- a/tests/training/test_sae_trainer.py
+++ b/tests/training/test_sae_trainer.py
@@ -185,6 +185,9 @@ def test_build_train_step_log_dict(
             "mse_loss": torch.tensor(0.25),
             "l1_loss": torch.tensor(0.1),
         },
+        metrics={
+            "topk_threshold": torch.tensor(0.5),
+        },
     )
 
     # we're relying on the trainer only for some of the metrics here
@@ -206,6 +209,7 @@ def test_build_train_step_log_dict(
         "details/current_learning_rate": 2e-4,
         "details/l1_coefficient": trainer.sae.cfg.l1_coefficient,
         "details/n_training_samples": 123,
+        "metrics/topk_threshold": 0.5,
     }
     assert log_dict.keys() == expected.keys()
     assert log_dict == pytest.approx(expected)


### PR DESCRIPTION
# Description

This PR adds support for [BatchTopK](https://arxiv.org/abs/2412.06410) SAE training. These SAEs save as JumpReLU SAEs in inference mode.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)