### PR TITLE
Update Documentation to reference save_inference_move methode

### DIFF
--- a/docs/training_saes.md
+++ b/docs/training_saes.md
@@ -104,6 +104,9 @@ cfg = LanguageModelSAERunnerConfig(
     dtype="float32"
 )
 sparse_autoencoder = LanguageModelSAETrainingRunner(cfg).run()
+
+# Save for inference
+sparse_autoencoder.save_inference_model("path/to/save/dir")
 ```
 
 As you can see, the training setup provides a large number of options to explore. The full list of options can be found by inspecting the `LanguageModelSAERunnerConfig` class and the specific SAE configuration class you intend to use (e.g., `StandardTrainingSAEConfig`, `TopKTrainingSAEConfig`, etc.).


### PR DESCRIPTION
# Description

Updates the documentation to include the `save_inference_model` method.
Motivation: saves new users time and trouble when training and then loading a locally trained SAE.

Fixes # (issue)

## Type of change

Documentation fix


# Checklist:

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)