### PR TITLE
move automated-interpretability to an optional dependency in sae-lens

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,12 @@ babe = "^0.0.7"
 nltk = "^3.8.1"
 safetensors = ">=0.4.2,<1.0.0"
 mamba-lens = { version = "^0.0.4", optional = true }
-automated-interpretability = ">=0.0.5,<1.0.0"
 python-dotenv = ">=1.0.1"
 pyyaml = "^6.0.1"
 typing-extensions = "^4.10.0"
 simple-parsing = "^0.1.6"
 tenacity = ">=9.0.0"
+automated-interpretability = { version = ">=0.0.5,<1.0.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.2"
@@ -59,6 +59,7 @@ trio = "^0.30.0"
 
 [tool.poetry.extras]
 mamba = ["mamba-lens"]
+neuronpedia = ["automated-interpretability"]
 
 [tool.ruff.lint]
 exclude = ["*.ipynb"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ ruff = "^0.7.4"
 eai-sparsify = "^1.1.1"
 mike = "^2.0.0"
 trio = "^0.30.0"
+automated-interpretability = "^0.0.13"
 
 [tool.poetry.extras]
 mamba = ["mamba-lens"]

--- a/sae_lens/analysis/neuronpedia_integration.py
+++ b/sae_lens/analysis/neuronpedia_integration.py
@@ -8,27 +8,6 @@ from typing import Any, TypeVar
 
 import requests
 from dotenv import load_dotenv
-from neuron_explainer.activations.activation_records import calculate_max_activation
-from neuron_explainer.activations.activations import ActivationRecord
-from neuron_explainer.explanations.calibrated_simulator import (
-    UncalibratedNeuronSimulator,
-)
-from neuron_explainer.explanations.explainer import (
-    HARMONY_V4_MODELS,
-    ContextSize,
-    TokenActivationPairExplainer,
-)
-from neuron_explainer.explanations.explanations import ScoredSimulation
-from neuron_explainer.explanations.few_shot_examples import FewShotExampleSet
-from neuron_explainer.explanations.prompt_builder import PromptFormat
-from neuron_explainer.explanations.scoring import (
-    _simulate_and_score_sequence,
-    aggregate_scored_sequence_simulations,
-)
-from neuron_explainer.explanations.simulator import (
-    LogprobFreeExplanationTokenSimulator,
-    NeuronSimulator,
-)
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 
 from sae_lens import SAE, logger
@@ -158,10 +137,15 @@ def sleep_identity(x: T) -> T:
 
 @retry(wait=wait_random_exponential(min=1, max=500), stop=stop_after_attempt(10))
 async def simulate_and_score(  # type: ignore
-    simulator: NeuronSimulator,
-    activation_records: list[ActivationRecord],  # type: ignore
-) -> ScoredSimulation:  # type: ignore
+    simulator: Any,
+    activation_records: list[Any],
+) -> Any:
     """Score an explanation of a neuron by how well it predicts activations on the given text sequences."""
+    from neuron_explainer.explanations.scoring import (
+        _simulate_and_score_sequence,
+        aggregate_scored_sequence_simulations,
+    )
+
     scored_sequence_simulations = await asyncio.gather(
         *[
             sleep_identity(
@@ -253,6 +237,22 @@ async def autointerp_neuronpedia_features(  # noqa: C901
     Returns:
         None
     """
+    from neuron_explainer.activations.activation_records import calculate_max_activation
+    from neuron_explainer.activations.activations import ActivationRecord
+    from neuron_explainer.explanations.calibrated_simulator import (
+        UncalibratedNeuronSimulator,
+    )
+    from neuron_explainer.explanations.explainer import (
+        HARMONY_V4_MODELS,
+        ContextSize,
+        TokenActivationPairExplainer,
+    )
+    from neuron_explainer.explanations.few_shot_examples import FewShotExampleSet
+    from neuron_explainer.explanations.prompt_builder import PromptFormat
+    from neuron_explainer.explanations.simulator import (
+        LogprobFreeExplanationTokenSimulator,
+    )
+
     logger.info("\n\n")
 
     if os.getenv("OPENAI_API_KEY") is None:

--- a/sae_lens/analysis/neuronpedia_integration.py
+++ b/sae_lens/analysis/neuronpedia_integration.py
@@ -141,10 +141,17 @@ async def simulate_and_score(  # type: ignore
     activation_records: list[Any],
 ) -> Any:
     """Score an explanation of a neuron by how well it predicts activations on the given text sequences."""
-    from neuron_explainer.explanations.scoring import (
-        _simulate_and_score_sequence,
-        aggregate_scored_sequence_simulations,
-    )
+    try:
+        from neuron_explainer.explanations.scoring import (
+            _simulate_and_score_sequence,
+            aggregate_scored_sequence_simulations,
+        )
+    except ImportError as e:
+        raise ImportError(
+            "The neuron_explainer package is required to use this function. "
+            "Please install SAELens with the neuronpedia optional dependencies: "
+            "pip install sae-lens[neuronpedia]"
+        ) from e
 
     scored_sequence_simulations = await asyncio.gather(
         *[
@@ -237,21 +244,30 @@ async def autointerp_neuronpedia_features(  # noqa: C901
     Returns:
         None
     """
-    from neuron_explainer.activations.activation_records import calculate_max_activation
-    from neuron_explainer.activations.activations import ActivationRecord
-    from neuron_explainer.explanations.calibrated_simulator import (
-        UncalibratedNeuronSimulator,
-    )
-    from neuron_explainer.explanations.explainer import (
-        HARMONY_V4_MODELS,
-        ContextSize,
-        TokenActivationPairExplainer,
-    )
-    from neuron_explainer.explanations.few_shot_examples import FewShotExampleSet
-    from neuron_explainer.explanations.prompt_builder import PromptFormat
-    from neuron_explainer.explanations.simulator import (
-        LogprobFreeExplanationTokenSimulator,
-    )
+    try:
+        from neuron_explainer.activations.activation_records import (
+            calculate_max_activation,
+        )
+        from neuron_explainer.activations.activations import ActivationRecord
+        from neuron_explainer.explanations.calibrated_simulator import (
+            UncalibratedNeuronSimulator,
+        )
+        from neuron_explainer.explanations.explainer import (
+            HARMONY_V4_MODELS,
+            ContextSize,
+            TokenActivationPairExplainer,
+        )
+        from neuron_explainer.explanations.few_shot_examples import FewShotExampleSet
+        from neuron_explainer.explanations.prompt_builder import PromptFormat
+        from neuron_explainer.explanations.simulator import (
+            LogprobFreeExplanationTokenSimulator,
+        )
+    except ImportError as e:
+        raise ImportError(
+            "The automated-interpretability package is required to use autointerp functionality. "
+            "Please install SAELens with the neuronpedia optional dependencies: "
+            "pip install sae-lens[neuronpedia]"
+        ) from e
 
     logger.info("\n\n")
 

--- a/tests/analysis/test_neuronpedia_integration.py
+++ b/tests/analysis/test_neuronpedia_integration.py
@@ -106,7 +106,7 @@ def test_open_neuronpedia_feature_dashboard_with_none_id(
 @pytest.mark.anyio
 @patch("sae_lens.analysis.neuronpedia_integration.requests.get")
 @patch("sae_lens.analysis.neuronpedia_integration.requests.post")
-@patch("sae_lens.analysis.neuronpedia_integration.TokenActivationPairExplainer")
+@patch("neuron_explainer.explanations.explainer.TokenActivationPairExplainer")
 @patch("sae_lens.analysis.neuronpedia_integration.simulate_and_score")
 @patch("sae_lens.analysis.neuronpedia_integration.os.makedirs")
 @patch("sae_lens.analysis.neuronpedia_integration.os.getenv")
@@ -199,7 +199,15 @@ async def test_autointerp_neuronpedia_features_success(
 
     # Verify file operations
     mock_makedirs.assert_called_once()
-    mock_file_open.assert_called_once()
+    # Check that our output file was opened (the second call is for our file)
+    assert mock_file_open.call_count >= 1
+    # Verify the output file was opened with the correct path pattern
+    output_calls = [
+        call
+        for call in mock_file_open.call_args_list
+        if "neuronpedia_outputs" in str(call)
+    ]
+    assert len(output_calls) == 1
 
     # Verify the feature was populated
     assert features[0].autointerp_explanation == "This feature detects greetings"
@@ -411,7 +419,7 @@ async def test_autointerp_neuronpedia_features_dead_feature(
 
 @pytest.mark.anyio
 @patch("sae_lens.analysis.neuronpedia_integration.requests.get")
-@patch("sae_lens.analysis.neuronpedia_integration.TokenActivationPairExplainer")
+@patch("neuron_explainer.explanations.explainer.TokenActivationPairExplainer")
 @patch("sae_lens.analysis.neuronpedia_integration.os.getenv")
 async def test_autointerp_neuronpedia_features_without_scoring(
     mock_getenv: MagicMock,


### PR DESCRIPTION
# Description

The `automated-interpretability` dependency causes a bunch of issues since it has very strict dependency requirement that are not frequently updated, and this means that SAELens thus can't be used with a lot of model python packages (e.g. see https://github.com/hijohnnylin/automated-interpretability/pull/4). `automated-interpretability` is only needed for Neuronpedia, so there's no reason normal users of SAELens should need this dependency anyway. This PR just moves the dependency to be optional, and can be installed with `pip install sae-lens[neuronpedia]`.

Fixes #517