### PR TITLE
Update link for pre-trained SAEs in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This library is maintained by [Joseph Bloom](https://www.decoderesearch.com/), [
 
 ## Loading Pre-trained SAEs.
 
-Pre-trained SAEs for various models can be imported via SAE Lens. See this [page](https://decoderesearch.github.io/SAELens/pretrained_saes/) for a list of all SAEs.
+Pre-trained SAEs for various models can be imported via SAE Lens. See this [page](https://decoderesearch.github.io/SAELens/latest/pretrained_saes/) for a list of all SAEs.
 
 ## Migrating to SAELens v6
 


### PR DESCRIPTION
# Description
Seems that the link currently leads to an image? Added correct link.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
