### PR TITLE
feat: support sharded HF models via device_map

### DIFF
--- a/sae_lens/load_model.py
+++ b/sae_lens/load_model.py
@@ -55,8 +55,9 @@ def load_model(
         )
         # When the user passes an explicit `device_map`, accelerate has already
         # placed the weights — calling .to(device) afterwards would either
-        # error or undo the sharding.
-        if "device_map" not in model_from_pretrained_kwargs:
+        # error or undo the sharding. `device_map=None` means the user opted
+        # out, so treat it the same as not passing the kwarg at all.
+        if model_from_pretrained_kwargs.get("device_map") is None:
             hf_model = hf_model.to(device)  # type: ignore
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         return HookedProxyLM(hf_model, tokenizer)

--- a/sae_lens/load_model.py
+++ b/sae_lens/load_model.py
@@ -52,7 +52,12 @@ def load_model(
     if model_class_name == "AutoModelForCausalLM":
         hf_model = AutoModelForCausalLM.from_pretrained(
             model_name, **model_from_pretrained_kwargs
-        ).to(device)  # type: ignore
+        )
+        # When the user passes an explicit `device_map`, accelerate has already
+        # placed the weights — calling .to(device) afterwards would either
+        # error or undo the sharding.
+        if "device_map" not in model_from_pretrained_kwargs:
+            hf_model = hf_model.to(device)  # type: ignore
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         return HookedProxyLM(hf_model, tokenizer)
 

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -539,7 +539,7 @@ class ActivationsStore:
                     )
                 sequences.append(next(self.iterable_sequences))
 
-        return torch.stack(sequences, dim=0).to(_get_model_device(self.model))
+        return torch.stack(sequences, dim=0).to(_get_input_token_device(self.model))
 
     @torch.no_grad()
     def get_activations(self, batch_tokens: torch.Tensor):
@@ -674,7 +674,7 @@ class ActivationsStore:
 
         # move batch toks to gpu for model
         batch_tokens = self.get_batch_tokens(raise_at_epoch_end=raise_on_epoch_end).to(
-            _get_model_device(self.model)
+            _get_input_token_device(self.model)
         )
         activations = self.get_activations(batch_tokens).to(self.device)
 
@@ -823,9 +823,23 @@ def validate_pretokenized_dataset_tokenizer(
         )
 
 
-def _get_model_device(model: HookedRootModule) -> torch.device:
+def _get_input_token_device(model: HookedRootModule) -> torch.device:
+    """Return the device where input tokens should be placed.
+
+    For sharded models (HookedTransformer with ``n_devices`` or HF with
+    ``device_map``) this is the device hosting the input embedding layer,
+    which is not necessarily the "first" device in the shard.
+    """
     if hasattr(model, "W_E"):
         return model.W_E.device  # type: ignore
+    # HF models (wrapped in HookedProxyLM) expose input embeddings via
+    # get_input_embeddings(); use that to find the embedding device under
+    # `device_map`.
+    underlying = getattr(model, "model", model)
+    if hasattr(underlying, "get_input_embeddings"):
+        embed = underlying.get_input_embeddings()  # type: ignore
+        if embed is not None and hasattr(embed, "weight"):
+            return embed.weight.device  # type: ignore
     if hasattr(model, "cfg") and hasattr(model.cfg, "device"):
         return model.cfg.device  # type: ignore
     return next(model.parameters()).device  # type: ignore

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -672,10 +672,8 @@ class ActivationsStore:
         if self.cached_activation_dataset is not None:
             return self._load_raw_llm_batch_from_cached(raise_on_epoch_end)
 
-        # move batch toks to gpu for model
-        batch_tokens = self.get_batch_tokens(raise_at_epoch_end=raise_on_epoch_end).to(
-            _get_input_token_device(self.model)
-        )
+        # get_batch_tokens already returns tokens on the model's input device.
+        batch_tokens = self.get_batch_tokens(raise_at_epoch_end=raise_on_epoch_end)
         activations = self.get_activations(batch_tokens).to(self.device)
 
         # handle seqpos_slice, this is done for activations in get_activations

--- a/tests/training/test_activations_store.py
+++ b/tests/training/test_activations_store.py
@@ -19,6 +19,7 @@ from sae_lens.saes.standard_sae import StandardSAEConfig, StandardTrainingSAECon
 from sae_lens.training.activations_store import (
     ActivationsStore,
     _filter_buffer_acts,
+    _get_input_token_device,
     validate_pretokenized_dataset_tokenizer,
 )
 from tests.helpers import (
@@ -338,6 +339,49 @@ def test_activations_store_moves_with_model(ts_model: HookedTransformer):
     assert activations[0].device == torch.device("cpu")
     assert activations[1] is not None
     assert activations[1].device == torch.device("cpu")
+
+
+def test_get_input_token_device_uses_W_E_for_hooked_transformer(
+    ts_model: HookedTransformer,
+):
+    assert _get_input_token_device(ts_model) == ts_model.W_E.device
+
+
+def test_get_input_token_device_uses_input_embeddings_for_hf_proxy():
+    proxy = load_model(
+        model_class_name="AutoModelForCausalLM",
+        model_name="gpt2",
+        device="cpu",
+    )
+    expected = proxy.model.get_input_embeddings().weight.device  # type: ignore
+    assert _get_input_token_device(proxy) == expected
+
+
+def test_get_input_token_device_returns_input_embedding_device_when_sharded():
+    """When the input embedding lives on a different device than other params,
+    _get_input_token_device must follow the embedding (where tokens need to go),
+    not the first parameter encountered."""
+
+    class FakeShardedHF(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            # `lm_head` registers first, so next(parameters()).device would
+            # return its device. The input embedding lives elsewhere (meta).
+            self.lm_head = torch.nn.Linear(4, 4)
+            self._embed = torch.nn.Embedding(8, 4).to_empty(device="meta")
+
+        def get_input_embeddings(self) -> torch.nn.Module:
+            return self._embed
+
+    class FakeProxy(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = FakeShardedHF()
+
+    proxy = FakeProxy()
+    assert _get_input_token_device(proxy) == torch.device("meta")  # type: ignore[arg-type]
+    # Sanity: the first parameter is on cpu, so a naive impl would disagree.
+    assert next(proxy.parameters()).device == torch.device("cpu")
 
 
 def test_activations_store___iterate_tokenized_sequences__yields_concat_and_batched_sequences(

--- a/tests/training/test_activations_store.py
+++ b/tests/training/test_activations_store.py
@@ -351,10 +351,9 @@ def test_get_input_token_device_uses_input_embeddings_for_hf_proxy():
     proxy = load_model(
         model_class_name="AutoModelForCausalLM",
         model_name="gpt2",
-        device="cpu",
+        device="meta",
     )
-    expected = proxy.model.get_input_embeddings().weight.device  # type: ignore
-    assert _get_input_token_device(proxy) == expected
+    assert _get_input_token_device(proxy) == torch.device("meta")
 
 
 def test_get_input_token_device_returns_input_embedding_device_when_sharded():

--- a/tests/training/test_activations_store.py
+++ b/tests/training/test_activations_store.py
@@ -358,10 +358,6 @@ def test_get_input_token_device_uses_input_embeddings_for_hf_proxy():
 
 
 def test_get_input_token_device_returns_input_embedding_device_when_sharded():
-    """When the input embedding lives on a different device than other params,
-    _get_input_token_device must follow the embedding (where tokens need to go),
-    not the first parameter encountered."""
-
     class FakeShardedHF(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/tests/training/test_load_model.py
+++ b/tests/training/test_load_model.py
@@ -61,18 +61,16 @@ def test_load_model_with_generic_huggingface_lm():
     assert isinstance(model, HookedProxyLM)
 
 
-def test_load_model_skips_device_move_when_device_map_is_set(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """When the user passes device_map, the post-load .to(device) must be skipped
-    so we don't undo accelerate's sharding."""
+def _spy_on_from_pretrained(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch AutoModelForCausalLM.from_pretrained so the loaded model tracks
+    whether `.to()` was subsequently called via a `_to_called` attribute."""
     real_from_pretrained = AutoModelForCausalLM.from_pretrained
 
     def fake_from_pretrained(*args, **kwargs):  # type: ignore
+        # Strip device_map since we may not have accelerate installed in CI.
         m = real_from_pretrained(
             *args, **{k: v for k, v in kwargs.items() if k != "device_map"}
         )
-        # Track whether .to() is called after loading
         original_to = m.to
 
         def to_spy(*to_args, **to_kwargs):  # type: ignore
@@ -85,6 +83,11 @@ def test_load_model_skips_device_move_when_device_map_is_set(
 
     monkeypatch.setattr(AutoModelForCausalLM, "from_pretrained", fake_from_pretrained)
 
+
+def test_load_model_skips_device_move_when_device_map_is_set(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _spy_on_from_pretrained(monkeypatch)
     model = load_model(
         model_class_name="AutoModelForCausalLM",
         model_name="gpt2",
@@ -95,25 +98,25 @@ def test_load_model_skips_device_move_when_device_map_is_set(
     assert model.model._to_called is False  # type: ignore
 
 
+def test_load_model_calls_device_move_when_device_map_is_explicitly_none(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # device_map=None should be treated the same as no device_map kwarg.
+    _spy_on_from_pretrained(monkeypatch)
+    model = load_model(
+        model_class_name="AutoModelForCausalLM",
+        model_name="gpt2",
+        device="cpu",
+        model_from_pretrained_kwargs={"device_map": None},
+    )
+    assert isinstance(model, HookedProxyLM)
+    assert model.model._to_called is True  # type: ignore
+
+
 def test_load_model_calls_device_move_when_device_map_is_not_set(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    real_from_pretrained = AutoModelForCausalLM.from_pretrained
-
-    def fake_from_pretrained(*args, **kwargs):  # type: ignore
-        m = real_from_pretrained(*args, **kwargs)
-        original_to = m.to
-
-        def to_spy(*to_args, **to_kwargs):  # type: ignore
-            m._to_called = True  # type: ignore
-            return original_to(*to_args, **to_kwargs)
-
-        m.to = to_spy  # type: ignore
-        m._to_called = False  # type: ignore
-        return m
-
-    monkeypatch.setattr(AutoModelForCausalLM, "from_pretrained", fake_from_pretrained)
-
+    _spy_on_from_pretrained(monkeypatch)
     model = load_model(
         model_class_name="AutoModelForCausalLM",
         model_name="gpt2",

--- a/tests/training/test_load_model.py
+++ b/tests/training/test_load_model.py
@@ -61,6 +61,68 @@ def test_load_model_with_generic_huggingface_lm():
     assert isinstance(model, HookedProxyLM)
 
 
+def test_load_model_skips_device_move_when_device_map_is_set(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When the user passes device_map, the post-load .to(device) must be skipped
+    so we don't undo accelerate's sharding."""
+    real_from_pretrained = AutoModelForCausalLM.from_pretrained
+
+    def fake_from_pretrained(*args, **kwargs):  # type: ignore
+        m = real_from_pretrained(
+            *args, **{k: v for k, v in kwargs.items() if k != "device_map"}
+        )
+        # Track whether .to() is called after loading
+        original_to = m.to
+
+        def to_spy(*to_args, **to_kwargs):  # type: ignore
+            m._to_called = True  # type: ignore
+            return original_to(*to_args, **to_kwargs)
+
+        m.to = to_spy  # type: ignore
+        m._to_called = False  # type: ignore
+        return m
+
+    monkeypatch.setattr(AutoModelForCausalLM, "from_pretrained", fake_from_pretrained)
+
+    model = load_model(
+        model_class_name="AutoModelForCausalLM",
+        model_name="gpt2",
+        device="cpu",
+        model_from_pretrained_kwargs={"device_map": "cpu"},
+    )
+    assert isinstance(model, HookedProxyLM)
+    assert model.model._to_called is False  # type: ignore
+
+
+def test_load_model_calls_device_move_when_device_map_is_not_set(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    real_from_pretrained = AutoModelForCausalLM.from_pretrained
+
+    def fake_from_pretrained(*args, **kwargs):  # type: ignore
+        m = real_from_pretrained(*args, **kwargs)
+        original_to = m.to
+
+        def to_spy(*to_args, **to_kwargs):  # type: ignore
+            m._to_called = True  # type: ignore
+            return original_to(*to_args, **to_kwargs)
+
+        m.to = to_spy  # type: ignore
+        m._to_called = False  # type: ignore
+        return m
+
+    monkeypatch.setattr(AutoModelForCausalLM, "from_pretrained", fake_from_pretrained)
+
+    model = load_model(
+        model_class_name="AutoModelForCausalLM",
+        model_name="gpt2",
+        device="cpu",
+    )
+    assert isinstance(model, HookedProxyLM)
+    assert model.model._to_called is True  # type: ignore
+
+
 @pytest.mark.skipif(
     sys.platform == "darwin", reason="Test crashes Python interpreter on macOS"
 )


### PR DESCRIPTION
## Summary

Follow-up to #672. Two related fixes for using SAELens with sharded LLMs:

- **`load_model`**: skip the post-load `.to(device)` when the user passes `device_map` in `model_from_pretrained_kwargs`. accelerate has already placed the weights — calling `.to(device)` afterwards either errors or undoes the sharding.
- **`_get_model_device` → `_get_input_token_device`**: renamed to reflect what it actually returns (the device input tokens should be moved to). For HF models it now consults \`get_input_embeddings().weight.device\` instead of relying on \`next(model.parameters()).device\`, which is the canonical answer when the model is sharded across devices.

`HookedTransformer` users with `n_devices` still hit the existing `W_E.device` branch — no behavior change for them.

## Test plan

- [x] New unit tests in \`tests/training/test_load_model.py\` use a monkeypatched \`AutoModelForCausalLM.from_pretrained\` to verify \`.to()\` is called when \`device_map\` is absent and skipped when it's present.
- [x] New unit tests in \`tests/training/test_activations_store.py\` cover \`_get_input_token_device\` for HookedTransformer (W_E branch), HF proxy (input-embeddings branch), and a synthetic sharded model where the embedding sits on \`meta\` while the first registered parameter is on \`cpu\` — confirms we follow the embedding, not the first param.
- [x] All existing \`tests/training/test_load_model.py\` and \`tests/training/test_activations_store.py\` tests still pass.
- [x] \`poetry run pyright sae_lens/\` and \`poetry run ruff check .\` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)