### PR TITLE
docs: migration- note that non-essential config have moved to cfg.metadata

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -92,3 +92,5 @@ The removed options include:
 `SAETrainingRunner` has been renamed to `LanguageModelSAETrainingRunner`, although the `SAETrainingRunner` name will still keep working for now. This change was made to allow other types of SAETrainingRunners to be added in the future (e.g. for vision models).
 
 Running SAE training from the CLI now requires running the script: `python -m sae_lens.llm_sae_training_runner` to reflect this change.
+
+`SAE.cfg` now only contains config keys that are essential for running the SAE. Everything else, such as `prepend_bos`, has been moved to `SAE.cfg.metadata`.


### PR DESCRIPTION
# Description

Small doc change to note that non-essential SAE config have moved to cfg.metadata in v6. Feel free to modify the note as needed.

## Type of change
- [x] This change requires a documentation update

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have not rewritten tests relating to key interfaces which would affect backward compatibility
