### PR TITLE
feat: include step num in train step input

### DIFF
--- a/benchmark/bench_fwd_perf.py
+++ b/benchmark/bench_fwd_perf.py
@@ -62,6 +62,7 @@ step_input = TrainStepInput(
     sae_in=input_acts,
     dead_neuron_mask=dead_neuron_mask,
     coefficients={},
+    n_training_steps=0,
 )
 
 

--- a/docs/custom_saes.md
+++ b/docs/custom_saes.md
@@ -182,6 +182,7 @@ class TrainStepInput:
     sae_in: torch.Tensor
     coefficients: dict[str, float]
     dead_neuron_mask: torch.Tensor | None
+    n_training_steps: int
 ```
 
 This method should return a `TrainStepOutput` object, which contains the output of the training step. It's signature is below:

--- a/sae_lens/saes/sae.py
+++ b/sae_lens/saes/sae.py
@@ -217,6 +217,7 @@ class TrainStepInput:
     sae_in: torch.Tensor
     coefficients: dict[str, float]
     dead_neuron_mask: torch.Tensor | None
+    n_training_steps: int
 
 
 class TrainCoefficientConfig(NamedTuple):

--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -249,6 +249,7 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
                     sae_in=sae_in,
                     dead_neuron_mask=self.dead_neurons,
                     coefficients=self.get_coefficients(),
+                    n_training_steps=self.n_training_steps,
                 ),
             )
 

--- a/tests/refactor_compatibility/test_gated_sae_equivalence.py
+++ b/tests/refactor_compatibility/test_gated_sae_equivalence.py
@@ -356,6 +356,7 @@ def test_gated_training_equivalence():  # type: ignore
             sae_in=x,
             coefficients={"l1": new_sae.cfg.l1_coefficient},
             dead_neuron_mask=None,
+            n_training_steps=0,
         )
     )
 

--- a/tests/refactor_compatibility/test_jumprelu_sae_equivalence.py
+++ b/tests/refactor_compatibility/test_jumprelu_sae_equivalence.py
@@ -372,6 +372,7 @@ def test_jumprelu_training_equivalence():  # type: ignore # Kept ignore as retur
             sae_in=x,
             coefficients={"l0": new_sae.cfg.l0_coefficient},
             dead_neuron_mask=None,
+            n_training_steps=0,
         )
     )
 

--- a/tests/refactor_compatibility/test_standard_sae_equivalence.py
+++ b/tests/refactor_compatibility/test_standard_sae_equivalence.py
@@ -469,6 +469,7 @@ def test_standard_sae_training_hook_z_equivalence(hook_name: str):
             sae_in=new_input_data,
             coefficients={"l1": old_training_cfg.l1_coefficient},
             dead_neuron_mask=None,
+            n_training_steps=0,
         )
     )
 
@@ -784,6 +785,7 @@ def test_standard_sae_training_equivalence():
             sae_in=x,
             coefficients={"l1": l1_coefficient},
             dead_neuron_mask=None,
+            n_training_steps=0,
         )
     )
 
@@ -886,6 +888,7 @@ def test_sae_hook_z_training_equivalence():
             sae_in=x_reshaped,
             coefficients={"l1": l1_coefficient},
             dead_neuron_mask=None,
+            n_training_steps=0,
         )
     )
 

--- a/tests/refactor_compatibility/test_topk_sae_equivalence.py
+++ b/tests/refactor_compatibility/test_topk_sae_equivalence.py
@@ -297,6 +297,7 @@ def test_topk_sae_training_equivalence():
             sae_in=x,
             coefficients={},  # topk SAEs don't care about L1 coefficient
             dead_neuron_mask=None,
+            n_training_steps=0,
         )
     )
 

--- a/tests/saes/test_batchtopk_sae.py
+++ b/tests/saes/test_batchtopk_sae.py
@@ -166,6 +166,7 @@ def test_BatchTopKTrainingSAE_save_and_load_inference_sae(
         sae_in=sae_in,
         coefficients={},
         dead_neuron_mask=None,
+        n_training_steps=0,
     )
 
     # run some test data through to learn the correct threshold
@@ -246,6 +247,7 @@ def test_BatchTopKTrainingSAE_training_step_updates_threshold() -> None:
         sae_in=sae_in,
         coefficients={},
         dead_neuron_mask=None,
+        n_training_steps=0,
     )
 
     # Do training step

--- a/tests/saes/test_gated_sae.py
+++ b/tests/saes/test_gated_sae.py
@@ -98,6 +98,7 @@ def test_GatedTrainingSAE_loss():
             sae_in=x,
             coefficients={"l1": sae.cfg.l1_coefficient},
             dead_neuron_mask=None,
+            n_training_steps=0,
         ),
     )
 
@@ -167,6 +168,7 @@ def test_GatedTrainingSAE_forward_pass():
             sae_in=x,
             coefficients={"l1": sae.cfg.l1_coefficient},
             dead_neuron_mask=None,
+            n_training_steps=0,
         ),
     )
 

--- a/tests/saes/test_jumprelu_sae.py
+++ b/tests/saes/test_jumprelu_sae.py
@@ -56,6 +56,7 @@ def test_JumpReLUTrainingSAE_training_forward_pass():
             sae_in=x,
             coefficients={"l0": sae.cfg.l0_coefficient},
             dead_neuron_mask=None,
+            n_training_steps=0,
         ),
     )
 
@@ -303,6 +304,7 @@ def test_JumpReLUTrainingSAE_forward_tanh_sparsity_with_pre_act_loss():
             sae_in=x,
             coefficients={"l0": sae.cfg.l0_coefficient},
             dead_neuron_mask=dead_neuron_mask,
+            n_training_steps=0,
         ),
     )
 
@@ -363,6 +365,7 @@ def test_JumpReLUTrainingSAE_tanh_scale_increases_l0_loss():
             sae_in=x,
             coefficients={"l0": 1.0},
             dead_neuron_mask=None,
+            n_training_steps=0,
         ),
     )
 
@@ -372,6 +375,7 @@ def test_JumpReLUTrainingSAE_tanh_scale_increases_l0_loss():
             sae_in=x,
             coefficients={"l0": 1.0},
             dead_neuron_mask=None,
+            n_training_steps=0,
         ),
     )
 
@@ -406,5 +410,6 @@ def test_JumpReLUTrainingSAE_errors_on_invalid_sparsity_loss_mode():
                 sae_in=x,
                 coefficients={"l0": 1.0},
                 dead_neuron_mask=None,
+                n_training_steps=0,
             ),
         )

--- a/tests/saes/test_matryoshka_batchtopk_sae.py
+++ b/tests/saes/test_matryoshka_batchtopk_sae.py
@@ -111,6 +111,7 @@ def test_MatryoshkaBatchTopKTrainingSAE_training_forward_pass_computes_inner_los
         sae_in=sae_in,
         coefficients={},
         dead_neuron_mask=None,
+        n_training_steps=0,
     )
 
     output = sae.training_forward_pass(train_step_input)
@@ -139,6 +140,7 @@ def test_MatryoshkaBatchTopKTrainingSAE_training_forward_pass_adds_inner_losses_
         sae_in=sae_in,
         coefficients={},
         dead_neuron_mask=None,
+        n_training_steps=0,
     )
 
     output = sae.training_forward_pass(train_step_input)
@@ -170,6 +172,7 @@ def test_MatryoshkaBatchTopKTrainingSAE_with_single_matryoshka_level_matches_bat
         sae_in=sae_in,
         coefficients={},
         dead_neuron_mask=None,
+        n_training_steps=0,
     )
 
     output = sae.training_forward_pass(train_step_input)
@@ -205,6 +208,7 @@ def test_MatryoshkaBatchTopKTrainingSAE_inner_levels_matches_batchtopk_with_smal
         sae_in=sae_in,
         coefficients={},
         dead_neuron_mask=None,
+        n_training_steps=0,
     )
 
     output = sae.training_forward_pass(train_step_input)
@@ -243,6 +247,7 @@ def test_MatryoshkaBatchTopKTrainingSAE_with_two_matryoshka_levels():
         sae_in=sae_in,
         coefficients={},
         dead_neuron_mask=None,
+        n_training_steps=0,
     )
 
     output = sae.training_forward_pass(train_step_input)
@@ -294,6 +299,7 @@ def test_MatryoshkaBatchTopKTrainingSAE_save_and_load_inference_sae(
         sae_in=sae_in,
         coefficients={},
         dead_neuron_mask=None,
+        n_training_steps=0,
     )
 
     # run some test data through to learn the correct threshold

--- a/tests/saes/test_topk_sae.py
+++ b/tests/saes/test_topk_sae.py
@@ -53,6 +53,7 @@ def test_TopKTrainingSAE_topk_aux_loss_matches_unnormalized_sparsify_implementat
             sae_in=input_acts,
             dead_neuron_mask=dead_neuron_mask,
             coefficients={},
+            n_training_steps=0,
         ),
     )
     comparison_sae_out = sparse_coder_sae.forward(


### PR DESCRIPTION
# Description

This PR include the step num (`n_training_steps`) in the input passed to `SAE.training_forward_pass()`. This should make it easier for custom SAE architectures to tweak how training works based on the current step num without needing the SAE to track this manually.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
