### PR TITLE
fix: properly convert old SAELens TopK SAEs on load

### DIFF
--- a/sae_lens/loading/pretrained_sae_loaders.py
+++ b/sae_lens/loading/pretrained_sae_loaders.py
@@ -233,6 +233,12 @@ def handle_pre_6_0_config(cfg_dict: dict[str, Any]) -> dict[str, Any]:
         "reshape_activations",
         "hook_z" if "hook_z" in new_cfg.get("hook_name", "") else "none",
     )
+    if (
+        new_cfg.get("activation_fn") == "topk"
+        and new_cfg.get("activation_fn_kwargs", {}).get("k") is not None
+    ):
+        new_cfg["architecture"] = "topk"
+        new_cfg["k"] = new_cfg["activation_fn_kwargs"]["k"]
 
     if "normalize_activations" in new_cfg and isinstance(
         new_cfg["normalize_activations"], bool

--- a/tests/loading/test_pretrained_sae_loaders.py
+++ b/tests/loading/test_pretrained_sae_loaders.py
@@ -84,6 +84,37 @@ def test_load_sae_config_from_huggingface_connor_rob_hook_z():
     assert cfg_dict == expected_cfg_dict
 
 
+def test_load_old_topk_saes_from_huggingface():
+    cfg_dict = load_sae_config_from_huggingface(
+        "gpt2-small-resid-post-v5-32k",
+        sae_id="blocks.11.hook_resid_post",
+    )
+
+    expected_cfg_dict = {
+        "d_in": 768,
+        "d_sae": 32768,
+        "dtype": "torch.float32",
+        "device": "cpu",
+        "apply_b_dec_to_input": True,
+        "normalize_activations": "layer_norm",
+        "reshape_activations": "none",
+        "metadata": {
+            "model_name": "gpt2-small",
+            "hook_name": "blocks.11.hook_resid_post",
+            "hook_head_index": None,
+            "sae_lens_training_version": None,
+            "prepend_bos": False,
+            "dataset_path": "Skylion007/openwebtext",
+            "context_size": 64,
+            "neuronpedia_id": "gpt2-small/11-res_post_32k-oai",
+        },
+        "architecture": "topk",
+        "k": 32,
+    }
+
+    assert cfg_dict == expected_cfg_dict
+
+
 def test_load_sae_config_from_huggingface_gemma_2():
     cfg_dict = load_sae_config_from_huggingface(
         "gemma-scope-2b-pt-res",


### PR DESCRIPTION
# Description

This PR fixes a bug where old SAELens TopK SAEs are being loaded as relu SAEs in `SAE.from_pretrained()`

Fixes #553

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)