### PR TITLE
fix: fix batchtopk handling of 3d+ inputs

### DIFF
--- a/sae_lens/saes/batchtopk_sae.py
+++ b/sae_lens/saes/batchtopk_sae.py
@@ -23,7 +23,9 @@ class BatchTopK(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         acts = x.relu()
         flat_acts = acts.flatten()
-        acts_topk_flat = torch.topk(flat_acts, int(self.k * acts.shape[0]), dim=-1)
+        # Calculate total number of samples across all non-feature dimensions
+        num_samples = acts.shape[:-1].numel()
+        acts_topk_flat = torch.topk(flat_acts, int(self.k * num_samples), dim=-1)
         return (
             torch.zeros_like(flat_acts)
             .scatter(-1, acts_topk_flat.indices, acts_topk_flat.values)


### PR DESCRIPTION
# Description

This PR fixes a bug where BatchTopK SAEs are incorrectly reporting L0 during evaluation in training. The issue is that the `BatchTopK` module assumes only the first dim is the batch dim, and thus does not handle 3d inputs correct (batch x seq x res). This PR fixes this issue by treating all dimensions aside from the final dimension as the "batch" for the `BatchTopK` module.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update