### PR TITLE
feat: add `output_path` option to LLM training runner

### DIFF
--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -170,7 +170,7 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
         logger (LoggingConfig): Configuration for logging (e.g. W&B).
         n_checkpoints (int): The number of checkpoints to save during training. 0 means no checkpoints.
         checkpoint_path (str | None): The path to save checkpoints. A unique ID will be appended to this path. Set to None to disable checkpoint saving. (default is "checkpoints")
-        include_final_checkpoint (bool): Whether to include an additional final checkpoint when training is finished. (default is False).
+        save_final_checkpoint (bool): Whether to include an additional final checkpoint when training is finished. (default is False).
         output_path (str | None): The path to save outputs. Set to None to disable output saving. (default is "output")
         verbose (bool): Whether to print verbose output. (default is True)
         model_kwargs (dict[str, Any]): Keyword arguments for `model.run_with_cache`
@@ -259,7 +259,7 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
     # Outputs/Checkpoints
     n_checkpoints: int = 0
     checkpoint_path: str | None = "checkpoints"
-    include_final_checkpoint: bool = False
+    save_final_checkpoint: bool = False
     output_path: str | None = "output"
 
     # Misc
@@ -400,7 +400,7 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
         return SAETrainerConfig(
             n_checkpoints=self.n_checkpoints,
             checkpoint_path=self.checkpoint_path,
-            save_final_checkpoint=self.include_final_checkpoint,
+            save_final_checkpoint=self.save_final_checkpoint,
             total_training_samples=self.total_training_tokens,
             device=self.device,
             autocast=self.autocast,

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -169,9 +169,9 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
         eval_batch_size_prompts (int, optional): The batch size for evaluation, in prompts. Useful if evals cause OOM.
         logger (LoggingConfig): Configuration for logging (e.g. W&B).
         n_checkpoints (int): The number of checkpoints to save during training. 0 means no checkpoints.
-        checkpoint_path (str): The path to save checkpoints. A unique ID will be appended to this path. (default is "checkpoints")
-        include_final_checkpoint (bool): Whether to include the final checkpoint in the W&B artifact (default is False).
-        output_path (str): The path to save outputs. (default is "output")
+        checkpoint_path (str | None): The path to save checkpoints. A unique ID will be appended to this path. Set to None to disable checkpoint saving. (default is "checkpoints")
+        include_final_checkpoint (bool): Whether to include an additional final checkpoint when training is finished. (default is False).
+        output_path (str | None): The path to save outputs. Set to None to disable output saving. (default is "output")
         verbose (bool): Whether to print verbose output. (default is True)
         model_kwargs (dict[str, Any]): Keyword arguments for `model.run_with_cache`
         model_from_pretrained_kwargs (dict[str, Any], optional): Additional keyword arguments to pass to the model's `from_pretrained` method.
@@ -258,7 +258,7 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
 
     # Outputs/Checkpoints
     n_checkpoints: int = 0
-    checkpoint_path: str = "checkpoints"
+    checkpoint_path: str | None = "checkpoints"
     include_final_checkpoint: bool = False
     output_path: str | None = "output"
 
@@ -625,7 +625,7 @@ class PretokenizeRunnerConfig:
 @dataclass
 class SAETrainerConfig:
     n_checkpoints: int
-    checkpoint_path: str
+    checkpoint_path: str | None
     save_final_checkpoint: bool
     total_training_samples: int
     device: str

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -169,8 +169,10 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
         eval_batch_size_prompts (int, optional): The batch size for evaluation, in prompts. Useful if evals cause OOM.
         logger (LoggingConfig): Configuration for logging (e.g. W&B).
         n_checkpoints (int): The number of checkpoints to save during training. 0 means no checkpoints.
-        checkpoint_path (str): The path to save checkpoints. A unique ID will be appended to this path.
-        verbose (bool): Whether to print verbose output.
+        checkpoint_path (str): The path to save checkpoints. A unique ID will be appended to this path. (default is "checkpoints")
+        include_final_checkpoint (bool): Whether to include the final checkpoint in the W&B artifact (default is False).
+        output_path (str): The path to save outputs. (default is "output")
+        verbose (bool): Whether to print verbose output. (default is True)
         model_kwargs (dict[str, Any]): Keyword arguments for `model.run_with_cache`
         model_from_pretrained_kwargs (dict[str, Any], optional): Additional keyword arguments to pass to the model's `from_pretrained` method.
         sae_lens_version (str): The version of the sae_lens library.
@@ -254,9 +256,13 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
 
     logger: LoggingConfig = field(default_factory=LoggingConfig)
 
-    # Misc
+    # Outputs/Checkpoints
     n_checkpoints: int = 0
     checkpoint_path: str = "checkpoints"
+    include_final_checkpoint: bool = False
+    output_path: str | None = "output"
+
+    # Misc
     verbose: bool = True
     model_kwargs: dict[str, Any] = dict_field(default={})
     model_from_pretrained_kwargs: dict[str, Any] | None = dict_field(default=None)
@@ -394,6 +400,7 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
         return SAETrainerConfig(
             n_checkpoints=self.n_checkpoints,
             checkpoint_path=self.checkpoint_path,
+            save_final_checkpoint=self.include_final_checkpoint,
             total_training_samples=self.total_training_tokens,
             device=self.device,
             autocast=self.autocast,
@@ -619,6 +626,7 @@ class PretokenizeRunnerConfig:
 class SAETrainerConfig:
     n_checkpoints: int
     checkpoint_path: str
+    save_final_checkpoint: bool
     total_training_samples: int
     device: str
     autocast: bool

--- a/sae_lens/llm_sae_training_runner.py
+++ b/sae_lens/llm_sae_training_runner.py
@@ -8,13 +8,18 @@ from typing import Any, Generic
 
 import torch
 import wandb
+from safetensors.torch import save_file
 from simple_parsing import ArgumentParser
 from transformer_lens.hook_points import HookedRootModule
 from typing_extensions import deprecated
 
 from sae_lens import logger
 from sae_lens.config import HfDataset, LanguageModelSAERunnerConfig
-from sae_lens.constants import ACTIVATIONS_STORE_STATE_FILENAME, RUNNER_CFG_FILENAME
+from sae_lens.constants import (
+    ACTIVATIONS_STORE_STATE_FILENAME,
+    RUNNER_CFG_FILENAME,
+    SPARSITY_FILENAME,
+)
 from sae_lens.evals import EvalConfig, run_evals
 from sae_lens.load_model import load_model
 from sae_lens.saes.batchtopk_sae import BatchTopKTrainingSAEConfig
@@ -185,10 +190,42 @@ class LanguageModelSAETrainingRunner:
         self._compile_if_needed()
         sae = self.run_trainer_with_interruption_handling(trainer)
 
+        if self.cfg.output_path is not None:
+            self.save_final_sae(
+                sae=sae,
+                output_path=self.cfg.output_path,
+                log_feature_sparsity=trainer.log_feature_sparsity,
+            )
+
         if self.cfg.logger.log_to_wandb:
             wandb.finish()
 
         return sae
+
+    def save_final_sae(
+        self,
+        sae: TrainingSAE[Any],
+        output_path: str,
+        log_feature_sparsity: torch.Tensor | None = None,
+    ):
+        base_output_path = Path(output_path)
+        base_output_path.mkdir(exist_ok=True, parents=True)
+
+        weights_path, cfg_path = sae.save_inference_model(str(base_output_path))
+
+        sparsity_path = None
+        if log_feature_sparsity is not None:
+            sparsity_path = base_output_path / SPARSITY_FILENAME
+            save_file({"sparsity": log_feature_sparsity}, sparsity_path)
+
+        if self.cfg.logger.log_to_wandb:
+            self.cfg.logger.log(
+                self,
+                weights_path,
+                cfg_path,
+                sparsity_path=sparsity_path,
+                wandb_aliases=["final_model"],
+            )
 
     def _set_sae_metadata(self):
         self.sae.cfg.metadata.dataset_path = self.cfg.dataset_path

--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -187,12 +187,8 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
             )
             self.activation_scaler.scaling_factor = None
 
-        # save final inference sae group to checkpoints folder
-        self.save_checkpoint(
-            checkpoint_name=f"final_{self.n_training_samples}",
-            wandb_aliases=["final_model"],
-            save_inference_model=True,
-        )
+        if self.cfg.save_final_checkpoint:
+            self.save_checkpoint(checkpoint_name=f"final_{self.n_training_samples}")
 
         pbar.close()
         return self.sae
@@ -201,17 +197,11 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
         self,
         checkpoint_name: str,
         wandb_aliases: list[str] | None = None,
-        save_inference_model: bool = False,
     ) -> None:
         checkpoint_path = Path(self.cfg.checkpoint_path) / checkpoint_name
         checkpoint_path.mkdir(exist_ok=True, parents=True)
 
-        save_fn = (
-            self.sae.save_inference_model
-            if save_inference_model
-            else self.sae.save_model
-        )
-        weights_path, cfg_path = save_fn(str(checkpoint_path))
+        weights_path, cfg_path = self.sae.save_model(str(checkpoint_path))
 
         sparsity_path = checkpoint_path / SPARSITY_FILENAME
         save_file({"sparsity": self.log_feature_sparsity}, sparsity_path)

--- a/sae_lens/util.py
+++ b/sae_lens/util.py
@@ -1,5 +1,8 @@
 import re
+import tempfile
+from contextlib import contextmanager
 from dataclasses import asdict, fields, is_dataclass
+from pathlib import Path
 from typing import Sequence, TypeVar
 
 K = TypeVar("K")
@@ -45,3 +48,18 @@ def extract_layer_from_tlens_hook_name(hook_name: str) -> int | None:
     """
     hook_match = re.search(r"\.(\d+)\.", hook_name)
     return None if hook_match is None else int(hook_match.group(1))
+
+
+@contextmanager
+def path_or_tmp_dir(path: str | Path | None):
+    """Context manager that yields a concrete Path for path.
+
+    - If path is None, creates a TemporaryDirectory and yields its Path.
+      The directory is cleaned up on context exit.
+    - Otherwise, yields Path(path) without creating or cleaning.
+    """
+    if path is None:
+        with tempfile.TemporaryDirectory() as td:
+            yield Path(td)
+    else:
+        yield Path(path)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -71,6 +71,8 @@ class LanguageModelSAERunnerConfigDict(TypedDict, total=False):
     logger: LoggingConfig
     n_checkpoints: int
     checkpoint_path: str
+    include_final_checkpoint: bool
+    output_path: str | None
     verbose: bool
     model_kwargs: dict[str, Any]
     model_from_pretrained_kwargs: dict[str, Any] | None
@@ -165,6 +167,8 @@ def _get_default_runner_config() -> LanguageModelSAERunnerConfigDict:
         ),
         "n_checkpoints": 0,
         "checkpoint_path": "test/checkpoints",
+        "include_final_checkpoint": False,
+        "output_path": None,
         "verbose": True,
         "model_kwargs": {},
         "model_from_pretrained_kwargs": None,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -71,7 +71,7 @@ class LanguageModelSAERunnerConfigDict(TypedDict, total=False):
     logger: LoggingConfig
     n_checkpoints: int
     checkpoint_path: str | None
-    include_final_checkpoint: bool
+    save_final_checkpoint: bool
     output_path: str | None
     verbose: bool
     model_kwargs: dict[str, Any]
@@ -167,7 +167,7 @@ def _get_default_runner_config() -> LanguageModelSAERunnerConfigDict:
         ),
         "n_checkpoints": 0,
         "checkpoint_path": None,
-        "include_final_checkpoint": False,
+        "save_final_checkpoint": False,
         "output_path": None,
         "verbose": True,
         "model_kwargs": {},

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -70,7 +70,7 @@ class LanguageModelSAERunnerConfigDict(TypedDict, total=False):
     eval_batch_size_prompts: int | None
     logger: LoggingConfig
     n_checkpoints: int
-    checkpoint_path: str
+    checkpoint_path: str | None
     include_final_checkpoint: bool
     output_path: str | None
     verbose: bool
@@ -166,7 +166,7 @@ def _get_default_runner_config() -> LanguageModelSAERunnerConfigDict:
             eval_every_n_wandb_logs=100,
         ),
         "n_checkpoints": 0,
-        "checkpoint_path": "test/checkpoints",
+        "checkpoint_path": None,
         "include_final_checkpoint": False,
         "output_path": None,
         "verbose": True,

--- a/tests/test_llm_sae_training_runner.py
+++ b/tests/test_llm_sae_training_runner.py
@@ -48,6 +48,8 @@ def test_LanguageModelSAETrainingRunner_runs_and_saves_all_architectures(
         model_name=TINYSTORIES_MODEL,
         n_checkpoints=0,
         exclude_special_tokens=True,
+        include_final_checkpoint=True,  # Enable final checkpoint for this test
+        output_path=str(tmp_path / "test_output"),
     )
     runner = LanguageModelSAETrainingRunner(cfg, override_model=ts_model)
     sae = runner.run()
@@ -73,20 +75,31 @@ def test_LanguageModelSAETrainingRunner_runs_and_saves_all_architectures(
     assert sae.cfg.metadata.sae_lens_training_version == __version__
 
     assert (tmp_path / "final_100").exists()
-    loaded_sae = SAE.load_from_disk(tmp_path / "final_100")
+    loaded_sae = TrainingSAE.load_from_disk(tmp_path / "final_100")
 
     # json turns tuples into lists, so just dump and load the metadata to make things consistent
     original_metadata_dict = json.loads(json.dumps(sae.cfg.metadata.__dict__))
-    if architecture == "batchtopk":
-        assert loaded_sae.cfg.architecture() == "jumprelu"
-    else:
-        assert loaded_sae.cfg.architecture() == architecture
+    assert loaded_sae.cfg.architecture() == architecture
     assert loaded_sae.cfg.d_in == sae.cfg.d_in
     assert loaded_sae.cfg.d_sae == sae.cfg.d_sae
     assert loaded_sae.cfg.dtype == sae.cfg.dtype
     assert loaded_sae.cfg.device == sae.cfg.device
     assert loaded_sae.cfg.apply_b_dec_to_input == sae.cfg.apply_b_dec_to_input
     assert loaded_sae.cfg.metadata.__dict__ == original_metadata_dict
+
+    # compare the saved inference SAE as well
+    output_sae = SAE.load_from_disk(tmp_path / "test_output")
+
+    if architecture == "batchtopk":
+        assert output_sae.cfg.architecture() == "jumprelu"
+    else:
+        assert output_sae.cfg.architecture() == architecture
+    assert output_sae.cfg.d_in == sae.cfg.d_in
+    assert output_sae.cfg.d_sae == sae.cfg.d_sae
+    assert output_sae.cfg.dtype == sae.cfg.dtype
+    assert output_sae.cfg.device == sae.cfg.device
+    assert output_sae.cfg.apply_b_dec_to_input == sae.cfg.apply_b_dec_to_input
+    assert output_sae.cfg.metadata.__dict__ == original_metadata_dict
 
 
 def test_parse_cfg_args_raises_system_exit_on_empty_args():
@@ -505,3 +518,124 @@ class TestLLMSaeEvaluator:
                 assert metrics1[key].keys() == metrics2[key].keys()
             # Note: Due to potential randomness in evaluation, we don't assert exact equality
             # but we do check that the structure is consistent
+
+
+def test_LanguageModelSAETrainingRunner_save_final_sae_saves_model_files(
+    tmp_path: Path, ts_model: HookedTransformer
+):
+    """Test that save_final_sae saves the model weights and config."""
+    output_path = tmp_path / "test_output"
+    cfg = build_runner_cfg_for_arch(
+        d_in=64,
+        d_sae=128,
+        architecture="batchtopk",
+        training_tokens=100,
+        store_batch_size_prompts=2,
+        train_batch_size_tokens=4,
+        model_batch_size=1,
+        context_size=10,
+        n_batches_in_buffer=2,
+        dataset_path=NEEL_NANDA_C4_10K_DATASET,
+        hook_name="blocks.0.hook_resid_post",
+        model_name=TINYSTORIES_MODEL,
+        n_checkpoints=0,
+        output_path=str(output_path),
+    )
+    runner = LanguageModelSAETrainingRunner(cfg, override_model=ts_model)
+
+    sae = TrainingSAE.from_dict(cfg.get_training_sae_cfg_dict())
+
+    runner.save_final_sae(sae=sae, output_path=str(output_path))
+
+    # Check that model files exist
+    assert (output_path / "sae_weights.safetensors").exists()
+    assert (output_path / "cfg.json").exists()
+
+    output_sae = SAE.load_from_disk(output_path)
+    checkpoint_sae = SAE.load_from_disk(output_path)
+
+    # we should save the inference model in the final output, not the training model
+    assert sae.cfg.architecture() == "batchtopk"
+    assert output_sae.cfg.architecture() == "jumprelu"
+
+    # Models should have the same architecture and dimensions
+    assert output_sae.cfg.d_in == checkpoint_sae.cfg.d_in
+    assert output_sae.cfg.d_sae == checkpoint_sae.cfg.d_sae
+
+    # Weight tensors should be identical
+    assert torch.equal(
+        torch.Tensor(output_sae.W_enc), torch.Tensor(checkpoint_sae.W_enc)
+    )
+    assert torch.equal(
+        torch.Tensor(output_sae.W_dec), torch.Tensor(checkpoint_sae.W_dec)
+    )
+    # Handle b_enc which might not exist in all architectures
+    if hasattr(output_sae, "b_enc") and hasattr(checkpoint_sae, "b_enc"):
+        assert torch.equal(
+            torch.Tensor(output_sae.b_enc), torch.Tensor(checkpoint_sae.b_enc)
+        )
+    assert torch.equal(
+        torch.Tensor(output_sae.b_dec), torch.Tensor(checkpoint_sae.b_dec)
+    )
+
+
+def test_LanguageModelSAETrainingRunner_save_final_sae_saves_sparsity_when_provided(
+    tmp_path: Path, ts_model: HookedTransformer
+):
+    """Test that save_final_sae saves sparsity data when provided."""
+    cfg = build_runner_cfg_for_arch(
+        d_in=64,
+        d_sae=128,
+        architecture="standard",
+        training_tokens=100,
+        store_batch_size_prompts=2,
+        train_batch_size_tokens=4,
+        model_batch_size=1,
+        context_size=10,
+        n_batches_in_buffer=2,
+        dataset_path=NEEL_NANDA_C4_10K_DATASET,
+        hook_name="blocks.0.hook_resid_post",
+        model_name=TINYSTORIES_MODEL,
+        n_checkpoints=0,
+    )
+    runner = LanguageModelSAETrainingRunner(cfg, override_model=ts_model)
+
+    output_path = tmp_path / "test_output"
+    sae = TrainingSAE.from_dict(cfg.get_training_sae_cfg_dict())
+    sparsity_tensor = torch.randn(128)  # d_sae features
+
+    runner.save_final_sae(
+        sae=sae, output_path=str(output_path), log_feature_sparsity=sparsity_tensor
+    )
+
+    # Check that sparsity file exists
+    assert (output_path / "sparsity.safetensors").exists()
+
+
+def test_LanguageModelSAETrainingRunner_skips_save_final_sae_when_output_path_none(
+    ts_model: HookedTransformer,
+):
+    """Test that runner skips save_final_sae when output_path is None."""
+    cfg = build_runner_cfg_for_arch(
+        d_in=64,
+        d_sae=128,
+        architecture="standard",
+        training_tokens=100,
+        store_batch_size_prompts=2,
+        train_batch_size_tokens=4,
+        model_batch_size=1,
+        context_size=10,
+        n_batches_in_buffer=2,
+        dataset_path=NEEL_NANDA_C4_10K_DATASET,
+        hook_name="blocks.0.hook_resid_post",
+        model_name=TINYSTORIES_MODEL,
+        n_checkpoints=0,
+        output_path=None,  # Explicitly set to None
+    )
+    runner = LanguageModelSAETrainingRunner(cfg, override_model=ts_model)
+
+    sae = runner.run()
+
+    # Check that the SAE was returned
+    assert sae is not None
+    assert not Path("output").exists()

--- a/tests/test_llm_sae_training_runner.py
+++ b/tests/test_llm_sae_training_runner.py
@@ -101,6 +101,11 @@ def test_LanguageModelSAETrainingRunner_runs_and_saves_all_architectures(
     assert output_sae.cfg.apply_b_dec_to_input == sae.cfg.apply_b_dec_to_input
     assert output_sae.cfg.metadata.__dict__ == original_metadata_dict
 
+    with open(tmp_path / "test_output" / "runner_cfg.json") as f:
+        runner_cfg = json.load(f)
+    # json turns tuples into lists, so just dump and load the metadata to make things consistent
+    assert runner_cfg == json.loads(json.dumps(cfg.to_dict()))
+
 
 def test_parse_cfg_args_raises_system_exit_on_empty_args():
     with pytest.raises(SystemExit):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,8 @@
+from pathlib import Path
+
 import pytest
 
-from sae_lens.util import extract_stop_at_layer_from_tlens_hook_name
+from sae_lens.util import extract_stop_at_layer_from_tlens_hook_name, path_or_tmp_dir
 
 
 @pytest.mark.parametrize(
@@ -30,3 +32,42 @@ def test_extract_stop_at_layer_from_tlens_hook_name_valid(
 )
 def test_extract_stop_at_layer_from_tlens_hook_name_invalid(hook_name: str):
     assert extract_stop_at_layer_from_tlens_hook_name(hook_name) is None
+
+
+def test_path_or_tmp_dir_with_none():
+    with path_or_tmp_dir(None) as path:
+        assert isinstance(path, Path)
+        assert path.exists()
+        assert path.is_dir()
+        # Create a test file to verify the directory works
+        test_file = path / "test.txt"
+        test_file.write_text("test content")
+        assert test_file.exists()
+    # Directory should be cleaned up after context exit
+    assert not path.exists()
+
+
+def test_path_or_tmp_dir_with_path(tmp_path: Path):
+    test_dir = tmp_path / "test_dir"
+    test_dir.mkdir()
+
+    with path_or_tmp_dir(test_dir) as path:
+        assert isinstance(path, Path)
+        assert path == test_dir
+        assert path.exists()
+        assert path.is_dir()
+    # Directory should still exist after context exit (not cleaned up)
+    assert test_dir.exists()
+
+
+def test_path_or_tmp_dir_with_string_path(tmp_path: Path):
+    test_dir = tmp_path / "test_dir"
+    test_dir.mkdir()
+
+    with path_or_tmp_dir(str(test_dir)) as path:
+        assert isinstance(path, Path)
+        assert path == test_dir
+        assert path.exists()
+        assert path.is_dir()
+    # Directory should still exist after context exit (not cleaned up)
+    assert test_dir.exists()

--- a/tests/training/test_sae_trainer.py
+++ b/tests/training/test_sae_trainer.py
@@ -266,7 +266,7 @@ def test_checkpoints_save_runner_cfg(
         training_tokens=100,  # Increased to ensure we hit checkpoints
         context_size=8,
         n_checkpoints=2,  # Explicitly request 2 checkpoints during training
-        include_final_checkpoint=True,  # Enable final checkpoint
+        save_final_checkpoint=True,  # Enable final checkpoint
     )
 
     # Create a small dataset
@@ -323,7 +323,7 @@ def test_skips_saving_checkpoint_when_checkpoint_path_is_none(
         training_tokens=100,  # Increased to ensure we hit checkpoints
         context_size=8,
         n_checkpoints=2,  # Explicitly request 2 checkpoints during training
-        include_final_checkpoint=True,  # Enable final checkpoint
+        save_final_checkpoint=True,  # Enable final checkpoint
     )
     trainer_cfg = cfg.to_sae_trainer_config()
 
@@ -366,7 +366,7 @@ def test_estimated_norm_scaling_factor_persistence(
         context_size=8,
         normalize_activations="expected_average_only_in",
         n_checkpoints=2,  # Explicitly request 2 checkpoints during training
-        include_final_checkpoint=True,  # Enable final checkpoint
+        save_final_checkpoint=True,  # Enable final checkpoint
     )
 
     # Create a small dataset
@@ -433,7 +433,7 @@ def test_sae_trainer_saves_final_checkpoint_when_enabled(
         checkpoint_path=str(checkpoint_dir),
         training_tokens=20,
         context_size=8,
-        include_final_checkpoint=True,  # Enable final checkpoint
+        save_final_checkpoint=True,  # Enable final checkpoint
     )
 
     dataset = Dataset.from_list([{"text": "hello world"}] * 100)
@@ -470,7 +470,7 @@ def test_sae_trainer_skips_final_checkpoint_when_disabled(
         checkpoint_path=str(checkpoint_dir),
         training_tokens=20,
         context_size=8,
-        include_final_checkpoint=False,  # Disable final checkpoint
+        save_final_checkpoint=False,  # Disable final checkpoint
     )
 
     dataset = Dataset.from_list([{"text": "hello world"}] * 100)


### PR DESCRIPTION
# Description

This PR adds an `output_path` option to the LLM training runner, where the inference version of the trained SAE is saved, defaulting to `"output"`. Previously, the final model was saved to a checkpoint called `final_<total training tokens>`, even if `n_checkpoints=0` is set, which seems like an unintuitive place to look for the final trained SAE, and is a confusing behavior for `n_checkpoints`. This PR separates checkpointing from saving the final output. A final checkpoint can be enable by setting `include_final_checkpoint=True` in the LLM runner config. 

In addition, this PR allows the user to set the `checkpoint_path` and `output_path` to `None` to disable saving checkpoints or the final model to disk entirely. If `checkpoint_path=None`, but wandb logging is enabled, checkpoints will still be saved to wandb.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)