### PR TITLE
feat: adding mwhanna qwen transcoders to pretrained list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,16 +32,16 @@ jobs:
       - name: Cache Huggingface assets
         uses: actions/cache@v4
         with:
-          key: huggingface-1-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+          key: huggingface-2-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
           path: ~/.cache/huggingface
           restore-keys: |
-            huggingface-1-${{ runner.os }}-${{ matrix.python-version }}-
+            huggingface-2-${{ runner.os }}-${{ matrix.python-version }}-
       - name: Load cached Poetry installation
         id: cached-poetry
         uses: actions/cache@v4
         with:
           path: ~/.local # the path depends on the OS
-          key: poetry-${{ runner.os }}-${{ matrix.python-version }}-2 # increment to reset cache
+          key: poetry-${{ runner.os }}-${{ matrix.python-version }}-3 # increment to reset cache
       - name: Install Poetry
         if: steps.cached-poetry.outputs.cache-hit != 'true'
         uses: snok/install-poetry@v1
@@ -54,9 +54,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-1-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+          key: venv-2-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: |
-            venv-1-${{ runner.os }}-${{ matrix.python-version }}-
+            venv-2-${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = ["Topic :: Scientific/Engineering :: Artificial Intelligence"]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-transformer-lens = "^2.0.0"
+transformer-lens = "^2.16.1"
 transformers = "^4.38.1"
 plotly = "^5.19.0"
 plotly-express = "^0.4.1"

--- a/sae_lens/loading/pretrained_sae_loaders.py
+++ b/sae_lens/loading/pretrained_sae_loaders.py
@@ -1266,7 +1266,7 @@ def get_mwhanna_transcoder_config_from_hf(
         "activation_fn": "relu",
         "normalize_activations": "none",
         "model_name": base_cfg_info["model_name"],
-        "hook_name": f"blocks.{layer}.ln2.hook_normalized",
+        "hook_name": f"blocks.{layer}.mlp.hook_in",
         "hook_name_out": f"blocks.{layer}.hook_mlp_out",
         "dataset_path": "monology/pile-uncopyrighted",
         "context_size": wandb_cfg_info["batch_size"]["value"],

--- a/sae_lens/loading/pretrained_sae_loaders.py
+++ b/sae_lens/loading/pretrained_sae_loaders.py
@@ -1271,6 +1271,7 @@ def get_mwhanna_transcoder_config_from_hf(
         "dataset_path": "monology/pile-uncopyrighted",
         "context_size": wandb_cfg_info["batch_size"]["value"],
         "apply_b_dec_to_input": False,
+        "model_from_pretrained_kwargs": {"fold_ln": False},
         **(cfg_overrides or {}),
     }
 

--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -14084,3 +14084,458 @@ gemma-scope-2b-pt-transcoders:
     neuronpedia: gemma-2-2b/25-gemmascope-transcoder-16k
     l0: 41
     path: layer_25/width_16k/average_l0_41
+
+
+mwhanna-qwen3-4b-transcoders:
+  conversion_func: mwhanna_transcoder
+  model: qwen3-4b
+  repo_id: mwhanna/qwen3-4b-transcoders
+  saes:
+  - id: layer_0
+    path: layer_0.safetensors
+  - id: layer_1
+    path: layer_1.safetensors
+  - id: layer_2
+    path: layer_2.safetensors
+  - id: layer_3
+    path: layer_3.safetensors
+  - id: layer_4
+    path: layer_4.safetensors
+  - id: layer_5
+    path: layer_5.safetensors
+  - id: layer_6
+    path: layer_6.safetensors
+  - id: layer_7
+    path: layer_7.safetensors
+  - id: layer_8
+    path: layer_8.safetensors
+  - id: layer_9
+    path: layer_9.safetensors
+  - id: layer_10
+    path: layer_10.safetensors
+  - id: layer_11
+    path: layer_11.safetensors
+  - id: layer_12
+    path: layer_12.safetensors
+  - id: layer_13
+    path: layer_13.safetensors
+  - id: layer_14
+    path: layer_14.safetensors
+  - id: layer_15
+    path: layer_15.safetensors
+  - id: layer_16
+    path: layer_16.safetensors
+  - id: layer_17
+    path: layer_17.safetensors
+  - id: layer_18
+    path: layer_18.safetensors
+  - id: layer_19
+    path: layer_19.safetensors
+  - id: layer_20
+    path: layer_20.safetensors
+  - id: layer_21
+    path: layer_21.safetensors
+  - id: layer_22
+    path: layer_22.safetensors
+  - id: layer_23
+    path: layer_23.safetensors
+  - id: layer_24
+    path: layer_24.safetensors
+  - id: layer_25
+    path: layer_25.safetensors
+  - id: layer_26
+    path: layer_26.safetensors
+  - id: layer_27
+    path: layer_27.safetensors
+  - id: layer_28
+    path: layer_28.safetensors
+  - id: layer_29
+    path: layer_29.safetensors
+  - id: layer_30
+    path: layer_30.safetensors
+  - id: layer_31
+    path: layer_31.safetensors
+  - id: layer_32
+    path: layer_32.safetensors
+  - id: layer_33
+    path: layer_33.safetensors
+  - id: layer_34
+    path: layer_34.safetensors
+  - id: layer_35
+    path: layer_35.safetensors
+
+mwhanna-qwen3-8b-transcoders:
+  conversion_func: mwhanna_transcoder
+  model: qwen3-8b
+  repo_id: mwhanna/qwen3-8b-transcoders
+  saes:
+  - id: layer_0
+    path: layer_0.safetensors
+  - id: layer_1
+    path: layer_1.safetensors
+  - id: layer_2
+    path: layer_2.safetensors
+  - id: layer_3
+    path: layer_3.safetensors
+  - id: layer_4
+    path: layer_4.safetensors
+  - id: layer_5
+    path: layer_5.safetensors
+  - id: layer_6
+    path: layer_6.safetensors
+  - id: layer_7
+    path: layer_7.safetensors
+  - id: layer_8
+    path: layer_8.safetensors
+  - id: layer_9
+    path: layer_9.safetensors
+  - id: layer_10
+    path: layer_10.safetensors
+  - id: layer_11
+    path: layer_11.safetensors
+  - id: layer_12
+    path: layer_12.safetensors
+  - id: layer_13
+    path: layer_13.safetensors
+  - id: layer_14
+    path: layer_14.safetensors
+  - id: layer_15
+    path: layer_15.safetensors
+  - id: layer_16
+    path: layer_16.safetensors
+  - id: layer_17
+    path: layer_17.safetensors
+  - id: layer_18
+    path: layer_18.safetensors
+  - id: layer_19
+    path: layer_19.safetensors
+  - id: layer_20
+    path: layer_20.safetensors
+  - id: layer_21
+    path: layer_21.safetensors
+  - id: layer_22
+    path: layer_22.safetensors
+  - id: layer_23
+    path: layer_23.safetensors
+  - id: layer_24
+    path: layer_24.safetensors
+  - id: layer_25
+    path: layer_25.safetensors
+  - id: layer_26
+    path: layer_26.safetensors
+  - id: layer_27
+    path: layer_27.safetensors
+  - id: layer_28
+    path: layer_28.safetensors
+  - id: layer_29
+    path: layer_29.safetensors
+  - id: layer_30
+    path: layer_30.safetensors
+  - id: layer_31
+    path: layer_31.safetensors
+  - id: layer_32
+    path: layer_32.safetensors
+  - id: layer_33
+    path: layer_33.safetensors
+  - id: layer_34
+    path: layer_34.safetensors
+  - id: layer_35
+    path: layer_35.safetensors
+
+mwhanna-qwen3-14b-transcoders:
+  conversion_func: mwhanna_transcoder
+  model: qwen3-14b
+  repo_id: mwhanna/qwen3-14b-transcoders
+  saes:
+  - id: layer_0
+    path: layer_0.safetensors
+  - id: layer_1
+    path: layer_1.safetensors
+  - id: layer_2
+    path: layer_2.safetensors
+  - id: layer_3
+    path: layer_3.safetensors
+  - id: layer_4
+    path: layer_4.safetensors
+  - id: layer_5
+    path: layer_5.safetensors
+  - id: layer_6
+    path: layer_6.safetensors
+  - id: layer_7
+    path: layer_7.safetensors
+  - id: layer_8
+    path: layer_8.safetensors
+  - id: layer_9
+    path: layer_9.safetensors
+  - id: layer_10
+    path: layer_10.safetensors
+  - id: layer_11
+    path: layer_11.safetensors
+  - id: layer_12
+    path: layer_12.safetensors
+  - id: layer_13
+    path: layer_13.safetensors
+  - id: layer_14
+    path: layer_14.safetensors
+  - id: layer_15
+    path: layer_15.safetensors
+  - id: layer_16
+    path: layer_16.safetensors
+  - id: layer_17
+    path: layer_17.safetensors
+  - id: layer_18
+    path: layer_18.safetensors
+  - id: layer_19
+    path: layer_19.safetensors
+  - id: layer_20
+    path: layer_20.safetensors
+  - id: layer_21
+    path: layer_21.safetensors
+  - id: layer_22
+    path: layer_22.safetensors
+  - id: layer_23
+    path: layer_23.safetensors
+  - id: layer_24
+    path: layer_24.safetensors
+  - id: layer_25
+    path: layer_25.safetensors
+  - id: layer_26
+    path: layer_26.safetensors
+  - id: layer_27
+    path: layer_27.safetensors
+  - id: layer_28
+    path: layer_28.safetensors
+  - id: layer_29
+    path: layer_29.safetensors
+  - id: layer_30
+    path: layer_30.safetensors
+  - id: layer_31
+    path: layer_31.safetensors
+  - id: layer_32
+    path: layer_32.safetensors
+  - id: layer_33
+    path: layer_33.safetensors
+  - id: layer_34
+    path: layer_34.safetensors
+  - id: layer_35
+    path: layer_35.safetensors
+  - id: layer_36
+    path: layer_36.safetensors
+  - id: layer_37
+    path: layer_37.safetensors
+  - id: layer_38
+    path: layer_38.safetensors
+  - id: layer_39
+    path: layer_39.safetensors
+
+mwhanna-qwen3-14b-transcoders-lowl0:
+  conversion_func: mwhanna_transcoder
+  model: qwen3-14b
+  repo_id: mwhanna/qwen3-14b-transcoders
+  saes:
+  - id: layer_0
+    path: layer_0.safetensors
+  - id: layer_1
+    path: layer_1.safetensors
+  - id: layer_2
+    path: layer_2.safetensors
+  - id: layer_3
+    path: layer_3.safetensors
+  - id: layer_4
+    path: layer_4.safetensors
+  - id: layer_5
+    path: layer_5.safetensors
+  - id: layer_6
+    path: layer_6.safetensors
+  - id: layer_7
+    path: layer_7.safetensors
+  - id: layer_8
+    path: layer_8.safetensors
+  - id: layer_9
+    path: layer_9.safetensors
+  - id: layer_10
+    path: layer_10.safetensors
+  - id: layer_11
+    path: layer_11.safetensors
+  - id: layer_12
+    path: layer_12.safetensors
+  - id: layer_13
+    path: layer_13.safetensors
+  - id: layer_14
+    path: layer_14.safetensors
+  - id: layer_15
+    path: layer_15.safetensors
+  - id: layer_16
+    path: layer_16.safetensors
+  - id: layer_17
+    path: layer_17.safetensors
+  - id: layer_18
+    path: layer_18.safetensors
+  - id: layer_19
+    path: layer_19.safetensors
+  - id: layer_20
+    path: layer_20.safetensors
+  - id: layer_21
+    path: layer_21.safetensors
+  - id: layer_22
+    path: layer_22.safetensors
+  - id: layer_23
+    path: layer_23.safetensors
+  - id: layer_24
+    path: layer_24.safetensors
+  - id: layer_25
+    path: layer_25.safetensors
+  - id: layer_26
+    path: layer_26.safetensors
+  - id: layer_27
+    path: layer_27.safetensors
+  - id: layer_28
+    path: layer_28.safetensors
+  - id: layer_29
+    path: layer_29.safetensors
+  - id: layer_30
+    path: layer_30.safetensors
+  - id: layer_31
+    path: layer_31.safetensors
+  - id: layer_32
+    path: layer_32.safetensors
+  - id: layer_33
+    path: layer_33.safetensors
+  - id: layer_34
+    path: layer_34.safetensors
+  - id: layer_35
+    path: layer_35.safetensors
+  - id: layer_36
+    path: layer_36.safetensors
+  - id: layer_37
+    path: layer_37.safetensors
+  - id: layer_38
+    path: layer_38.safetensors
+  - id: layer_39
+    path: layer_39.safetensors
+
+mwhanna-qwen3-1.7b-transcoders-lowl0:
+  conversion_func: mwhanna_transcoder
+  model: qwen3-1.7b
+  repo_id: mwhanna/qwen3-1.7b-transcoders
+  saes:
+  - id: layer_0
+    path: layer_0.safetensors
+  - id: layer_1
+    path: layer_1.safetensors
+  - id: layer_2
+    path: layer_2.safetensors
+  - id: layer_3
+    path: layer_3.safetensors
+  - id: layer_4
+    path: layer_4.safetensors
+  - id: layer_5
+    path: layer_5.safetensors
+  - id: layer_6
+    path: layer_6.safetensors
+  - id: layer_7
+    path: layer_7.safetensors
+  - id: layer_8
+    path: layer_8.safetensors
+  - id: layer_9
+    path: layer_9.safetensors
+  - id: layer_10
+    path: layer_10.safetensors
+  - id: layer_11
+    path: layer_11.safetensors
+  - id: layer_12
+    path: layer_12.safetensors
+  - id: layer_13
+    path: layer_13.safetensors
+  - id: layer_14
+    path: layer_14.safetensors
+  - id: layer_15
+    path: layer_15.safetensors
+  - id: layer_16
+    path: layer_16.safetensors
+  - id: layer_17
+    path: layer_17.safetensors
+  - id: layer_18
+    path: layer_18.safetensors
+  - id: layer_19
+    path: layer_19.safetensors
+  - id: layer_20
+    path: layer_20.safetensors
+  - id: layer_21
+    path: layer_21.safetensors
+  - id: layer_22
+    path: layer_22.safetensors
+  - id: layer_23
+    path: layer_23.safetensors
+  - id: layer_24
+    path: layer_24.safetensors
+  - id: layer_25
+    path: layer_25.safetensors
+  - id: layer_26
+    path: layer_26.safetensors
+  - id: layer_27
+    path: layer_27.safetensors
+
+
+
+mwhanna-qwen3-0.6b-transcoders-lowl0:
+  conversion_func: mwhanna_transcoder
+  model: qwen3-0.6b
+  repo_id: mwhanna/qwen3-0.6b-transcoders
+  saes:
+  - id: layer_0
+    path: layer_0.safetensors
+  - id: layer_1
+    path: layer_1.safetensors
+  - id: layer_2
+    path: layer_2.safetensors
+  - id: layer_3
+    path: layer_3.safetensors
+  - id: layer_4
+    path: layer_4.safetensors
+  - id: layer_5
+    path: layer_5.safetensors
+  - id: layer_6
+    path: layer_6.safetensors
+  - id: layer_7
+    path: layer_7.safetensors
+  - id: layer_8
+    path: layer_8.safetensors
+  - id: layer_9
+    path: layer_9.safetensors
+  - id: layer_10
+    path: layer_10.safetensors
+  - id: layer_11
+    path: layer_11.safetensors
+  - id: layer_12
+    path: layer_12.safetensors
+  - id: layer_13
+    path: layer_13.safetensors
+  - id: layer_14
+    path: layer_14.safetensors
+  - id: layer_15
+    path: layer_15.safetensors
+  - id: layer_16
+    path: layer_16.safetensors
+  - id: layer_17
+    path: layer_17.safetensors
+  - id: layer_18
+    path: layer_18.safetensors
+  - id: layer_19
+    path: layer_19.safetensors
+  - id: layer_20
+    path: layer_20.safetensors
+  - id: layer_21
+    path: layer_21.safetensors
+  - id: layer_22
+    path: layer_22.safetensors
+  - id: layer_23
+    path: layer_23.safetensors
+  - id: layer_24
+    path: layer_24.safetensors
+  - id: layer_25
+    path: layer_25.safetensors
+  - id: layer_26
+    path: layer_26.safetensors
+  - id: layer_27
+    path: layer_27.safetensors

--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -14093,76 +14093,112 @@ mwhanna-qwen3-4b-transcoders:
   saes:
   - id: layer_0
     path: layer_0.safetensors
+    neuronpedia: qwen3-4b/0-transcoder-hp
   - id: layer_1
     path: layer_1.safetensors
+    neuronpedia: qwen3-4b/1-transcoder-hp
   - id: layer_2
     path: layer_2.safetensors
+    neuronpedia: qwen3-4b/2-transcoder-hp
   - id: layer_3
     path: layer_3.safetensors
+    neuronpedia: qwen3-4b/3-transcoder-hp
   - id: layer_4
     path: layer_4.safetensors
+    neuronpedia: qwen3-4b/4-transcoder-hp
   - id: layer_5
     path: layer_5.safetensors
+    neuronpedia: qwen3-4b/5-transcoder-hp
   - id: layer_6
     path: layer_6.safetensors
+    neuronpedia: qwen3-4b/6-transcoder-hp
   - id: layer_7
     path: layer_7.safetensors
+    neuronpedia: qwen3-4b/7-transcoder-hp
   - id: layer_8
     path: layer_8.safetensors
+    neuronpedia: qwen3-4b/8-transcoder-hp
   - id: layer_9
     path: layer_9.safetensors
+    neuronpedia: qwen3-4b/9-transcoder-hp
   - id: layer_10
     path: layer_10.safetensors
+    neuronpedia: qwen3-4b/10-transcoder-hp
   - id: layer_11
     path: layer_11.safetensors
+    neuronpedia: qwen3-4b/11-transcoder-hp
   - id: layer_12
     path: layer_12.safetensors
+    neuronpedia: qwen3-4b/12-transcoder-hp
   - id: layer_13
     path: layer_13.safetensors
+    neuronpedia: qwen3-4b/13-transcoder-hp
   - id: layer_14
     path: layer_14.safetensors
+    neuronpedia: qwen3-4b/14-transcoder-hp
   - id: layer_15
     path: layer_15.safetensors
+    neuronpedia: qwen3-4b/15-transcoder-hp
   - id: layer_16
     path: layer_16.safetensors
+    neuronpedia: qwen3-4b/16-transcoder-hp
   - id: layer_17
     path: layer_17.safetensors
+    neuronpedia: qwen3-4b/17-transcoder-hp
   - id: layer_18
     path: layer_18.safetensors
+    neuronpedia: qwen3-4b/18-transcoder-hp
   - id: layer_19
     path: layer_19.safetensors
+    neuronpedia: qwen3-4b/19-transcoder-hp
   - id: layer_20
     path: layer_20.safetensors
+    neuronpedia: qwen3-4b/20-transcoder-hp
   - id: layer_21
     path: layer_21.safetensors
+    neuronpedia: qwen3-4b/21-transcoder-hp
   - id: layer_22
     path: layer_22.safetensors
+    neuronpedia: qwen3-4b/22-transcoder-hp
   - id: layer_23
     path: layer_23.safetensors
+    neuronpedia: qwen3-4b/23-transcoder-hp
   - id: layer_24
     path: layer_24.safetensors
+    neuronpedia: qwen3-4b/24-transcoder-hp
   - id: layer_25
     path: layer_25.safetensors
+    neuronpedia: qwen3-4b/25-transcoder-hp
   - id: layer_26
     path: layer_26.safetensors
+    neuronpedia: qwen3-4b/26-transcoder-hp
   - id: layer_27
     path: layer_27.safetensors
+    neuronpedia: qwen3-4b/27-transcoder-hp
   - id: layer_28
     path: layer_28.safetensors
+    neuronpedia: qwen3-4b/28-transcoder-hp
   - id: layer_29
     path: layer_29.safetensors
+    neuronpedia: qwen3-4b/29-transcoder-hp
   - id: layer_30
     path: layer_30.safetensors
+    neuronpedia: qwen3-4b/30-transcoder-hp
   - id: layer_31
     path: layer_31.safetensors
+    neuronpedia: qwen3-4b/31-transcoder-hp
   - id: layer_32
     path: layer_32.safetensors
+    neuronpedia: qwen3-4b/32-transcoder-hp
   - id: layer_33
     path: layer_33.safetensors
+    neuronpedia: qwen3-4b/33-transcoder-hp
   - id: layer_34
     path: layer_34.safetensors
+    neuronpedia: qwen3-4b/34-transcoder-hp
   - id: layer_35
     path: layer_35.safetensors
+    neuronpedia: qwen3-4b/35-transcoder-hp
 
 mwhanna-qwen3-8b-transcoders:
   conversion_func: mwhanna_transcoder
@@ -14171,76 +14207,112 @@ mwhanna-qwen3-8b-transcoders:
   saes:
   - id: layer_0
     path: layer_0.safetensors
+    neuronpedia: qwen3-8b/0-transcoder-hp
   - id: layer_1
     path: layer_1.safetensors
+    neuronpedia: qwen3-8b/1-transcoder-hp
   - id: layer_2
     path: layer_2.safetensors
+    neuronpedia: qwen3-8b/2-transcoder-hp
   - id: layer_3
     path: layer_3.safetensors
+    neuronpedia: qwen3-8b/3-transcoder-hp
   - id: layer_4
     path: layer_4.safetensors
+    neuronpedia: qwen3-8b/4-transcoder-hp
   - id: layer_5
     path: layer_5.safetensors
+    neuronpedia: qwen3-8b/5-transcoder-hp
   - id: layer_6
     path: layer_6.safetensors
+    neuronpedia: qwen3-8b/6-transcoder-hp
   - id: layer_7
     path: layer_7.safetensors
+    neuronpedia: qwen3-8b/7-transcoder-hp
   - id: layer_8
     path: layer_8.safetensors
+    neuronpedia: qwen3-8b/8-transcoder-hp
   - id: layer_9
     path: layer_9.safetensors
+    neuronpedia: qwen3-8b/9-transcoder-hp
   - id: layer_10
     path: layer_10.safetensors
+    neuronpedia: qwen3-8b/10-transcoder-hp
   - id: layer_11
     path: layer_11.safetensors
+    neuronpedia: qwen3-8b/11-transcoder-hp
   - id: layer_12
     path: layer_12.safetensors
+    neuronpedia: qwen3-8b/12-transcoder-hp
   - id: layer_13
     path: layer_13.safetensors
+    neuronpedia: qwen3-8b/13-transcoder-hp
   - id: layer_14
     path: layer_14.safetensors
+    neuronpedia: qwen3-8b/14-transcoder-hp
   - id: layer_15
     path: layer_15.safetensors
+    neuronpedia: qwen3-8b/15-transcoder-hp
   - id: layer_16
     path: layer_16.safetensors
+    neuronpedia: qwen3-8b/16-transcoder-hp
   - id: layer_17
     path: layer_17.safetensors
+    neuronpedia: qwen3-8b/17-transcoder-hp
   - id: layer_18
     path: layer_18.safetensors
+    neuronpedia: qwen3-8b/18-transcoder-hp
   - id: layer_19
     path: layer_19.safetensors
+    neuronpedia: qwen3-8b/19-transcoder-hp
   - id: layer_20
     path: layer_20.safetensors
+    neuronpedia: qwen3-8b/20-transcoder-hp
   - id: layer_21
     path: layer_21.safetensors
+    neuronpedia: qwen3-8b/21-transcoder-hp
   - id: layer_22
     path: layer_22.safetensors
+    neuronpedia: qwen3-8b/22-transcoder-hp
   - id: layer_23
     path: layer_23.safetensors
+    neuronpedia: qwen3-8b/23-transcoder-hp
   - id: layer_24
     path: layer_24.safetensors
+    neuronpedia: qwen3-8b/24-transcoder-hp
   - id: layer_25
     path: layer_25.safetensors
+    neuronpedia: qwen3-8b/25-transcoder-hp
   - id: layer_26
     path: layer_26.safetensors
+    neuronpedia: qwen3-8b/26-transcoder-hp
   - id: layer_27
     path: layer_27.safetensors
+    neuronpedia: qwen3-8b/27-transcoder-hp
   - id: layer_28
     path: layer_28.safetensors
+    neuronpedia: qwen3-8b/28-transcoder-hp
   - id: layer_29
     path: layer_29.safetensors
+    neuronpedia: qwen3-8b/29-transcoder-hp
   - id: layer_30
     path: layer_30.safetensors
+    neuronpedia: qwen3-8b/30-transcoder-hp
   - id: layer_31
     path: layer_31.safetensors
+    neuronpedia: qwen3-8b/31-transcoder-hp
   - id: layer_32
     path: layer_32.safetensors
+    neuronpedia: qwen3-8b/32-transcoder-hp
   - id: layer_33
     path: layer_33.safetensors
+    neuronpedia: qwen3-8b/33-transcoder-hp
   - id: layer_34
     path: layer_34.safetensors
+    neuronpedia: qwen3-8b/34-transcoder-hp
   - id: layer_35
     path: layer_35.safetensors
+    neuronpedia: qwen3-8b/35-transcoder-hp
 
 mwhanna-qwen3-14b-transcoders:
   conversion_func: mwhanna_transcoder
@@ -14249,293 +14321,427 @@ mwhanna-qwen3-14b-transcoders:
   saes:
   - id: layer_0
     path: layer_0.safetensors
+    neuronpedia: qwen3-14b/0-transcoder-hp
   - id: layer_1
     path: layer_1.safetensors
+    neuronpedia: qwen3-14b/1-transcoder-hp
   - id: layer_2
     path: layer_2.safetensors
+    neuronpedia: qwen3-14b/2-transcoder-hp
   - id: layer_3
     path: layer_3.safetensors
+    neuronpedia: qwen3-14b/3-transcoder-hp
   - id: layer_4
     path: layer_4.safetensors
+    neuronpedia: qwen3-14b/4-transcoder-hp
   - id: layer_5
     path: layer_5.safetensors
+    neuronpedia: qwen3-14b/5-transcoder-hp
   - id: layer_6
     path: layer_6.safetensors
+    neuronpedia: qwen3-14b/6-transcoder-hp
   - id: layer_7
     path: layer_7.safetensors
+    neuronpedia: qwen3-14b/7-transcoder-hp
   - id: layer_8
     path: layer_8.safetensors
+    neuronpedia: qwen3-14b/8-transcoder-hp
   - id: layer_9
     path: layer_9.safetensors
+    neuronpedia: qwen3-14b/9-transcoder-hp
   - id: layer_10
     path: layer_10.safetensors
+    neuronpedia: qwen3-14b/10-transcoder-hp
   - id: layer_11
     path: layer_11.safetensors
+    neuronpedia: qwen3-14b/11-transcoder-hp
   - id: layer_12
     path: layer_12.safetensors
+    neuronpedia: qwen3-14b/12-transcoder-hp
   - id: layer_13
     path: layer_13.safetensors
+    neuronpedia: qwen3-14b/13-transcoder-hp
   - id: layer_14
     path: layer_14.safetensors
+    neuronpedia: qwen3-14b/14-transcoder-hp
   - id: layer_15
     path: layer_15.safetensors
+    neuronpedia: qwen3-14b/15-transcoder-hp
   - id: layer_16
     path: layer_16.safetensors
+    neuronpedia: qwen3-14b/16-transcoder-hp
   - id: layer_17
     path: layer_17.safetensors
+    neuronpedia: qwen3-14b/17-transcoder-hp
   - id: layer_18
     path: layer_18.safetensors
+    neuronpedia: qwen3-14b/18-transcoder-hp
   - id: layer_19
     path: layer_19.safetensors
+    neuronpedia: qwen3-14b/19-transcoder-hp
   - id: layer_20
     path: layer_20.safetensors
+    neuronpedia: qwen3-14b/20-transcoder-hp
   - id: layer_21
     path: layer_21.safetensors
+    neuronpedia: qwen3-14b/21-transcoder-hp
   - id: layer_22
     path: layer_22.safetensors
+    neuronpedia: qwen3-14b/22-transcoder-hp
   - id: layer_23
     path: layer_23.safetensors
+    neuronpedia: qwen3-14b/23-transcoder-hp
   - id: layer_24
     path: layer_24.safetensors
+    neuronpedia: qwen3-14b/24-transcoder-hp
   - id: layer_25
     path: layer_25.safetensors
+    neuronpedia: qwen3-14b/25-transcoder-hp
   - id: layer_26
     path: layer_26.safetensors
+    neuronpedia: qwen3-14b/26-transcoder-hp
   - id: layer_27
     path: layer_27.safetensors
+    neuronpedia: qwen3-14b/27-transcoder-hp
   - id: layer_28
     path: layer_28.safetensors
+    neuronpedia: qwen3-14b/28-transcoder-hp
   - id: layer_29
     path: layer_29.safetensors
+    neuronpedia: qwen3-14b/29-transcoder-hp
   - id: layer_30
     path: layer_30.safetensors
+    neuronpedia: qwen3-14b/30-transcoder-hp
   - id: layer_31
     path: layer_31.safetensors
+    neuronpedia: qwen3-14b/31-transcoder-hp
   - id: layer_32
     path: layer_32.safetensors
+    neuronpedia: qwen3-14b/32-transcoder-hp
   - id: layer_33
     path: layer_33.safetensors
+    neuronpedia: qwen3-14b/33-transcoder-hp
   - id: layer_34
     path: layer_34.safetensors
+    neuronpedia: qwen3-14b/34-transcoder-hp
   - id: layer_35
     path: layer_35.safetensors
+    neuronpedia: qwen3-14b/35-transcoder-hp
   - id: layer_36
     path: layer_36.safetensors
+    neuronpedia: qwen3-14b/36-transcoder-hp
   - id: layer_37
     path: layer_37.safetensors
+    neuronpedia: qwen3-14b/37-transcoder-hp
   - id: layer_38
     path: layer_38.safetensors
+    neuronpedia: qwen3-14b/38-transcoder-hp
   - id: layer_39
     path: layer_39.safetensors
+    neuronpedia: qwen3-14b/39-transcoder-hp
 
 mwhanna-qwen3-14b-transcoders-lowl0:
   conversion_func: mwhanna_transcoder
   model: qwen3-14b
-  repo_id: mwhanna/qwen3-14b-transcoders
+  repo_id: mwhanna/qwen3-14b-transcoders-lowl0
   saes:
   - id: layer_0
     path: layer_0.safetensors
+    neuronpedia: qwen3-14b/0-transcoder-hp-lowl0
   - id: layer_1
     path: layer_1.safetensors
+    neuronpedia: qwen3-14b/1-transcoder-hp-lowl0
   - id: layer_2
     path: layer_2.safetensors
+    neuronpedia: qwen3-14b/2-transcoder-hp-lowl0
   - id: layer_3
     path: layer_3.safetensors
+    neuronpedia: qwen3-14b/3-transcoder-hp-lowl0
   - id: layer_4
     path: layer_4.safetensors
+    neuronpedia: qwen3-14b/4-transcoder-hp-lowl0
   - id: layer_5
     path: layer_5.safetensors
+    neuronpedia: qwen3-14b/5-transcoder-hp-lowl0
   - id: layer_6
     path: layer_6.safetensors
+    neuronpedia: qwen3-14b/6-transcoder-hp-lowl0
   - id: layer_7
     path: layer_7.safetensors
+    neuronpedia: qwen3-14b/7-transcoder-hp-lowl0
   - id: layer_8
     path: layer_8.safetensors
+    neuronpedia: qwen3-14b/8-transcoder-hp-lowl0
   - id: layer_9
     path: layer_9.safetensors
+    neuronpedia: qwen3-14b/9-transcoder-hp-lowl0
   - id: layer_10
     path: layer_10.safetensors
+    neuronpedia: qwen3-14b/10-transcoder-hp-lowl0
   - id: layer_11
     path: layer_11.safetensors
+    neuronpedia: qwen3-14b/11-transcoder-hp-lowl0
   - id: layer_12
     path: layer_12.safetensors
+    neuronpedia: qwen3-14b/12-transcoder-hp-lowl0
   - id: layer_13
     path: layer_13.safetensors
+    neuronpedia: qwen3-14b/13-transcoder-hp-lowl0
   - id: layer_14
     path: layer_14.safetensors
+    neuronpedia: qwen3-14b/14-transcoder-hp-lowl0
   - id: layer_15
     path: layer_15.safetensors
+    neuronpedia: qwen3-14b/15-transcoder-hp-lowl0
   - id: layer_16
     path: layer_16.safetensors
+    neuronpedia: qwen3-14b/16-transcoder-hp-lowl0
   - id: layer_17
     path: layer_17.safetensors
+    neuronpedia: qwen3-14b/17-transcoder-hp-lowl0
   - id: layer_18
     path: layer_18.safetensors
+    neuronpedia: qwen3-14b/18-transcoder-hp-lowl0
   - id: layer_19
     path: layer_19.safetensors
+    neuronpedia: qwen3-14b/19-transcoder-hp-lowl0
   - id: layer_20
     path: layer_20.safetensors
+    neuronpedia: qwen3-14b/20-transcoder-hp-lowl0
   - id: layer_21
     path: layer_21.safetensors
+    neuronpedia: qwen3-14b/21-transcoder-hp-lowl0
   - id: layer_22
     path: layer_22.safetensors
+    neuronpedia: qwen3-14b/22-transcoder-hp-lowl0
   - id: layer_23
     path: layer_23.safetensors
+    neuronpedia: qwen3-14b/23-transcoder-hp-lowl0
   - id: layer_24
     path: layer_24.safetensors
+    neuronpedia: qwen3-14b/24-transcoder-hp-lowl0
   - id: layer_25
     path: layer_25.safetensors
+    neuronpedia: qwen3-14b/25-transcoder-hp-lowl0
   - id: layer_26
     path: layer_26.safetensors
+    neuronpedia: qwen3-14b/26-transcoder-hp-lowl0
   - id: layer_27
     path: layer_27.safetensors
+    neuronpedia: qwen3-14b/27-transcoder-hp-lowl0
   - id: layer_28
     path: layer_28.safetensors
+    neuronpedia: qwen3-14b/28-transcoder-hp-lowl0
   - id: layer_29
     path: layer_29.safetensors
+    neuronpedia: qwen3-14b/29-transcoder-hp-lowl0
   - id: layer_30
     path: layer_30.safetensors
+    neuronpedia: qwen3-14b/30-transcoder-hp-lowl0
   - id: layer_31
     path: layer_31.safetensors
+    neuronpedia: qwen3-14b/31-transcoder-hp-lowl0
   - id: layer_32
     path: layer_32.safetensors
+    neuronpedia: qwen3-14b/32-transcoder-hp-lowl0
   - id: layer_33
     path: layer_33.safetensors
+    neuronpedia: qwen3-14b/33-transcoder-hp-lowl0
   - id: layer_34
     path: layer_34.safetensors
+    neuronpedia: qwen3-14b/34-transcoder-hp-lowl0
   - id: layer_35
     path: layer_35.safetensors
+    neuronpedia: qwen3-14b/35-transcoder-hp-lowl0
   - id: layer_36
     path: layer_36.safetensors
+    neuronpedia: qwen3-14b/36-transcoder-hp-lowl0
   - id: layer_37
     path: layer_37.safetensors
+    neuronpedia: qwen3-14b/37-transcoder-hp-lowl0
   - id: layer_38
     path: layer_38.safetensors
+    neuronpedia: qwen3-14b/38-transcoder-hp-lowl0
   - id: layer_39
     path: layer_39.safetensors
+    neuronpedia: qwen3-14b/39-transcoder-hp-lowl0
 
 mwhanna-qwen3-1.7b-transcoders-lowl0:
   conversion_func: mwhanna_transcoder
   model: qwen3-1.7b
-  repo_id: mwhanna/qwen3-1.7b-transcoders
+  repo_id: mwhanna/qwen3-1.7b-transcoders-lowl0
   saes:
   - id: layer_0
     path: layer_0.safetensors
+    neuronpedia: qwen3-1.7b/0-transcoder-hp-lowl0
   - id: layer_1
     path: layer_1.safetensors
+    neuronpedia: qwen3-1.7b/1-transcoder-hp-lowl0
   - id: layer_2
     path: layer_2.safetensors
+    neuronpedia: qwen3-1.7b/2-transcoder-hp-lowl0
   - id: layer_3
     path: layer_3.safetensors
+    neuronpedia: qwen3-1.7b/3-transcoder-hp-lowl0
   - id: layer_4
     path: layer_4.safetensors
+    neuronpedia: qwen3-1.7b/4-transcoder-hp-lowl0
   - id: layer_5
     path: layer_5.safetensors
+    neuronpedia: qwen3-1.7b/5-transcoder-hp-lowl0
   - id: layer_6
     path: layer_6.safetensors
+    neuronpedia: qwen3-1.7b/6-transcoder-hp-lowl0
   - id: layer_7
     path: layer_7.safetensors
+    neuronpedia: qwen3-1.7b/7-transcoder-hp-lowl0
   - id: layer_8
     path: layer_8.safetensors
+    neuronpedia: qwen3-1.7b/8-transcoder-hp-lowl0
   - id: layer_9
     path: layer_9.safetensors
+    neuronpedia: qwen3-1.7b/9-transcoder-hp-lowl0
   - id: layer_10
     path: layer_10.safetensors
+    neuronpedia: qwen3-1.7b/10-transcoder-hp-lowl0
   - id: layer_11
     path: layer_11.safetensors
+    neuronpedia: qwen3-1.7b/11-transcoder-hp-lowl0
   - id: layer_12
     path: layer_12.safetensors
+    neuronpedia: qwen3-1.7b/12-transcoder-hp-lowl0
   - id: layer_13
     path: layer_13.safetensors
+    neuronpedia: qwen3-1.7b/13-transcoder-hp-lowl0
   - id: layer_14
     path: layer_14.safetensors
+    neuronpedia: qwen3-1.7b/14-transcoder-hp-lowl0
   - id: layer_15
     path: layer_15.safetensors
+    neuronpedia: qwen3-1.7b/15-transcoder-hp-lowl0
   - id: layer_16
     path: layer_16.safetensors
+    neuronpedia: qwen3-1.7b/16-transcoder-hp-lowl0
   - id: layer_17
     path: layer_17.safetensors
+    neuronpedia: qwen3-1.7b/17-transcoder-hp-lowl0
   - id: layer_18
     path: layer_18.safetensors
+    neuronpedia: qwen3-1.7b/18-transcoder-hp-lowl0
   - id: layer_19
     path: layer_19.safetensors
+    neuronpedia: qwen3-1.7b/19-transcoder-hp-lowl0
   - id: layer_20
     path: layer_20.safetensors
+    neuronpedia: qwen3-1.7b/20-transcoder-hp-lowl0
   - id: layer_21
     path: layer_21.safetensors
+    neuronpedia: qwen3-1.7b/21-transcoder-hp-lowl0
   - id: layer_22
     path: layer_22.safetensors
+    neuronpedia: qwen3-1.7b/22-transcoder-hp-lowl0
   - id: layer_23
     path: layer_23.safetensors
+    neuronpedia: qwen3-1.7b/23-transcoder-hp-lowl0
   - id: layer_24
     path: layer_24.safetensors
+    neuronpedia: qwen3-1.7b/24-transcoder-hp-lowl0
   - id: layer_25
     path: layer_25.safetensors
+    neuronpedia: qwen3-1.7b/25-transcoder-hp-lowl0
   - id: layer_26
     path: layer_26.safetensors
+    neuronpedia: qwen3-1.7b/26-transcoder-hp-lowl0
   - id: layer_27
     path: layer_27.safetensors
-
-
+    neuronpedia: qwen3-1.7b/27-transcoder-hp-lowl0
 
 mwhanna-qwen3-0.6b-transcoders-lowl0:
   conversion_func: mwhanna_transcoder
   model: qwen3-0.6b
-  repo_id: mwhanna/qwen3-0.6b-transcoders
+  repo_id: mwhanna/qwen3-0.6b-transcoders-lowl0
   saes:
   - id: layer_0
     path: layer_0.safetensors
+    neuronpedia: qwen3-0.6b/0-transcoder-hp-lowl0
   - id: layer_1
     path: layer_1.safetensors
+    neuronpedia: qwen3-0.6b/1-transcoder-hp-lowl0
   - id: layer_2
     path: layer_2.safetensors
+    neuronpedia: qwen3-0.6b/2-transcoder-hp-lowl0
   - id: layer_3
     path: layer_3.safetensors
+    neuronpedia: qwen3-0.6b/3-transcoder-hp-lowl0
   - id: layer_4
     path: layer_4.safetensors
+    neuronpedia: qwen3-0.6b/4-transcoder-hp-lowl0
   - id: layer_5
     path: layer_5.safetensors
+    neuronpedia: qwen3-0.6b/5-transcoder-hp-lowl0
   - id: layer_6
     path: layer_6.safetensors
+    neuronpedia: qwen3-0.6b/6-transcoder-hp-lowl0
   - id: layer_7
     path: layer_7.safetensors
+    neuronpedia: qwen3-0.6b/7-transcoder-hp-lowl0
   - id: layer_8
     path: layer_8.safetensors
+    neuronpedia: qwen3-0.6b/8-transcoder-hp-lowl0
   - id: layer_9
     path: layer_9.safetensors
+    neuronpedia: qwen3-0.6b/9-transcoder-hp-lowl0
   - id: layer_10
     path: layer_10.safetensors
+    neuronpedia: qwen3-0.6b/10-transcoder-hp-lowl0
   - id: layer_11
     path: layer_11.safetensors
+    neuronpedia: qwen3-0.6b/11-transcoder-hp-lowl0
   - id: layer_12
     path: layer_12.safetensors
+    neuronpedia: qwen3-0.6b/12-transcoder-hp-lowl0
   - id: layer_13
     path: layer_13.safetensors
+    neuronpedia: qwen3-0.6b/13-transcoder-hp-lowl0
   - id: layer_14
     path: layer_14.safetensors
+    neuronpedia: qwen3-0.6b/14-transcoder-hp-lowl0
   - id: layer_15
     path: layer_15.safetensors
+    neuronpedia: qwen3-0.6b/15-transcoder-hp-lowl0
   - id: layer_16
     path: layer_16.safetensors
+    neuronpedia: qwen3-0.6b/16-transcoder-hp-lowl0
   - id: layer_17
     path: layer_17.safetensors
+    neuronpedia: qwen3-0.6b/17-transcoder-hp-lowl0
   - id: layer_18
     path: layer_18.safetensors
+    neuronpedia: qwen3-0.6b/18-transcoder-hp-lowl0
   - id: layer_19
     path: layer_19.safetensors
+    neuronpedia: qwen3-0.6b/19-transcoder-hp-lowl0
   - id: layer_20
     path: layer_20.safetensors
+    neuronpedia: qwen3-0.6b/20-transcoder-hp-lowl0
   - id: layer_21
     path: layer_21.safetensors
+    neuronpedia: qwen3-0.6b/21-transcoder-hp-lowl0
   - id: layer_22
     path: layer_22.safetensors
+    neuronpedia: qwen3-0.6b/22-transcoder-hp-lowl0
   - id: layer_23
     path: layer_23.safetensors
+    neuronpedia: qwen3-0.6b/23-transcoder-hp-lowl0
   - id: layer_24
     path: layer_24.safetensors
+    neuronpedia: qwen3-0.6b/24-transcoder-hp-lowl0
   - id: layer_25
     path: layer_25.safetensors
+    neuronpedia: qwen3-0.6b/25-transcoder-hp-lowl0
   - id: layer_26
     path: layer_26.safetensors
+    neuronpedia: qwen3-0.6b/26-transcoder-hp-lowl0
   - id: layer_27
     path: layer_27.safetensors
+    neuronpedia: qwen3-0.6b/27-transcoder-hp-lowl0

--- a/tests/analysis/test_hooked_sae_transformer.py
+++ b/tests/analysis/test_hooked_sae_transformer.py
@@ -672,3 +672,11 @@ def test_HookedSAETransformer_works_with_hook_z_saes():
     assert (
         cache[sae.cfg.metadata.hook_name + ".hook_sae_output"].shape == expected_shape
     )
+
+
+def test_HookedSAETransformer_adds_hook_in_to_mlp():
+    model = HookedSAETransformer.from_pretrained("gpt2", device="cpu")
+    _, cache = model.run_with_cache(prompt)
+    for n in range(model.cfg.n_layers):
+        assert f"blocks.{n}.mlp.hook_in" in cache
+        assert cache[f"blocks.{n}.mlp.hook_in"].shape == (1, 4, 768)

--- a/tests/loading/test_pretrained_sae_loaders.py
+++ b/tests/loading/test_pretrained_sae_loaders.py
@@ -236,6 +236,7 @@ def test_get_mwhanna_transcoder_config_from_hf():
         "hook_name_out": "blocks.10.hook_mlp_out",
         "dataset_path": "monology/pile-uncopyrighted",
         "context_size": 8192,
+        "model_from_pretrained_kwargs": {"fold_ln": False},
         "apply_b_dec_to_input": False,
     }
 
@@ -294,10 +295,11 @@ def test_load_sae_config_from_huggingface_mwhanna_transcoder():
         "reshape_activations": "none",
         "metadata": {
             "model_name": "Qwen/Qwen3-4B",
-            "hook_name": "blocks.10.ln2.hook_normalized",
+            "hook_name": "blocks.10.mlp.hook_in",
             "hook_name_out": "blocks.10.hook_mlp_out",
             "dataset_path": "monology/pile-uncopyrighted",
             "context_size": 8192,
+            "model_from_pretrained_kwargs": {"fold_ln": False},
             "neuronpedia_id": "qwen3-4b/10-transcoder-hp",
             "prepend_bos": True,
             "sae_lens_training_version": None,

--- a/tests/loading/test_pretrained_sae_loaders.py
+++ b/tests/loading/test_pretrained_sae_loaders.py
@@ -297,7 +297,7 @@ def test_load_sae_config_from_huggingface_mwhanna_transcoder():
             "hook_name_out": "blocks.10.hook_mlp_out",
             "dataset_path": "monology/pile-uncopyrighted",
             "context_size": 8192,
-            "neuronpedia_id": None,
+            "neuronpedia_id": "qwen3-4b/10-transcoder-hp",
             "prepend_bos": True,
             "sae_lens_training_version": None,
         },

--- a/tests/loading/test_pretrained_sae_loaders.py
+++ b/tests/loading/test_pretrained_sae_loaders.py
@@ -11,6 +11,7 @@ from sae_lens.loading.pretrained_sae_loaders import (
     get_gemma_2_transcoder_config_from_hf,
     get_llama_scope_config_from_hf,
     get_llama_scope_r1_distill_config_from_hf,
+    get_mwhanna_transcoder_config_from_hf,
     load_sae_config_from_huggingface,
     read_sae_components_from_disk,
     sparsify_disk_loader,
@@ -191,7 +192,7 @@ def test_get_gemma_2_transcoder_config_from_hf():
         device="cpu",
     )
 
-    expected_cfg = expected_cfg = {
+    expected_cfg = {
         "architecture": "jumprelu_transcoder",
         "d_in": 2304,
         "d_out": 2304,
@@ -208,6 +209,33 @@ def test_get_gemma_2_transcoder_config_from_hf():
         "prepend_bos": True,
         "dataset_path": "monology/pile-uncopyrighted",
         "context_size": 1024,
+    }
+
+    assert cfg == expected_cfg
+
+
+def test_get_mwhanna_transcoder_config_from_hf():
+    cfg = get_mwhanna_transcoder_config_from_hf(
+        repo_id="mwhanna/qwen3-4b-transcoders",
+        folder_name="layer_10.safetensors",
+        device="cpu",
+    )
+
+    expected_cfg = {
+        "architecture": "transcoder",
+        "d_in": 2560,
+        "d_out": 2560,
+        "d_sae": 163840,
+        "dtype": "float32",
+        "device": "cpu",
+        "activation_fn": "relu",
+        "normalize_activations": "none",
+        "model_name": "Qwen/Qwen3-4B",
+        "hook_name": "blocks.10.ln2.hook_normalized",
+        "hook_name_out": "blocks.10.hook_mlp_out",
+        "dataset_path": "monology/pile-uncopyrighted",
+        "context_size": 8192,
+        "apply_b_dec_to_input": False,
     }
 
     assert cfg == expected_cfg
@@ -242,6 +270,38 @@ def test_load_sae_config_from_huggingface_gemma_2_transcoder():
             "sae_lens_training_version": None,
         },
         "architecture": "jumprelu_transcoder",
+    }
+
+    assert cfg == expected_cfg
+
+
+def test_load_sae_config_from_huggingface_mwhanna_transcoder():
+    cfg = load_sae_config_from_huggingface(
+        release="mwhanna-qwen3-4b-transcoders",
+        sae_id="layer_10",
+        device="cpu",
+    )
+
+    expected_cfg = {
+        "d_in": 2560,
+        "d_out": 2560,
+        "d_sae": 163840,
+        "dtype": "float32",
+        "device": "cpu",
+        "normalize_activations": "none",
+        "apply_b_dec_to_input": False,
+        "reshape_activations": "none",
+        "metadata": {
+            "model_name": "Qwen/Qwen3-4B",
+            "hook_name": "blocks.10.ln2.hook_normalized",
+            "hook_name_out": "blocks.10.hook_mlp_out",
+            "dataset_path": "monology/pile-uncopyrighted",
+            "context_size": 8192,
+            "neuronpedia_id": None,
+            "prepend_bos": True,
+            "sae_lens_training_version": None,
+        },
+        "architecture": "transcoder",
     }
 
     assert cfg == expected_cfg

--- a/tests/loading/test_pretrained_sae_loaders.py
+++ b/tests/loading/test_pretrained_sae_loaders.py
@@ -232,7 +232,7 @@ def test_get_mwhanna_transcoder_config_from_hf():
         "activation_fn": "relu",
         "normalize_activations": "none",
         "model_name": "Qwen/Qwen3-4B",
-        "hook_name": "blocks.10.ln2.hook_normalized",
+        "hook_name": "blocks.10.mlp.hook_in",
         "hook_name_out": "blocks.10.hook_mlp_out",
         "dataset_path": "monology/pile-uncopyrighted",
         "context_size": 8192,


### PR DESCRIPTION
# Description

This PR adds the qwen transcoders from https://huggingface.co/mwhanna to SAELens pretrained list. This PR also adds a new `blocks.N.mlp.hook_in` to `HookedSAETransformer` to mimic what's in `circuit-tracer`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update