### PR TITLE
feat: support Anthropic's JumpReLU training setup

### DIFF
--- a/docs/training_saes.md
+++ b/docs/training_saes.md
@@ -154,6 +154,37 @@ sparse_autoencoder = LanguageModelSAETrainingRunner(cfg).run()
 
 [JumpReLU SAEs](https://arxiv.org/abs/2407.14435) are a state-of-the-art SAE architecture. To train one, provide a `JumpReLUTrainingSAEConfig` to the `sae` field. JumpReLU SAEs use a sparsity penalty controlled by the `l0_coefficient` parameter. The `JumpReLUTrainingSAEConfig` also has parameters `jumprelu_bandwidth` and `jumprelu_init_threshold` which affect the learning of the thresholds.
 
+We support both the original JumpReLU sparsity loss and the more modern [tanh sparsity loss](https://transformer-circuits.pub/2025/january-update/index.html) variant from Anthropic. To use the tanh sparsity loss, set `jumprelu_sparsity_loss_mode="tanh"`. The tanh sparsity loss variant is a bit easier to train, but has more hyper-parameters. We recommend using the tanh with `normalize_activations="expected_average_only_in"` to match what Anthropic's setup. We also recommend enabling the pre-act loss by setting `pre_act_loss_coefficient` to match Anthropic's setup. An example of this is below:
+
+```python
+from sae_lens import LanguageModelSAERunnerConfig, LanguageModelSAETrainingRunner, JumpReLUTrainingSAEConfig
+
+cfg = LanguageModelSAERunnerConfig( # Full config would be defined here
+    # ... other LanguageModelSAERunnerConfig parameters ...
+    sae=JumpReLUTrainingSAEConfig(
+        l0_coefficient=5.0, # Sparsity penalty coefficient
+        jumprelu_sparsity_loss_mode="tanh",
+        jumprelu_tanh_scale=4.0, # default value
+        jumprelu_bandwidth=2.0,
+        jumprelu_init_threshold=0.1,
+        pre_act_loss_coefficient=3e-6,
+        # Anthropic's settings assume normalized activations
+        normalize_activations="expected_average_only_in",
+        # Anthropic recommends using the full training steps for the warm-up
+        l0_warm_up_steps=total_training_steps,
+        d_in=1024, # must match your hook point
+        d_sae=16 * 1024,
+        # ... other common SAE parameters from SAEConfig ...
+    ),
+    # Anthropic recommends decaying the LR for the final 20% of training
+    lr_decay_steps=total_training_steps // 5,
+    # ...
+)
+sparse_autoencoder = LanguageModelSAETrainingRunner(cfg).run()
+```
+
+If you'd like to use the original JumpReLU sparsity loss from DeepMind, set `jumprelu_sparsity_loss_mode="step"`. This requires a bit more tuning to work compared with the Anthropic tanh variant. If you don't see L0 decreasing with this setup, try increasing the `jumprelu_bandwidth` and possibly also the `jumprelu_init_threshold`.
+
 ```python
 from sae_lens import LanguageModelSAERunnerConfig, LanguageModelSAETrainingRunner, JumpReLUTrainingSAEConfig
 

--- a/docs/training_saes.md
+++ b/docs/training_saes.md
@@ -154,7 +154,7 @@ sparse_autoencoder = LanguageModelSAETrainingRunner(cfg).run()
 
 [JumpReLU SAEs](https://arxiv.org/abs/2407.14435) are a state-of-the-art SAE architecture. To train one, provide a `JumpReLUTrainingSAEConfig` to the `sae` field. JumpReLU SAEs use a sparsity penalty controlled by the `l0_coefficient` parameter. The `JumpReLUTrainingSAEConfig` also has parameters `jumprelu_bandwidth` and `jumprelu_init_threshold` which affect the learning of the thresholds.
 
-We support both the original JumpReLU sparsity loss and the more modern [tanh sparsity loss](https://transformer-circuits.pub/2025/january-update/index.html) variant from Anthropic. To use the tanh sparsity loss, set `jumprelu_sparsity_loss_mode="tanh"`. The tanh sparsity loss variant is a bit easier to train, but has more hyper-parameters. We recommend using the tanh with `normalize_activations="expected_average_only_in"` to match what Anthropic's setup. We also recommend enabling the pre-act loss by setting `pre_act_loss_coefficient` to match Anthropic's setup. An example of this is below:
+We support both the original JumpReLU sparsity loss and the more modern [tanh sparsity loss](https://transformer-circuits.pub/2025/january-update/index.html) variant from Anthropic. To use the tanh sparsity loss, set `jumprelu_sparsity_loss_mode="tanh"`. The tanh sparsity loss variant is a bit easier to train, but has more hyper-parameters. We recommend using the tanh with `normalize_activations="expected_average_only_in"` to match Anthropic's setup. We also recommend enabling the pre-act loss by setting `pre_act_loss_coefficient` to match Anthropic's setup. An example of this is below:
 
 ```python
 from sae_lens import LanguageModelSAERunnerConfig, LanguageModelSAETrainingRunner, JumpReLUTrainingSAEConfig

--- a/sae_lens/saes/jumprelu_sae.py
+++ b/sae_lens/saes/jumprelu_sae.py
@@ -364,7 +364,7 @@ def calculate_pre_act_loss(
     """
     Calculate Anthropic's pre-activation loss, except we only calculate this for latents that are actually dead.
     """
-    if dead_neuron_mask is None or int(dead_neuron_mask.sum()) == 0:
+    if dead_neuron_mask is None or dead_neuron_mask.sum() == 0:
         return hidden_pre.new_tensor(0.0)
     per_item_loss = (
         (threshold - hidden_pre).relu() * dead_neuron_mask * W_dec_norm

--- a/sae_lens/saes/jumprelu_sae.py
+++ b/sae_lens/saes/jumprelu_sae.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import torch
@@ -187,12 +187,28 @@ class JumpReLUSAE(SAE[JumpReLUSAEConfig]):
 class JumpReLUTrainingSAEConfig(TrainingSAEConfig):
     """
     Configuration class for training a JumpReLUTrainingSAE.
+
+    - jumprelu_init_threshold: initial threshold for the JumpReLU activation
+    - jumprelu_bandwidth: bandwidth for the JumpReLU activation
+    - jumprelu_sparsity_loss_mode: mode for the sparsity loss, either "step" or "tanh". "step" is Google Deepmind's L0 loss, "tanh" is Anthropic's sparsity loss.
+    - l0_coefficient: coefficient for the l0 sparsity loss
+    - l0_warm_up_steps: number of warm-up steps for the l0 sparsity loss
+    - pre_act_loss_coefficient: coefficient for the pre-activation loss. Set to None to disable. Set to 3e-6 to match Anthropic's setup. Default is None.
+    - jumprelu_tanh_scale: scale for the tanh sparsity loss. Only relevant for "tanh" sparsity loss mode. Default is 4.0.
     """
 
     jumprelu_init_threshold: float = 0.01
     jumprelu_bandwidth: float = 0.05
+    # step is Google Deepmind, tanh is Anthropic
+    jumprelu_sparsity_loss_mode: Literal["step", "tanh"] = "step"
     l0_coefficient: float = 1.0
     l0_warm_up_steps: int = 0
+
+    # anthropic's auxiliary loss to avoid dead features
+    pre_act_loss_coefficient: float | None = None
+
+    # only relevant for tanh sparsity loss mode
+    jumprelu_tanh_scale: float = 4.0
 
     @override
     @classmethod
@@ -267,9 +283,35 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
         sae_out: torch.Tensor,
     ) -> dict[str, torch.Tensor]:
         """Calculate architecture-specific auxiliary loss terms."""
-        l0 = torch.sum(Step.apply(hidden_pre, self.threshold, self.bandwidth), dim=-1)  # type: ignore
-        l0_loss = (step_input.coefficients["l0"] * l0).mean()
-        return {"l0_loss": l0_loss}
+
+        threshold = self.threshold
+        W_dec_norm = self.W_dec.norm(dim=1)
+        if self.cfg.jumprelu_sparsity_loss_mode == "step":
+            l0 = torch.sum(
+                Step.apply(hidden_pre, threshold, self.bandwidth),  # type: ignore
+                dim=-1,
+            )
+            l0_loss = (step_input.coefficients["l0"] * l0).mean()
+        elif self.cfg.jumprelu_sparsity_loss_mode == "tanh":
+            per_item_l0_loss = torch.tanh(
+                self.cfg.jumprelu_tanh_scale * feature_acts * W_dec_norm
+            ).sum(dim=-1)
+            l0_loss = (step_input.coefficients["l0"] * per_item_l0_loss).mean()
+        else:
+            raise ValueError(
+                f"Invalid sparsity loss mode: {self.cfg.jumprelu_sparsity_loss_mode}"
+            )
+        losses = {"l0_loss": l0_loss}
+
+        if self.cfg.pre_act_loss_coefficient is not None:
+            losses["pre_act_loss"] = calculate_pre_act_loss(
+                self.cfg.pre_act_loss_coefficient,
+                threshold,
+                hidden_pre,
+                step_input.dead_neuron_mask,
+                W_dec_norm,
+            )
+        return losses
 
     @override
     def get_coefficients(self) -> dict[str, float | TrainCoefficientConfig]:
@@ -310,3 +352,21 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
             threshold = state_dict["threshold"]
             del state_dict["threshold"]
             state_dict["log_threshold"] = torch.log(threshold).detach().contiguous()
+
+
+def calculate_pre_act_loss(
+    pre_act_loss_coefficient: float,
+    threshold: torch.Tensor,
+    hidden_pre: torch.Tensor,
+    dead_neuron_mask: torch.Tensor | None,
+    W_dec_norm: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Calculate Anthropic's pre-activation loss, except we only calculate this for latents that are actually dead.
+    """
+    if dead_neuron_mask is None or int(dead_neuron_mask.sum()) == 0:
+        return hidden_pre.new_tensor(0.0)
+    per_item_loss = (
+        (threshold - hidden_pre).relu() * dead_neuron_mask * W_dec_norm
+    ).sum(dim=-1)
+    return pre_act_loss_coefficient * per_item_loss.mean()

--- a/sae_lens/saes/jumprelu_sae.py
+++ b/sae_lens/saes/jumprelu_sae.py
@@ -364,7 +364,7 @@ def calculate_pre_act_loss(
     """
     Calculate Anthropic's pre-activation loss, except we only calculate this for latents that are actually dead.
     """
-    if dead_neuron_mask is None or dead_neuron_mask.sum() == 0:
+    if dead_neuron_mask is None or not dead_neuron_mask.any():
         return hidden_pre.new_tensor(0.0)
     per_item_loss = (
         (threshold - hidden_pre).relu() * dead_neuron_mask * W_dec_norm

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -101,6 +101,8 @@ class TrainingSAEConfigDict(TypedDict, total=False):
     l0_warm_up_steps: int
     pre_act_loss_coefficient: float | None  # For JumpReLU
     topk_threshold_lr: float  # For BatchTopK
+    jumprelu_sparsity_loss_mode: Literal["step", "tanh"]  # For JumpReLU
+    jumprelu_tanh_scale: float  # For JumpReLU
 
 
 class SAEConfigDict(TypedDict, total=False):
@@ -290,6 +292,8 @@ def build_jumprelu_runner_cfg(
         "normalize_activations": "none",
         "apply_b_dec_to_input": False,
         "decoder_init_norm": 0.1,
+        "jumprelu_sparsity_loss_mode": "step",
+        "jumprelu_tanh_scale": 4.0,
         "jumprelu_init_threshold": 0.001,
         "jumprelu_bandwidth": 0.001,
         "l0_coefficient": 0.3,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -99,6 +99,7 @@ class TrainingSAEConfigDict(TypedDict, total=False):
     k: int  # For TopK
     l0_coefficient: float  # For JumpReLU
     l0_warm_up_steps: int
+    pre_act_loss_coefficient: float | None  # For JumpReLU
     topk_threshold_lr: float  # For BatchTopK
 
 
@@ -293,6 +294,7 @@ def build_jumprelu_runner_cfg(
         "jumprelu_bandwidth": 0.001,
         "l0_coefficient": 0.3,
         "l0_warm_up_steps": 0,
+        "pre_act_loss_coefficient": None,
     }
     return _build_runner_config(
         JumpReLUTrainingSAEConfig,


### PR DESCRIPTION
# Description

This PR implements Anthropic's JumpReLU setup, based on https://transformer-circuits.pub/2025/january-update/index.html#DL. This has some minor changes from the proposal in #427, specifically:

`jumprelu_ste_method` is instead called `jumprelu_loss_mode`, with options `step` for DeepMind or `tanh` for Anthropic. On further inspection, Anthropic is still technically using a rectangle straight through estimator, but they changed the sparsity loss equation from what Deepmind used. 

I also changed the pre-enc loss to only get applied if SAE latents are actually dead rather than applying any time the latent doesn't fire. It just seems strange to apply a distorting loss to all latents when they're otherwise firing normally IMO.

This PR does not include Anthropic's `b_enc` init method, since when I tested this out it didn't seem to require it to avoide dead features. I suspect that `b_enc` init is likely useful only if the SAE is extremely wide. We can always add that in a follow-up PR. The `b_enc` init method is also likely useable for any SAE, not just JumpReLUs anyway.

I can't find any existing open-source implementation of Anthropic's JumpReLU implementation to compare against, so hopefully this is correct. It seems to work though from what I've experimented with so far. 

Here's a dashboard from a quick test-run on GPT2-small: https://api.wandb.ai/links/chanind/08lb4q3l

Fixes #427 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)