### PR TITLE
fix: top 10 activations tutorial

### DIFF
--- a/tutorials/tutorial_2_0.ipynb
+++ b/tutorials/tutorial_2_0.ipynb
@@ -933,7 +933,7 @@
     "html = get_dashboard_html(\n",
     "    sae_release=\"gpt2-small\",\n",
     "    sae_id=f\"{extract_layer_from_tlens_hook_name(sae.cfg.metadata.hook_name)}-res-jb\",\n",
-    "    feature_idx=feature_list[0],\n",
+    "    feature_idx=feature_list[feature_idx],\n",
     ")\n",
     "IFrame(html, width=1200, height=600)"
    ]


### PR DESCRIPTION
# Description

- top_10_activations will currently show 10 activating examples even if there is less than 10 in reality, added a non-zero filtering
- fix  hardcoded index 0 to feature_idx var

## Type of change

Please delete options that are not relevant.

- [x] Tutorial fix (non-breaking change)

# Checklist:

N/A

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
