### PR TITLE
fix: add config loader for mntss clt by layer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,10 @@ jobs:
       - name: Cache Huggingface assets
         uses: actions/cache@v4
         with:
-          key: huggingface-3-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+          key: huggingface-4-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
           path: ~/.cache/huggingface
           restore-keys: |
-            huggingface-3-${{ runner.os }}-${{ matrix.python-version }}-
+            huggingface-4-${{ runner.os }}-${{ matrix.python-version }}-
       - name: Load cached Poetry installation
         id: cached-poetry
         uses: actions/cache@v4

--- a/sae_lens/loading/pretrained_sae_loaders.py
+++ b/sae_lens/loading/pretrained_sae_loaders.py
@@ -1393,7 +1393,7 @@ def mntss_clt_layer_huggingface_loader(
 def get_mntss_clt_layer_config_from_hf(
     repo_id: str,
     folder_name: str,
-    device: str | None = None,
+    device: str,
     force_download: bool = False,  # noqa: ARG001
     cfg_overrides: dict[str, Any] | None = None,
 ) -> dict[str, Any]:

--- a/sae_lens/loading/pretrained_sae_loaders.py
+++ b/sae_lens/loading/pretrained_sae_loaders.py
@@ -1369,11 +1369,9 @@ def get_safetensors_tensor_shapes(url: str) -> dict[str, list[int]]:
     metadata = json.loads(metadata_json)
 
     # Extract tensor shapes, excluding the __metadata__ key
-    tensor_shapes = {
+    return {
         name: info["shape"] for name, info in metadata.items() if name != "__metadata__"
     }
-
-    return tensor_shapes
 
 
 def mntss_clt_layer_huggingface_loader(
@@ -1453,7 +1451,7 @@ def get_mntss_clt_layer_config_from_hf(
     b_dec_shape = encoder_shapes[f"b_dec_{folder_name}"]
     b_enc_shape = encoder_shapes[f"b_enc_{folder_name}"]
 
-    cfg_dict = {
+    return {
         "architecture": "transcoder",
         "d_in": b_dec_shape[0],
         "d_out": b_dec_shape[0],
@@ -1469,8 +1467,6 @@ def get_mntss_clt_layer_config_from_hf(
         "model_from_pretrained_kwargs": {"fold_ln": False},
         **(cfg_overrides or {}),
     }
-
-    return cfg_dict
 
 
 NAMED_PRETRAINED_SAE_LOADERS: dict[str, PretrainedSaeHuggingfaceLoader] = {

--- a/sae_lens/loading/pretrained_sae_loaders.py
+++ b/sae_lens/loading/pretrained_sae_loaders.py
@@ -1390,6 +1390,30 @@ def mntss_clt_layer_huggingface_loader(
     return cfg_dict, state_dict, None
 
 
+def get_mntss_clt_layer_config_from_hf(
+    repo_id: str,
+    folder_name: str,
+    device: str | None = None,
+    force_download: bool = False,  # noqa: ARG001
+    cfg_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Get config for MNTSS CLT by layer
+    Load a MNTSS CLT layer as a single layer transcoder.
+    The assumption is that the `folder_name` is the layer to load as an int
+    """
+    logger.warning(
+        "Getting the MNTSS CLT config requires downloading weights, since that's where config is stored"
+    )
+    # call mntss_clt_layer_huggingface_loader to get the config
+    return mntss_clt_layer_huggingface_loader(
+        repo_id,
+        folder_name,
+        device,
+        force_download,
+        cfg_overrides,
+    )[0]
+
+
 NAMED_PRETRAINED_SAE_LOADERS: dict[str, PretrainedSaeHuggingfaceLoader] = {
     "sae_lens": sae_lens_huggingface_loader,
     "connor_rob_hook_z": connor_rob_hook_z_huggingface_loader,
@@ -1416,4 +1440,5 @@ NAMED_PRETRAINED_SAE_CONFIG_GETTERS: dict[str, PretrainedSaeConfigHuggingfaceLoa
     "sparsify": get_sparsify_config_from_hf,
     "gemma_2_transcoder": get_gemma_2_transcoder_config_from_hf,
     "mwhanna_transcoder": get_mwhanna_transcoder_config_from_hf,
+    "mntss_clt_layer_transcoder": get_mntss_clt_layer_config_from_hf,
 }

--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -14745,3 +14745,87 @@ mwhanna-qwen3-0.6b-transcoders-lowl0:
   - id: layer_27
     path: layer_27.safetensors
     neuronpedia: qwen3-0.6b/27-transcoder-hp-lowl0
+
+mntss-gemma-2-2b-2.5m-clt-as-per-layer:
+  conversion_func: mntss_clt_layer_transcoder
+  model: gemma-2-2b
+  repo_id: mntss/clt-gemma-2-2b-2.5M
+  saes:
+  - id: layer_0
+    path: 0
+    neuronpedia: gemma-2-2b/0-clt-hp
+  - id: layer_1
+    path: 1
+    neuronpedia: gemma-2-2b/1-clt-hp
+  - id: layer_2
+    path: 2
+    neuronpedia: gemma-2-2b/2-clt-hp
+  - id: layer_3
+    path: 3
+    neuronpedia: gemma-2-2b/3-clt-hp
+  - id: layer_4
+    path: 4
+    neuronpedia: gemma-2-2b/4-clt-hp
+  - id: layer_5
+    path: 5
+    neuronpedia: gemma-2-2b/5-clt-hp
+  - id: layer_6
+    path: 6
+    neuronpedia: gemma-2-2b/6-clt-hp
+  - id: layer_7
+    path: 7
+    neuronpedia: gemma-2-2b/7-clt-hp
+  - id: layer_8
+    path: 8
+    neuronpedia: gemma-2-2b/8-clt-hp
+  - id: layer_9
+    path: 9
+    neuronpedia: gemma-2-2b/9-clt-hp
+  - id: layer_10
+    path: 10
+    neuronpedia: gemma-2-2b/10-clt-hp
+  - id: layer_11
+    path: 11
+    neuronpedia: gemma-2-2b/11-clt-hp
+  - id: layer_12
+    path: 12
+    neuronpedia: gemma-2-2b/12-clt-hp
+  - id: layer_13
+    path: 13
+    neuronpedia: gemma-2-2b/13-clt-hp
+  - id: layer_14
+    path: 14
+    neuronpedia: gemma-2-2b/14-clt-hp
+  - id: layer_15
+    path: 15
+    neuronpedia: gemma-2-2b/15-clt-hp
+  - id: layer_16
+    path: 16
+    neuronpedia: gemma-2-2b/16-clt-hp
+  - id: layer_17
+    path: 17
+    neuronpedia: gemma-2-2b/17-clt-hp
+  - id: layer_18
+    path: 18
+    neuronpedia: gemma-2-2b/18-clt-hp
+  - id: layer_19
+    path: 19
+    neuronpedia: gemma-2-2b/19-clt-hp
+  - id: layer_20
+    path: 20
+    neuronpedia: gemma-2-2b/20-clt-hp
+  - id: layer_21
+    path: 21
+    neuronpedia: gemma-2-2b/21-clt-hp
+  - id: layer_22
+    path: 22
+    neuronpedia: gemma-2-2b/22-clt-hp
+  - id: layer_23
+    path: 23
+    neuronpedia: gemma-2-2b/23-clt-hp
+  - id: layer_24
+    path: 24
+    neuronpedia: gemma-2-2b/24-clt-hp
+  - id: layer_25
+    path: 25
+    neuronpedia: gemma-2-2b/25-clt-hp


### PR DESCRIPTION
# Description

My previous commit https://github.com/jbloomAus/SAELens/pull/534 broke deploy docs because the doc build assumes that each pretrained_sae_loader has a corresponding config_getter.
This makes the config_getter for it, which basically just calls the sae_loader and gets the first value in the tuple.

Since the mntss CLT loader requires loading weights (and config getting is presumed to be a "lightweight" operation"), I've also added a warning log.

Fingers crossed that this doesn't OOM or timeout the CI!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)