### PR TITLE
Load CLTs from mntss as single-layer transcoders

### DIFF
--- a/sae_lens/loading/pretrained_sae_loaders.py
+++ b/sae_lens/loading/pretrained_sae_loaders.py
@@ -1326,7 +1326,7 @@ def mwhanna_transcoder_huggingface_loader(
     return cfg_dict, state_dict, None
 
 
-def get_mntss_clt_layer_huggingface_loader(
+def mntss_clt_layer_huggingface_loader(
     repo_id: str,
     folder_name: str,
     device: str = "cpu",
@@ -1397,7 +1397,7 @@ NAMED_PRETRAINED_SAE_LOADERS: dict[str, PretrainedSaeHuggingfaceLoader] = {
     "sparsify": sparsify_huggingface_loader,
     "gemma_2_transcoder": gemma_2_transcoder_huggingface_loader,
     "mwhanna_transcoder": mwhanna_transcoder_huggingface_loader,
-    "mntss_clt_layer_transcoder": get_mntss_clt_layer_huggingface_loader,
+    "mntss_clt_layer_transcoder": mntss_clt_layer_huggingface_loader,
 }
 
 

--- a/sae_lens/loading/pretrained_sae_loaders.py
+++ b/sae_lens/loading/pretrained_sae_loaders.py
@@ -1355,8 +1355,8 @@ def mntss_clt_layer_huggingface_loader(
         force_download=force_download,
     )
 
-    encoder_state_dict = load_file(encoder_path, device=device)["W_enc"]
-    decoder_state_dict = load_file(decoder_path, device=device)["W_dec"]
+    encoder_state_dict = load_file(encoder_path, device=device)
+    decoder_state_dict = load_file(decoder_path, device=device)
 
     with torch.no_grad():
         state_dict = {

--- a/sae_lens/loading/pretrained_sae_loaders.py
+++ b/sae_lens/loading/pretrained_sae_loaders.py
@@ -1248,11 +1248,11 @@ def get_mwhanna_transcoder_config_from_hf(
     try:
         # mwhanna transcoders sometimes have a typo in the config file name, so check for both
         wandb_config_path = hf_hub_download(
-            repo_id, "wanb-config.yaml", force_download=force_download
+            repo_id, "wandb-config.yaml", force_download=force_download
         )
     except EntryNotFoundError:
         wandb_config_path = hf_hub_download(
-            repo_id, "wandb-config.yaml", force_download=force_download
+            repo_id, "wanb-config.yaml", force_download=force_download
         )
     try:
         base_config_path = hf_hub_download(
@@ -1326,6 +1326,66 @@ def mwhanna_transcoder_huggingface_loader(
     return cfg_dict, state_dict, None
 
 
+def get_mntss_clt_layer_huggingface_loader(
+    repo_id: str,
+    folder_name: str,
+    device: str = "cpu",
+    force_download: bool = False,  # noqa: ARG001
+    cfg_overrides: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], dict[str, torch.Tensor], torch.Tensor | None]:
+    """
+    Load a MNTSS CLT layer as a single layer transcoder.
+    The assumption is that the `folder_name` is the layer to load as an int
+    """
+    base_config_path = hf_hub_download(
+        repo_id, "config.yaml", force_download=force_download
+    )
+    with open(base_config_path) as f:
+        cfg_info: dict[str, Any] = yaml.safe_load(f)
+
+    # We need to actually load the weights, since the config is missing most information
+    encoder_path = hf_hub_download(
+        repo_id,
+        f"W_enc_{folder_name}.safetensors",
+        force_download=force_download,
+    )
+    decoder_path = hf_hub_download(
+        repo_id,
+        f"W_dec_{folder_name}.safetensors",
+        force_download=force_download,
+    )
+
+    encoder_state_dict = load_file(encoder_path, device=device)["W_enc"]
+    decoder_state_dict = load_file(decoder_path, device=device)["W_dec"]
+
+    with torch.no_grad():
+        state_dict = {
+            "W_enc": encoder_state_dict[f"W_enc_{folder_name}"].T,  # type: ignore
+            "b_enc": encoder_state_dict[f"b_enc_{folder_name}"],  # type: ignore
+            "b_dec": encoder_state_dict[f"b_dec_{folder_name}"],  # type: ignore
+            "W_dec": decoder_state_dict[f"W_dec_{folder_name}"].sum(dim=1),  # type: ignore
+        }
+
+    cfg_dict = {
+        "architecture": "transcoder",
+        "d_in": state_dict["b_dec"].shape[0],
+        "d_out": state_dict["b_dec"].shape[0],
+        "d_sae": state_dict["b_enc"].shape[0],
+        "dtype": "float32",
+        "device": device if device is not None else "cpu",
+        "activation_fn": "relu",
+        "normalize_activations": "none",
+        "model_name": cfg_info["model_name"],
+        "hook_name": f"blocks.{folder_name}.{cfg_info['feature_input_hook']}",
+        "hook_name_out": f"blocks.{folder_name}.{cfg_info['feature_output_hook']}",
+        "apply_b_dec_to_input": False,
+        "model_from_pretrained_kwargs": {"fold_ln": False},
+        **(cfg_overrides or {}),
+    }
+
+    return cfg_dict, state_dict, None
+
+
 NAMED_PRETRAINED_SAE_LOADERS: dict[str, PretrainedSaeHuggingfaceLoader] = {
     "sae_lens": sae_lens_huggingface_loader,
     "connor_rob_hook_z": connor_rob_hook_z_huggingface_loader,
@@ -1337,6 +1397,7 @@ NAMED_PRETRAINED_SAE_LOADERS: dict[str, PretrainedSaeHuggingfaceLoader] = {
     "sparsify": sparsify_huggingface_loader,
     "gemma_2_transcoder": gemma_2_transcoder_huggingface_loader,
     "mwhanna_transcoder": mwhanna_transcoder_huggingface_loader,
+    "mntss_clt_layer_transcoder": get_mntss_clt_layer_huggingface_loader,
 }
 
 

--- a/tests/loading/test_pretrained_sae_loaders.py
+++ b/tests/loading/test_pretrained_sae_loaders.py
@@ -14,9 +14,9 @@ from sae_lens.loading.pretrained_sae_loaders import (
     get_gemma_2_transcoder_config_from_hf,
     get_llama_scope_config_from_hf,
     get_llama_scope_r1_distill_config_from_hf,
-    get_mntss_clt_layer_huggingface_loader,
     get_mwhanna_transcoder_config_from_hf,
     load_sae_config_from_huggingface,
+    mntss_clt_layer_huggingface_loader,
     read_sae_components_from_disk,
     sparsify_disk_loader,
     sparsify_huggingface_loader,
@@ -904,7 +904,7 @@ def test_get_mntss_clt_layer_huggingface_loader(
     )
 
     # Call the function
-    cfg_dict, state_dict, log_sparsity = get_mntss_clt_layer_huggingface_loader(
+    cfg_dict, state_dict, log_sparsity = mntss_clt_layer_huggingface_loader(
         repo_id=repo_id,
         folder_name=folder_name,
         device=device,

--- a/tests/loading/test_pretrained_sae_loaders.py
+++ b/tests/loading/test_pretrained_sae_loaders.py
@@ -876,23 +876,15 @@ def test_get_mntss_clt_layer_huggingface_loader(
         raise ValueError(f"Unexpected filename: {filename}")
 
     # Mock load_file to return the expected nested structure
-    def mock_load_file(
-        file_path: str, device: str = "cpu"
-    ) -> dict[str, dict[str, torch.Tensor]]:
+    def mock_load_file(file_path: str, device: str = "cpu") -> dict[str, torch.Tensor]:
         if f"W_enc_{folder_name}.safetensors" in file_path:
             return {
-                "W_enc": {
-                    f"W_enc_{folder_name}": W_enc_tensor,
-                    f"b_enc_{folder_name}": b_enc_tensor,
-                    f"b_dec_{folder_name}": b_dec_tensor,
-                }
+                f"W_enc_{folder_name}": W_enc_tensor,
+                f"b_enc_{folder_name}": b_enc_tensor,
+                f"b_dec_{folder_name}": b_dec_tensor,
             }
         if f"W_dec_{folder_name}.safetensors" in file_path:
-            return {
-                "W_dec": {
-                    f"W_dec_{folder_name}": W_dec_tensor,
-                }
-            }
+            return {f"W_dec_{folder_name}": W_dec_tensor}
         raise ValueError(f"Unexpected file path: {file_path}")
 
     # Apply the mocks


### PR DESCRIPTION
# Description

This PR adds a loader for CLTs from mntss as single-layer transcoders to generate dashboards. This PR does not add this to the public API of the library or add these to the pretrained_saes.yaml file, since this is likely a pretty niche functionality for now. 

To load a CLT from a layer, you can run this like the following:

```
from sae_lens import SAE
from sae_lens.loading.pretrained_sae_loaders import mntss_clt_layer_huggingface_loader

clt10 = SAE.from_pretrained("mntss/clt-gemma-2-2b-426k", "10", converter=mntss_clt_layer_huggingface_loader)
```

The second param to `from_pretrained` is the layer number as a string.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update