### PR TITLE
feat: add Qwen Scope TopK SAEs

### DIFF
--- a/sae_lens/loading/pretrained_sae_loaders.py
+++ b/sae_lens/loading/pretrained_sae_loaders.py
@@ -1134,7 +1134,6 @@ def get_qwen_scope_config_from_hf(
         # Qwen Scope SAEs are trained on Qwen's in-house pretraining data, which
         # is not publicly available; leave the dataset_path unset.
         "dataset_path": None,
-        "dataset_trust_remote_code": True,
         "sae_lens_training_version": None,
         "normalize_activations": "none",
         "device": device,

--- a/sae_lens/loading/pretrained_sae_loaders.py
+++ b/sae_lens/loading/pretrained_sae_loaders.py
@@ -1067,6 +1067,121 @@ def deepseek_r1_sae_huggingface_loader(
     return cfg_dict, state_dict, None
 
 
+# Maps the model identifier embedded in a Qwen Scope SAE repo name (the part
+# between "SAE-Res-" and "-W{N}K-L0_{K}") to the HF model id and its hidden size.
+QWEN_SCOPE_MODEL_INFO: dict[str, tuple[str, int]] = {
+    "Qwen3-1.7B-Base": ("Qwen/Qwen3-1.7B-Base", 2048),
+    "Qwen3-8B-Base": ("Qwen/Qwen3-8B-Base", 4096),
+    "Qwen3-30B-A3B-Base": ("Qwen/Qwen3-30B-A3B-Base", 2048),
+    "Qwen3.5-2B-Base": ("Qwen/Qwen3.5-2B-Base", 2048),
+    "Qwen3.5-9B-Base": ("Qwen/Qwen3.5-9B-Base", 4096),
+    "Qwen3.5-27B": ("Qwen/Qwen3.5-27B", 5120),
+    "Qwen3.5-35B-A3B-Base": ("Qwen/Qwen3.5-35B-A3B-Base", 2048),
+}
+
+
+def _parse_qwen_scope_repo_id(repo_id: str) -> tuple[str, int, int]:
+    """Parse a Qwen Scope repo id into (model_key, d_sae, k).
+
+    Repo ids look like ``Qwen/SAE-Res-{model_key}-W{N}K-L0_{K}``, e.g.
+    ``Qwen/SAE-Res-Qwen3-1.7B-Base-W32K-L0_50``.
+    """
+    match = re.search(r"SAE-Res-(.+)-W(\d+)K-L0_(\d+)", repo_id)
+    if match is None:
+        raise ValueError(f"Could not parse Qwen Scope repo_id: {repo_id}")
+    model_key, width_k, k = match.group(1), int(match.group(2)), int(match.group(3))
+    return model_key, width_k * 1024, k
+
+
+def get_qwen_scope_config_from_hf(
+    repo_id: str,
+    folder_name: str,
+    device: str,
+    force_download: bool = False,  # noqa: ARG001
+    cfg_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Get config for Qwen Scope SAEs (https://huggingface.co/collections/Qwen/qwen-scope).
+
+    Repo ids look like ``Qwen/SAE-Res-Qwen3-1.7B-Base-W32K-L0_50``.
+    Folder names are the per-layer checkpoint files, e.g. ``layer0.sae.pt``.
+    """
+    layer_match = re.search(r"layer(\d+)\.sae\.pt", folder_name)
+    if layer_match is None:
+        raise ValueError(f"Could not find layer number in filename: {folder_name}")
+    layer = int(layer_match.group(1))
+
+    model_key, d_sae, k = _parse_qwen_scope_repo_id(repo_id)
+    if model_key not in QWEN_SCOPE_MODEL_INFO:
+        raise ValueError(
+            f"Unknown Qwen Scope base model: {model_key!r}. "
+            f"Known models: {sorted(QWEN_SCOPE_MODEL_INFO)}"
+        )
+    model_name, d_in = QWEN_SCOPE_MODEL_INFO[model_key]
+
+    return {
+        "architecture": "topk",
+        "activation_fn": "topk",
+        "activation_fn_kwargs": {"k": k},
+        "d_in": d_in,
+        "d_sae": d_sae,
+        "dtype": "float32",
+        "context_size": 1024,
+        "model_name": model_name,
+        "hook_name": f"blocks.{layer}.hook_resid_post",
+        "hf_hook_name": f"model.layers.{layer}",
+        "hook_head_index": None,
+        "prepend_bos": True,
+        # Qwen Scope SAEs are trained on Qwen's in-house pretraining data, which
+        # is not publicly available; leave the dataset_path unset.
+        "dataset_path": None,
+        "dataset_trust_remote_code": True,
+        "sae_lens_training_version": None,
+        "normalize_activations": "none",
+        "device": device,
+        "apply_b_dec_to_input": False,
+        "finetuning_scaling_factor": False,
+        **(cfg_overrides or {}),
+    }
+
+
+def qwen_scope_sae_huggingface_loader(
+    repo_id: str,
+    folder_name: str,
+    device: str = "cpu",
+    force_download: bool = False,
+    cfg_overrides: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], dict[str, torch.Tensor], torch.Tensor | None]:
+    """Load a Qwen Scope TopK SAE.
+
+    Each ``layer{n}.sae.pt`` checkpoint is a dict with ``W_enc`` of shape
+    (d_sae, d_in), ``W_dec`` of shape (d_in, d_sae), ``b_enc`` and ``b_dec``.
+    SAELens uses the transposed convention, so we transpose both weight matrices.
+    """
+    cfg_dict = get_qwen_scope_config_from_hf(
+        repo_id,
+        folder_name,
+        device,
+        force_download,
+        cfg_overrides,
+    )
+
+    sae_path = hf_hub_download(
+        repo_id=repo_id,
+        filename=folder_name,
+        force_download=force_download,
+    )
+    state_dict_loaded = torch.load(sae_path, map_location=device)
+
+    state_dict = {
+        "W_enc": state_dict_loaded["W_enc"].T.contiguous(),
+        "W_dec": state_dict_loaded["W_dec"].T.contiguous(),
+        "b_enc": state_dict_loaded["b_enc"],
+        "b_dec": state_dict_loaded["b_dec"],
+    }
+
+    return cfg_dict, state_dict, None
+
+
 def get_conversion_loader_name(release: str) -> str:
     saes_directory = get_pretrained_saes_directory()
     sae_info = saes_directory.get(release, None)
@@ -1892,6 +2007,7 @@ NAMED_PRETRAINED_SAE_LOADERS: dict[str, PretrainedSaeHuggingfaceLoader] = {
     "llama_scope_r1_distill": llama_scope_r1_distill_sae_huggingface_loader,
     "dictionary_learning_1": dictionary_learning_sae_huggingface_loader_1,
     "deepseek_r1": deepseek_r1_sae_huggingface_loader,
+    "qwen_scope": qwen_scope_sae_huggingface_loader,
     "sparsify": sparsify_huggingface_loader,
     "gemma_2_transcoder": gemma_2_transcoder_huggingface_loader,
     "mwhanna_transcoder": mwhanna_transcoder_huggingface_loader,
@@ -1910,6 +2026,7 @@ NAMED_PRETRAINED_SAE_CONFIG_GETTERS: dict[str, PretrainedSaeConfigHuggingfaceLoa
     "llama_scope_r1_distill": get_llama_scope_r1_distill_config_from_hf,
     "dictionary_learning_1": get_dictionary_learning_config_1_from_hf,
     "deepseek_r1": get_deepseek_r1_config_from_hf,
+    "qwen_scope": get_qwen_scope_config_from_hf,
     "sparsify": get_sparsify_config_from_hf,
     "gemma_2_transcoder": get_gemma_2_transcoder_config_from_hf,
     "mwhanna_transcoder": get_mwhanna_transcoder_config_from_hf,

--- a/sae_lens/pretrained_saes.yaml
+++ b/sae_lens/pretrained_saes.yaml
@@ -41925,3 +41925,1705 @@ gemma-2b-res-jb:
     l0: 54.0
     path: gemma_2b_blocks.17.hook_resid_post_16384
     variance_explained: -0.85
+qwen-scope-3-1.7b-base-w32k-l50:
+  conversion_func: qwen_scope
+  model: Qwen/Qwen3-1.7B-Base
+  repo_id: Qwen/SAE-Res-Qwen3-1.7B-Base-W32K-L0_50
+  saes:
+  - id: layer0
+    l0: 50
+    path: layer0.sae.pt
+  - id: layer1
+    l0: 50
+    path: layer1.sae.pt
+  - id: layer2
+    l0: 50
+    path: layer2.sae.pt
+  - id: layer3
+    l0: 50
+    path: layer3.sae.pt
+  - id: layer4
+    l0: 50
+    path: layer4.sae.pt
+  - id: layer5
+    l0: 50
+    path: layer5.sae.pt
+  - id: layer6
+    l0: 50
+    path: layer6.sae.pt
+  - id: layer7
+    l0: 50
+    path: layer7.sae.pt
+  - id: layer8
+    l0: 50
+    path: layer8.sae.pt
+  - id: layer9
+    l0: 50
+    path: layer9.sae.pt
+  - id: layer10
+    l0: 50
+    path: layer10.sae.pt
+  - id: layer11
+    l0: 50
+    path: layer11.sae.pt
+  - id: layer12
+    l0: 50
+    path: layer12.sae.pt
+  - id: layer13
+    l0: 50
+    path: layer13.sae.pt
+  - id: layer14
+    l0: 50
+    path: layer14.sae.pt
+  - id: layer15
+    l0: 50
+    path: layer15.sae.pt
+  - id: layer16
+    l0: 50
+    path: layer16.sae.pt
+  - id: layer17
+    l0: 50
+    path: layer17.sae.pt
+  - id: layer18
+    l0: 50
+    path: layer18.sae.pt
+  - id: layer19
+    l0: 50
+    path: layer19.sae.pt
+  - id: layer20
+    l0: 50
+    path: layer20.sae.pt
+  - id: layer21
+    l0: 50
+    path: layer21.sae.pt
+  - id: layer22
+    l0: 50
+    path: layer22.sae.pt
+  - id: layer23
+    l0: 50
+    path: layer23.sae.pt
+  - id: layer24
+    l0: 50
+    path: layer24.sae.pt
+  - id: layer25
+    l0: 50
+    path: layer25.sae.pt
+  - id: layer26
+    l0: 50
+    path: layer26.sae.pt
+  - id: layer27
+    l0: 50
+    path: layer27.sae.pt
+qwen-scope-3-1.7b-base-w32k-l100:
+  conversion_func: qwen_scope
+  model: Qwen/Qwen3-1.7B-Base
+  repo_id: Qwen/SAE-Res-Qwen3-1.7B-Base-W32K-L0_100
+  saes:
+  - id: layer0
+    l0: 100
+    path: layer0.sae.pt
+  - id: layer1
+    l0: 100
+    path: layer1.sae.pt
+  - id: layer2
+    l0: 100
+    path: layer2.sae.pt
+  - id: layer3
+    l0: 100
+    path: layer3.sae.pt
+  - id: layer4
+    l0: 100
+    path: layer4.sae.pt
+  - id: layer5
+    l0: 100
+    path: layer5.sae.pt
+  - id: layer6
+    l0: 100
+    path: layer6.sae.pt
+  - id: layer7
+    l0: 100
+    path: layer7.sae.pt
+  - id: layer8
+    l0: 100
+    path: layer8.sae.pt
+  - id: layer9
+    l0: 100
+    path: layer9.sae.pt
+  - id: layer10
+    l0: 100
+    path: layer10.sae.pt
+  - id: layer11
+    l0: 100
+    path: layer11.sae.pt
+  - id: layer12
+    l0: 100
+    path: layer12.sae.pt
+  - id: layer13
+    l0: 100
+    path: layer13.sae.pt
+  - id: layer14
+    l0: 100
+    path: layer14.sae.pt
+  - id: layer15
+    l0: 100
+    path: layer15.sae.pt
+  - id: layer16
+    l0: 100
+    path: layer16.sae.pt
+  - id: layer17
+    l0: 100
+    path: layer17.sae.pt
+  - id: layer18
+    l0: 100
+    path: layer18.sae.pt
+  - id: layer19
+    l0: 100
+    path: layer19.sae.pt
+  - id: layer20
+    l0: 100
+    path: layer20.sae.pt
+  - id: layer21
+    l0: 100
+    path: layer21.sae.pt
+  - id: layer22
+    l0: 100
+    path: layer22.sae.pt
+  - id: layer23
+    l0: 100
+    path: layer23.sae.pt
+  - id: layer24
+    l0: 100
+    path: layer24.sae.pt
+  - id: layer25
+    l0: 100
+    path: layer25.sae.pt
+  - id: layer26
+    l0: 100
+    path: layer26.sae.pt
+  - id: layer27
+    l0: 100
+    path: layer27.sae.pt
+qwen-scope-3-8b-base-w64k-l50:
+  conversion_func: qwen_scope
+  model: Qwen/Qwen3-8B-Base
+  repo_id: Qwen/SAE-Res-Qwen3-8B-Base-W64K-L0_50
+  saes:
+  - id: layer0
+    l0: 50
+    path: layer0.sae.pt
+  - id: layer1
+    l0: 50
+    path: layer1.sae.pt
+  - id: layer2
+    l0: 50
+    path: layer2.sae.pt
+  - id: layer3
+    l0: 50
+    path: layer3.sae.pt
+  - id: layer4
+    l0: 50
+    path: layer4.sae.pt
+  - id: layer5
+    l0: 50
+    path: layer5.sae.pt
+  - id: layer6
+    l0: 50
+    path: layer6.sae.pt
+  - id: layer7
+    l0: 50
+    path: layer7.sae.pt
+  - id: layer8
+    l0: 50
+    path: layer8.sae.pt
+  - id: layer9
+    l0: 50
+    path: layer9.sae.pt
+  - id: layer10
+    l0: 50
+    path: layer10.sae.pt
+  - id: layer11
+    l0: 50
+    path: layer11.sae.pt
+  - id: layer12
+    l0: 50
+    path: layer12.sae.pt
+  - id: layer13
+    l0: 50
+    path: layer13.sae.pt
+  - id: layer14
+    l0: 50
+    path: layer14.sae.pt
+  - id: layer15
+    l0: 50
+    path: layer15.sae.pt
+  - id: layer16
+    l0: 50
+    path: layer16.sae.pt
+  - id: layer17
+    l0: 50
+    path: layer17.sae.pt
+  - id: layer18
+    l0: 50
+    path: layer18.sae.pt
+  - id: layer19
+    l0: 50
+    path: layer19.sae.pt
+  - id: layer20
+    l0: 50
+    path: layer20.sae.pt
+  - id: layer21
+    l0: 50
+    path: layer21.sae.pt
+  - id: layer22
+    l0: 50
+    path: layer22.sae.pt
+  - id: layer23
+    l0: 50
+    path: layer23.sae.pt
+  - id: layer24
+    l0: 50
+    path: layer24.sae.pt
+  - id: layer25
+    l0: 50
+    path: layer25.sae.pt
+  - id: layer26
+    l0: 50
+    path: layer26.sae.pt
+  - id: layer27
+    l0: 50
+    path: layer27.sae.pt
+  - id: layer28
+    l0: 50
+    path: layer28.sae.pt
+  - id: layer29
+    l0: 50
+    path: layer29.sae.pt
+  - id: layer30
+    l0: 50
+    path: layer30.sae.pt
+  - id: layer31
+    l0: 50
+    path: layer31.sae.pt
+  - id: layer32
+    l0: 50
+    path: layer32.sae.pt
+  - id: layer33
+    l0: 50
+    path: layer33.sae.pt
+  - id: layer34
+    l0: 50
+    path: layer34.sae.pt
+  - id: layer35
+    l0: 50
+    path: layer35.sae.pt
+qwen-scope-3-8b-base-w64k-l100:
+  conversion_func: qwen_scope
+  model: Qwen/Qwen3-8B-Base
+  repo_id: Qwen/SAE-Res-Qwen3-8B-Base-W64K-L0_100
+  saes:
+  - id: layer0
+    l0: 100
+    path: layer0.sae.pt
+  - id: layer1
+    l0: 100
+    path: layer1.sae.pt
+  - id: layer2
+    l0: 100
+    path: layer2.sae.pt
+  - id: layer3
+    l0: 100
+    path: layer3.sae.pt
+  - id: layer4
+    l0: 100
+    path: layer4.sae.pt
+  - id: layer5
+    l0: 100
+    path: layer5.sae.pt
+  - id: layer6
+    l0: 100
+    path: layer6.sae.pt
+  - id: layer7
+    l0: 100
+    path: layer7.sae.pt
+  - id: layer8
+    l0: 100
+    path: layer8.sae.pt
+  - id: layer9
+    l0: 100
+    path: layer9.sae.pt
+  - id: layer10
+    l0: 100
+    path: layer10.sae.pt
+  - id: layer11
+    l0: 100
+    path: layer11.sae.pt
+  - id: layer12
+    l0: 100
+    path: layer12.sae.pt
+  - id: layer13
+    l0: 100
+    path: layer13.sae.pt
+  - id: layer14
+    l0: 100
+    path: layer14.sae.pt
+  - id: layer15
+    l0: 100
+    path: layer15.sae.pt
+  - id: layer16
+    l0: 100
+    path: layer16.sae.pt
+  - id: layer17
+    l0: 100
+    path: layer17.sae.pt
+  - id: layer18
+    l0: 100
+    path: layer18.sae.pt
+  - id: layer19
+    l0: 100
+    path: layer19.sae.pt
+  - id: layer20
+    l0: 100
+    path: layer20.sae.pt
+  - id: layer21
+    l0: 100
+    path: layer21.sae.pt
+  - id: layer22
+    l0: 100
+    path: layer22.sae.pt
+  - id: layer23
+    l0: 100
+    path: layer23.sae.pt
+  - id: layer24
+    l0: 100
+    path: layer24.sae.pt
+  - id: layer25
+    l0: 100
+    path: layer25.sae.pt
+  - id: layer26
+    l0: 100
+    path: layer26.sae.pt
+  - id: layer27
+    l0: 100
+    path: layer27.sae.pt
+  - id: layer28
+    l0: 100
+    path: layer28.sae.pt
+  - id: layer29
+    l0: 100
+    path: layer29.sae.pt
+  - id: layer30
+    l0: 100
+    path: layer30.sae.pt
+  - id: layer31
+    l0: 100
+    path: layer31.sae.pt
+  - id: layer32
+    l0: 100
+    path: layer32.sae.pt
+  - id: layer33
+    l0: 100
+    path: layer33.sae.pt
+  - id: layer34
+    l0: 100
+    path: layer34.sae.pt
+  - id: layer35
+    l0: 100
+    path: layer35.sae.pt
+qwen-scope-3-30b-a3b-base-w32k-l50:
+  conversion_func: qwen_scope
+  model: Qwen/Qwen3-30B-A3B-Base
+  repo_id: Qwen/SAE-Res-Qwen3-30B-A3B-Base-W32K-L0_50
+  saes:
+  - id: layer0
+    l0: 50
+    path: layer0.sae.pt
+  - id: layer1
+    l0: 50
+    path: layer1.sae.pt
+  - id: layer2
+    l0: 50
+    path: layer2.sae.pt
+  - id: layer3
+    l0: 50
+    path: layer3.sae.pt
+  - id: layer4
+    l0: 50
+    path: layer4.sae.pt
+  - id: layer5
+    l0: 50
+    path: layer5.sae.pt
+  - id: layer6
+    l0: 50
+    path: layer6.sae.pt
+  - id: layer7
+    l0: 50
+    path: layer7.sae.pt
+  - id: layer8
+    l0: 50
+    path: layer8.sae.pt
+  - id: layer9
+    l0: 50
+    path: layer9.sae.pt
+  - id: layer10
+    l0: 50
+    path: layer10.sae.pt
+  - id: layer11
+    l0: 50
+    path: layer11.sae.pt
+  - id: layer12
+    l0: 50
+    path: layer12.sae.pt
+  - id: layer13
+    l0: 50
+    path: layer13.sae.pt
+  - id: layer14
+    l0: 50
+    path: layer14.sae.pt
+  - id: layer15
+    l0: 50
+    path: layer15.sae.pt
+  - id: layer16
+    l0: 50
+    path: layer16.sae.pt
+  - id: layer17
+    l0: 50
+    path: layer17.sae.pt
+  - id: layer18
+    l0: 50
+    path: layer18.sae.pt
+  - id: layer19
+    l0: 50
+    path: layer19.sae.pt
+  - id: layer20
+    l0: 50
+    path: layer20.sae.pt
+  - id: layer21
+    l0: 50
+    path: layer21.sae.pt
+  - id: layer22
+    l0: 50
+    path: layer22.sae.pt
+  - id: layer23
+    l0: 50
+    path: layer23.sae.pt
+  - id: layer24
+    l0: 50
+    path: layer24.sae.pt
+  - id: layer25
+    l0: 50
+    path: layer25.sae.pt
+  - id: layer26
+    l0: 50
+    path: layer26.sae.pt
+  - id: layer27
+    l0: 50
+    path: layer27.sae.pt
+  - id: layer28
+    l0: 50
+    path: layer28.sae.pt
+  - id: layer29
+    l0: 50
+    path: layer29.sae.pt
+  - id: layer30
+    l0: 50
+    path: layer30.sae.pt
+  - id: layer31
+    l0: 50
+    path: layer31.sae.pt
+  - id: layer32
+    l0: 50
+    path: layer32.sae.pt
+  - id: layer33
+    l0: 50
+    path: layer33.sae.pt
+  - id: layer34
+    l0: 50
+    path: layer34.sae.pt
+  - id: layer35
+    l0: 50
+    path: layer35.sae.pt
+  - id: layer36
+    l0: 50
+    path: layer36.sae.pt
+  - id: layer37
+    l0: 50
+    path: layer37.sae.pt
+  - id: layer38
+    l0: 50
+    path: layer38.sae.pt
+  - id: layer39
+    l0: 50
+    path: layer39.sae.pt
+  - id: layer40
+    l0: 50
+    path: layer40.sae.pt
+  - id: layer41
+    l0: 50
+    path: layer41.sae.pt
+  - id: layer42
+    l0: 50
+    path: layer42.sae.pt
+  - id: layer43
+    l0: 50
+    path: layer43.sae.pt
+  - id: layer44
+    l0: 50
+    path: layer44.sae.pt
+  - id: layer45
+    l0: 50
+    path: layer45.sae.pt
+  - id: layer46
+    l0: 50
+    path: layer46.sae.pt
+  - id: layer47
+    l0: 50
+    path: layer47.sae.pt
+qwen-scope-3-30b-a3b-base-w128k-l100:
+  conversion_func: qwen_scope
+  model: Qwen/Qwen3-30B-A3B-Base
+  repo_id: Qwen/SAE-Res-Qwen3-30B-A3B-Base-W128K-L0_100
+  saes:
+  - id: layer0
+    l0: 100
+    path: layer0.sae.pt
+  - id: layer1
+    l0: 100
+    path: layer1.sae.pt
+  - id: layer2
+    l0: 100
+    path: layer2.sae.pt
+  - id: layer3
+    l0: 100
+    path: layer3.sae.pt
+  - id: layer4
+    l0: 100
+    path: layer4.sae.pt
+  - id: layer5
+    l0: 100
+    path: layer5.sae.pt
+  - id: layer6
+    l0: 100
+    path: layer6.sae.pt
+  - id: layer7
+    l0: 100
+    path: layer7.sae.pt
+  - id: layer8
+    l0: 100
+    path: layer8.sae.pt
+  - id: layer9
+    l0: 100
+    path: layer9.sae.pt
+  - id: layer10
+    l0: 100
+    path: layer10.sae.pt
+  - id: layer11
+    l0: 100
+    path: layer11.sae.pt
+  - id: layer12
+    l0: 100
+    path: layer12.sae.pt
+  - id: layer13
+    l0: 100
+    path: layer13.sae.pt
+  - id: layer14
+    l0: 100
+    path: layer14.sae.pt
+  - id: layer15
+    l0: 100
+    path: layer15.sae.pt
+  - id: layer16
+    l0: 100
+    path: layer16.sae.pt
+  - id: layer17
+    l0: 100
+    path: layer17.sae.pt
+  - id: layer18
+    l0: 100
+    path: layer18.sae.pt
+  - id: layer19
+    l0: 100
+    path: layer19.sae.pt
+  - id: layer20
+    l0: 100
+    path: layer20.sae.pt
+  - id: layer21
+    l0: 100
+    path: layer21.sae.pt
+  - id: layer22
+    l0: 100
+    path: layer22.sae.pt
+  - id: layer23
+    l0: 100
+    path: layer23.sae.pt
+  - id: layer24
+    l0: 100
+    path: layer24.sae.pt
+  - id: layer25
+    l0: 100
+    path: layer25.sae.pt
+  - id: layer26
+    l0: 100
+    path: layer26.sae.pt
+  - id: layer27
+    l0: 100
+    path: layer27.sae.pt
+  - id: layer28
+    l0: 100
+    path: layer28.sae.pt
+  - id: layer29
+    l0: 100
+    path: layer29.sae.pt
+  - id: layer30
+    l0: 100
+    path: layer30.sae.pt
+  - id: layer31
+    l0: 100
+    path: layer31.sae.pt
+  - id: layer32
+    l0: 100
+    path: layer32.sae.pt
+  - id: layer33
+    l0: 100
+    path: layer33.sae.pt
+  - id: layer34
+    l0: 100
+    path: layer34.sae.pt
+  - id: layer35
+    l0: 100
+    path: layer35.sae.pt
+  - id: layer36
+    l0: 100
+    path: layer36.sae.pt
+  - id: layer37
+    l0: 100
+    path: layer37.sae.pt
+  - id: layer38
+    l0: 100
+    path: layer38.sae.pt
+  - id: layer39
+    l0: 100
+    path: layer39.sae.pt
+  - id: layer40
+    l0: 100
+    path: layer40.sae.pt
+  - id: layer41
+    l0: 100
+    path: layer41.sae.pt
+  - id: layer42
+    l0: 100
+    path: layer42.sae.pt
+  - id: layer43
+    l0: 100
+    path: layer43.sae.pt
+  - id: layer44
+    l0: 100
+    path: layer44.sae.pt
+  - id: layer45
+    l0: 100
+    path: layer45.sae.pt
+  - id: layer46
+    l0: 100
+    path: layer46.sae.pt
+  - id: layer47
+    l0: 100
+    path: layer47.sae.pt
+qwen-scope-3.5-2b-base-w32k-l50:
+  conversion_func: qwen_scope
+  model: Qwen/Qwen3.5-2B-Base
+  repo_id: Qwen/SAE-Res-Qwen3.5-2B-Base-W32K-L0_50
+  saes:
+  - id: layer0
+    l0: 50
+    path: layer0.sae.pt
+  - id: layer1
+    l0: 50
+    path: layer1.sae.pt
+  - id: layer2
+    l0: 50
+    path: layer2.sae.pt
+  - id: layer3
+    l0: 50
+    path: layer3.sae.pt
+  - id: layer4
+    l0: 50
+    path: layer4.sae.pt
+  - id: layer5
+    l0: 50
+    path: layer5.sae.pt
+  - id: layer6
+    l0: 50
+    path: layer6.sae.pt
+  - id: layer7
+    l0: 50
+    path: layer7.sae.pt
+  - id: layer8
+    l0: 50
+    path: layer8.sae.pt
+  - id: layer9
+    l0: 50
+    path: layer9.sae.pt
+  - id: layer10
+    l0: 50
+    path: layer10.sae.pt
+  - id: layer11
+    l0: 50
+    path: layer11.sae.pt
+  - id: layer12
+    l0: 50
+    path: layer12.sae.pt
+  - id: layer13
+    l0: 50
+    path: layer13.sae.pt
+  - id: layer14
+    l0: 50
+    path: layer14.sae.pt
+  - id: layer15
+    l0: 50
+    path: layer15.sae.pt
+  - id: layer16
+    l0: 50
+    path: layer16.sae.pt
+  - id: layer17
+    l0: 50
+    path: layer17.sae.pt
+  - id: layer18
+    l0: 50
+    path: layer18.sae.pt
+  - id: layer19
+    l0: 50
+    path: layer19.sae.pt
+  - id: layer20
+    l0: 50
+    path: layer20.sae.pt
+  - id: layer21
+    l0: 50
+    path: layer21.sae.pt
+  - id: layer22
+    l0: 50
+    path: layer22.sae.pt
+  - id: layer23
+    l0: 50
+    path: layer23.sae.pt
+qwen-scope-3.5-2b-base-w32k-l100:
+  conversion_func: qwen_scope
+  model: Qwen/Qwen3.5-2B-Base
+  repo_id: Qwen/SAE-Res-Qwen3.5-2B-Base-W32K-L0_100
+  saes:
+  - id: layer0
+    l0: 100
+    path: layer0.sae.pt
+  - id: layer1
+    l0: 100
+    path: layer1.sae.pt
+  - id: layer2
+    l0: 100
+    path: layer2.sae.pt
+  - id: layer3
+    l0: 100
+    path: layer3.sae.pt
+  - id: layer4
+    l0: 100
+    path: layer4.sae.pt
+  - id: layer5
+    l0: 100
+    path: layer5.sae.pt
+  - id: layer6
+    l0: 100
+    path: layer6.sae.pt
+  - id: layer7
+    l0: 100
+    path: layer7.sae.pt
+  - id: layer8
+    l0: 100
+    path: layer8.sae.pt
+  - id: layer9
+    l0: 100
+    path: layer9.sae.pt
+  - id: layer10
+    l0: 100
+    path: layer10.sae.pt
+  - id: layer11
+    l0: 100
+    path: layer11.sae.pt
+  - id: layer12
+    l0: 100
+    path: layer12.sae.pt
+  - id: layer13
+    l0: 100
+    path: layer13.sae.pt
+  - id: layer14
+    l0: 100
+    path: layer14.sae.pt
+  - id: layer15
+    l0: 100
+    path: layer15.sae.pt
+  - id: layer16
+    l0: 100
+    path: layer16.sae.pt
+  - id: layer17
+    l0: 100
+    path: layer17.sae.pt
+  - id: layer18
+    l0: 100
+    path: layer18.sae.pt
+  - id: layer19
+    l0: 100
+    path: layer19.sae.pt
+  - id: layer20
+    l0: 100
+    path: layer20.sae.pt
+  - id: layer21
+    l0: 100
+    path: layer21.sae.pt
+  - id: layer22
+    l0: 100
+    path: layer22.sae.pt
+  - id: layer23
+    l0: 100
+    path: layer23.sae.pt
+qwen-scope-3.5-9b-base-w64k-l50:
+  conversion_func: qwen_scope
+  model: Qwen/Qwen3.5-9B-Base
+  repo_id: Qwen/SAE-Res-Qwen3.5-9B-Base-W64K-L0_50
+  saes:
+  - id: layer0
+    l0: 50
+    path: layer0.sae.pt
+  - id: layer1
+    l0: 50
+    path: layer1.sae.pt
+  - id: layer2
+    l0: 50
+    path: layer2.sae.pt
+  - id: layer3
+    l0: 50
+    path: layer3.sae.pt
+  - id: layer4
+    l0: 50
+    path: layer4.sae.pt
+  - id: layer5
+    l0: 50
+    path: layer5.sae.pt
+  - id: layer6
+    l0: 50
+    path: layer6.sae.pt
+  - id: layer7
+    l0: 50
+    path: layer7.sae.pt
+  - id: layer8
+    l0: 50
+    path: layer8.sae.pt
+  - id: layer9
+    l0: 50
+    path: layer9.sae.pt
+  - id: layer10
+    l0: 50
+    path: layer10.sae.pt
+  - id: layer11
+    l0: 50
+    path: layer11.sae.pt
+  - id: layer12
+    l0: 50
+    path: layer12.sae.pt
+  - id: layer13
+    l0: 50
+    path: layer13.sae.pt
+  - id: layer14
+    l0: 50
+    path: layer14.sae.pt
+  - id: layer15
+    l0: 50
+    path: layer15.sae.pt
+  - id: layer16
+    l0: 50
+    path: layer16.sae.pt
+  - id: layer17
+    l0: 50
+    path: layer17.sae.pt
+  - id: layer18
+    l0: 50
+    path: layer18.sae.pt
+  - id: layer19
+    l0: 50
+    path: layer19.sae.pt
+  - id: layer20
+    l0: 50
+    path: layer20.sae.pt
+  - id: layer21
+    l0: 50
+    path: layer21.sae.pt
+  - id: layer22
+    l0: 50
+    path: layer22.sae.pt
+  - id: layer23
+    l0: 50
+    path: layer23.sae.pt
+  - id: layer24
+    l0: 50
+    path: layer24.sae.pt
+  - id: layer25
+    l0: 50
+    path: layer25.sae.pt
+  - id: layer26
+    l0: 50
+    path: layer26.sae.pt
+  - id: layer27
+    l0: 50
+    path: layer27.sae.pt
+  - id: layer28
+    l0: 50
+    path: layer28.sae.pt
+  - id: layer29
+    l0: 50
+    path: layer29.sae.pt
+  - id: layer30
+    l0: 50
+    path: layer30.sae.pt
+  - id: layer31
+    l0: 50
+    path: layer31.sae.pt
+qwen-scope-3.5-9b-base-w64k-l100:
+  conversion_func: qwen_scope
+  model: Qwen/Qwen3.5-9B-Base
+  repo_id: Qwen/SAE-Res-Qwen3.5-9B-Base-W64K-L0_100
+  saes:
+  - id: layer0
+    l0: 100
+    path: layer0.sae.pt
+  - id: layer1
+    l0: 100
+    path: layer1.sae.pt
+  - id: layer2
+    l0: 100
+    path: layer2.sae.pt
+  - id: layer3
+    l0: 100
+    path: layer3.sae.pt
+  - id: layer4
+    l0: 100
+    path: layer4.sae.pt
+  - id: layer5
+    l0: 100
+    path: layer5.sae.pt
+  - id: layer6
+    l0: 100
+    path: layer6.sae.pt
+  - id: layer7
+    l0: 100
+    path: layer7.sae.pt
+  - id: layer8
+    l0: 100
+    path: layer8.sae.pt
+  - id: layer9
+    l0: 100
+    path: layer9.sae.pt
+  - id: layer10
+    l0: 100
+    path: layer10.sae.pt
+  - id: layer11
+    l0: 100
+    path: layer11.sae.pt
+  - id: layer12
+    l0: 100
+    path: layer12.sae.pt
+  - id: layer13
+    l0: 100
+    path: layer13.sae.pt
+  - id: layer14
+    l0: 100
+    path: layer14.sae.pt
+  - id: layer15
+    l0: 100
+    path: layer15.sae.pt
+  - id: layer16
+    l0: 100
+    path: layer16.sae.pt
+  - id: layer17
+    l0: 100
+    path: layer17.sae.pt
+  - id: layer18
+    l0: 100
+    path: layer18.sae.pt
+  - id: layer19
+    l0: 100
+    path: layer19.sae.pt
+  - id: layer20
+    l0: 100
+    path: layer20.sae.pt
+  - id: layer21
+    l0: 100
+    path: layer21.sae.pt
+  - id: layer22
+    l0: 100
+    path: layer22.sae.pt
+  - id: layer23
+    l0: 100
+    path: layer23.sae.pt
+  - id: layer24
+    l0: 100
+    path: layer24.sae.pt
+  - id: layer25
+    l0: 100
+    path: layer25.sae.pt
+  - id: layer26
+    l0: 100
+    path: layer26.sae.pt
+  - id: layer27
+    l0: 100
+    path: layer27.sae.pt
+  - id: layer28
+    l0: 100
+    path: layer28.sae.pt
+  - id: layer29
+    l0: 100
+    path: layer29.sae.pt
+  - id: layer30
+    l0: 100
+    path: layer30.sae.pt
+  - id: layer31
+    l0: 100
+    path: layer31.sae.pt
+qwen-scope-3.5-27b-w80k-l50:
+  conversion_func: qwen_scope
+  model: Qwen/Qwen3.5-27B
+  repo_id: Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_50
+  saes:
+  - id: layer0
+    l0: 50
+    path: layer0.sae.pt
+  - id: layer1
+    l0: 50
+    path: layer1.sae.pt
+  - id: layer2
+    l0: 50
+    path: layer2.sae.pt
+  - id: layer3
+    l0: 50
+    path: layer3.sae.pt
+  - id: layer4
+    l0: 50
+    path: layer4.sae.pt
+  - id: layer5
+    l0: 50
+    path: layer5.sae.pt
+  - id: layer6
+    l0: 50
+    path: layer6.sae.pt
+  - id: layer7
+    l0: 50
+    path: layer7.sae.pt
+  - id: layer8
+    l0: 50
+    path: layer8.sae.pt
+  - id: layer9
+    l0: 50
+    path: layer9.sae.pt
+  - id: layer10
+    l0: 50
+    path: layer10.sae.pt
+  - id: layer11
+    l0: 50
+    path: layer11.sae.pt
+  - id: layer12
+    l0: 50
+    path: layer12.sae.pt
+  - id: layer13
+    l0: 50
+    path: layer13.sae.pt
+  - id: layer14
+    l0: 50
+    path: layer14.sae.pt
+  - id: layer15
+    l0: 50
+    path: layer15.sae.pt
+  - id: layer16
+    l0: 50
+    path: layer16.sae.pt
+  - id: layer17
+    l0: 50
+    path: layer17.sae.pt
+  - id: layer18
+    l0: 50
+    path: layer18.sae.pt
+  - id: layer19
+    l0: 50
+    path: layer19.sae.pt
+  - id: layer20
+    l0: 50
+    path: layer20.sae.pt
+  - id: layer21
+    l0: 50
+    path: layer21.sae.pt
+  - id: layer22
+    l0: 50
+    path: layer22.sae.pt
+  - id: layer23
+    l0: 50
+    path: layer23.sae.pt
+  - id: layer24
+    l0: 50
+    path: layer24.sae.pt
+  - id: layer25
+    l0: 50
+    path: layer25.sae.pt
+  - id: layer26
+    l0: 50
+    path: layer26.sae.pt
+  - id: layer27
+    l0: 50
+    path: layer27.sae.pt
+  - id: layer28
+    l0: 50
+    path: layer28.sae.pt
+  - id: layer29
+    l0: 50
+    path: layer29.sae.pt
+  - id: layer30
+    l0: 50
+    path: layer30.sae.pt
+  - id: layer31
+    l0: 50
+    path: layer31.sae.pt
+  - id: layer32
+    l0: 50
+    path: layer32.sae.pt
+  - id: layer33
+    l0: 50
+    path: layer33.sae.pt
+  - id: layer34
+    l0: 50
+    path: layer34.sae.pt
+  - id: layer35
+    l0: 50
+    path: layer35.sae.pt
+  - id: layer36
+    l0: 50
+    path: layer36.sae.pt
+  - id: layer37
+    l0: 50
+    path: layer37.sae.pt
+  - id: layer38
+    l0: 50
+    path: layer38.sae.pt
+  - id: layer39
+    l0: 50
+    path: layer39.sae.pt
+  - id: layer40
+    l0: 50
+    path: layer40.sae.pt
+  - id: layer41
+    l0: 50
+    path: layer41.sae.pt
+  - id: layer42
+    l0: 50
+    path: layer42.sae.pt
+  - id: layer43
+    l0: 50
+    path: layer43.sae.pt
+  - id: layer44
+    l0: 50
+    path: layer44.sae.pt
+  - id: layer45
+    l0: 50
+    path: layer45.sae.pt
+  - id: layer46
+    l0: 50
+    path: layer46.sae.pt
+  - id: layer47
+    l0: 50
+    path: layer47.sae.pt
+  - id: layer48
+    l0: 50
+    path: layer48.sae.pt
+  - id: layer49
+    l0: 50
+    path: layer49.sae.pt
+  - id: layer50
+    l0: 50
+    path: layer50.sae.pt
+  - id: layer51
+    l0: 50
+    path: layer51.sae.pt
+  - id: layer52
+    l0: 50
+    path: layer52.sae.pt
+  - id: layer53
+    l0: 50
+    path: layer53.sae.pt
+  - id: layer54
+    l0: 50
+    path: layer54.sae.pt
+  - id: layer55
+    l0: 50
+    path: layer55.sae.pt
+  - id: layer56
+    l0: 50
+    path: layer56.sae.pt
+  - id: layer57
+    l0: 50
+    path: layer57.sae.pt
+  - id: layer58
+    l0: 50
+    path: layer58.sae.pt
+  - id: layer59
+    l0: 50
+    path: layer59.sae.pt
+  - id: layer60
+    l0: 50
+    path: layer60.sae.pt
+  - id: layer61
+    l0: 50
+    path: layer61.sae.pt
+  - id: layer62
+    l0: 50
+    path: layer62.sae.pt
+  - id: layer63
+    l0: 50
+    path: layer63.sae.pt
+qwen-scope-3.5-27b-w80k-l100:
+  conversion_func: qwen_scope
+  model: Qwen/Qwen3.5-27B
+  repo_id: Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100
+  saes:
+  - id: layer0
+    l0: 100
+    path: layer0.sae.pt
+  - id: layer1
+    l0: 100
+    path: layer1.sae.pt
+  - id: layer2
+    l0: 100
+    path: layer2.sae.pt
+  - id: layer3
+    l0: 100
+    path: layer3.sae.pt
+  - id: layer4
+    l0: 100
+    path: layer4.sae.pt
+  - id: layer5
+    l0: 100
+    path: layer5.sae.pt
+  - id: layer6
+    l0: 100
+    path: layer6.sae.pt
+  - id: layer7
+    l0: 100
+    path: layer7.sae.pt
+  - id: layer8
+    l0: 100
+    path: layer8.sae.pt
+  - id: layer9
+    l0: 100
+    path: layer9.sae.pt
+  - id: layer10
+    l0: 100
+    path: layer10.sae.pt
+  - id: layer11
+    l0: 100
+    path: layer11.sae.pt
+  - id: layer12
+    l0: 100
+    path: layer12.sae.pt
+  - id: layer13
+    l0: 100
+    path: layer13.sae.pt
+  - id: layer14
+    l0: 100
+    path: layer14.sae.pt
+  - id: layer15
+    l0: 100
+    path: layer15.sae.pt
+  - id: layer16
+    l0: 100
+    path: layer16.sae.pt
+  - id: layer17
+    l0: 100
+    path: layer17.sae.pt
+  - id: layer18
+    l0: 100
+    path: layer18.sae.pt
+  - id: layer19
+    l0: 100
+    path: layer19.sae.pt
+  - id: layer20
+    l0: 100
+    path: layer20.sae.pt
+  - id: layer21
+    l0: 100
+    path: layer21.sae.pt
+  - id: layer22
+    l0: 100
+    path: layer22.sae.pt
+  - id: layer23
+    l0: 100
+    path: layer23.sae.pt
+  - id: layer24
+    l0: 100
+    path: layer24.sae.pt
+  - id: layer25
+    l0: 100
+    path: layer25.sae.pt
+  - id: layer26
+    l0: 100
+    path: layer26.sae.pt
+  - id: layer27
+    l0: 100
+    path: layer27.sae.pt
+  - id: layer28
+    l0: 100
+    path: layer28.sae.pt
+  - id: layer29
+    l0: 100
+    path: layer29.sae.pt
+  - id: layer30
+    l0: 100
+    path: layer30.sae.pt
+  - id: layer31
+    l0: 100
+    path: layer31.sae.pt
+  - id: layer32
+    l0: 100
+    path: layer32.sae.pt
+  - id: layer33
+    l0: 100
+    path: layer33.sae.pt
+  - id: layer34
+    l0: 100
+    path: layer34.sae.pt
+  - id: layer35
+    l0: 100
+    path: layer35.sae.pt
+  - id: layer36
+    l0: 100
+    path: layer36.sae.pt
+  - id: layer37
+    l0: 100
+    path: layer37.sae.pt
+  - id: layer38
+    l0: 100
+    path: layer38.sae.pt
+  - id: layer39
+    l0: 100
+    path: layer39.sae.pt
+  - id: layer40
+    l0: 100
+    path: layer40.sae.pt
+  - id: layer41
+    l0: 100
+    path: layer41.sae.pt
+  - id: layer42
+    l0: 100
+    path: layer42.sae.pt
+  - id: layer43
+    l0: 100
+    path: layer43.sae.pt
+  - id: layer44
+    l0: 100
+    path: layer44.sae.pt
+  - id: layer45
+    l0: 100
+    path: layer45.sae.pt
+  - id: layer46
+    l0: 100
+    path: layer46.sae.pt
+  - id: layer47
+    l0: 100
+    path: layer47.sae.pt
+  - id: layer48
+    l0: 100
+    path: layer48.sae.pt
+  - id: layer49
+    l0: 100
+    path: layer49.sae.pt
+  - id: layer50
+    l0: 100
+    path: layer50.sae.pt
+  - id: layer51
+    l0: 100
+    path: layer51.sae.pt
+  - id: layer52
+    l0: 100
+    path: layer52.sae.pt
+  - id: layer53
+    l0: 100
+    path: layer53.sae.pt
+  - id: layer54
+    l0: 100
+    path: layer54.sae.pt
+  - id: layer55
+    l0: 100
+    path: layer55.sae.pt
+  - id: layer56
+    l0: 100
+    path: layer56.sae.pt
+  - id: layer57
+    l0: 100
+    path: layer57.sae.pt
+  - id: layer58
+    l0: 100
+    path: layer58.sae.pt
+  - id: layer59
+    l0: 100
+    path: layer59.sae.pt
+  - id: layer60
+    l0: 100
+    path: layer60.sae.pt
+  - id: layer61
+    l0: 100
+    path: layer61.sae.pt
+  - id: layer62
+    l0: 100
+    path: layer62.sae.pt
+  - id: layer63
+    l0: 100
+    path: layer63.sae.pt
+qwen-scope-3.5-35b-a3b-base-w32k-l50:
+  conversion_func: qwen_scope
+  model: Qwen/Qwen3.5-35B-A3B-Base
+  repo_id: Qwen/SAE-Res-Qwen3.5-35B-A3B-Base-W32K-L0_50
+  saes:
+  - id: layer0
+    l0: 50
+    path: layer0.sae.pt
+  - id: layer1
+    l0: 50
+    path: layer1.sae.pt
+  - id: layer2
+    l0: 50
+    path: layer2.sae.pt
+  - id: layer3
+    l0: 50
+    path: layer3.sae.pt
+  - id: layer4
+    l0: 50
+    path: layer4.sae.pt
+  - id: layer5
+    l0: 50
+    path: layer5.sae.pt
+  - id: layer6
+    l0: 50
+    path: layer6.sae.pt
+  - id: layer7
+    l0: 50
+    path: layer7.sae.pt
+  - id: layer8
+    l0: 50
+    path: layer8.sae.pt
+  - id: layer9
+    l0: 50
+    path: layer9.sae.pt
+  - id: layer10
+    l0: 50
+    path: layer10.sae.pt
+  - id: layer11
+    l0: 50
+    path: layer11.sae.pt
+  - id: layer12
+    l0: 50
+    path: layer12.sae.pt
+  - id: layer13
+    l0: 50
+    path: layer13.sae.pt
+  - id: layer14
+    l0: 50
+    path: layer14.sae.pt
+  - id: layer15
+    l0: 50
+    path: layer15.sae.pt
+  - id: layer16
+    l0: 50
+    path: layer16.sae.pt
+  - id: layer17
+    l0: 50
+    path: layer17.sae.pt
+  - id: layer18
+    l0: 50
+    path: layer18.sae.pt
+  - id: layer19
+    l0: 50
+    path: layer19.sae.pt
+  - id: layer20
+    l0: 50
+    path: layer20.sae.pt
+  - id: layer21
+    l0: 50
+    path: layer21.sae.pt
+  - id: layer22
+    l0: 50
+    path: layer22.sae.pt
+  - id: layer23
+    l0: 50
+    path: layer23.sae.pt
+  - id: layer24
+    l0: 50
+    path: layer24.sae.pt
+  - id: layer25
+    l0: 50
+    path: layer25.sae.pt
+  - id: layer26
+    l0: 50
+    path: layer26.sae.pt
+  - id: layer27
+    l0: 50
+    path: layer27.sae.pt
+  - id: layer28
+    l0: 50
+    path: layer28.sae.pt
+  - id: layer29
+    l0: 50
+    path: layer29.sae.pt
+  - id: layer30
+    l0: 50
+    path: layer30.sae.pt
+  - id: layer31
+    l0: 50
+    path: layer31.sae.pt
+  - id: layer32
+    l0: 50
+    path: layer32.sae.pt
+  - id: layer33
+    l0: 50
+    path: layer33.sae.pt
+  - id: layer34
+    l0: 50
+    path: layer34.sae.pt
+  - id: layer35
+    l0: 50
+    path: layer35.sae.pt
+  - id: layer36
+    l0: 50
+    path: layer36.sae.pt
+  - id: layer37
+    l0: 50
+    path: layer37.sae.pt
+  - id: layer38
+    l0: 50
+    path: layer38.sae.pt
+  - id: layer39
+    l0: 50
+    path: layer39.sae.pt
+qwen-scope-3.5-35b-a3b-base-w128k-l100:
+  conversion_func: qwen_scope
+  model: Qwen/Qwen3.5-35B-A3B-Base
+  repo_id: Qwen/SAE-Res-Qwen3.5-35B-A3B-Base-W128K-L0_100
+  saes:
+  - id: layer0
+    l0: 100
+    path: layer0.sae.pt
+  - id: layer1
+    l0: 100
+    path: layer1.sae.pt
+  - id: layer2
+    l0: 100
+    path: layer2.sae.pt
+  - id: layer3
+    l0: 100
+    path: layer3.sae.pt
+  - id: layer4
+    l0: 100
+    path: layer4.sae.pt
+  - id: layer5
+    l0: 100
+    path: layer5.sae.pt
+  - id: layer6
+    l0: 100
+    path: layer6.sae.pt
+  - id: layer7
+    l0: 100
+    path: layer7.sae.pt
+  - id: layer8
+    l0: 100
+    path: layer8.sae.pt
+  - id: layer9
+    l0: 100
+    path: layer9.sae.pt
+  - id: layer10
+    l0: 100
+    path: layer10.sae.pt
+  - id: layer11
+    l0: 100
+    path: layer11.sae.pt
+  - id: layer12
+    l0: 100
+    path: layer12.sae.pt
+  - id: layer13
+    l0: 100
+    path: layer13.sae.pt
+  - id: layer14
+    l0: 100
+    path: layer14.sae.pt
+  - id: layer15
+    l0: 100
+    path: layer15.sae.pt
+  - id: layer16
+    l0: 100
+    path: layer16.sae.pt
+  - id: layer17
+    l0: 100
+    path: layer17.sae.pt
+  - id: layer18
+    l0: 100
+    path: layer18.sae.pt
+  - id: layer19
+    l0: 100
+    path: layer19.sae.pt
+  - id: layer20
+    l0: 100
+    path: layer20.sae.pt
+  - id: layer21
+    l0: 100
+    path: layer21.sae.pt
+  - id: layer22
+    l0: 100
+    path: layer22.sae.pt
+  - id: layer23
+    l0: 100
+    path: layer23.sae.pt
+  - id: layer24
+    l0: 100
+    path: layer24.sae.pt
+  - id: layer25
+    l0: 100
+    path: layer25.sae.pt
+  - id: layer26
+    l0: 100
+    path: layer26.sae.pt
+  - id: layer27
+    l0: 100
+    path: layer27.sae.pt
+  - id: layer28
+    l0: 100
+    path: layer28.sae.pt
+  - id: layer29
+    l0: 100
+    path: layer29.sae.pt
+  - id: layer30
+    l0: 100
+    path: layer30.sae.pt
+  - id: layer31
+    l0: 100
+    path: layer31.sae.pt
+  - id: layer32
+    l0: 100
+    path: layer32.sae.pt
+  - id: layer33
+    l0: 100
+    path: layer33.sae.pt
+  - id: layer34
+    l0: 100
+    path: layer34.sae.pt
+  - id: layer35
+    l0: 100
+    path: layer35.sae.pt
+  - id: layer36
+    l0: 100
+    path: layer36.sae.pt
+  - id: layer37
+    l0: 100
+    path: layer37.sae.pt
+  - id: layer38
+    l0: 100
+    path: layer38.sae.pt
+  - id: layer39
+    l0: 100
+    path: layer39.sae.pt

--- a/tests/loading/test_pretrained_sae_loaders.py
+++ b/tests/loading/test_pretrained_sae_loaders.py
@@ -2262,7 +2262,7 @@ def test_get_qwen_scope_config_from_hf_qwen3_5_27b():
     cfg = get_qwen_scope_config_from_hf(
         repo_id="Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
         folder_name="layer42.sae.pt",
-        device="cuda",
+        device="cpu",
     )
 
     assert cfg["activation_fn_kwargs"] == {"k": 100}
@@ -2271,7 +2271,6 @@ def test_get_qwen_scope_config_from_hf_qwen3_5_27b():
     assert cfg["model_name"] == "Qwen/Qwen3.5-27B"
     assert cfg["hook_name"] == "blocks.42.hook_resid_post"
     assert cfg["hf_hook_name"] == "model.layers.42"
-    assert cfg["device"] == "cuda"
 
 
 def test_get_qwen_scope_config_from_hf_overrides():
@@ -2379,8 +2378,6 @@ def test_qwen_scope_sae_huggingface_loader_with_mocked_download(
 def test_qwen_scope_sae_loads_via_from_pretrained(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """End-to-end: an SAE built from a Qwen Scope checkpoint reproduces the
-    reference TopK encode (residual @ W_enc.T + b_enc, then keep top k)."""
     d_in = 64
     d_sae = 256
     k = 8

--- a/tests/loading/test_pretrained_sae_loaders.py
+++ b/tests/loading/test_pretrained_sae_loaders.py
@@ -2262,7 +2262,7 @@ def test_get_qwen_scope_config_from_hf_qwen3_5_27b():
     cfg = get_qwen_scope_config_from_hf(
         repo_id="Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
         folder_name="layer42.sae.pt",
-        device="cpu",
+        device="meta",
     )
 
     assert cfg["activation_fn_kwargs"] == {"k": 100}
@@ -2271,6 +2271,7 @@ def test_get_qwen_scope_config_from_hf_qwen3_5_27b():
     assert cfg["model_name"] == "Qwen/Qwen3.5-27B"
     assert cfg["hook_name"] == "blocks.42.hook_resid_post"
     assert cfg["hf_hook_name"] == "model.layers.42"
+    assert cfg["device"] == "meta"
 
 
 def test_get_qwen_scope_config_from_hf_overrides():

--- a/tests/loading/test_pretrained_sae_loaders.py
+++ b/tests/loading/test_pretrained_sae_loaders.py
@@ -28,12 +28,14 @@ from sae_lens.loading.pretrained_sae_loaders import (
     get_llama_scope_r1_distill_config_from_hf,
     get_mntss_clt_layer_config_from_hf,
     get_mwhanna_transcoder_config_from_hf,
+    get_qwen_scope_config_from_hf,
     handle_pre_6_0_config,
     llama_scope_r1_distill_sae_huggingface_loader,
     llama_scope_sae_huggingface_loader,
     load_sae_config_from_huggingface,
     mntss_clt_layer_huggingface_loader,
     mwhanna_transcoder_huggingface_loader,
+    qwen_scope_sae_huggingface_loader,
     read_sae_components_from_disk,
     sparsify_disk_loader,
     sparsify_huggingface_loader,
@@ -2233,3 +2235,196 @@ def test_temporal_sae_huggingface_loader_with_mocked_download(
     assert "b_dec" in state_dict
     assert state_dict["W_enc"].shape == (d_sae, d_in)
     assert state_dict["W_dec"].shape == (d_sae, d_in)
+
+
+def test_get_qwen_scope_config_from_hf_qwen3_1_7b():
+    cfg = get_qwen_scope_config_from_hf(
+        repo_id="Qwen/SAE-Res-Qwen3-1.7B-Base-W32K-L0_50",
+        folder_name="layer5.sae.pt",
+        device="cpu",
+    )
+
+    assert cfg["architecture"] == "topk"
+    assert cfg["activation_fn"] == "topk"
+    assert cfg["activation_fn_kwargs"] == {"k": 50}
+    assert cfg["d_in"] == 2048
+    assert cfg["d_sae"] == 32768
+    assert cfg["model_name"] == "Qwen/Qwen3-1.7B-Base"
+    assert cfg["hook_name"] == "blocks.5.hook_resid_post"
+    assert cfg["hook_head_index"] is None
+    assert cfg["device"] == "cpu"
+    assert cfg["normalize_activations"] == "none"
+    assert cfg["apply_b_dec_to_input"] is False
+
+
+def test_get_qwen_scope_config_from_hf_qwen3_5_27b():
+    # The 27B repo lacks the "-Base" suffix; ensure parsing handles that.
+    cfg = get_qwen_scope_config_from_hf(
+        repo_id="Qwen/SAE-Res-Qwen3.5-27B-W80K-L0_100",
+        folder_name="layer42.sae.pt",
+        device="cuda",
+    )
+
+    assert cfg["activation_fn_kwargs"] == {"k": 100}
+    assert cfg["d_in"] == 5120
+    assert cfg["d_sae"] == 80 * 1024
+    assert cfg["model_name"] == "Qwen/Qwen3.5-27B"
+    assert cfg["hook_name"] == "blocks.42.hook_resid_post"
+    assert cfg["hf_hook_name"] == "model.layers.42"
+    assert cfg["device"] == "cuda"
+
+
+def test_get_qwen_scope_config_from_hf_overrides():
+    cfg = get_qwen_scope_config_from_hf(
+        repo_id="Qwen/SAE-Res-Qwen3-1.7B-Base-W32K-L0_50",
+        folder_name="layer0.sae.pt",
+        device="cpu",
+        cfg_overrides={"dataset_path": "custom/dataset", "context_size": 4096},
+    )
+
+    assert cfg["dataset_path"] == "custom/dataset"
+    assert cfg["context_size"] == 4096
+
+
+def test_get_qwen_scope_config_from_hf_invalid_layer():
+    with pytest.raises(
+        ValueError, match="Could not find layer number in filename: invalid.pt"
+    ):
+        get_qwen_scope_config_from_hf(
+            repo_id="Qwen/SAE-Res-Qwen3-1.7B-Base-W32K-L0_50",
+            folder_name="invalid.pt",
+            device="cpu",
+        )
+
+
+def test_get_qwen_scope_config_from_hf_unknown_model():
+    with pytest.raises(ValueError, match="Unknown Qwen Scope base model"):
+        get_qwen_scope_config_from_hf(
+            repo_id="Qwen/SAE-Res-Qwen99-1B-Base-W32K-L0_50",
+            folder_name="layer0.sae.pt",
+            device="cpu",
+        )
+
+
+def test_get_qwen_scope_config_from_hf_invalid_repo_id():
+    with pytest.raises(ValueError, match="Could not parse Qwen Scope repo_id"):
+        get_qwen_scope_config_from_hf(
+            repo_id="someone/random-repo",
+            folder_name="layer0.sae.pt",
+            device="cpu",
+        )
+
+
+def test_qwen_scope_sae_huggingface_loader_with_mocked_download(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    d_in = 2048
+    d_sae = 32 * 1024
+
+    # Qwen Scope stores W_enc as (d_sae, d_in) and W_dec as (d_in, d_sae).
+    # The loader transposes both to SAELens convention.
+    raw_W_enc = torch.randn(d_sae, d_in)
+    raw_W_dec = torch.randn(d_in, d_sae)
+    raw_b_enc = torch.randn(d_sae)
+    raw_b_dec = torch.randn(d_in)
+
+    sae_path = tmp_path / "layer3.sae.pt"
+    torch.save(
+        {
+            "W_enc": raw_W_enc,
+            "W_dec": raw_W_dec,
+            "b_enc": raw_b_enc,
+            "b_dec": raw_b_dec,
+        },
+        sae_path,
+    )
+
+    def mock_hf_hub_download(*args: Any, **kwargs: Any) -> str:  # noqa: ARG001
+        return str(sae_path)
+
+    monkeypatch.setattr(
+        "sae_lens.loading.pretrained_sae_loaders.hf_hub_download", mock_hf_hub_download
+    )
+
+    cfg_dict, state_dict, log_sparsity = qwen_scope_sae_huggingface_loader(
+        repo_id="Qwen/SAE-Res-Qwen3-1.7B-Base-W32K-L0_50",
+        folder_name="layer3.sae.pt",
+        device="cpu",
+    )
+
+    assert cfg_dict["d_in"] == d_in
+    assert cfg_dict["d_sae"] == d_sae
+    assert cfg_dict["activation_fn_kwargs"] == {"k": 50}
+    assert cfg_dict["hook_name"] == "blocks.3.hook_resid_post"
+    assert log_sparsity is None
+    assert set(state_dict.keys()) == {"W_enc", "W_dec", "b_enc", "b_dec"}
+    assert state_dict["W_enc"].shape == (d_in, d_sae)
+    assert state_dict["W_dec"].shape == (d_sae, d_in)
+
+    # The transpose must preserve the underlying linear operation: in the
+    # native Qwen Scope formula, pre_acts = residual @ raw_W_enc.T + b_enc.
+    # In SAELens, pre_acts = residual @ W_enc + b_enc. They must agree.
+    residual = torch.randn(2, 7, d_in)
+    expected_pre_acts = residual @ raw_W_enc.T + raw_b_enc
+    actual_pre_acts = residual @ state_dict["W_enc"] + state_dict["b_enc"]
+    assert_close(actual_pre_acts, expected_pre_acts)
+
+    # Same for the decoder: native is feats @ raw_W_dec.T + b_dec, SAELens is feats @ W_dec + b_dec.
+    feats = torch.randn(2, 7, d_sae)
+    expected_recon = feats @ raw_W_dec.T + raw_b_dec
+    actual_recon = feats @ state_dict["W_dec"] + state_dict["b_dec"]
+    assert_close(actual_recon, expected_recon)
+
+
+def test_qwen_scope_sae_loads_via_from_pretrained(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """End-to-end: an SAE built from a Qwen Scope checkpoint reproduces the
+    reference TopK encode (residual @ W_enc.T + b_enc, then keep top k)."""
+    d_in = 64
+    d_sae = 256
+    k = 8
+    layer = 2
+
+    raw_W_enc = torch.randn(d_sae, d_in)
+    raw_W_dec = torch.randn(d_in, d_sae)
+    raw_b_enc = torch.randn(d_sae)
+    raw_b_dec = torch.randn(d_in)
+
+    sae_path = tmp_path / f"layer{layer}.sae.pt"
+    torch.save(
+        {
+            "W_enc": raw_W_enc,
+            "W_dec": raw_W_dec,
+            "b_enc": raw_b_enc,
+            "b_dec": raw_b_dec,
+        },
+        sae_path,
+    )
+
+    def mock_hf_hub_download(*args: Any, **kwargs: Any) -> str:  # noqa: ARG001
+        return str(sae_path)
+
+    monkeypatch.setattr(
+        "sae_lens.loading.pretrained_sae_loaders.hf_hub_download", mock_hf_hub_download
+    )
+
+    cfg_dict, state_dict, _ = qwen_scope_sae_huggingface_loader(
+        repo_id=f"Qwen/SAE-Res-Qwen3-1.7B-Base-W32K-L0_{k}",
+        folder_name=f"layer{layer}.sae.pt",
+        # Override d_in / d_sae to avoid mismatch with the real Qwen3-1.7B sizes.
+        cfg_overrides={"d_in": d_in, "d_sae": d_sae},
+        device="cpu",
+    )
+    cfg_dict = handle_pre_6_0_config(cfg_dict)
+    sae = SAE.from_dict(cfg_dict)
+    sae.load_state_dict(state_dict)
+
+    residual = torch.randn(3, 5, d_in)
+    pre_acts = residual @ raw_W_enc.T + raw_b_enc
+    topk_vals, topk_idx = pre_acts.topk(k, dim=-1)
+    expected_acts = torch.zeros_like(pre_acts)
+    expected_acts.scatter_(-1, topk_idx, topk_vals.relu())
+
+    actual_acts = sae.encode(residual)
+    assert_close(actual_acts, expected_acts)


### PR DESCRIPTION
## Summary

Adds support for the 14 [Qwen Scope](https://huggingface.co/collections/Qwen/qwen-scope) TopK SAE releases — 552 SAEs across 7 Qwen3 / Qwen3.5 backbones (dense and MoE), residual stream, all transformer layers.

- New `qwen_scope` loader (`get_qwen_scope_config_from_hf` + `qwen_scope_sae_huggingface_loader`) that parses the SAE repo name (`SAE-Res-{model}-W{N}K-L0_{K}`) and per-layer filename (`layer{n}.sae.pt`) to derive `d_in`, `d_sae`, `k`, `model_name`, `hook_name`, and `hf_hook_name`. Transposes `W_enc` (d_sae,d_in) and `W_dec` (d_in,d_sae) into SAELens convention.
- 14 YAML releases (Qwen3 1.7B/8B/30B-A3B-Base, Qwen3.5 2B/9B/35B-A3B-Base, Qwen3.5-27B), each at L0 ∈ {50, 100} and width 16× / 64× hidden_size. Per the [technical report](https://qianwen-res.oss-accelerate.aliyuncs.com/qwen-scope/Qwen_Scope.pdf) Table 1, all backbones are the `-Base` variant except Qwen3.5-27B, which is trained on the instruct variant. SAE ids use the `layer{n}` form to mirror the source path.
- `dataset_path` is left as `None` since Qwen Scope is trained on Qwen's in-house pretraining data, which is not public.

## Test plan

- [x] `poetry run pytest tests/loading/test_pretrained_sae_loaders.py` (67 passed, 1 unrelated skip)
- [x] `poetry run ruff check` clean on changed files
- [x] `poetry run pyright` clean on the loader file
- [x] 8 new tests covering: config parsing for both Qwen3 and Qwen3.5 variants, overrides, three error cases, end-to-end weight transpose correctness (verifies `residual @ W_enc.T + b_enc` matches SAELens `residual @ W_enc + b_enc` after the transpose), and a full `SAE.from_dict` + `sae.encode(...)` reproducing the README's reference TopK formula.

🤖 Generated with [Claude Code](https://claude.com/claude-code)