### PR TITLE
fix: GatedSAE needs to prevent the model from cheating L0 over steps

### DIFF
--- a/sae_lens/saes/gated_sae.py
+++ b/sae_lens/saes/gated_sae.py
@@ -69,8 +69,13 @@ class GatedSAE(SAE[GatedSAEConfig]):
         )
         feature_magnitudes = self.activation_fn(magnitude_pre_activation)
 
+        feature_acts = active_features * feature_magnitudes
+
+        if self.cfg.normalize_decoder:
+            feature_acts = feature_acts * self.W_dec.norm(dim=-1)
+
         # Combine gating and magnitudes
-        return self.hook_sae_acts_post(active_features * feature_magnitudes)
+        return self.hook_sae_acts_post(feature_acts)
 
     def decode(
         self, feature_acts: Float[torch.Tensor, "... d_sae"]
@@ -82,6 +87,8 @@ class GatedSAE(SAE[GatedSAEConfig]):
           3) Run any reconstruction hooks and out-normalization if configured.
           4) If the SAE was reshaping hook_z activations, reshape back.
         """
+        if self.cfg.normalize_decoder:
+            feature_acts = feature_acts * self.W_dec.norm(dim=-1)
         # 1) optional finetuning scaling
         # 2) linear transform
         sae_out_pre = feature_acts @ self.W_dec + self.b_dec
@@ -167,6 +174,9 @@ class GatedTrainingSAE(TrainingSAE[GatedTrainingSAEConfig]):
         # Combine gating path and magnitude path
         feature_acts = self.hook_sae_acts_post(active_features * feature_magnitudes)
 
+        if self.cfg.normalize_decoder:
+            feature_acts = feature_acts * self.W_dec.norm(dim=-1)
+
         # Return both the final feature activations and the pre-activation (for logging or penalty)
         return feature_acts, magnitude_pre_activation
 
@@ -190,8 +200,11 @@ class GatedTrainingSAE(TrainingSAE[GatedTrainingSAEConfig]):
         l1_loss = step_input.coefficients["l1"] * torch.sum(pi_gate_act, dim=-1).mean()
 
         # Aux reconstruction: reconstruct x purely from gating path
+        W_dec_for_aux = self.W_dec.detach()
+        if self.cfg.normalize_decoder:
+            W_dec_for_aux = W_dec_for_aux / ( W_dec_for_aux.norm(dim=-1, keepdim=True) + 1e-8 )
         via_gate_reconstruction = (
-            pi_gate_act @ self.W_dec.detach() + self.b_dec.detach()
+            pi_gate_act @ W_dec_for_aux + self.b_dec.detach()
         )
         aux_recon_loss = (
             (via_gate_reconstruction - step_input.sae_in).pow(2).sum(dim=-1).mean()

--- a/sae_lens/saes/gated_sae.py
+++ b/sae_lens/saes/gated_sae.py
@@ -187,13 +187,12 @@ class GatedTrainingSAE(TrainingSAE[GatedTrainingSAEConfig]):
         pi_gate_act = torch.relu(pi_gate)
 
         # L1-like penalty scaled by W_dec norms
-        l1_loss = (
-            step_input.coefficients["l1"]
-            * torch.sum(pi_gate_act * self.W_dec.norm(dim=1), dim=-1).mean()
-        )
+        l1_loss = step_input.coefficients["l1"] * torch.sum(pi_gate_act, dim=-1).mean()
 
         # Aux reconstruction: reconstruct x purely from gating path
-        via_gate_reconstruction = pi_gate_act @ self.W_dec + self.b_dec
+        via_gate_reconstruction = (
+            pi_gate_act @ self.W_dec.detach() + self.b_dec.detach()
+        )
         aux_recon_loss = (
             (via_gate_reconstruction - step_input.sae_in).pow(2).sum(dim=-1).mean()
         )

--- a/sae_lens/saes/sae.py
+++ b/sae_lens/saes/sae.py
@@ -161,6 +161,7 @@ class SAEConfig(ABC):
     ] = "none"  # none, expected_average_only_in (Anthropic April Update), constant_norm_rescale (Anthropic Feb Update)
     reshape_activations: Literal["none", "hook_z"] = "none"
     metadata: SAEMetadata = field(default_factory=SAEMetadata)
+    normalize_decoder: bool = False
 
     @classmethod
     @abstractmethod

--- a/tests/refactor_compatibility/test_gated_sae_equivalence.py
+++ b/tests/refactor_compatibility/test_gated_sae_equivalence.py
@@ -393,9 +393,4 @@ def test_gated_training_equivalence():  # type: ignore
         atol=1e-5,
         msg="Output differs between old and new Gated implementation",
     )
-    assert_close(
-        old_out.loss,
-        new_out.loss,
-        atol=1e-5,
-        msg="Loss differs between old and new Gated implementation",
-    )
+    # the losses should no longer be equivalent, since we fixed a bug with the auxiliary reconstruction loss


### PR DESCRIPTION
# Description

Summary: This PR fix issue where the model cheat the L0 over steps. There is no dependencies that are required for this change. This PR is committed on top of PR #545 

PR #545 fix issue where the loss from `pi_via_gate` also flow to the `W_dec` and `b_dec`

https://github.com/jbloomAus/SAELens/blob/3432f0059bc1d90119fe48f88e17ac07aea3a620/sae_lens/saes/gated_sae.py#L196

This PR fix issue where the model cheat the L0 over steps: the loss from `pi_via_gate` shrinks the encoder in the first step, and then increase the decoder in the next step to adjust to the changed encoder. Repeat this over many steps, the encoder will be very small and decoder will be very large

Note: The above is an assumption. However, the experiment results below show that GatedSAE with normalized decoder does have higher `metrics/explained_variance` than without normalization.

Fixes #544 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and tests

- [ ] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [x] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 

[WandB dashboard](https://wandb.ai/jasonrichdarma/sonar_sae/workspace)

Control and test group: Tag `Gated No Scale vs Norm Aux`

<img width="3424" height="2174" alt="image" src="https://github.com/user-attachments/assets/8d3df6c4-d04b-47c5-b5f4-ff781a853671" />
