### PR TITLE
feat: add LLMRunnerConfig.from_dict() method

### DIFF
--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -7,6 +7,7 @@ from sae_lens.config import (
     LanguageModelSAERunnerConfig,
     _default_cached_activations_path,
 )
+from sae_lens.saes.jumprelu_sae import JumpReLUTrainingSAEConfig
 from sae_lens.saes.standard_sae import StandardTrainingSAEConfig
 
 test_cases_for_seqpos = [
@@ -69,3 +70,46 @@ def test_default_cached_activations_path():
         )
         == "activations/ds_path/model_name/hook_name"
     )
+
+
+def test_LanguageModelSAERunnerConfig_to_dict_and_from_dict():
+    cfg = LanguageModelSAERunnerConfig(
+        sae=JumpReLUTrainingSAEConfig(
+            d_in=5,
+            d_sae=10,
+            jumprelu_init_threshold=0.1,
+            jumprelu_bandwidth=0.1,
+            jumprelu_sparsity_loss_mode="tanh",
+        ),
+        seqpos_slice=(0, 10),
+        context_size=10,
+    )
+    cfg_dict = cfg.to_dict()
+    assert cfg_dict == cfg.to_dict()
+    assert cfg == LanguageModelSAERunnerConfig.from_dict(cfg_dict)
+
+
+def test_LanguageModelSAERunnerConfig_errors_when_loading_from_dict_with_missing_fields():
+    cfg = LanguageModelSAERunnerConfig(
+        sae=StandardTrainingSAEConfig(d_in=5, d_sae=10),
+        seqpos_slice=(0, 10),
+        context_size=10,
+    )
+    with pytest.raises(
+        ValueError, match="sae field is required in the config dictionary"
+    ):
+        test_dict = cfg.to_dict()
+        del test_dict["sae"]
+        LanguageModelSAERunnerConfig.from_dict(test_dict)
+    with pytest.raises(
+        ValueError, match="architecture field is required in the sae dictionary"
+    ):
+        test_dict = cfg.to_dict()
+        del test_dict["sae"]["architecture"]
+        LanguageModelSAERunnerConfig.from_dict(test_dict)
+    with pytest.raises(
+        ValueError, match="logger field is required in the config dictionary"
+    ):
+        test_dict = cfg.to_dict()
+        del test_dict["logger"]
+        LanguageModelSAERunnerConfig.from_dict(test_dict)


### PR DESCRIPTION
# Description

This PR adds a `LanguageModelSAERunnerConfig.from_dict()` classmethod, to load a config previously serialized by `LanguageModelSAERunnerConfig.to_dict()`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)