### PR TITLE
fix: handle empty or nearly empty sequences when disable_concat_sequences=True

### DIFF
--- a/sae_lens/tokenization_and_batching.py
+++ b/sae_lens/tokenization_and_batching.py
@@ -85,8 +85,8 @@ def concat_and_batch_sequences(
         for sequence in tokens_iterator:
             if (
                 begin_sequence_token_id is not None
-                and sequence[0] != begin_sequence_token_id
                 and len(sequence) >= context_size - 1
+                and sequence[0] != begin_sequence_token_id
             ):
                 begin_sequence_token_id_tensor = torch.tensor(
                     [begin_sequence_token_id],

--- a/tests/training/test_tokenization_and_batching.py
+++ b/tests/training/test_tokenization_and_batching.py
@@ -463,3 +463,46 @@ def test_concat_and_batch_sequences_disable_concat_sequences():
         [10, 11, 12, 13, 14],
     ]
     assert batches.tolist() == expected
+
+
+def test_concat_and_batch_sequences_handles_empty_sequences_with_disable_concat():
+    seqs = [
+        torch.tensor([]),  # empty sequence
+        torch.arange(10),  # long enough sequence
+        torch.tensor([]),  # another empty sequence
+        torch.arange(5, 15),  # another long enough sequence
+    ]
+    batches_list = list(
+        concat_and_batch_sequences(
+            tokens_iterator=iter(seqs),
+            context_size=5,
+            begin_batch_token_id=999,
+            disable_concat_sequences=True,
+        )
+    )
+    batches = torch.stack(batches_list)
+    expected = [
+        [999, 0, 1, 2, 3],
+        [999, 5, 6, 7, 8],
+    ]
+    assert batches.tolist() == expected
+
+
+def test_concat_and_batch_sequences_handles_empty_sequences_with_begin_sequence_token():
+    seqs = [
+        torch.tensor([]),  # empty sequence
+        torch.arange(10),  # long enough sequence
+    ]
+    batches_list = list(
+        concat_and_batch_sequences(
+            tokens_iterator=iter(seqs),
+            context_size=5,
+            begin_sequence_token_id=999,
+            disable_concat_sequences=True,
+        )
+    )
+    batches = torch.stack(batches_list)
+    expected = [
+        [999, 0, 1, 2, 3],
+    ]
+    assert batches.tolist() == expected


### PR DESCRIPTION
This PR fixes a bug where if a dataset has an empty (or nearly empty sequence) and `disable_concat_sequences=True`, the tokenization and batching code will crash. This PR changes the tokenization / batching logic to instead just skip these sequences.