### PR TITLE
fix: compare unscaled input with unscaled output in var explained

### DIFF
--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -459,14 +459,16 @@ def get_sparsity_and_variance_metrics(
             original_act = cache[hook_name]
 
         # normalise if necessary (necessary in training only, otherwise we should fold the scaling in)
-        original_act = activation_scaler.scale(original_act)
+        original_act_scaled = activation_scaler.scale(original_act)
 
         # send the (maybe normalised) activations into the SAE
-        sae_feature_activations = sae.encode(original_act.to(sae.device))
-        sae_out = sae.decode(sae_feature_activations).to(original_act.device)
+        sae_feature_activations = sae.encode(original_act_scaled.to(sae.device))
+        sae_out_scaled = sae.decode(sae_feature_activations).to(
+            original_act_scaled.device
+        )
         del cache
 
-        sae_out = activation_scaler.unscale(sae_out)
+        sae_out = activation_scaler.unscale(sae_out_scaled)
 
         flattened_sae_input = einops.rearrange(original_act, "b ctx d -> (b ctx) d")
         flattened_sae_feature_acts = einops.rearrange(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -546,9 +546,11 @@ def test_get_saes_from_regex_multiple_matches(mock_all_loadable_saes: MagicMock)
     assert result == expected
 
 
+@pytest.mark.parametrize("scaling_factor", [None, 3.0])
 def test_get_sparsity_and_variance_metrics_identity_sae_perfect_reconstruction(
     model: HookedTransformer,
     example_dataset: Dataset,
+    scaling_factor: float | None,
 ):
     """Test that an identity SAE (d_in = d_sae, W_enc = W_dec = Identity, zero biases) gets perfect variance explained."""
     # Create a special configuration for an identity SAE
@@ -582,7 +584,7 @@ def test_get_sparsity_and_variance_metrics_identity_sae_perfect_reconstruction(
         sae=identity_sae,
         model=model,
         activation_store=activation_store,
-        activation_scaler=ActivationScaler(),
+        activation_scaler=ActivationScaler(scaling_factor),
         n_batches=3,
         compute_l2_norms=True,
         compute_sparsity_metrics=True,


### PR DESCRIPTION
# Description

This PR fixes a bug in the variance explained metrics when scaling inputs, as pointed out by @coaster41. Previously, we were comparing scaled inputs with unscaled outputs. This PR compares unscaled inputs with unscaled outputs. I'm not sure if that's better than comparing scaled inputs with scaled outputs 🤷. Or we could add a new `scaled_variance_explained` if scaling is used, might not be worth it though. 

Fixes #518 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)