### PR TITLE
deletes TrainSAEOutput

### DIFF
--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -1,5 +1,4 @@
 import contextlib
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Generic, Protocol
 
@@ -36,13 +35,6 @@ def _update_sae_lens_training_version(sae: TrainingSAE[Any]) -> None:
     Make sure we record the version of SAELens used for the training run
     """
     sae.cfg.sae_lens_training_version = str(__version__)
-
-
-@dataclass
-class TrainSAEOutput:
-    sae: TrainingSAE[Any]
-    checkpoint_path: str
-    log_feature_sparsities: torch.Tensor
 
 
 class SaveCheckpointFn(Protocol):

--- a/tests/_comparison/sae_lens_old/training/sae_trainer.py
+++ b/tests/_comparison/sae_lens_old/training/sae_trainer.py
@@ -1,5 +1,4 @@
 import contextlib
-from dataclasses import dataclass
 from typing import Any, Protocol, cast
 
 import torch
@@ -37,13 +36,6 @@ def _update_sae_lens_training_version(sae: TrainingSAE) -> None:
     Make sure we record the version of SAELens used for the training run
     """
     sae.cfg.sae_lens_training_version = str(__version__)
-
-
-@dataclass
-class TrainSAEOutput:
-    sae: TrainingSAE
-    checkpoint_path: str
-    log_feature_sparsities: torch.Tensor
 
 
 class SaveCheckpointFn(Protocol):


### PR DESCRIPTION
# Description

Deletes `TrainSAEOutput`. It's unused and not documented.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.




# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 