### PR TITLE
chore: skip temporal sae from HF test on CI to save disk space

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
 
     env:
       # Increment this number to bust all caches (HuggingFace, Poetry, venv)
-      CACHE_VERSION: 7
+      CACHE_VERSION: 8
 
     steps:
       - uses: actions/checkout@v4

--- a/tests/saes/test_temporal_sae.py
+++ b/tests/saes/test_temporal_sae.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import torch
 
@@ -113,6 +115,10 @@ def test_TemporalSAE_n_attn_layers(n_attn_layers: int):
     assert reconstruction.shape == x.shape
 
 
+@pytest.mark.skipif(
+    os.getenv("GITHUB_ACTIONS") == "true",
+    reason="Uses too much disk space on CI",
+)
 def test_TemporalSAE_load_from_pretrained_and_forward():
     """Test loading a TemporalSAE from HuggingFace and performing a forward pass."""
     # Load the TemporalSAE from HuggingFace


### PR DESCRIPTION
# Description

CI is running out of disk space and crashing because the temporal SAEs test is downloading a real SAE from huggingface. This PR skips that test on CI so CI can run successfully.