### PR TITLE
docs: removing unnecessary fields from sae-table generation

### DIFF
--- a/docs/generate_sae_table.py
+++ b/docs/generate_sae_table.py
@@ -18,8 +18,6 @@ INCLUDED_CFG = [
     "neuronpedia",
     "hook_name",
     "d_sae",
-    "context_size",
-    "dataset_path",
     "normalize_activations",
 ]
 


### PR DESCRIPTION
# Description

This PR fixes docs generation by removing unused fields from the SAE table generation script. This does not affect the output of the docs table, but allows the docs to builds