### PR TITLE
chore: improve docs caching in CI

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -46,12 +46,12 @@ jobs:
           path: ~/.cache/huggingface
           restore-keys: |
             huggingface-${{ runner.os }}-3.11-
-      - name: Cache SAE config cache
-        uses: actions/cache@v4
+      - name: Restore SAE config cache
+        id: cache-sae-config-restore
+        uses: actions/cache/restore@v4
         with:
           key: sae-config-cache-${{ hashFiles('sae_lens/pretrained_saes.yaml') }}
           path: ~/.cache/sae_config_cache
-          save-always: true
           restore-keys: |
             sae-config-cache-
       - name: Load cached Poetry installation
@@ -140,3 +140,9 @@ jobs:
           if ! poetry run mike list | grep -q "latest"; then
             poetry run mike set-default --push dev
           fi
+      - name: Save SAE config cache
+        if: always() && steps.cache-sae-config-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          key: ${{ steps.cache-sae-config-restore.outputs.cache-primary-key }}
+          path: ~/.cache/sae_config_cache


### PR DESCRIPTION
This PR always caches loaded SAEs during docs build so if the build crashes we don't lose everything.