### PR TITLE
fix: raise error when context_size > training_tokens

### DIFF
--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -557,6 +557,12 @@ class CacheActivationsRunnerConfig:
                 context_size=self.context_size,
             )
 
+        if self.context_size > self.training_tokens:
+            raise ValueError(
+                f"context_size ({self.context_size}) is greater than training_tokens "
+                f"({self.training_tokens}). Please reduce context_size or increase training_tokens."
+            )
+
         if self.new_cached_activations_path is None:
             self.new_cached_activations_path = _default_cached_activations_path(  # type: ignore
                 self.dataset_path, self.model_name, self.hook_name, None

--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -60,6 +60,22 @@ def test_cache_activations_runner_config_seqpos(
         )
 
 
+def test_cache_activations_runner_config_context_size_greater_than_training_tokens():
+    with pytest.raises(
+        ValueError,
+        match=r"context_size \(1024\) is greater than training_tokens \(100\)",
+    ):
+        CacheActivationsRunnerConfig(
+            dataset_path="",
+            model_name="",
+            model_batch_size=1,
+            hook_name="",
+            d_in=1,
+            training_tokens=100,
+            context_size=1024,
+        )
+
+
 def test_default_cached_activations_path():
     assert (
         _default_cached_activations_path(


### PR DESCRIPTION
Fixes #581

# Description

Adds validation in CacheActivationsRunnerConfig to raise a clear error when context_size is greater than training_tokens. Previously this caused confusing downstream errors.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and tests

- [ ] I have run make check-ci to check format and linting.