### PR TITLE
fix: more cross-device tensor bugs in evals

### DIFF
--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -576,7 +576,9 @@ def get_sparsity_and_variance_metrics(
             total_feature_prompts += (sae_feature_activations_bool.sum(dim=1) > 0).sum(
                 dim=0
             )
-            total_tokens += mask.sum()
+            # total_tokens is divided by total_feature_acts (on sae.device)
+            # below, so accumulate on the SAE device.
+            total_tokens += mask.sum().to(sae.device)
 
     # Aggregate scalar metrics
     metrics: dict[str, float] = {}

--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -488,8 +488,12 @@ def get_sparsity_and_variance_metrics(
         flattened_sae_out = einops.rearrange(sae_out, "b ctx d -> (b ctx) d")
 
         # TODO: Clean this up.
-        # apply mask
-        masked_sae_feature_activations = sae_feature_activations * mask.unsqueeze(-1)
+        # apply mask. mask is built from batch_tokens on the LLM device, but
+        # sae_feature_activations live on the SAE device (post sae.encode), so
+        # mirror the per-use .to() pattern used for flattened_mask below.
+        masked_sae_feature_activations = sae_feature_activations * mask.unsqueeze(
+            -1
+        ).to(sae_feature_activations.device)
         flattened_sae_input = flattened_sae_input[
             flattened_mask.to(flattened_sae_input.device)
         ]


### PR DESCRIPTION
## Summary

Two more cross-device bugs in \`sae_lens/evals.py\` that surface when the LLM and SAE live on different GPUs (\`device\` ≠ \`llm_device\`). Same shape as #675 but in different code paths.

**1. \`get_sparsity_and_variance_metrics\` line 492:**
\`mask\` is built from \`batch_tokens\` (LLM device) and used in \`sae_feature_activations * mask.unsqueeze(-1)\` where \`sae_feature_activations\` lives on \`sae.device\`. The lines just below (\`flattened_mask.to(*.device)\`) already do per-use device alignment — this multiplication line was missed.

**2. \`get_sparsity_and_variance_metrics\` total_tokens accumulator:**
\`total_tokens = 0\` accumulates \`mask.sum()\` (LLM device). At the end of the function it's divided by \`total_feature_acts\` which is initialized on \`sae.device\`. Cross-device division. Fix: \`mask.sum().to(sae.device)\` before accumulating.

I audited the rest of evals.py for similar patterns and didn't find more — \`get_downstream_reconstruction_metrics\` keeps everything on the LLM device, and the replacement hooks already handle device transitions correctly (also fixed in #675).

## Test plan

- [x] Existing \`tests/test_evals.py\` tests (46) still pass.
- [x] \`poetry run pyright sae_lens/evals.py\` and \`poetry run ruff check\` are clean.

The bugs only manifest on a real multi-GPU setup, so I didn't add a regression test (would always be skipped on CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)