### PR TITLE
fix: move eval mask onto sae.device for cross-device runs

### DIFF
--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -628,6 +628,10 @@ def get_recons_loss(
         )
     else:
         mask = torch.ones_like(batch_tokens, dtype=torch.bool)
+    # The replacement hook moves activations to sae.device for the SAE forward
+    # pass; mask is consumed alongside those activations in torch.where, so it
+    # must live on the same device.
+    mask = mask.to(sae.device)
 
     metrics = {}
 


### PR DESCRIPTION
## Summary

Bug fix for the multi-device eval path introduced by #672 / #673.

When the LLM and SAE live on different GPUs (e.g. \`device=\"cuda:1\"\`, \`llm_device=\"cuda:0\"\`), \`get_recons_loss\` constructs \`mask\` from \`batch_tokens\` (LLM device, cuda:0). The replacement hook then moves the LLM activations to \`sae.device\` (cuda:1) for the SAE forward pass, so the final \`torch.where(mask[..., None], new_activations, activations)\` ends up with operands on different devices:

\`\`\`
RuntimeError: Expected all tensors to be on the same device,
but found at least two devices, cuda:0 and cuda:1!
\`\`\`

This shows up only after the first eval interval, mid-training, after the model has otherwise been training fine for tens of minutes.

Fix: move \`mask\` to \`sae.device\` once after construction, so the \`torch.where\` inside the hook is single-device. Mask is small, so the cross-device transfer is negligible.

## Test plan

- [x] Existing \`tests/test_evals.py\` tests (46 tests) still pass.
- [x] \`poetry run pyright sae_lens/evals.py\` and \`poetry run ruff check\` are clean.

I didn't add a regression test because the bug only manifests on a real multi-GPU setup — the existing tests run with everything on cpu, so a CI test of this exact path would be skipped on GitHub Actions runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)