### PR TITLE
fix: gemma 3 270m workaround is no longer needed

### DIFF
--- a/sae_lens/loading/pretrained_sae_loaders.py
+++ b/sae_lens/loading/pretrained_sae_loaders.py
@@ -682,15 +682,6 @@ def gemma_3_sae_huggingface_loader(
         cfg_overrides,
     )
 
-    # replace folder name of 65k with 64k
-    # TODO: remove this workaround once weights are fixed
-    if "270m-pt" in repo_id:
-        if "65k" in folder_name:
-            folder_name = folder_name.replace("65k", "64k")
-        # replace folder name of 262k with 250k
-        if "262k" in folder_name:
-            folder_name = folder_name.replace("262k", "250k")
-
     params_file = "params.safetensors"
     if "clt" in folder_name:
         params_file = folder_name.split("/")[-1] + ".safetensors"


### PR DESCRIPTION
# Description

I originally created a workaround for some GS2 repos for the 270m model where the config files were in the wrong folder. But now that we have an automatic fallback, we don't need this workaround and in fact it causes more issues. This PR removes the workaround.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

make check-ci gives this error but I think it is unrelated or maybe I have my local env set up incorrectly
```
make check-type
poetry run pyright .
WARNING: there is a new pyright version available (v1.1.365 -> v1.1.407).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`

/Users/johnnylin/Documents/Projects/saelens/benchmark/bench_fwd_perf.py
  /Users/johnnylin/Documents/Projects/saelens/benchmark/bench_fwd_perf.py:7:8 - error: Import "triton" could not be resolved (reportMissingImports)
/Users/johnnylin/Documents/Projects/saelens/tests/saes/test_matryoshka_batchtopk_sae.py
  /Users/johnnylin/Documents/Projects/saelens/tests/saes/test_matryoshka_batchtopk_sae.py:6:6 - error: Import "dictionary_learning.trainers.matryoshka_batch_top_k" could not be resolved (reportMissingImports)
2 errors, 0 warnings, 0 informations 
make[1]: *** [check-type] Error 1
make: *** [check-ci] Error 2
```