### PR TITLE
fix: sync matryoshka implementation with dictionary_learning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ ruff = "^0.7.4"
 eai-sparsify = "^1.1.1"
 mike = "^2.0.0"
 trio = "^0.30.0"
+dictionary-learning = "^0.1.0"
 
 [tool.poetry.extras]
 mamba = ["mamba-lens"]


### PR DESCRIPTION
# Description

This PR synchronizes how SAELens handles the `BatchTopK` operation in Matryoshka SAEs with how the dictionary_learning library does it. Specifically, instead of calculating a separate topk per level, we instead only calculate a single global topk and reuse it across all levels. This PR also updates tests to compare against dictionary_learning directly.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update