### PR TITLE
fix: dont apply b_dec to Gemma Scope transcoder inputs

### DIFF
--- a/sae_lens/loading/pretrained_sae_loaders.py
+++ b/sae_lens/loading/pretrained_sae_loaders.py
@@ -1177,6 +1177,7 @@ def get_gemma_2_transcoder_config_from_hf(
         "prepend_bos": True,
         "dataset_path": "monology/pile-uncopyrighted",
         "context_size": 1024,
+        "apply_b_dec_to_input": False,
         **(cfg_overrides or {}),
     }
 

--- a/sae_lens/saes/transcoder.py
+++ b/sae_lens/saes/transcoder.py
@@ -52,6 +52,11 @@ class TranscoderConfig(SAEConfig):
 
         return res
 
+    def __post_init__(self):
+        if self.apply_b_dec_to_input:
+            raise ValueError("apply_b_dec_to_input is not supported for transcoders")
+        return super().__post_init__()
+
 
 class Transcoder(SAE[TranscoderConfig]):
     """

--- a/tests/loading/test_pretrained_sae_loaders.py
+++ b/tests/loading/test_pretrained_sae_loaders.py
@@ -208,6 +208,7 @@ def test_get_gemma_2_transcoder_config_from_hf():
         "prepend_bos": True,
         "dataset_path": "monology/pile-uncopyrighted",
         "context_size": 1024,
+        "apply_b_dec_to_input": False,
     }
 
     assert cfg == expected_cfg
@@ -227,7 +228,7 @@ def test_load_sae_config_from_huggingface_gemma_2_transcoder():
         "dtype": "float32",
         "device": "cpu",
         "normalize_activations": "none",
-        "apply_b_dec_to_input": True,
+        "apply_b_dec_to_input": False,
         "reshape_activations": "none",
         "metadata": {
             "model_name": "gemma-2-2b",


### PR DESCRIPTION
# Description

This PR fixes a bug with the newly added Gemma Scope transcoders where the `b_dec` was being subtracted from the input to the transcoder. This does not make sense for transcoders, and will now raise an error if this setting is accidentally enabled.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update