### PR TITLE
Add option to disable weights upload to wandb

### DIFF
--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -82,6 +82,7 @@ class LoggingConfig:
     log_to_wandb: bool = True
     log_activations_store_to_wandb: bool = False
     log_optimizer_state_to_wandb: bool = False
+    log_weights_to_wandb: bool = True
     wandb_project: str = "sae_lens_training"
     wandb_id: str | None = None
     run_name: str | None = None
@@ -107,7 +108,8 @@ class LoggingConfig:
             type="model",
             metadata=dict(trainer.cfg.__dict__),
         )
-        model_artifact.add_file(str(weights_path))
+        if self.log_weights_to_wandb:
+            model_artifact.add_file(str(weights_path))
         model_artifact.add_file(str(cfg_path))
         wandb.log_artifact(model_artifact, aliases=wandb_aliases)
 


### PR DESCRIPTION
Adds configuration to disable SAE weight uploads to wandb while preserving config and sparsity artifact uploads. Useful for large models where bandwidth/storage costs are a concern.

## Changes

- **`sae_lens/config.py`**: Added `log_weights_to_wandb: bool = True` field to `LoggingConfig` and conditional upload logic in `log()` method
- **`tests/training/test_logging_config.py`**: Test coverage for default behavior, flag settings, and selective upload behavior

## Usage

```python
from sae_lens.config import LoggingConfig

config = LoggingConfig(
    log_to_wandb=True,
    log_weights_to_wandb=False,  # Skip weights, upload config + sparsity
    wandb_project="my_project"
)
```

Default value is `True` for backward compatibility.