### PR TITLE
fix: add leave=False to nested tqdm progress bars for Jupyter

### DIFF
--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -335,7 +335,7 @@ def get_downstream_reconstruction_metrics(
 
     batch_iter = range(n_batches)
     if verbose:
-        batch_iter = tqdm(batch_iter, desc="Reconstruction Batches")
+        batch_iter = tqdm(batch_iter, desc="Reconstruction Batches", leave=False)
 
     for _ in batch_iter:
         batch_tokens = activation_store.get_batch_tokens(eval_batch_size_prompts)
@@ -430,7 +430,7 @@ def get_sparsity_and_variance_metrics(
 
     batch_iter = range(n_batches)
     if verbose:
-        batch_iter = tqdm(batch_iter, desc="Sparsity and Variance Batches")
+        batch_iter = tqdm(batch_iter, desc="Sparsity and Variance Batches", leave=False)
 
     for _ in batch_iter:
         batch_tokens = activation_store.get_batch_tokens(eval_batch_size_prompts)

--- a/sae_lens/training/activation_scaler.py
+++ b/sae_lens/training/activation_scaler.py
@@ -28,7 +28,9 @@ class ActivationScaler:
     ) -> float:
         norms_per_batch: list[float] = []
         for _ in tqdm(
-            range(n_batches_for_norm_estimate), desc="Estimating norm scaling factor"
+            range(n_batches_for_norm_estimate),
+            desc="Estimating norm scaling factor",
+            leave=False,
         ):
             acts = next(data_provider)
             norms_per_batch.append(acts.norm(dim=-1).mean().item())


### PR DESCRIPTION
Fixes #495

# Description

Adds leave=False to nested tqdm progress bars that run inside other training loops. Without this parameter, tqdm renders a newline on every update in Jupyter notebooks, causing the output spam shown in the issue.

Files changed:
- activation_scaler.py: norm estimation progress bar (runs during training init)
- evals.py: reconstruction and sparsity batch progress bars (run during eval)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My changes generate no new warnings
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and tests

- [ ] I have run make check-ci to check format and linting.