### PR TITLE
chore: show hf-hook in docs

### DIFF
--- a/docs/assets/saetable.css
+++ b/docs/assets/saetable.css
@@ -62,3 +62,49 @@
 .saetable-copyButton:hover {
     background-color: #45a049;
 }
+
+/* Hook label styles */
+.saetable-hookLabel {
+    display: inline-block;
+    font-size: 0.75em;
+    color: #888;
+    margin-left: 4px;
+    cursor: help;
+    position: relative;
+}
+
+.saetable-hookLabel:hover::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #333;
+    color: white;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 0.9em;
+    white-space: nowrap;
+    z-index: 1000;
+    margin-bottom: 4px;
+}
+
+.saetable-hookLabel:hover::before {
+    content: "";
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 5px solid transparent;
+    border-top-color: #333;
+    z-index: 1000;
+}
+
+.saetable-hookRow {
+    display: block;
+    margin-bottom: 2px;
+}
+
+.saetable-hookRow:last-child {
+    margin-bottom: 0;
+}

--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -40631,7 +40631,7 @@ gemma-3-1b-res-matryoshka-dc:
   conversion_func: null
   links:
     model: https://huggingface.co/google/gemma-3-1b-pt
-  model: gemma-3-1b
+  model: google/gemma-3-1b-pt
   repo_id: chanind/gemma-3-1b-batch-topk-matryoshka-saes-w-32k-l0-40
   saes:
   - id: blocks.0.hook_resid_post


### PR DESCRIPTION
This PR shows the huggingface / nnsight hooks in docs if present, with a mouseover explaining what they are.

<img width="1462" height="594" alt="Screenshot 2026-01-08 at 20 40 42" src="https://github.com/user-attachments/assets/e4ca8ac4-7036-4997-b159-8a0810870557" />
