### PR TITLE
fix: allow float for batchtopk k param

### DIFF
--- a/sae_lens/saes/batchtopk_sae.py
+++ b/sae_lens/saes/batchtopk_sae.py
@@ -15,7 +15,7 @@ class BatchTopK(nn.Module):
 
     def __init__(
         self,
-        k: int,
+        k: float,
     ):
         super().__init__()
         self.k = k
@@ -23,7 +23,7 @@ class BatchTopK(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         acts = x.relu()
         flat_acts = acts.flatten()
-        acts_topk_flat = torch.topk(flat_acts, self.k * acts.shape[0], dim=-1)
+        acts_topk_flat = torch.topk(flat_acts, int(self.k * acts.shape[0]), dim=-1)
         return (
             torch.zeros_like(flat_acts)
             .scatter(-1, acts_topk_flat.indices, acts_topk_flat.values)
@@ -37,6 +37,7 @@ class BatchTopKTrainingSAEConfig(TopKTrainingSAEConfig):
     Configuration class for training a BatchTopKTrainingSAE.
     """
 
+    k: float = 100  # type: ignore[assignment]
     topk_threshold_lr: float = 0.01
 
     @override


### PR DESCRIPTION
# Description

Since BatchTopK ensures that a mean k across a batch rather than ensuring that every sample in the batch has a set k, it can operate with a floating point number for k without issue. E.g., it's fine to set `k = 1.5` for BatchTopK, and for a batch of 10 items, there will be 15 non-zero activations across the batch. However, our current implementation types the k param as an `int` instead of a `float.

This PR updates the types for BatchTopK to accept floats, and adds tests to ensure this works as expected.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update