### PR TITLE
feat: add MultiSAETrainingRunner for parallel SAE training

### DIFF
--- a/docs/training_saes.md
+++ b/docs/training_saes.md
@@ -359,6 +359,71 @@ cfg = LanguageModelSAERunnerConfig( # Full config would be defined here
 sparse_autoencoder = LanguageModelSAETrainingRunner(cfg).run()
 ```
 
+## Training multiple SAEs in parallel (experimental)
+
+<!-- prettier-ignore-start -->
+!!! warning "Experimental feature"
+    Multi-SAE training is a new feature and the API may change. The V1 release intentionally omits CLI/argparse support, cached activations, `from_pretrained_path` per entry, and `compile_sae=True`. `compile_llm=True` is supported because the model is shared.
+<!-- prettier-ignore-end -->
+
+If you want to train a sweep of SAEs that share the same model — e.g., several `l1_coefficient` values at one hook point, or one SAE per layer for a layer-by-layer study — you can use [MultiSAETrainingRunner][sae_lens.MultiSAETrainingRunner] to run the LLM forward pass once per batch and feed the captured activations to every SAE in parallel. Each SAE keeps its own optimizer, learning-rate schedule, coefficient schedulers, activation scaler, and sparsity tracking, exactly as in single-SAE training; the runner just multiplexes the shared activation stream.
+
+The runner accepts a dict of SAE configs and a hook-name spec. Pass `hook_names` as a single string when all SAEs share one hook, or as a dict when they don't. Different SAEs can use different architectures, but SAEs sharing a hook in V1 must agree on `d_in` and `hook_head_index`.
+
+```python
+from sae_lens import (
+    MultiSAETrainingRunner,
+    MultiSAETrainingRunnerConfig,
+    StandardTrainingSAEConfig,
+    TopKTrainingSAEConfig,
+    LoggingConfig,
+)
+
+cfg = MultiSAETrainingRunnerConfig(
+    saes={
+        "h5_l1_low":  StandardTrainingSAEConfig(d_in=768, d_sae=16 * 1024, l1_coefficient=2.0),
+        "h5_l1_high": StandardTrainingSAEConfig(d_in=768, d_sae=16 * 1024, l1_coefficient=5.0),
+        "h10_topk":   TopKTrainingSAEConfig(d_in=768, d_sae=16 * 1024, k=64),
+    },
+    hook_names={
+        "h5_l1_low":  "blocks.5.hook_resid_pre",
+        "h5_l1_high": "blocks.5.hook_resid_pre",
+        "h10_topk":   "blocks.10.hook_resid_pre",
+    },
+    # OR a single string when every SAE shares one hook:
+    # hook_names="blocks.5.hook_resid_pre",
+
+    model_name="gpt2",
+    dataset_path="apollo-research/Skylion007-openwebtext-tokenizer-gpt2",
+    training_tokens=int(1e8),
+    train_batch_size_tokens=4096,
+    output_path="output/sweep_run_1",
+    logger=LoggingConfig(log_to_wandb=True, wandb_project="multi_sae_sweep"),
+)
+
+trained_saes = MultiSAETrainingRunner(cfg).run()  # dict[name, TrainingSAE]
+```
+
+Wandb metrics are namespaced by SAE name (e.g. `h5_l1_low/losses/overall_loss`) so per-SAE curves can be inspected side-by-side in one run. Built-in evals run sequentially per SAE; eval cost therefore scales linearly with the number of SAEs — if this becomes a bottleneck, raise `eval_every_n_wandb_logs` so evals run less often. You can also pass a custom per-SAE `evaluator` callable; it will be applied to every SAE with that SAE's single-hook view of the data provider.
+
+Checkpointing follows the single-SAE layout but adds a per-SAE subdirectory inside each checkpoint:
+
+```
+checkpoints/<unique_id>/<n_training_samples>/
+├── runner_cfg.json
+├── activations_store.pt
+├── h5_l1_low/
+│   ├── sae_weights.safetensors
+│   ├── cfg.json
+│   ├── sparsity.safetensors
+│   ├── trainer_state.pt
+│   └── activation_scaler.json
+├── h5_l1_high/...
+└── h10_topk/...
+```
+
+Resume by passing `resume_from_checkpoint=<checkpoint_dir>`. The per-SAE keys in `cfg.saes` must exactly match the subdirectories saved in the checkpoint.
+
 ## CLI Runner
 
 The SAE training runner can also be run from the command line via the `sae_lens.sae_training_runner` module. This can be useful for quickly testing different hyperparameters or running training on a remote server. The command line interface is shown below. All options to the CLI are the same as the [LanguageModelSAERunnerConfig][sae_lens.LanguageModelSAERunnerConfig] with a `--` prefix. E.g., `--model_name` is the same as `model_name` in the config.

--- a/sae_lens/__init__.py
+++ b/sae_lens/__init__.py
@@ -60,6 +60,11 @@ from .loading.pretrained_sae_loaders import (
     PretrainedSaeDiskLoader,
     PretrainedSaeHuggingfaceLoader,
 )
+from .multi_sae_training_runner import (
+    MultiSAEEvaluator,
+    MultiSAETrainingRunner,
+    MultiSAETrainingRunnerConfig,
+)
 from .pretokenize_runner import PretokenizeRunner, pretokenize_runner
 from .registry import register_sae_class, register_sae_training_class
 from .training.activations_store import ActivationsStore
@@ -123,6 +128,9 @@ __all__ = [
     "MatchingPursuitTrainingSAE",
     "MatchingPursuitSAEConfig",
     "MatchingPursuitTrainingSAEConfig",
+    "MultiSAEEvaluator",
+    "MultiSAETrainingRunner",
+    "MultiSAETrainingRunnerConfig",
 ]
 
 # Conditional export for SAETransformerBridge (requires transformer-lens v3+)

--- a/sae_lens/llm_sae_training_runner.py
+++ b/sae_lens/llm_sae_training_runner.py
@@ -29,19 +29,12 @@ from sae_lens.saes.sae import (
     TrainingSAE,
     TrainingSAEConfig,
 )
+from sae_lens.training._interruption import InterruptedException, interrupt_callback
 from sae_lens.training.activation_scaler import ActivationScaler
 from sae_lens.training.activations_store import ActivationsStore
 from sae_lens.training.prefetch import PrefetchingIterator
 from sae_lens.training.sae_trainer import SAETrainer
 from sae_lens.training.types import DataProvider
-
-
-class InterruptedException(Exception):
-    pass
-
-
-def interrupt_callback(sig_num: Any, stack_frame: Any):  # noqa: ARG001
-    raise InterruptedException()
 
 
 @dataclass
@@ -75,13 +68,11 @@ class LLMSaeEvaluator(Generic[T_TRAINING_SAE]):
         )
 
         # Eval calls into self.activations_store directly, which would race the
-        # prefetcher's producer thread on shared generator state. Pause it (if
-        # the data provider exposes a paused() context manager) for the
-        # duration of the eval. Duck-typed so that wrappers around
-        # PrefetchingIterator that forward `paused` still get pause coverage.
+        # prefetcher's producer thread on shared generator state. Pause it for
+        # the duration of the eval.
         pause_ctx: AbstractContextManager[None] = (
-            data_provider.paused()  # pyright: ignore[reportAttributeAccessIssue]
-            if hasattr(data_provider, "paused")
+            data_provider.paused()
+            if isinstance(data_provider, PrefetchingIterator)
             else nullcontext()
         )
         with pause_ctx:

--- a/sae_lens/loading/pretrained_sae_loaders.py
+++ b/sae_lens/loading/pretrained_sae_loaders.py
@@ -1652,7 +1652,7 @@ def get_safetensors_tensor_shapes(repo_id: str, filename: str) -> dict[str, list
     hf_headers = build_hf_headers()
 
     # Fetch first 8 bytes to get metadata size
-    headers = {**hf_headers, "Range": "bytes=0-7"}
+    headers: dict[str, str | bytes] = {**hf_headers, "Range": "bytes=0-7"}
     response = requests.get(url, headers=headers, timeout=10)
     response.raise_for_status()
 

--- a/sae_lens/multi_sae_training_runner.py
+++ b/sae_lens/multi_sae_training_runner.py
@@ -1,0 +1,669 @@
+"""
+Public entrypoint for training multiple SAEs in parallel from a shared LLM
+forward pass.
+
+Use `MultiSAETrainingRunner(MultiSAETrainingRunnerConfig(...)).run()` to train
+N SAEs that share a model and capture activations from one or more hook points
+in a single forward. Each SAE has its own optimizer, learning-rate schedule,
+coefficient schedulers, activation scaler, and sparsity tracking — exactly as
+in single-SAE training. The runner just orchestrates the shared model and
+multi-hook activations.
+
+V1 limitations (see plan: out-of-scope):
+
+- Argparse/CLI not supported (programmatic config only).
+- `from_pretrained_path` per entry not supported (resume from a multi-SAE
+  checkpoint instead).
+- Cached activations not supported in multi-hook mode.
+- `compile_sae=True` not supported (`compile_llm=True` works fine — model is
+  shared).
+"""
+
+from __future__ import annotations
+
+import json
+import signal
+from collections.abc import Callable, Mapping
+from contextlib import AbstractContextManager, nullcontext
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import torch
+import wandb
+from safetensors.torch import save_file
+from transformer_lens.hook_points import HookedRootModule
+
+from sae_lens import __version__, logger
+from sae_lens.config import HfDataset, LoggingConfig, SAETrainerConfig
+from sae_lens.constants import RUNNER_CFG_FILENAME, SPARSITY_FILENAME
+from sae_lens.evals import EvalConfig, run_evals
+from sae_lens.load_model import load_model
+from sae_lens.saes.sae import TrainingSAE, TrainingSAEConfig
+from sae_lens.training.activation_scaler import ActivationScaler
+from sae_lens.training.activations_store import ActivationsStore
+from sae_lens.training.multi_sae_trainer import MultiSAETrainer
+from sae_lens.training.prefetch import PrefetchingIterator
+from sae_lens.training.types import MultiHookDataProvider
+
+
+class InterruptedException(Exception):
+    pass
+
+
+def _interrupt_callback(sig_num: Any, stack_frame: Any) -> None:  # noqa: ARG001
+    raise InterruptedException()
+
+
+# A user-supplied custom evaluator. Mirrors the single-SAE Evaluator signature
+# but applied per SAE: `(sae, single_hook_data_provider_view, sae's scaler)`.
+# Returns a flat dict that the runner prefixes with `{sae_name}/` when merging.
+PerSAEEvaluator = Callable[[TrainingSAE[Any], Any, ActivationScaler], dict[str, Any]]
+
+
+@dataclass
+class MultiSAETrainingRunnerConfig:
+    """
+    Configuration for parallel multi-SAE training.
+
+    `saes` is a dict from a user-chosen name to a `TrainingSAEConfig`
+    (different SAEs can use different architectures). `hook_names` maps the
+    same names to TransformerLens hook points; pass a single string to share
+    one hook across every SAE. SAEs sharing a hook in V1 must agree on `d_in`
+    and `hook_head_index`.
+    """
+
+    saes: Mapping[str, TrainingSAEConfig]
+    hook_names: Mapping[str, str] | str
+
+    hook_head_indices: dict[str, int | None] | int | None = None
+
+    # Data Generating Function
+    model_name: str = "gelu-2l"
+    model_class_name: str = "HookedTransformer"
+    dataset_path: str = ""
+    dataset_trust_remote_code: bool = True
+    streaming: bool = True
+    use_chat_formatting: bool = False
+    context_size: int = 128
+
+    # Activation Store Parameters
+    n_batches_in_buffer: int = 20
+    training_tokens: int = 2_000_000
+    store_batch_size_prompts: int = 32
+    seqpos_slice: tuple[int | None, ...] = (None,)
+    disable_concat_sequences: bool = False
+    sequence_separator_token: int | Literal["bos", "eos", "sep"] | None = "bos"
+    activations_mixing_fraction: float = 0.5
+
+    # Devices
+    device: str = "cpu"
+    llm_device: str | None = None
+    act_store_device: str | None = None
+    prefetch_llm_batches: bool | int = False
+
+    # Performance
+    seed: int = 42
+    dtype: str = "float32"
+    prepend_bos: bool = True
+    autocast: bool = False
+    autocast_lm: bool = False
+    compile_llm: bool = False
+    llm_compilation_mode: str | None = None
+
+    # Training Parameters
+    train_batch_size_tokens: int = 4096
+    adam_beta1: float = 0.9
+    adam_beta2: float = 0.999
+    lr: float = 3e-4
+    lr_scheduler_name: str = "constant"
+    lr_warm_up_steps: int = 0
+    lr_end: float | None = None
+    lr_decay_steps: int = 0
+    n_restart_cycles: int = 1
+
+    # Resampling protocol
+    dead_feature_window: int = 1000
+    feature_sampling_window: int = 2000
+    dead_feature_threshold: float = 1e-8
+
+    # Evals
+    n_eval_batches: int = 10
+    eval_batch_size_prompts: int | None = None
+    evaluator: PerSAEEvaluator | None = None
+
+    # Logging
+    logger: LoggingConfig = field(default_factory=LoggingConfig)
+
+    # Outputs / Checkpoints
+    n_checkpoints: int = 0
+    checkpoint_path: str | None = "checkpoints"
+    save_final_checkpoint: bool = False
+    output_path: str | None = "output"
+    resume_from_checkpoint: str | None = None
+
+    # Misc
+    verbose: bool = True
+    model_kwargs: dict[str, Any] = field(default_factory=dict)
+    model_from_pretrained_kwargs: dict[str, Any] | None = None
+    sae_lens_version: str = field(default_factory=lambda: __version__)
+    sae_lens_training_version: str = field(default_factory=lambda: __version__)
+    exclude_special_tokens: bool | list[int] = False
+    n_batches_for_norm_estimate: int = 1000
+
+    # Internal: populated by __post_init__
+    _hook_names_per_sae: dict[str, str] = field(default_factory=dict)
+    _hook_head_indices_per_sae: dict[str, int | None] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.saes:
+            raise ValueError("saes must contain at least one entry")
+
+        # Normalize hook_names to a per-SAE dict.
+        if isinstance(self.hook_names, str):
+            self._hook_names_per_sae = {name: self.hook_names for name in self.saes}
+        else:
+            extra = set(self.hook_names) - set(self.saes)
+            missing = set(self.saes) - set(self.hook_names)
+            if extra or missing:
+                raise ValueError(
+                    f"hook_names keys must match saes keys; "
+                    f"extra: {sorted(extra)}; missing: {sorted(missing)}"
+                )
+            self._hook_names_per_sae = dict(self.hook_names)
+
+        # Normalize hook_head_indices to a per-SAE dict.
+        if self.hook_head_indices is None or isinstance(self.hook_head_indices, int):
+            shared_head = self.hook_head_indices
+            self._hook_head_indices_per_sae = {name: shared_head for name in self.saes}
+        else:
+            extra = set(self.hook_head_indices) - set(self.saes)
+            if extra:
+                raise ValueError(
+                    f"hook_head_indices has unknown keys (not in saes): {sorted(extra)}"
+                )
+            self._hook_head_indices_per_sae = {
+                name: self.hook_head_indices.get(name) for name in self.saes
+            }
+
+        # SAEs sharing a hook must agree on d_in and hook_head_index in V1.
+        per_hook_d_in: dict[str, int] = {}
+        per_hook_head_idx: dict[str, int | None] = {}
+        for name, hook in self._hook_names_per_sae.items():
+            d_in = self.saes[name].d_in
+            head_idx = self._hook_head_indices_per_sae[name]
+            if hook in per_hook_d_in:
+                if per_hook_d_in[hook] != d_in:
+                    raise ValueError(
+                        f"SAEs sharing hook {hook!r} must have the same d_in; "
+                        f"saw {per_hook_d_in[hook]} and {d_in}"
+                    )
+                if per_hook_head_idx[hook] != head_idx:
+                    raise ValueError(
+                        f"SAEs sharing hook {hook!r} must have the same hook_head_index in V1; "
+                        f"saw {per_hook_head_idx[hook]} and {head_idx}"
+                    )
+            else:
+                per_hook_d_in[hook] = d_in
+                per_hook_head_idx[hook] = head_idx
+
+        if self.logger.run_name is None:
+            archs = sorted({sae.architecture() for sae in self.saes.values()})
+            self.logger.run_name = (
+                f"multi-{'+'.join(archs)}-N{len(self.saes)}-LR-{self.lr}"
+                f"-Tokens-{self.training_tokens:.3e}"
+            )
+
+        if self.model_from_pretrained_kwargs is None:
+            if self.model_class_name == "HookedTransformer":
+                self.model_from_pretrained_kwargs = {"center_writing_weights": False}
+            else:
+                self.model_from_pretrained_kwargs = {}
+
+        if self.llm_device is None:
+            self.llm_device = self.device
+        if self.act_store_device is None:
+            self.act_store_device = self.device
+        elif self.act_store_device == "with_model":
+            self.act_store_device = self.llm_device
+
+        if (
+            not isinstance(self.prefetch_llm_batches, bool)
+            and self.prefetch_llm_batches < 0
+        ):
+            raise ValueError(
+                "prefetch_llm_batches must be a bool or a non-negative int "
+                f"(0 / False disables prefetching), got {self.prefetch_llm_batches}"
+            )
+
+        if self.lr_end is None:
+            self.lr_end = self.lr / 10
+
+        unique_id = self.logger.wandb_id
+        if unique_id is None:
+            unique_id = wandb.util.generate_id()  # type: ignore[attr-defined]
+        if self.checkpoint_path is not None:
+            self.checkpoint_path = f"{self.checkpoint_path}/{unique_id}"
+
+        if isinstance(self.exclude_special_tokens, list) and not all(
+            isinstance(x, int) for x in self.exclude_special_tokens
+        ):
+            raise ValueError("exclude_special_tokens list must contain only integers")
+
+    @property
+    def hook_names_per_sae(self) -> dict[str, str]:
+        return self._hook_names_per_sae
+
+    @property
+    def hook_head_indices_per_sae(self) -> dict[str, int | None]:
+        return self._hook_head_indices_per_sae
+
+    @property
+    def total_training_tokens(self) -> int:
+        return self.training_tokens
+
+    @property
+    def total_training_steps(self) -> int:
+        return self.total_training_tokens // self.train_batch_size_tokens
+
+    def to_sae_trainer_config(self) -> SAETrainerConfig:
+        return SAETrainerConfig(
+            n_checkpoints=self.n_checkpoints,
+            checkpoint_path=self.checkpoint_path,
+            save_final_checkpoint=self.save_final_checkpoint,
+            total_training_samples=self.total_training_tokens,
+            device=self.device,
+            autocast=self.autocast,
+            lr=self.lr,
+            lr_end=self.lr_end,
+            lr_scheduler_name=self.lr_scheduler_name,
+            lr_warm_up_steps=self.lr_warm_up_steps,
+            adam_beta1=self.adam_beta1,
+            adam_beta2=self.adam_beta2,
+            lr_decay_steps=self.lr_decay_steps,
+            n_restart_cycles=self.n_restart_cycles,
+            train_batch_size_samples=self.train_batch_size_tokens,
+            dead_feature_window=self.dead_feature_window,
+            feature_sampling_window=self.feature_sampling_window,
+            logger=self.logger,
+            n_batches_for_norm_estimate=self.n_batches_for_norm_estimate,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        from dataclasses import asdict
+
+        d = asdict(self)
+        d["logger"] = asdict(self.logger)
+        d["saes"] = {name: cfg.to_dict() for name, cfg in self.saes.items()}
+        d.pop("evaluator", None)  # not serializable
+        return d
+
+
+class _SingleHookDataProviderView:
+    """Adapter exposing one hook's slice of a multi-hook DataProvider as `Iterator[Tensor]`."""
+
+    def __init__(self, source: MultiHookDataProvider, hook_name: str) -> None:
+        self._source = source
+        self._hook_name = hook_name
+
+    def __iter__(self) -> _SingleHookDataProviderView:
+        return self
+
+    def __next__(self) -> torch.Tensor:
+        return next(self._source)[self._hook_name]
+
+
+@dataclass
+class MultiSAEEvaluator:
+    """
+    Per-SAE built-in evaluator wrapper. Built-in evals (`run_evals`) run once
+    per SAE — sequential, with model substitution for KL / CE recovered.
+    Optionally also runs a user-supplied per-SAE evaluator on a single-hook
+    view of the multi-hook DataProvider.
+    """
+
+    model: HookedRootModule
+    activations_store: ActivationsStore
+    eval_batch_size_prompts: int | None
+    n_eval_batches: int
+    model_kwargs: Mapping[str, Any]
+    user_evaluator: PerSAEEvaluator | None = None
+
+    def __call__(
+        self,
+        saes: dict[str, TrainingSAE[Any]],
+        data_provider: MultiHookDataProvider,
+        activation_scalers: dict[str, ActivationScaler],
+        hook_names: dict[str, str],
+    ) -> dict[str, Any]:
+        exclude_special_tokens: bool | list[int] = False
+        if self.activations_store.exclude_special_tokens is not None:
+            exclude_special_tokens = (
+                self.activations_store.exclude_special_tokens.tolist()
+            )
+
+        eval_config = EvalConfig(
+            batch_size_prompts=self.eval_batch_size_prompts,
+            n_eval_reconstruction_batches=self.n_eval_batches,
+            n_eval_sparsity_variance_batches=self.n_eval_batches,
+            compute_ce_loss=True,
+            compute_l2_norms=True,
+            compute_sparsity_metrics=True,
+            compute_variance_metrics=True,
+        )
+
+        # Pause the prefetcher (if any) for the whole eval cycle; both built-in
+        # and user evaluators may pull from the underlying generator state.
+        pause_ctx: AbstractContextManager[None] = (
+            data_provider.paused()  # type: ignore[attr-defined]
+            if hasattr(data_provider, "paused")
+            else nullcontext()
+        )
+        out: dict[str, Any] = {}
+        with pause_ctx:
+            for name, sae in saes.items():
+                # `run_evals` reads sae.cfg.metadata.hook_name to know which hook
+                # to substitute; the activation_store is just a token source so
+                # passing the multi-hook store directly is correct.
+                metrics, _ = run_evals(
+                    sae=sae,
+                    activation_store=self.activations_store,
+                    model=self.model,
+                    activation_scaler=activation_scalers[name],
+                    eval_config=eval_config,
+                    exclude_special_tokens=exclude_special_tokens,
+                    model_kwargs=dict(self.model_kwargs),
+                )
+                # Drop metrics that are already logged during training (matches
+                # the single-SAE LLMSaeEvaluator).
+                for k in (
+                    "metrics/explained_variance",
+                    "metrics/explained_variance_std",
+                    "metrics/l0",
+                    "metrics/l1",
+                    "metrics/mse",
+                    "metrics/total_tokens_evaluated",
+                ):
+                    metrics.pop(k, None)
+                for k, v in metrics.items():
+                    out[f"{name}/{k}"] = v
+
+                if self.user_evaluator is not None:
+                    user_view = _SingleHookDataProviderView(
+                        data_provider, hook_names[name]
+                    )
+                    user_metrics = self.user_evaluator(
+                        sae, user_view, activation_scalers[name]
+                    )
+                    for k, v in user_metrics.items():
+                        out[f"{name}/{k}"] = v
+        return out
+
+
+class MultiSAETrainingRunner:
+    """
+    Orchestrator that wires the model, multi-hook ActivationsStore, dict of
+    `TrainingSAE`s, evaluator, and `MultiSAETrainer`. Public surface:
+    `__init__(cfg, ...)` and `run() -> dict[str, TrainingSAE]`.
+    """
+
+    cfg: MultiSAETrainingRunnerConfig
+    model: HookedRootModule
+    saes: dict[str, TrainingSAE[Any]]
+    activations_store: ActivationsStore
+
+    def __init__(
+        self,
+        cfg: MultiSAETrainingRunnerConfig,
+        override_dataset: HfDataset | None = None,
+        override_model: HookedRootModule | None = None,
+        override_saes: dict[str, TrainingSAE[Any]] | None = None,
+    ) -> None:
+        self.cfg = cfg
+
+        if override_dataset is not None:
+            logger.warning(
+                f"override_dataset overrides cfg.dataset_path={cfg.dataset_path!r}; "
+                "this run will not be reproducible from configuration alone."
+            )
+        if override_model is not None:
+            logger.warning(
+                f"override_model overrides cfg.model_name={cfg.model_name!r}; "
+                "this run will not be reproducible from configuration alone."
+            )
+
+        llm_device = cfg.llm_device
+        assert llm_device is not None  # set in __post_init__
+
+        self.model = (
+            override_model
+            if override_model is not None
+            else load_model(
+                cfg.model_class_name,
+                cfg.model_name,
+                device=llm_device,
+                model_from_pretrained_kwargs=cfg.model_from_pretrained_kwargs,
+            )
+        )
+
+        unique_hooks = list(dict.fromkeys(cfg.hook_names_per_sae.values()))
+        hook_d_ins: dict[str, int] = {}
+        hook_head_indices: dict[str, int | None] = {}
+        for name, hook in cfg.hook_names_per_sae.items():
+            hook_d_ins.setdefault(hook, cfg.saes[name].d_in)
+            hook_head_indices.setdefault(hook, cfg.hook_head_indices_per_sae[name])
+
+        # All SAEs share normalize_activations? No — each SAE's normalize is per-SAE,
+        # but the store doesn't apply normalization itself (the trainer's per-SAE
+        # ActivationScaler does). Pass "none" to the store to keep its normalize
+        # field a no-op; per-SAE scaling is handled inside the trainer.
+        self.activations_store = ActivationsStore.from_config_multi_hook(
+            model=self.model,
+            dataset=override_dataset
+            if override_dataset is not None
+            else cfg.dataset_path,
+            hook_names=unique_hooks,
+            hook_d_ins=hook_d_ins,
+            hook_head_indices=hook_head_indices,
+            streaming=cfg.streaming,
+            context_size=cfg.context_size,
+            n_batches_in_buffer=cfg.n_batches_in_buffer,
+            total_training_tokens=cfg.training_tokens,
+            store_batch_size_prompts=cfg.store_batch_size_prompts,
+            train_batch_size_tokens=cfg.train_batch_size_tokens,
+            prepend_bos=cfg.prepend_bos,
+            normalize_activations="none",
+            device=torch.device(cfg.act_store_device),  # type: ignore[arg-type]
+            dtype=cfg.dtype,
+            model_kwargs=cfg.model_kwargs,
+            autocast_lm=cfg.autocast_lm,
+            dataset_trust_remote_code=cfg.dataset_trust_remote_code,
+            seqpos_slice=cfg.seqpos_slice,
+            exclude_special_tokens=_resolve_exclude_special_tokens(
+                cfg.exclude_special_tokens,
+                self.model,
+                torch.device(cfg.act_store_device),  # type: ignore[arg-type]
+            ),
+            disable_concat_sequences=cfg.disable_concat_sequences,
+            sequence_separator_token=cfg.sequence_separator_token,
+            activations_mixing_fraction=cfg.activations_mixing_fraction,
+            use_chat_formatting=cfg.use_chat_formatting,
+        )
+
+        if override_saes is None:
+            self.saes = {
+                name: TrainingSAE.from_dict(sae_cfg.to_dict())
+                for name, sae_cfg in cfg.saes.items()
+            }
+        else:
+            extra = set(override_saes) - set(cfg.saes)
+            missing = set(cfg.saes) - set(override_saes)
+            if extra or missing:
+                raise ValueError(
+                    f"override_saes keys must match cfg.saes; extra: {sorted(extra)}; missing: {sorted(missing)}"
+                )
+            self.saes = override_saes
+
+        for sae in self.saes.values():
+            sae.to(cfg.device)
+
+    def run(self) -> dict[str, TrainingSAE[Any]]:
+        self._set_sae_metadata()
+        if self.cfg.logger.log_to_wandb:
+            wandb.init(
+                project=self.cfg.logger.wandb_project,
+                entity=self.cfg.logger.wandb_entity,
+                config=self.cfg.to_dict(),
+                name=self.cfg.logger.run_name,
+                id=self.cfg.logger.wandb_id,
+            )
+
+        evaluator = MultiSAEEvaluator(
+            model=self.model,
+            activations_store=self.activations_store,
+            eval_batch_size_prompts=self.cfg.eval_batch_size_prompts,
+            n_eval_batches=self.cfg.n_eval_batches,
+            model_kwargs=self.cfg.model_kwargs,
+            user_evaluator=self.cfg.evaluator,
+        )
+
+        data_provider: MultiHookDataProvider = (
+            self.activations_store.get_multi_hook_data_loader()
+        )
+        if self.cfg.prefetch_llm_batches:
+            prefetch_size = (
+                1
+                if isinstance(self.cfg.prefetch_llm_batches, bool)
+                else self.cfg.prefetch_llm_batches
+            )
+            data_provider = PrefetchingIterator(data_provider, prefetch=prefetch_size)
+
+        if self.cfg.compile_llm:
+            self.model = torch.compile(self.model, mode=self.cfg.llm_compilation_mode)  # type: ignore[assignment]
+
+        trainer = MultiSAETrainer(
+            cfg=self.cfg.to_sae_trainer_config(),
+            saes=self.saes,
+            hook_names=self.cfg.hook_names_per_sae,
+            data_provider=data_provider,
+            evaluator=evaluator,
+            save_checkpoint_fn=self._save_runner_checkpoint_files,
+        )
+
+        if self.cfg.resume_from_checkpoint is not None:
+            logger.info(f"Resuming from checkpoint: {self.cfg.resume_from_checkpoint}")
+            trainer.load_checkpoint(self.cfg.resume_from_checkpoint)
+            self.activations_store.load_from_checkpoint(self.cfg.resume_from_checkpoint)
+
+        saes = self._run_with_interruption_handling(trainer)
+
+        if self.cfg.output_path is not None:
+            self._save_final_outputs(saes)
+
+        if self.cfg.logger.log_to_wandb:
+            wandb.finish()
+
+        return saes
+
+    def _run_with_interruption_handling(
+        self, trainer: MultiSAETrainer
+    ) -> dict[str, TrainingSAE[Any]]:
+        try:
+            signal.signal(signal.SIGINT, _interrupt_callback)
+            signal.signal(signal.SIGTERM, _interrupt_callback)
+            return trainer.fit()
+        except (KeyboardInterrupt, InterruptedException):
+            if self.cfg.checkpoint_path is not None:
+                logger.warning("interrupted, saving progress")
+                trainer.save_checkpoint(checkpoint_name=str(trainer.n_training_samples))
+                logger.info("done saving")
+            raise
+
+    def _set_sae_metadata(self) -> None:
+        for name, sae in self.saes.items():
+            sae.cfg.metadata.dataset_path = self.cfg.dataset_path
+            sae.cfg.metadata.hook_name = self.cfg.hook_names_per_sae[name]
+            sae.cfg.metadata.model_name = self.cfg.model_name
+            sae.cfg.metadata.model_class_name = self.cfg.model_class_name
+            sae.cfg.metadata.hook_head_index = self.cfg.hook_head_indices_per_sae[name]
+            sae.cfg.metadata.context_size = self.cfg.context_size
+            sae.cfg.metadata.seqpos_slice = self.cfg.seqpos_slice
+            sae.cfg.metadata.model_from_pretrained_kwargs = (
+                self.cfg.model_from_pretrained_kwargs
+            )
+            sae.cfg.metadata.prepend_bos = self.cfg.prepend_bos
+            sae.cfg.metadata.exclude_special_tokens = self.cfg.exclude_special_tokens
+            sae.cfg.metadata.sequence_separator_token = (
+                self.cfg.sequence_separator_token
+            )
+            sae.cfg.metadata.disable_concat_sequences = (
+                self.cfg.disable_concat_sequences
+            )
+
+    def _save_runner_checkpoint_files(self, checkpoint_path: Path | None) -> None:
+        """Hook called by `MultiSAETrainer.save_checkpoint` to drop runner-level files."""
+        if checkpoint_path is None:
+            return
+        self.activations_store.save_to_checkpoint(checkpoint_path)
+        with open(checkpoint_path / RUNNER_CFG_FILENAME, "w") as f:
+            json.dump(self.cfg.to_dict(), f)
+
+    def _save_final_outputs(self, saes: dict[str, TrainingSAE[Any]]) -> None:
+        assert self.cfg.output_path is not None
+        base = Path(self.cfg.output_path)
+        base.mkdir(exist_ok=True, parents=True)
+
+        for name, sae in saes.items():
+            per_sae = base / name
+            per_sae.mkdir(exist_ok=True, parents=True)
+            weights_path, cfg_path = sae.save_inference_model(str(per_sae))
+
+            sparsity_path = None
+            # Try to find this SAE's log_feature_sparsity from the trainer if alive,
+            # else skip (caller can save them via final-checkpoint).
+            sparsity_tensor = self._maybe_get_log_feature_sparsity(name)
+            if sparsity_tensor is not None:
+                sparsity_path = per_sae / SPARSITY_FILENAME
+                save_file({"sparsity": sparsity_tensor}, sparsity_path)
+
+            if self.cfg.logger.log_to_wandb:
+                # Trainer's logger.log expects a `trainer` object with `sae` and `cfg` —
+                # we pass a tiny shim so wandb artifact naming and metadata work.
+                shim = _ArtifactLogShim(sae=sae, cfg=self.cfg.to_sae_trainer_config())
+                self.cfg.logger.log(
+                    shim,
+                    weights_path,
+                    cfg_path,
+                    sparsity_path=sparsity_path,
+                    wandb_aliases=["final_model"],
+                )
+
+        with open(base / RUNNER_CFG_FILENAME, "w") as f:
+            json.dump(self.cfg.to_dict(), f)
+
+    def _maybe_get_log_feature_sparsity(self, name: str) -> torch.Tensor | None:  # noqa: ARG002
+        # Sparsity is owned by the trainer; the runner isn't holding a ref after fit().
+        # Returning None is fine — the per-checkpoint dirs already contain sparsity.
+        return None
+
+
+@dataclass
+class _ArtifactLogShim:
+    sae: TrainingSAE[Any]
+    cfg: SAETrainerConfig
+
+
+def _resolve_exclude_special_tokens(
+    raw: bool | list[int],
+    model: HookedRootModule,
+    device: torch.device,
+) -> torch.Tensor | None:
+    if raw is False:
+        return None
+    if raw is True:
+        from sae_lens.util import get_special_token_ids
+
+        ids = list(get_special_token_ids(model.tokenizer))  # type: ignore[arg-type]
+    else:
+        ids = list(raw)
+    return torch.tensor(ids, dtype=torch.long, device=device)

--- a/sae_lens/multi_sae_training_runner.py
+++ b/sae_lens/multi_sae_training_runner.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import json
 import signal
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -57,8 +57,11 @@ def _interrupt_callback(sig_num: Any, stack_frame: Any) -> None:  # noqa: ARG001
 
 # A user-supplied custom evaluator. Mirrors the single-SAE Evaluator signature
 # but applied per SAE: `(sae, single_hook_data_provider_view, sae's scaler)`.
+# The data-provider view yields one hook's activation tensors per step.
 # Returns a flat dict that the runner prefixes with `{sae_name}/` when merging.
-PerSAEEvaluator = Callable[[TrainingSAE[Any], Any, ActivationScaler], dict[str, Any]]
+PerSAEEvaluator = Callable[
+    [TrainingSAE[Any], Iterator[torch.Tensor], ActivationScaler], dict[str, Any]
+]
 
 
 @dataclass
@@ -148,6 +151,8 @@ class MultiSAETrainingRunnerConfig:
     sae_lens_version: str = field(default_factory=lambda: __version__)
     sae_lens_training_version: str = field(default_factory=lambda: __version__)
     exclude_special_tokens: bool | list[int] = False
+    # Norm estimation caches this many multi-hook batches in memory at once;
+    # peak memory scales with n_hooks * d_in, not just d_in as in single-SAE.
     n_batches_for_norm_estimate: int = 1000
 
     # Internal: populated by __post_init__
@@ -289,13 +294,16 @@ class MultiSAETrainingRunnerConfig:
         )
 
     def to_dict(self) -> dict[str, Any]:
-        d = asdict(self)
+        # `evaluator` is not serializable; `_hook_*_per_sae` are internal
+        # derived fields, redundant with hook_names / hook_head_indices.
+        excluded = {
+            "evaluator",
+            "_hook_names_per_sae",
+            "_hook_head_indices_per_sae",
+        }
+        d = {k: v for k, v in asdict(self).items() if k not in excluded}
         d["logger"] = asdict(self.logger)
         d["saes"] = {name: cfg.to_dict() for name, cfg in self.saes.items()}
-        d.pop("evaluator", None)  # not serializable
-        # internal derived fields — redundant with hook_names / hook_head_indices
-        d.pop("_hook_names_per_sae", None)
-        d.pop("_hook_head_indices_per_sae", None)
         return d
 
 

--- a/sae_lens/multi_sae_training_runner.py
+++ b/sae_lens/multi_sae_training_runner.py
@@ -9,7 +9,7 @@ coefficient schedulers, activation scaler, and sparsity tracking — exactly as
 in single-SAE training. The runner just orchestrates the shared model and
 multi-hook activations.
 
-V1 limitations (see plan: out-of-scope):
+V1 limitations:
 
 - Argparse/CLI not supported (programmatic config only).
 - `from_pretrained_path` per entry not supported (resume from a multi-SAE
@@ -25,7 +25,7 @@ import json
 import signal
 from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager, nullcontext
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
@@ -143,7 +143,6 @@ class MultiSAETrainingRunnerConfig:
     resume_from_checkpoint: str | None = None
 
     # Misc
-    verbose: bool = True
     model_kwargs: dict[str, Any] = field(default_factory=dict)
     model_from_pretrained_kwargs: dict[str, Any] | None = None
     sae_lens_version: str = field(default_factory=lambda: __version__)
@@ -290,12 +289,13 @@ class MultiSAETrainingRunnerConfig:
         )
 
     def to_dict(self) -> dict[str, Any]:
-        from dataclasses import asdict
-
         d = asdict(self)
         d["logger"] = asdict(self.logger)
         d["saes"] = {name: cfg.to_dict() for name, cfg in self.saes.items()}
         d.pop("evaluator", None)  # not serializable
+        # internal derived fields — redundant with hook_names / hook_head_indices
+        d.pop("_hook_names_per_sae", None)
+        d.pop("_hook_head_indices_per_sae", None)
         return d
 
 
@@ -433,7 +433,8 @@ class MultiSAETrainingRunner:
             )
 
         llm_device = cfg.llm_device
-        assert llm_device is not None  # set in __post_init__
+        if llm_device is None:  # set in __post_init__
+            raise RuntimeError("cfg.llm_device must be set after __post_init__")
 
         self.model = (
             override_model

--- a/sae_lens/multi_sae_training_runner.py
+++ b/sae_lens/multi_sae_training_runner.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import signal
+import uuid
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import asdict, dataclass, field
@@ -47,6 +48,7 @@ from sae_lens.training.activations_store import ActivationsStore
 from sae_lens.training.multi_sae_trainer import MultiSAETrainer
 from sae_lens.training.prefetch import PrefetchingIterator
 from sae_lens.training.types import MultiHookDataProvider
+from sae_lens.util import get_special_token_ids
 
 # A user-supplied custom evaluator. Mirrors the single-SAE Evaluator signature
 # but applied per SAE: `(sae, single_hook_data_provider_view, sae's scaler)`.
@@ -236,10 +238,8 @@ class MultiSAETrainingRunnerConfig:
         if self.lr_end is None:
             self.lr_end = self.lr / 10
 
-        unique_id = self.logger.wandb_id
-        if unique_id is None:
-            unique_id = wandb.util.generate_id()  # type: ignore[attr-defined]
         if self.checkpoint_path is not None:
+            unique_id = self.logger.wandb_id or uuid.uuid4().hex[:8]
             self.checkpoint_path = f"{self.checkpoint_path}/{unique_id}"
 
         if isinstance(self.exclude_special_tokens, list) and not all(
@@ -295,7 +295,6 @@ class MultiSAETrainingRunnerConfig:
             "_hook_head_indices_per_sae",
         }
         d = {k: v for k, v in asdict(self).items() if k not in excluded}
-        d["logger"] = asdict(self.logger)
         d["saes"] = {name: cfg.to_dict() for name, cfg in self.saes.items()}
         return d
 
@@ -434,8 +433,7 @@ class MultiSAETrainingRunner:
             )
 
         llm_device = cfg.llm_device
-        if llm_device is None:  # set in __post_init__
-            raise RuntimeError("cfg.llm_device must be set after __post_init__")
+        assert llm_device is not None  # set in __post_init__
 
         self.model = (
             override_model
@@ -658,10 +656,9 @@ def _resolve_exclude_special_tokens(
 ) -> torch.Tensor | None:
     if raw is False:
         return None
-    if raw is True:
-        from sae_lens.util import get_special_token_ids
-
-        ids = list(get_special_token_ids(model.tokenizer))  # type: ignore[arg-type]
-    else:
-        ids = list(raw)
+    ids = (
+        list(get_special_token_ids(model.tokenizer))  # type: ignore[arg-type]
+        if raw is True
+        else list(raw)
+    )
     return torch.tensor(ids, dtype=torch.long, device=device)

--- a/sae_lens/multi_sae_training_runner.py
+++ b/sae_lens/multi_sae_training_runner.py
@@ -559,7 +559,7 @@ class MultiSAETrainingRunner:
         saes = self._run_with_interruption_handling(trainer)
 
         if self.cfg.output_path is not None:
-            self._save_final_outputs(saes)
+            self._save_final_outputs(saes, trainer)
 
         if self.cfg.logger.log_to_wandb:
             wandb.finish()
@@ -609,7 +609,9 @@ class MultiSAETrainingRunner:
         with open(checkpoint_path / RUNNER_CFG_FILENAME, "w") as f:
             json.dump(self.cfg.to_dict(), f)
 
-    def _save_final_outputs(self, saes: dict[str, TrainingSAE[Any]]) -> None:
+    def _save_final_outputs(
+        self, saes: dict[str, TrainingSAE[Any]], trainer: MultiSAETrainer
+    ) -> None:
         assert self.cfg.output_path is not None
         base = Path(self.cfg.output_path)
         base.mkdir(exist_ok=True, parents=True)
@@ -619,13 +621,11 @@ class MultiSAETrainingRunner:
             per_sae.mkdir(exist_ok=True, parents=True)
             weights_path, cfg_path = sae.save_inference_model(str(per_sae))
 
-            sparsity_path = None
-            # Try to find this SAE's log_feature_sparsity from the trainer if alive,
-            # else skip (caller can save them via final-checkpoint).
-            sparsity_tensor = self._maybe_get_log_feature_sparsity(name)
-            if sparsity_tensor is not None:
-                sparsity_path = per_sae / SPARSITY_FILENAME
-                save_file({"sparsity": sparsity_tensor}, sparsity_path)
+            sparsity_path = per_sae / SPARSITY_FILENAME
+            save_file(
+                {"sparsity": trainer.trainers[name].log_feature_sparsity},
+                sparsity_path,
+            )
 
             if self.cfg.logger.log_to_wandb:
                 # Trainer's logger.log expects a `trainer` object with `sae` and `cfg` —
@@ -641,11 +641,6 @@ class MultiSAETrainingRunner:
 
         with open(base / RUNNER_CFG_FILENAME, "w") as f:
             json.dump(self.cfg.to_dict(), f)
-
-    def _maybe_get_log_feature_sparsity(self, name: str) -> torch.Tensor | None:  # noqa: ARG002
-        # Sparsity is owned by the trainer; the runner isn't holding a ref after fit().
-        # Returning None is fine — the per-checkpoint dirs already contain sparsity.
-        return None
 
 
 @dataclass

--- a/sae_lens/multi_sae_training_runner.py
+++ b/sae_lens/multi_sae_training_runner.py
@@ -39,21 +39,14 @@ from sae_lens.config import HfDataset, LoggingConfig, SAETrainerConfig
 from sae_lens.constants import RUNNER_CFG_FILENAME, SPARSITY_FILENAME
 from sae_lens.evals import EvalConfig, run_evals
 from sae_lens.load_model import load_model
+from sae_lens.registry import get_sae_training_class
 from sae_lens.saes.sae import TrainingSAE, TrainingSAEConfig
+from sae_lens.training._interruption import InterruptedException, interrupt_callback
 from sae_lens.training.activation_scaler import ActivationScaler
 from sae_lens.training.activations_store import ActivationsStore
 from sae_lens.training.multi_sae_trainer import MultiSAETrainer
 from sae_lens.training.prefetch import PrefetchingIterator
 from sae_lens.training.types import MultiHookDataProvider
-
-
-class InterruptedException(Exception):
-    pass
-
-
-def _interrupt_callback(sig_num: Any, stack_frame: Any) -> None:  # noqa: ARG001
-    raise InterruptedException()
-
 
 # A user-supplied custom evaluator. Mirrors the single-SAE Evaluator signature
 # but applied per SAE: `(sae, single_hook_data_provider_view, sae's scaler)`.
@@ -363,8 +356,8 @@ class MultiSAEEvaluator:
         # Pause the prefetcher (if any) for the whole eval cycle; both built-in
         # and user evaluators may pull from the underlying generator state.
         pause_ctx: AbstractContextManager[None] = (
-            data_provider.paused()  # type: ignore[attr-defined]
-            if hasattr(data_provider, "paused")
+            data_provider.paused()
+            if isinstance(data_provider, PrefetchingIterator)
             else nullcontext()
         )
         out: dict[str, Any] = {}
@@ -500,10 +493,11 @@ class MultiSAETrainingRunner:
         )
 
         if override_saes is None:
-            self.saes = {
-                name: TrainingSAE.from_dict(sae_cfg.to_dict())
-                for name, sae_cfg in cfg.saes.items()
-            }
+            saes: dict[str, TrainingSAE[Any]] = {}
+            for name, sae_cfg in cfg.saes.items():
+                sae_class, _ = get_sae_training_class(sae_cfg.architecture())
+                saes[name] = sae_class(sae_cfg)
+            self.saes = saes
         else:
             extra = set(override_saes) - set(cfg.saes)
             missing = set(cfg.saes) - set(override_saes)
@@ -578,8 +572,8 @@ class MultiSAETrainingRunner:
         self, trainer: MultiSAETrainer
     ) -> dict[str, TrainingSAE[Any]]:
         try:
-            signal.signal(signal.SIGINT, _interrupt_callback)
-            signal.signal(signal.SIGTERM, _interrupt_callback)
+            signal.signal(signal.SIGINT, interrupt_callback)
+            signal.signal(signal.SIGTERM, interrupt_callback)
             return trainer.fit()
         except (KeyboardInterrupt, InterruptedException):
             if self.cfg.checkpoint_path is not None:

--- a/sae_lens/training/_interruption.py
+++ b/sae_lens/training/_interruption.py
@@ -1,0 +1,9 @@
+from typing import Any
+
+
+class InterruptedException(Exception):
+    pass
+
+
+def interrupt_callback(sig_num: Any, stack_frame: Any) -> None:  # noqa: ARG001
+    raise InterruptedException()

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -75,7 +75,7 @@ class ActivationsStore:
     # hook (`hook_names[0]`) but should not be relied on by multi-hook callers.
     _hook_names: list[str] | None = None
     _hook_d_ins: dict[str, int] | None = None
-    _hook_head_indices: dict[str, int | None] | None = None
+    _hook_head_indices: dict[str, int | None]
 
     @classmethod
     def from_cache_activations(
@@ -304,7 +304,7 @@ class ActivationsStore:
         )
         store._hook_names = unique_hook_names
         store._hook_d_ins = dict(hook_d_ins)
-        store._hook_head_indices = dict(head_indices) if head_indices else None
+        store._hook_head_indices = dict(head_indices)
         return store
 
     def __init__(
@@ -382,6 +382,7 @@ class ActivationsStore:
         )
         self.activations_mixing_fraction = activations_mixing_fraction
         self.use_chat_formatting = use_chat_formatting
+        self._hook_head_indices = {}
 
         self.n_dataset_processed = 0
 
@@ -854,7 +855,6 @@ class ActivationsStore:
                 "get_multi_hook_activations requires the store to be constructed "
                 "via from_config_multi_hook"
             )
-        head_indices = self._hook_head_indices or {}
         stops = [
             extract_stop_at_layer_from_tlens_hook_name(h) for h in self._hook_names
         ]
@@ -881,17 +881,13 @@ class ActivationsStore:
         for h in self._hook_names:
             layerwise = cache[h][:, slice(*self.seqpos_slice)]
             n_batches, n_context = layerwise.shape[:2]
-            d_in_h = self._hook_d_ins[h]
-            stacked = torch.zeros(
-                (n_batches, n_context, d_in_h), device=layerwise.device
-            )
-            head_idx = head_indices.get(h)
+            head_idx = self._hook_head_indices.get(h)
             if head_idx is not None:
-                stacked[:, :] = layerwise[:, :, head_idx]
+                stacked = layerwise[:, :, head_idx]
             elif layerwise.ndim > 3:
-                stacked[:, :] = layerwise.reshape(n_batches, n_context, -1)
+                stacked = layerwise.reshape(n_batches, n_context, -1)
             else:
-                stacked[:, :] = layerwise
+                stacked = layerwise
             out[h] = stacked
         return out
 

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -31,7 +31,10 @@ from sae_lens.tokenization_and_batching import (
     concat_and_batch_sequences,
     tokenize_with_chat_template,
 )
-from sae_lens.training.mixing_buffer import mixing_buffer
+from sae_lens.training.mixing_buffer import (
+    mixing_buffer,
+    multi_hook_concat_split_iter,
+)
 from sae_lens.util import (
     extract_stop_at_layer_from_tlens_hook_name,
     get_special_token_ids,
@@ -64,6 +67,15 @@ class ActivationsStore:
     _dataloader: Iterator[Any] | None = None
     exclude_special_tokens: torch.Tensor | None = None
     device: torch.device
+
+    # Multi-hook mode: populated by `from_config_multi_hook`. None means
+    # single-hook mode. When set, `get_multi_hook_activations` and
+    # `get_multi_hook_data_loader` are usable; the single-hook surface
+    # (`__iter__`/`__next__`/`get_activations`) still works on the canonical
+    # hook (`hook_names[0]`) but should not be relied on by multi-hook callers.
+    _hook_names: list[str] | None = None
+    _hook_d_ins: dict[str, int] | None = None
+    _hook_head_indices: dict[str, int | None] | None = None
 
     @classmethod
     def from_cache_activations(
@@ -210,6 +222,91 @@ class ActivationsStore:
             disable_concat_sequences=disable_concat_sequences,
             sequence_separator_token=sequence_separator_token,
         )
+
+    @classmethod
+    def from_config_multi_hook(
+        cls,
+        model: HookedRootModule,
+        *,
+        dataset: HfDataset | str,
+        hook_names: list[str],
+        hook_d_ins: dict[str, int],
+        hook_head_indices: dict[str, int | None] | None = None,
+        streaming: bool = True,
+        context_size: int = 128,
+        n_batches_in_buffer: int = 20,
+        total_training_tokens: int = 2_000_000,
+        store_batch_size_prompts: int = 32,
+        train_batch_size_tokens: int = 4096,
+        prepend_bos: bool = True,
+        normalize_activations: str = "none",
+        device: torch.device | str = "cpu",
+        dtype: str = "float32",
+        model_kwargs: dict[str, Any] | None = None,
+        autocast_lm: bool = False,
+        dataset_trust_remote_code: bool | None = None,
+        seqpos_slice: tuple[int | None, ...] = (None,),
+        exclude_special_tokens: torch.Tensor | None = None,
+        disable_concat_sequences: bool = False,
+        sequence_separator_token: int | Literal["bos", "eos", "sep"] | None = "bos",
+        activations_mixing_fraction: float = 0.5,
+        use_chat_formatting: bool = False,
+    ) -> ActivationsStore:
+        """
+        Construct a multi-hook ActivationsStore that captures activations at
+        multiple hook points from a single LLM forward pass.
+
+        `hook_d_ins` maps each unique hook name to the d_in expected at that
+        hook (after head-index slicing, if any). All SAEs sharing a hook in V1
+        must agree on `hook_head_index` and `d_in`.
+
+        Cached activations are not supported in multi-hook mode in V1.
+        """
+        if not hook_names:
+            raise ValueError("hook_names must be non-empty")
+
+        seen: set[str] = set()
+        unique_hook_names = [h for h in hook_names if not (h in seen or seen.add(h))]
+
+        missing = [h for h in unique_hook_names if h not in hook_d_ins]
+        if missing:
+            raise ValueError(f"hook_d_ins missing entries for {missing}")
+
+        head_indices = hook_head_indices or {}
+        canonical = unique_hook_names[0]
+        torch_device = torch.device(device) if isinstance(device, str) else device
+
+        store = cls(
+            model=model,
+            dataset=dataset,
+            streaming=streaming,
+            hook_name=canonical,
+            hook_head_index=head_indices.get(canonical),
+            context_size=context_size,
+            d_in=hook_d_ins[canonical],
+            n_batches_in_buffer=n_batches_in_buffer,
+            total_training_tokens=total_training_tokens,
+            store_batch_size_prompts=store_batch_size_prompts,
+            train_batch_size_tokens=train_batch_size_tokens,
+            prepend_bos=prepend_bos,
+            normalize_activations=normalize_activations,
+            device=torch_device,
+            dtype=dtype,
+            cached_activations_path=None,
+            model_kwargs=model_kwargs,
+            autocast_lm=autocast_lm,
+            dataset_trust_remote_code=dataset_trust_remote_code,
+            seqpos_slice=seqpos_slice,
+            exclude_special_tokens=exclude_special_tokens,
+            disable_concat_sequences=disable_concat_sequences,
+            sequence_separator_token=sequence_separator_token,
+            activations_mixing_fraction=activations_mixing_fraction,
+            use_chat_formatting=use_chat_formatting,
+        )
+        store._hook_names = unique_hook_names
+        store._hook_d_ins = dict(hook_d_ins)
+        store._hook_head_indices = dict(head_indices) if head_indices else None
+        return store
 
     def __init__(
         self,
@@ -742,6 +839,123 @@ class ActivationsStore:
 
     def __iter__(self) -> Iterator[torch.Tensor]:
         return self
+
+    @torch.no_grad()
+    def get_multi_hook_activations(
+        self, batch_tokens: torch.Tensor
+    ) -> dict[str, torch.Tensor]:
+        """
+        Multi-hook variant of `get_activations`.
+
+        Captures activations at every hook in `self._hook_names` from a single
+        LLM forward pass and returns a dict[hook_name, (batch, context, d_in_h)].
+        """
+        if self._hook_names is None or self._hook_d_ins is None:
+            raise RuntimeError(
+                "get_multi_hook_activations requires the store to be constructed "
+                "via from_config_multi_hook"
+            )
+        head_indices = self._hook_head_indices or {}
+        stops = [
+            extract_stop_at_layer_from_tlens_hook_name(h) for h in self._hook_names
+        ]
+        stop_at_layer: int | None = (
+            None
+            if any(s is None for s in stops)
+            else max(s for s in stops if s is not None)
+        )
+
+        with torch.autocast(
+            device_type="cuda",
+            dtype=torch.bfloat16,
+            enabled=self.autocast_lm,
+        ):
+            cache = self.model.run_with_cache(
+                batch_tokens,
+                names_filter=list(self._hook_names),
+                stop_at_layer=stop_at_layer,
+                prepend_bos=False,
+                **self.model_kwargs,
+            )[1]
+
+        out: dict[str, torch.Tensor] = {}
+        for h in self._hook_names:
+            layerwise = cache[h][:, slice(*self.seqpos_slice)]
+            n_batches, n_context = layerwise.shape[:2]
+            d_in_h = self._hook_d_ins[h]
+            stacked = torch.zeros((n_batches, n_context, d_in_h))
+            head_idx = head_indices.get(h)
+            if head_idx is not None:
+                stacked[:, :] = layerwise[:, :, head_idx]
+            elif layerwise.ndim > 3:
+                try:
+                    stacked[:, :] = layerwise.view(n_batches, n_context, -1)
+                except RuntimeError as e:
+                    logger.error(f"Error during view operation: {e}")
+                    stacked[:, :] = layerwise.reshape(n_batches, n_context, -1)
+            else:
+                stacked[:, :] = layerwise
+            out[h] = stacked
+        return out
+
+    def _get_filtered_multi_hook_llm_batch(
+        self, raise_on_epoch_end: bool = False
+    ) -> dict[str, torch.Tensor]:
+        """Multi-hook analog of `get_filtered_llm_batch`. Same special-token mask applied across all hooks."""
+        batch_tokens = self.get_batch_tokens(raise_at_epoch_end=raise_on_epoch_end)
+        activations_dict = self.get_multi_hook_activations(batch_tokens)
+        sliced_tokens = batch_tokens[:, slice(*self.seqpos_slice)]
+
+        flat: dict[str, torch.Tensor] = {
+            h: t.to(self.device).reshape(-1, t.shape[-1])
+            for h, t in activations_dict.items()
+        }
+        token_ids = sliced_tokens.reshape(-1).to(self.device)
+
+        if self.exclude_special_tokens is None:
+            return flat
+        keep_mask = ~torch.isin(token_ids, self.exclude_special_tokens)
+        return {h: t[keep_mask] for h, t in flat.items()}
+
+    def _iterate_filtered_multi_hook_activations(
+        self,
+    ) -> Generator[dict[str, torch.Tensor], None, None]:
+        while True:
+            try:
+                yield self._get_filtered_multi_hook_llm_batch(raise_on_epoch_end=True)
+            except StopIteration:
+                warnings.warn(
+                    "All samples in the training dataset have been exhausted, beginning new epoch."
+                )
+                try:
+                    yield self._get_filtered_multi_hook_llm_batch()
+                except StopIteration:
+                    raise ValueError(
+                        "Unable to fill buffer after starting new epoch. Dataset may be too small."
+                    )
+
+    def get_multi_hook_data_loader(
+        self,
+    ) -> Iterator[dict[str, torch.Tensor]]:
+        """
+        Auto-refilling stream of filtered, mixed multi-hook activations.
+
+        Yields `dict[hook_name, (train_batch_size_tokens, d_in_h)]` per call,
+        with token alignment across hooks preserved by a single shared shuffle
+        permutation in the underlying mixing buffer.
+        """
+        if self._hook_names is None:
+            raise RuntimeError(
+                "get_multi_hook_data_loader requires the store to be constructed "
+                "via from_config_multi_hook"
+            )
+        return multi_hook_concat_split_iter(
+            buffer_size=self.n_batches_in_buffer * self.training_context_size,
+            batch_size=self.train_batch_size_tokens,
+            activations_loader=self._iterate_filtered_multi_hook_activations(),
+            hook_names=list(self._hook_names),
+            mix_fraction=self.activations_mixing_fraction,
+        )
 
     def state_dict(self) -> dict[str, torch.Tensor]:
         return {"n_dataset_processed": torch.tensor(self.n_dataset_processed)}

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -865,7 +865,7 @@ class ActivationsStore:
         )
 
         with torch.autocast(
-            device_type="cuda",
+            device_type=_get_input_token_device(self.model).type,
             dtype=torch.bfloat16,
             enabled=self.autocast_lm,
         ):

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -265,8 +265,7 @@ class ActivationsStore:
         if not hook_names:
             raise ValueError("hook_names must be non-empty")
 
-        seen: set[str] = set()
-        unique_hook_names = [h for h in hook_names if not (h in seen or seen.add(h))]
+        unique_hook_names = list(dict.fromkeys(hook_names))
 
         missing = [h for h in unique_hook_names if h not in hook_d_ins]
         if missing:
@@ -883,16 +882,14 @@ class ActivationsStore:
             layerwise = cache[h][:, slice(*self.seqpos_slice)]
             n_batches, n_context = layerwise.shape[:2]
             d_in_h = self._hook_d_ins[h]
-            stacked = torch.zeros((n_batches, n_context, d_in_h))
+            stacked = torch.zeros(
+                (n_batches, n_context, d_in_h), device=layerwise.device
+            )
             head_idx = head_indices.get(h)
             if head_idx is not None:
                 stacked[:, :] = layerwise[:, :, head_idx]
             elif layerwise.ndim > 3:
-                try:
-                    stacked[:, :] = layerwise.view(n_batches, n_context, -1)
-                except RuntimeError as e:
-                    logger.error(f"Error during view operation: {e}")
-                    stacked[:, :] = layerwise.reshape(n_batches, n_context, -1)
+                stacked[:, :] = layerwise.reshape(n_batches, n_context, -1)
             else:
                 stacked[:, :] = layerwise
             out[h] = stacked

--- a/sae_lens/training/mixing_buffer.py
+++ b/sae_lens/training/mixing_buffer.py
@@ -4,6 +4,56 @@ import torch
 
 
 @torch.no_grad()
+def multi_hook_concat_split_iter(
+    buffer_size: int,
+    batch_size: int,
+    activations_loader: Iterator[dict[str, torch.Tensor]],
+    hook_names: list[str],
+    mix_fraction: float = 0.5,
+) -> Iterator[dict[str, torch.Tensor]]:
+    """
+    Multi-hook variant of `mixing_buffer`.
+
+    The producer yields `dict[hook_name, (n_tokens, d_in_h)]` per LLM forward
+    pass. Tensors at different hooks may have different feature dimensions
+    (e.g. attn vs resid, or transcoder input vs output).
+
+    To get a single shared shuffle across all hooks (preserving token
+    alignment), we concatenate along the feature dim into a packed
+    `(n_tokens, sum_d_in)` tensor, run it through the unmodified `mixing_buffer`,
+    and split the yielded batches back into a per-hook dict on the way out.
+    The single `torch.randperm(n_tokens)` inside `mixing_buffer` is therefore
+    automatically applied identically to every hook's slice.
+    """
+    iterator = iter(activations_loader)
+    try:
+        first = next(iterator)
+    except StopIteration:
+        return
+
+    missing = [h for h in hook_names if h not in first]
+    if missing:
+        raise ValueError(
+            f"producer did not yield activations for hooks {missing}; got keys {list(first.keys())}"
+        )
+
+    boundaries = [0]
+    for h in hook_names:
+        boundaries.append(boundaries[-1] + first[h].shape[1])
+
+    def packed() -> Iterator[torch.Tensor]:
+        yield torch.cat([first[h] for h in hook_names], dim=1)
+        for d in iterator:
+            yield torch.cat([d[h] for h in hook_names], dim=1)
+
+    for batch in mixing_buffer(buffer_size, batch_size, packed(), mix_fraction):
+        yield {
+            h: batch[:, boundaries[i] : boundaries[i + 1]]
+            for i, h in enumerate(hook_names)
+        }
+
+
+@torch.no_grad()
 def mixing_buffer(
     buffer_size: int,
     batch_size: int,

--- a/sae_lens/training/multi_sae_trainer.py
+++ b/sae_lens/training/multi_sae_trainer.py
@@ -310,17 +310,7 @@ class MultiSAETrainer:
     ) -> None:
         if self.n_training_steps % update_interval == 0:
             losses = " | ".join(
-                f"{name}: {_loss_value(out):.4f}" for name, out in step_outputs.items()
+                f"{name}: {out.loss.item():.4f}" for name, out in step_outputs.items()
             )
             pbar.set_description(f"{self.n_training_steps}| {losses}")
             pbar.update(update_interval * self.cfg.train_batch_size_samples)
-
-
-def _loss_value(out: TrainStepOutput) -> float:
-    loss = out.loss
-    if isinstance(loss, torch.Tensor):
-        return loss.item()
-    if callable(loss):
-        result: Any = loss()
-        return result.item() if isinstance(result, torch.Tensor) else float(result)
-    return float(loss)

--- a/sae_lens/training/multi_sae_trainer.py
+++ b/sae_lens/training/multi_sae_trainer.py
@@ -155,6 +155,7 @@ class MultiSAETrainer:
         pbar.close()
         return self.saes
 
+    @torch.no_grad()
     def _estimate_scaling_factors(self) -> None:
         """Estimate per-SAE activation scaling from a shared set of multi-hook batches."""
         needs = [

--- a/sae_lens/training/multi_sae_trainer.py
+++ b/sae_lens/training/multi_sae_trainer.py
@@ -204,7 +204,7 @@ class MultiSAETrainer:
             "details/n_training_samples": self.n_training_samples
         }
         for name, trainer in self.trainers.items():
-            log_dict = trainer._build_train_step_log_dict(  # type: ignore[reportPrivateUsage]
+            log_dict = trainer.build_train_step_log_dict(
                 output=step_outputs[name],
                 n_training_samples=self.n_training_samples,
             )
@@ -221,25 +221,27 @@ class MultiSAETrainer:
             return
         for sae in self.saes.values():
             sae.eval()
-        if self.evaluator is not None:
-            metrics = self.evaluator(
-                saes=self.saes,
-                data_provider=self.data_provider,
-                activation_scalers={
-                    name: t.activation_scaler for name, t in self.trainers.items()
-                },
-                hook_names=self.hook_names,
-            )
-            wandb.log(metrics, step=self.n_training_steps)
-        # Per-SAE histograms (as in single-SAE _run_and_log_evals).
-        hist_metrics: dict[str, Any] = {}
-        for name, sae in self.saes.items():
-            for k, v in sae.log_histograms().items():
-                hist_metrics[f"{name}/{k}"] = wandb.Histogram(v)  # type: ignore
-        if hist_metrics:
-            wandb.log(hist_metrics, step=self.n_training_steps)
-        for sae in self.saes.values():
-            sae.train()
+        try:
+            if self.evaluator is not None:
+                metrics = self.evaluator(
+                    saes=self.saes,
+                    data_provider=self.data_provider,
+                    activation_scalers={
+                        name: t.activation_scaler for name, t in self.trainers.items()
+                    },
+                    hook_names=self.hook_names,
+                )
+                wandb.log(metrics, step=self.n_training_steps)
+            # Per-SAE histograms (as in single-SAE _run_and_log_evals).
+            hist_metrics: dict[str, Any] = {}
+            for name, sae in self.saes.items():
+                for k, v in sae.log_histograms().items():
+                    hist_metrics[f"{name}/{k}"] = wandb.Histogram(v)  # type: ignore
+            if hist_metrics:
+                wandb.log(hist_metrics, step=self.n_training_steps)
+        finally:
+            for sae in self.saes.values():
+                sae.train()
 
     def _checkpoint_if_needed(self) -> None:
         if (

--- a/sae_lens/training/multi_sae_trainer.py
+++ b/sae_lens/training/multi_sae_trainer.py
@@ -1,0 +1,324 @@
+import math
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Protocol
+
+import torch
+import wandb
+from tqdm.auto import tqdm
+
+from sae_lens.config import SAETrainerConfig
+from sae_lens.saes.sae import T_TRAINING_SAE_CONFIG, TrainingSAE, TrainStepOutput
+from sae_lens.training.activation_scaler import ActivationScaler
+from sae_lens.training.sae_trainer import SAETrainer, SaveCheckpointFn
+from sae_lens.training.types import MultiHookDataProvider
+from sae_lens.util import path_or_tmp_dir
+
+
+class MultiSAEEvaluatorProtocol(Protocol):
+    def __call__(
+        self,
+        saes: dict[str, TrainingSAE[Any]],
+        data_provider: MultiHookDataProvider,
+        activation_scalers: dict[str, ActivationScaler],
+        hook_names: dict[str, str],
+    ) -> dict[str, Any]: ...
+
+
+class MultiSAETrainer:
+    """
+    Coordinator that trains multiple `TrainingSAE`s in lockstep on a shared
+    multi-hook activation stream.
+
+    Internally holds one `SAETrainer` per SAE (composition, not duplication)
+    and drives them via the public `step` / `maybe_reset_sparsity` /
+    `save_checkpoint` / `load_trainer_state` seams. Each per-SAE trainer
+    owns its own optimizer, lr scheduler, coefficient schedulers,
+    activation scaler, sparsity tracking, etc. — exactly as in single-SAE
+    mode. The coordinator only handles batch routing, log aggregation, and
+    multi-SAE checkpoint layout.
+    """
+
+    saes: dict[str, TrainingSAE[Any]]
+    hook_names: dict[str, str]
+    trainers: dict[str, SAETrainer[Any, Any]]
+    data_provider: MultiHookDataProvider
+    evaluator: MultiSAEEvaluatorProtocol | None
+    save_checkpoint_fn: SaveCheckpointFn | None
+    cfg: SAETrainerConfig
+    n_training_steps: int
+    n_training_samples: int
+
+    def __init__(
+        self,
+        cfg: SAETrainerConfig,
+        saes: dict[str, TrainingSAE[T_TRAINING_SAE_CONFIG]],
+        hook_names: dict[str, str],
+        data_provider: MultiHookDataProvider,
+        evaluator: MultiSAEEvaluatorProtocol | None = None,
+        save_checkpoint_fn: SaveCheckpointFn | None = None,
+    ) -> None:
+        if set(saes.keys()) != set(hook_names.keys()):
+            raise ValueError(
+                f"saes and hook_names must have identical keys; got "
+                f"{sorted(saes.keys())} vs {sorted(hook_names.keys())}"
+            )
+
+        self.cfg = cfg
+        self.saes = dict(saes)
+        self.hook_names = dict(hook_names)
+        self.data_provider = data_provider
+        self.evaluator = evaluator
+        self.save_checkpoint_fn = save_checkpoint_fn
+
+        self.n_training_steps = 0
+        self.n_training_samples = 0
+
+        # Each per-SAE trainer's config: same training hyperparams, but
+        # checkpointing/eval/save-final disabled — the coordinator drives those.
+        # Using replace() to avoid mutating the shared cfg.
+        per_sae_cfg = replace(
+            cfg,
+            n_checkpoints=0,
+            checkpoint_path=None,
+            save_final_checkpoint=False,
+        )
+        # Per-SAE SAETrainer instances. data_provider here is never consumed
+        # (the coordinator drives them via step()), so an empty iter satisfies
+        # the type without keeping refs to anything heavy.
+        self.trainers = {
+            name: SAETrainer(
+                cfg=per_sae_cfg,
+                sae=sae,
+                data_provider=iter(()),
+                evaluator=None,
+                save_checkpoint_fn=None,
+            )
+            for name, sae in self.saes.items()
+        }
+
+        self.checkpoint_thresholds: list[int] = []
+        if self.cfg.n_checkpoints > 0:
+            self.checkpoint_thresholds = list(
+                range(
+                    0,
+                    cfg.total_training_samples,
+                    math.ceil(
+                        cfg.total_training_samples / (self.cfg.n_checkpoints + 1)
+                    ),
+                )
+            )[1:]
+
+    def fit(self) -> dict[str, TrainingSAE[Any]]:
+        for sae in self.saes.values():
+            sae.to(self.cfg.device)
+
+        pbar = tqdm(total=self.cfg.total_training_samples, desc="Training Multi-SAE")
+
+        self._estimate_scaling_factors()
+
+        while self.n_training_samples < self.cfg.total_training_samples:
+            self._maybe_log_sparsity()
+
+            multi_batch = next(self.data_provider)
+            step_outputs: dict[str, TrainStepOutput] = {}
+            for name, trainer in self.trainers.items():
+                step_outputs[name] = trainer.step(multi_batch[self.hook_names[name]])
+
+            # All per-SAE trainers advance in lockstep; mirror onto outer counter.
+            self.n_training_samples = next(
+                iter(self.trainers.values())
+            ).n_training_samples
+
+            if self.cfg.logger.log_to_wandb:
+                self._log_train_step(step_outputs)
+                self._run_and_log_evals()
+
+            self._checkpoint_if_needed()
+
+            for trainer in self.trainers.values():
+                trainer.n_training_steps += 1
+            self.n_training_steps += 1
+
+            self._update_pbar(step_outputs, pbar)
+
+        for name, trainer in self.trainers.items():
+            if trainer.activation_scaler.scaling_factor is not None:
+                self.saes[name].fold_activation_norm_scaling_factor(
+                    trainer.activation_scaler.scaling_factor
+                )
+                trainer.activation_scaler.scaling_factor = None
+
+        if self.cfg.save_final_checkpoint:
+            self.save_checkpoint(checkpoint_name=f"final_{self.n_training_samples}")
+
+        pbar.close()
+        return self.saes
+
+    def _estimate_scaling_factors(self) -> None:
+        """Estimate per-SAE activation scaling from a shared set of multi-hook batches."""
+        needs = [
+            name
+            for name, sae in self.saes.items()
+            if sae.cfg.normalize_activations == "expected_average_only_in"
+        ]
+        if not needs:
+            return
+        n = self.cfg.n_batches_for_norm_estimate
+        cached: list[dict[str, torch.Tensor]] = [
+            next(self.data_provider) for _ in range(n)
+        ]
+        for name in needs:
+            hook = self.hook_names[name]
+            self.trainers[name].activation_scaler.estimate_scaling_factor(
+                d_in=self.saes[name].cfg.d_in,
+                data_provider=iter([batch[hook] for batch in cached]),
+                n_batches_for_norm_estimate=n,
+            )
+
+    def _is_logging_step(self) -> bool:
+        return (
+            self.cfg.logger.log_to_wandb
+            and (self.n_training_steps + 1) % self.cfg.logger.wandb_log_frequency == 0
+        )
+
+    def _maybe_log_sparsity(self) -> None:
+        sparsity_logs: dict[str, dict[str, Any]] = {}
+        for name, trainer in self.trainers.items():
+            d = trainer.maybe_reset_sparsity()
+            if d:
+                sparsity_logs[name] = d
+        if sparsity_logs and self.cfg.logger.log_to_wandb:
+            combined: dict[str, Any] = {
+                f"{name}/{k}": v
+                for name, log_dict in sparsity_logs.items()
+                for k, v in log_dict.items()
+            }
+            wandb.log(combined, step=self.n_training_steps)
+
+    @torch.no_grad()
+    def _log_train_step(self, step_outputs: dict[str, TrainStepOutput]) -> None:
+        if not self._is_logging_step():
+            return
+        combined: dict[str, Any] = {
+            "details/n_training_samples": self.n_training_samples
+        }
+        for name, trainer in self.trainers.items():
+            log_dict = trainer._build_train_step_log_dict(  # type: ignore[reportPrivateUsage]
+                output=step_outputs[name],
+                n_training_samples=self.n_training_samples,
+            )
+            for k, v in log_dict.items():
+                combined[f"{name}/{k}"] = v
+        wandb.log(combined, step=self.n_training_steps)
+
+    @torch.no_grad()
+    def _run_and_log_evals(self) -> None:
+        if (self.n_training_steps + 1) % (
+            self.cfg.logger.wandb_log_frequency
+            * self.cfg.logger.eval_every_n_wandb_logs
+        ) != 0:
+            return
+        for sae in self.saes.values():
+            sae.eval()
+        if self.evaluator is not None:
+            metrics = self.evaluator(
+                saes=self.saes,
+                data_provider=self.data_provider,
+                activation_scalers={
+                    name: t.activation_scaler for name, t in self.trainers.items()
+                },
+                hook_names=self.hook_names,
+            )
+            wandb.log(metrics, step=self.n_training_steps)
+        # Per-SAE histograms (as in single-SAE _run_and_log_evals).
+        hist_metrics: dict[str, Any] = {}
+        for name, sae in self.saes.items():
+            for k, v in sae.log_histograms().items():
+                hist_metrics[f"{name}/{k}"] = wandb.Histogram(v)  # type: ignore
+        if hist_metrics:
+            wandb.log(hist_metrics, step=self.n_training_steps)
+        for sae in self.saes.values():
+            sae.train()
+
+    def _checkpoint_if_needed(self) -> None:
+        if (
+            self.checkpoint_thresholds
+            and self.n_training_samples > self.checkpoint_thresholds[0]
+        ):
+            self.save_checkpoint(checkpoint_name=str(self.n_training_samples))
+            self.checkpoint_thresholds.pop(0)
+
+    def save_checkpoint(
+        self,
+        checkpoint_name: str,
+        wandb_aliases: list[str] | None = None,
+    ) -> None:
+        """
+        Write a per-checkpoint directory at
+        `<checkpoint_path>/<checkpoint_name>/`, with a per-SAE subdirectory
+        for each SAE containing its weights, sparsity, activation scaler,
+        and trainer state. The user-supplied `save_checkpoint_fn` (if any)
+        is invoked with the checkpoint directory so the runner can drop
+        runner-level files alongside.
+        """
+        base = self.cfg.checkpoint_path
+        if base is None and not self.cfg.logger.log_to_wandb:
+            if self.save_checkpoint_fn is not None:
+                self.save_checkpoint_fn(checkpoint_path=None)
+            return
+
+        with path_or_tmp_dir(base) as base_path:
+            checkpoint_path = base_path / checkpoint_name
+            checkpoint_path.mkdir(exist_ok=True, parents=True)
+
+            for name, trainer in self.trainers.items():
+                trainer.save_checkpoint(
+                    checkpoint_name=name,
+                    base_path=checkpoint_path,
+                    wandb_aliases=wandb_aliases,
+                )
+
+            if self.save_checkpoint_fn is not None:
+                self.save_checkpoint_fn(checkpoint_path=checkpoint_path)
+
+    def load_checkpoint(self, path: str | Path) -> None:
+        """Restore each per-SAE trainer's state and SAE weights from a multi-SAE checkpoint dir."""
+        path = Path(path)
+        missing = [name for name in self.saes if not (path / name).exists()]
+        if missing:
+            raise FileNotFoundError(
+                f"checkpoint at {path} is missing per-SAE subdirectories for {missing}; "
+                f"expected one subdirectory per key in cfg.saes"
+            )
+        for name, trainer in self.trainers.items():
+            per_sae = path / name
+            trainer.load_trainer_state(per_sae)
+            trainer.sae.load_weights_from_checkpoint(per_sae)
+        any_trainer = next(iter(self.trainers.values()))
+        self.n_training_steps = any_trainer.n_training_steps
+        self.n_training_samples = any_trainer.n_training_samples
+
+    @torch.no_grad()
+    def _update_pbar(
+        self,
+        step_outputs: dict[str, TrainStepOutput],
+        pbar: tqdm,  # type: ignore
+        update_interval: int = 100,
+    ) -> None:
+        if self.n_training_steps % update_interval == 0:
+            losses = " | ".join(
+                f"{name}: {_loss_value(out):.4f}" for name, out in step_outputs.items()
+            )
+            pbar.set_description(f"{self.n_training_steps}| {losses}")
+            pbar.update(update_interval * self.cfg.train_batch_size_samples)
+
+
+def _loss_value(out: TrainStepOutput) -> float:
+    loss = out.loss
+    if isinstance(loss, torch.Tensor):
+        return loss.item()
+    if callable(loss):
+        result: Any = loss()
+        return result.item() if isinstance(result, torch.Tensor) else float(result)
+    return float(loss)

--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -365,7 +365,7 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
     def _log_train_step(self, step_output: TrainStepOutput):
         if self._is_logging_step():
             wandb.log(
-                self._build_train_step_log_dict(
+                self.build_train_step_log_dict(
                     output=step_output,
                     n_training_samples=self.n_training_samples,
                 ),
@@ -380,7 +380,7 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
         }
 
     @torch.no_grad()
-    def _build_train_step_log_dict(
+    def build_train_step_log_dict(
         self,
         output: TrainStepOutput,
         n_training_samples: int,

--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -172,12 +172,11 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
 
         # Train loop
         while self.n_training_samples < self.cfg.total_training_samples:
-            # Do a training step.
-            batch = next(self.data_provider).to(self.sae.device)
-            self.n_training_samples += batch.shape[0]
-            scaled_batch = self.activation_scaler(batch)
+            sparsity_log = self.maybe_reset_sparsity()
+            if sparsity_log and self.cfg.logger.log_to_wandb:
+                wandb.log(sparsity_log, step=self.n_training_steps)
 
-            step_output = self._train_step(sae=self.sae, sae_in=scaled_batch)
+            step_output = self.step(next(self.data_provider))
 
             if self.cfg.logger.log_to_wandb:
                 self._log_train_step(step_output)
@@ -203,11 +202,19 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
     def save_checkpoint(
         self,
         checkpoint_name: str,
+        base_path: Path | str | None = None,
         wandb_aliases: list[str] | None = None,
     ) -> None:
+        """
+        Save a checkpoint named `checkpoint_name` under `base_path` (or
+        `self.cfg.checkpoint_path` if not provided). The explicit `base_path`
+        seam lets external coordinators (e.g. `MultiSAETrainer`) place per-SAE
+        checkpoints in a chosen directory layout.
+        """
+        base = base_path if base_path is not None else self.cfg.checkpoint_path
         checkpoint_path = None
-        if self.cfg.checkpoint_path is not None or self.cfg.logger.log_to_wandb:
-            with path_or_tmp_dir(self.cfg.checkpoint_path) as base_checkpoint_path:
+        if base is not None or self.cfg.logger.log_to_wandb:
+            with path_or_tmp_dir(base) as base_checkpoint_path:
                 checkpoint_path = base_checkpoint_path / checkpoint_name
                 checkpoint_path.mkdir(exist_ok=True, parents=True)
 
@@ -229,6 +236,36 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
 
         if self.save_checkpoint_fn is not None:
             self.save_checkpoint_fn(checkpoint_path=checkpoint_path)
+
+    def step(self, batch: torch.Tensor) -> TrainStepOutput:
+        """
+        Run one training step on a raw (unscaled) activation batch.
+
+        Public seam used by `fit()` and external coordinators (e.g.
+        `MultiSAETrainer`). Moves the batch onto the SAE's device, advances
+        `n_training_samples`, applies the activation scaler, and runs the
+        train step. Does NOT advance `n_training_steps` — callers do that
+        after they're done with this step's logging/checkpointing.
+        """
+        batch = batch.to(self.sae.device)
+        self.n_training_samples += batch.shape[0]
+        scaled_batch = self.activation_scaler(batch)
+        return self._train_step(sae=self.sae, sae_in=scaled_batch)
+
+    def maybe_reset_sparsity(self) -> dict[str, Any]:
+        """
+        If this is a sparsity-window-reset step, return the sparsity log dict
+        and reset running sparsity stats; otherwise return {}.
+
+        Public seam used by `fit()` and external coordinators (e.g.
+        `MultiSAETrainer`). Caller is responsible for emitting the returned
+        dict to wandb if logging is enabled.
+        """
+        if (self.n_training_steps + 1) % self.cfg.feature_sampling_window == 0:
+            log_dict = self._build_sparsity_log_dict()
+            self._reset_running_sparsity_stats()
+            return log_dict
+        return {}
 
     def save_trainer_state(self, checkpoint_path: Path) -> None:
         checkpoint_path.mkdir(exist_ok=True, parents=True)
@@ -274,13 +311,6 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
         sae_in: torch.Tensor,
     ) -> TrainStepOutput:
         sae.train()
-
-        # log and then reset the feature sparsity every feature_sampling_window steps
-        if (self.n_training_steps + 1) % self.cfg.feature_sampling_window == 0:
-            if self.cfg.logger.log_to_wandb:
-                sparsity_log_dict = self._build_sparsity_log_dict()
-                wandb.log(sparsity_log_dict, step=self.n_training_steps)
-            self._reset_running_sparsity_stats()
 
         # for documentation on autocasting see:
         # https://pytorch.org/tutorials/recipes/recipes/amp_recipe.html

--- a/sae_lens/training/types.py
+++ b/sae_lens/training/types.py
@@ -3,3 +3,4 @@ from collections.abc import Iterator
 import torch
 
 DataProvider = Iterator[torch.Tensor]
+MultiHookDataProvider = Iterator[dict[str, torch.Tensor]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from typing import Any
 import numpy as np
 import pytest
 import torch
+import wandb
 
 from sae_lens.saes.sae import SAE
 from sae_lens.saes.standard_sae import StandardSAEConfig
@@ -122,3 +123,23 @@ def gpt2_res_jb_l4_sae() -> SAE[StandardSAEConfig]:
         sae_id="blocks.4.hook_resid_pre",
         device="cpu",
     )
+
+
+class _FakeWandbArtifact:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def add_file(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+@pytest.fixture
+def captured_wandb_logs(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    logged: list[dict[str, Any]] = []
+    monkeypatch.setattr(wandb, "init", lambda *_a, **_k: None)
+    monkeypatch.setattr(wandb, "finish", lambda *_a, **_k: None)
+    monkeypatch.setattr(wandb, "log", lambda d, **_k: logged.append(d))
+    monkeypatch.setattr(wandb, "log_artifact", lambda *_a, **_k: None)
+    monkeypatch.setattr(wandb, "Histogram", lambda *_a, **_k: None)
+    monkeypatch.setattr(wandb, "Artifact", _FakeWandbArtifact)
+    return logged

--- a/tests/test_multi_sae_training_runner.py
+++ b/tests/test_multi_sae_training_runner.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 import torch
 from datasets import Dataset
+from safetensors.torch import load_file
 from transformer_lens import HookedTransformer
 
 from sae_lens import (
@@ -100,10 +101,16 @@ def test_multi_sae_runner_trains_two_saes_at_same_hook(
     saes = runner.run()
 
     assert set(saes.keys()) == {"low_l1", "high_l1"}
-    # Output dirs exist with weights/cfg files per SAE
+    # Output dirs exist with weights/cfg/sparsity files per SAE
     assert (tmp_path / "out" / "low_l1" / "sae_weights.safetensors").exists()
     assert (tmp_path / "out" / "high_l1" / "sae_weights.safetensors").exists()
     assert (tmp_path / "out" / "runner_cfg.json").exists()
+    # Each SAE gets its own log-feature-sparsity tensor of shape (d_sae,).
+    for name in ("low_l1", "high_l1"):
+        sparsity = load_file(tmp_path / "out" / name / "sparsity.safetensors")[
+            "sparsity"
+        ]
+        assert sparsity.shape == (saes[name].cfg.d_sae,)
     # Both SAEs should have non-zero W_dec (training did something)
     for sae in saes.values():
         assert sae.W_dec.abs().sum().item() > 0

--- a/tests/test_multi_sae_training_runner.py
+++ b/tests/test_multi_sae_training_runner.py
@@ -1,8 +1,10 @@
 from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 import pytest
 import torch
+import wandb
 from datasets import Dataset
 from safetensors.torch import load_file
 from transformer_lens import HookedTransformer
@@ -14,8 +16,10 @@ from sae_lens import (
     TopKTrainingSAEConfig,
 )
 from sae_lens.config import LoggingConfig
-from sae_lens.saes.sae import TrainingSAEConfig
+from sae_lens.multi_sae_training_runner import InterruptedException, PerSAEEvaluator
+from sae_lens.saes.sae import TrainingSAE, TrainingSAEConfig
 from sae_lens.training.activations_store import ActivationsStore
+from sae_lens.training.multi_sae_trainer import MultiSAETrainer
 from tests.helpers import TINYSTORIES_MODEL, load_model_cached
 
 
@@ -31,6 +35,30 @@ def dataset() -> Dataset:
     )
 
 
+class _FakeArtifact:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def add_file(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+@pytest.fixture
+def captured_wandb_logs(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Patch wandb so runner/trainer logging runs without a real session.
+
+    Returns the list of dicts passed to `wandb.log`.
+    """
+    logged: list[dict[str, Any]] = []
+    monkeypatch.setattr(wandb, "init", lambda *_a, **_k: None)
+    monkeypatch.setattr(wandb, "finish", lambda *_a, **_k: None)
+    monkeypatch.setattr(wandb, "log", lambda d, **_k: logged.append(d))
+    monkeypatch.setattr(wandb, "log_artifact", lambda *_a, **_k: None)
+    monkeypatch.setattr(wandb, "Histogram", lambda *_a, **_k: None)
+    monkeypatch.setattr(wandb, "Artifact", _FakeArtifact)
+    return logged
+
+
 def _build_cfg(
     *,
     saes: Mapping[str, TrainingSAEConfig],
@@ -40,10 +68,20 @@ def _build_cfg(
     n_checkpoints: int = 0,
     save_final_checkpoint: bool = False,
     training_tokens: int = 32,
+    logger: LoggingConfig | None = None,
+    evaluator: PerSAEEvaluator | None = None,
+    feature_sampling_window: int = 2000,
+    n_eval_batches: int = 10,
+    prefetch_llm_batches: bool | int = False,
+    resume_from_checkpoint: str | None = None,
+    exclude_special_tokens: bool | list[int] = False,
+    hook_head_indices: dict[str, int | None] | int | None = None,
 ) -> MultiSAETrainingRunnerConfig:
     return MultiSAETrainingRunnerConfig(
         saes=saes,
         hook_names=hook_names,
+        hook_head_indices=hook_head_indices,
+        exclude_special_tokens=exclude_special_tokens,
         model_name=TINYSTORIES_MODEL,
         dataset_path="placeholder",  # override_dataset is used
         streaming=False,
@@ -58,10 +96,15 @@ def _build_cfg(
         seqpos_slice=(None,),
         activations_mixing_fraction=0.0,
         lr=1e-3,
-        logger=LoggingConfig(log_to_wandb=False),
+        logger=logger if logger is not None else LoggingConfig(log_to_wandb=False),
+        evaluator=evaluator,
+        feature_sampling_window=feature_sampling_window,
+        n_eval_batches=n_eval_batches,
+        prefetch_llm_batches=prefetch_llm_batches,
         n_checkpoints=n_checkpoints,
         checkpoint_path=checkpoint_path,
         save_final_checkpoint=save_final_checkpoint,
+        resume_from_checkpoint=resume_from_checkpoint,
         output_path=output_path,
     )
 
@@ -160,44 +203,40 @@ def test_multi_sae_runner_trains_two_saes_at_different_hooks(
 def test_multi_sae_runner_resume_from_checkpoint(
     ts_model: HookedTransformer, dataset: Dataset, tmp_path: Path
 ):
+    """
+    Resuming from a final checkpoint must restore trainer state: a resumed
+    run already at its token budget does no further training, so the SAE
+    weights must come back bit-identical to the checkpointed ones.
+    """
     d_in = ts_model.cfg.d_model
-    saes_cfg = {
-        "a": StandardTrainingSAEConfig(
-            d_in=d_in,
-            d_sae=32,
-            l1_coefficient=1e-3,
-            decoder_init_norm=0.1,
-            normalize_activations="none",
-            dtype="float32",
-            device="cpu",
-        ),
-        "b": StandardTrainingSAEConfig(
-            d_in=d_in,
-            d_sae=32,
-            l1_coefficient=1e-3,
-            decoder_init_norm=0.1,
-            normalize_activations="none",
-            dtype="float32",
-            device="cpu",
-        ),
-    }
+
     cfg = _build_cfg(
-        saes=saes_cfg,
+        saes={"a": _std_sae_cfg(d_in), "b": _std_sae_cfg(d_in)},
         hook_names="blocks.0.hook_mlp_out",
         checkpoint_path=str(tmp_path / "ckpt"),
-        n_checkpoints=2,
         save_final_checkpoint=True,
         training_tokens=64,
     )
     MultiSAETrainingRunner(cfg, override_model=ts_model, override_dataset=dataset).run()
 
-    # Locate the final checkpoint (suffixed with `final_<n>`)
-    base = Path(cfg.checkpoint_path)  # type: ignore[arg-type]
-    final_dirs = list(base.glob("final_*"))
+    final_dirs = list(Path(cfg.checkpoint_path).glob("final_*"))  # type: ignore[arg-type]
     assert final_dirs, "expected a final_<n> checkpoint dir"
     final_dir = final_dirs[0]
-    assert (final_dir / "a" / "sae_weights.safetensors").exists()
-    assert (final_dir / "b" / "sae_weights.safetensors").exists()
+    checkpointed_w_dec = load_file(final_dir / "a" / "sae_weights.safetensors")["W_dec"]
+
+    # Resume from the final checkpoint at the same token budget: fit() should
+    # see the budget already met and return the loaded SAEs untouched.
+    resume_cfg = _build_cfg(
+        saes={"a": _std_sae_cfg(d_in), "b": _std_sae_cfg(d_in)},
+        hook_names="blocks.0.hook_mlp_out",
+        training_tokens=64,
+        resume_from_checkpoint=str(final_dir),
+    )
+    resumed = MultiSAETrainingRunner(
+        resume_cfg, override_model=ts_model, override_dataset=dataset
+    ).run()
+
+    torch.testing.assert_close(resumed["a"].W_dec, checkpointed_w_dec)
     assert (final_dir / "runner_cfg.json").exists()
 
 
@@ -239,6 +278,30 @@ def test_multi_sae_runner_config_rejects_mismatched_hook_keys():
             },
             hook_names={"b": "blocks.0.hook_mlp_out"},  # mismatch
             logger=LoggingConfig(log_to_wandb=False),
+        )
+
+
+def test_multi_sae_runner_config_accepts_per_sae_hook_head_indices_dict(
+    ts_model: HookedTransformer,
+):
+    d_in = ts_model.cfg.d_model
+    cfg = _build_cfg(
+        saes={"a": _std_sae_cfg(d_in), "b": _std_sae_cfg(d_in)},
+        hook_names={"a": "blocks.0.hook_resid_pre", "b": "blocks.0.hook_mlp_out"},
+        hook_head_indices={"a": 2, "b": None},
+    )
+    assert cfg.hook_head_indices_per_sae == {"a": 2, "b": None}
+
+
+def test_multi_sae_runner_config_rejects_unknown_hook_head_index_keys(
+    ts_model: HookedTransformer,
+):
+    d_in = ts_model.cfg.d_model
+    with pytest.raises(ValueError, match="hook_head_indices has unknown keys"):
+        _build_cfg(
+            saes={"a": _std_sae_cfg(d_in)},
+            hook_names="blocks.0.hook_mlp_out",
+            hook_head_indices={"a": 0, "ghost": 1},
         )
 
 
@@ -307,3 +370,119 @@ def test_multi_sae_runner_smoke_loss_decreases(
             f"reconstruction worse than zero baseline: {per_sample_mse.item()} vs "
             f"{baseline.item()}"
         )
+
+
+def _std_sae_cfg(d_in: int) -> StandardTrainingSAEConfig:
+    return StandardTrainingSAEConfig(
+        d_in=d_in,
+        d_sae=32,
+        l1_coefficient=1e-3,
+        decoder_init_norm=0.1,
+        normalize_activations="none",
+        dtype="float32",
+        device="cpu",
+    )
+
+
+def test_multi_sae_runner_logs_per_sae_metrics_to_wandb(
+    ts_model: HookedTransformer,
+    dataset: Dataset,
+    tmp_path: Path,
+    captured_wandb_logs: list[dict[str, Any]],
+):
+    """
+    With wandb logging on, train-step / eval / sparsity metrics and the
+    user evaluator's output must all be logged under per-SAE `{name}/` keys.
+    """
+    d_in = ts_model.cfg.d_model
+
+    def user_evaluator(
+        _sae: TrainingSAE[Any], data_view: Any, _scaler: Any
+    ) -> dict[str, float]:
+        batch = next(data_view)
+        return {"custom/batch_abs_mean": batch.abs().mean().item()}
+
+    cfg = _build_cfg(
+        saes={"a": _std_sae_cfg(d_in), "b": _std_sae_cfg(d_in)},
+        hook_names="blocks.0.hook_mlp_out",
+        output_path=str(tmp_path / "out"),
+        training_tokens=32,
+        # log_frequency=2 means some steps log and some skip, exercising both
+        # the logging and the early-return branches
+        logger=LoggingConfig(
+            log_to_wandb=True, wandb_log_frequency=2, eval_every_n_wandb_logs=1
+        ),
+        evaluator=user_evaluator,
+        feature_sampling_window=2,
+        n_eval_batches=1,
+        # exercise the prefetch path and the evaluator's prefetcher-pause branch
+        prefetch_llm_batches=2,
+        exclude_special_tokens=True,
+    )
+    MultiSAETrainingRunner(cfg, override_model=ts_model, override_dataset=dataset).run()
+
+    assert captured_wandb_logs, "expected wandb.log to be called"
+    all_keys = {k for d in captured_wandb_logs for k in d}
+    # train-step metrics are aggregated per SAE
+    assert any(k.startswith("a/") for k in all_keys)
+    assert any(k.startswith("b/") for k in all_keys)
+    # the built-in evaluator runs run_evals per SAE (CE loss is eval-only)
+    eval_log = next(
+        d for d in captured_wandb_logs if "a/model_performance_preservation" in d
+    )
+    assert "ce_loss_score" in eval_log["a/model_performance_preservation"]
+    assert "ce_loss_score" in eval_log["b/model_performance_preservation"]
+    # the user evaluator's metric is merged in under each SAE's prefix
+    assert "a/custom/batch_abs_mean" in all_keys
+    assert "b/custom/batch_abs_mean" in all_keys
+    # sparsity reset (feature_sampling_window=2) logs mean log10 feature sparsity
+    assert "a/metrics/mean_log10_feature_sparsity" in all_keys
+
+
+def test_multi_sae_runner_rejects_mismatched_override_saes(
+    ts_model: HookedTransformer, dataset: Dataset
+):
+    d_in = ts_model.cfg.d_model
+    cfg = _build_cfg(
+        saes={"a": _std_sae_cfg(d_in), "b": _std_sae_cfg(d_in)},
+        hook_names="blocks.0.hook_mlp_out",
+    )
+    # override_saes has an unknown key "c" and is missing "b"
+    bad_override = {"a": TrainingSAE.from_dict(_std_sae_cfg(d_in).to_dict())}
+    with pytest.raises(ValueError, match="override_saes keys must match"):
+        MultiSAETrainingRunner(
+            cfg,
+            override_model=ts_model,
+            override_dataset=dataset,
+            override_saes={**bad_override, "c": bad_override["a"]},
+        )
+
+
+def test_multi_sae_runner_saves_checkpoint_on_interruption(
+    ts_model: HookedTransformer,
+    dataset: Dataset,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An interrupt during fit() must trigger a progress checkpoint, then re-raise."""
+
+    def _interrupt(_self: MultiSAETrainer) -> dict[str, Any]:
+        raise InterruptedException()
+
+    monkeypatch.setattr(MultiSAETrainer, "fit", _interrupt)
+
+    d_in = ts_model.cfg.d_model
+    cfg = _build_cfg(
+        saes={"a": _std_sae_cfg(d_in)},
+        hook_names="blocks.0.hook_mlp_out",
+        checkpoint_path=str(tmp_path / "ckpt"),
+    )
+    runner = MultiSAETrainingRunner(
+        cfg, override_model=ts_model, override_dataset=dataset
+    )
+    with pytest.raises(InterruptedException):
+        runner.run()
+
+    assert cfg.checkpoint_path is not None
+    saved = list(Path(cfg.checkpoint_path).glob("*/a/sae_weights.safetensors"))
+    assert saved, "expected an interrupt checkpoint with the SAE's weights"

--- a/tests/test_multi_sae_training_runner.py
+++ b/tests/test_multi_sae_training_runner.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import pytest
 import torch
-import wandb
 from datasets import Dataset
 from safetensors.torch import load_file
 from transformer_lens import HookedTransformer
@@ -18,6 +17,7 @@ from sae_lens import (
 from sae_lens.config import LoggingConfig
 from sae_lens.multi_sae_training_runner import InterruptedException, PerSAEEvaluator
 from sae_lens.saes.sae import TrainingSAE, TrainingSAEConfig
+from sae_lens.saes.standard_sae import StandardTrainingSAE
 from sae_lens.training.activations_store import ActivationsStore
 from sae_lens.training.multi_sae_trainer import MultiSAETrainer
 from tests.helpers import TINYSTORIES_MODEL, load_model_cached
@@ -33,30 +33,6 @@ def dataset() -> Dataset:
     return Dataset.from_list(
         [{"text": f"the quick brown fox {i} jumps over"} for i in range(200)]
     )
-
-
-class _FakeArtifact:
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        pass
-
-    def add_file(self, *args: Any, **kwargs: Any) -> None:
-        pass
-
-
-@pytest.fixture
-def captured_wandb_logs(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
-    """Patch wandb so runner/trainer logging runs without a real session.
-
-    Returns the list of dicts passed to `wandb.log`.
-    """
-    logged: list[dict[str, Any]] = []
-    monkeypatch.setattr(wandb, "init", lambda *_a, **_k: None)
-    monkeypatch.setattr(wandb, "finish", lambda *_a, **_k: None)
-    monkeypatch.setattr(wandb, "log", lambda d, **_k: logged.append(d))
-    monkeypatch.setattr(wandb, "log_artifact", lambda *_a, **_k: None)
-    monkeypatch.setattr(wandb, "Histogram", lambda *_a, **_k: None)
-    monkeypatch.setattr(wandb, "Artifact", _FakeArtifact)
-    return logged
 
 
 def _build_cfg(
@@ -203,11 +179,6 @@ def test_multi_sae_runner_trains_two_saes_at_different_hooks(
 def test_multi_sae_runner_resume_from_checkpoint(
     ts_model: HookedTransformer, dataset: Dataset, tmp_path: Path
 ):
-    """
-    Resuming from a final checkpoint must restore trainer state: a resumed
-    run already at its token budget does no further training, so the SAE
-    weights must come back bit-identical to the checkpointed ones.
-    """
     d_in = ts_model.cfg.d_model
 
     cfg = _build_cfg(
@@ -308,7 +279,6 @@ def test_multi_sae_runner_config_rejects_unknown_hook_head_index_keys(
 def test_multi_sae_runner_smoke_loss_decreases(
     ts_model: HookedTransformer, dataset: Dataset
 ):
-    """Functional smoke: training reduces reconstruction loss for both SAEs."""
     d_in = ts_model.cfg.d_model
     cfg = _build_cfg(
         saes={
@@ -390,10 +360,6 @@ def test_multi_sae_runner_logs_per_sae_metrics_to_wandb(
     tmp_path: Path,
     captured_wandb_logs: list[dict[str, Any]],
 ):
-    """
-    With wandb logging on, train-step / eval / sparsity metrics and the
-    user evaluator's output must all be logged under per-SAE `{name}/` keys.
-    """
     d_in = ts_model.cfg.d_model
 
     def user_evaluator(
@@ -448,7 +414,7 @@ def test_multi_sae_runner_rejects_mismatched_override_saes(
         hook_names="blocks.0.hook_mlp_out",
     )
     # override_saes has an unknown key "c" and is missing "b"
-    bad_override = {"a": TrainingSAE.from_dict(_std_sae_cfg(d_in).to_dict())}
+    bad_override = {"a": StandardTrainingSAE(_std_sae_cfg(d_in))}
     with pytest.raises(ValueError, match="override_saes keys must match"):
         MultiSAETrainingRunner(
             cfg,
@@ -464,8 +430,6 @@ def test_multi_sae_runner_saves_checkpoint_on_interruption(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """An interrupt during fit() must trigger a progress checkpoint, then re-raise."""
-
     def _interrupt(_self: MultiSAETrainer) -> dict[str, Any]:
         raise InterruptedException()
 

--- a/tests/test_multi_sae_training_runner.py
+++ b/tests/test_multi_sae_training_runner.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
+import torch
 from datasets import Dataset
 from transformer_lens import HookedTransformer
 
@@ -13,6 +14,7 @@ from sae_lens import (
 )
 from sae_lens.config import LoggingConfig
 from sae_lens.saes.sae import TrainingSAEConfig
+from sae_lens.training.activations_store import ActivationsStore
 from tests.helpers import TINYSTORIES_MODEL, load_model_cached
 
 
@@ -60,7 +62,6 @@ def _build_cfg(
         checkpoint_path=checkpoint_path,
         save_final_checkpoint=save_final_checkpoint,
         output_path=output_path,
-        verbose=False,
     )
 
 
@@ -266,15 +267,30 @@ def test_multi_sae_runner_smoke_loss_decreases(
     runner = MultiSAETrainingRunner(
         cfg, override_model=ts_model, override_dataset=dataset
     )
-
-    # Get initial losses by running a single step manually via the trainer's helper
-    # — easier path: train for the full run and check final outputs are reasonable.
     saes = runner.run()
-    # After ~50 steps the SAEs should be reconstructing better than pure decode of zeros.
-    multi_store = runner.activations_store
-    multi_store._dataloader = None  # reset cursor for a fresh batch
-    batch_dict = next(multi_store.get_multi_hook_data_loader())
-    batch = batch_dict["blocks.0.hook_mlp_out"]
+
+    # Build a fresh store for a post-training reconstruction check (the
+    # runner's store has already been exhausted by fit()).
+    hook = "blocks.0.hook_mlp_out"
+    eval_store = ActivationsStore.from_config_multi_hook(
+        model=ts_model,
+        dataset=dataset,
+        hook_names=[hook],
+        hook_d_ins={hook: d_in},
+        streaming=False,
+        context_size=cfg.context_size,
+        n_batches_in_buffer=2,
+        total_training_tokens=cfg.training_tokens,
+        store_batch_size_prompts=cfg.store_batch_size_prompts,
+        train_batch_size_tokens=cfg.train_batch_size_tokens,
+        prepend_bos=cfg.prepend_bos,
+        normalize_activations="none",
+        device=torch.device(cfg.device),
+        dtype=cfg.dtype,
+        seqpos_slice=cfg.seqpos_slice,
+        activations_mixing_fraction=0.0,
+    )
+    batch = next(eval_store.get_multi_hook_data_loader())[hook]
     for sae in saes.values():
         recon = sae(batch)
         per_sample_mse = (recon - batch).pow(2).sum(-1).mean()

--- a/tests/test_multi_sae_training_runner.py
+++ b/tests/test_multi_sae_training_runner.py
@@ -1,0 +1,286 @@
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+from datasets import Dataset
+from transformer_lens import HookedTransformer
+
+from sae_lens import (
+    MultiSAETrainingRunner,
+    MultiSAETrainingRunnerConfig,
+    StandardTrainingSAEConfig,
+    TopKTrainingSAEConfig,
+)
+from sae_lens.config import LoggingConfig
+from sae_lens.saes.sae import TrainingSAEConfig
+from tests.helpers import TINYSTORIES_MODEL, load_model_cached
+
+
+@pytest.fixture
+def ts_model() -> HookedTransformer:
+    return load_model_cached(TINYSTORIES_MODEL)
+
+
+@pytest.fixture
+def dataset() -> Dataset:
+    return Dataset.from_list(
+        [{"text": f"the quick brown fox {i} jumps over"} for i in range(200)]
+    )
+
+
+def _build_cfg(
+    *,
+    saes: Mapping[str, TrainingSAEConfig],
+    hook_names: dict[str, str] | str,
+    output_path: str | None = None,
+    checkpoint_path: str | None = None,
+    n_checkpoints: int = 0,
+    save_final_checkpoint: bool = False,
+    training_tokens: int = 32,
+) -> MultiSAETrainingRunnerConfig:
+    return MultiSAETrainingRunnerConfig(
+        saes=saes,
+        hook_names=hook_names,
+        model_name=TINYSTORIES_MODEL,
+        dataset_path="placeholder",  # override_dataset is used
+        streaming=False,
+        context_size=8,
+        n_batches_in_buffer=2,
+        training_tokens=training_tokens,
+        store_batch_size_prompts=4,
+        train_batch_size_tokens=4,
+        prepend_bos=True,
+        device="cpu",
+        dtype="float32",
+        seqpos_slice=(None,),
+        activations_mixing_fraction=0.0,
+        lr=1e-3,
+        logger=LoggingConfig(log_to_wandb=False),
+        n_checkpoints=n_checkpoints,
+        checkpoint_path=checkpoint_path,
+        save_final_checkpoint=save_final_checkpoint,
+        output_path=output_path,
+        verbose=False,
+    )
+
+
+def test_multi_sae_runner_trains_two_saes_at_same_hook(
+    ts_model: HookedTransformer, dataset: Dataset, tmp_path: Path
+):
+    d_in = ts_model.cfg.d_model
+    cfg = _build_cfg(
+        saes={
+            "low_l1": StandardTrainingSAEConfig(
+                d_in=d_in,
+                d_sae=32,
+                l1_coefficient=1e-3,
+                decoder_init_norm=0.1,
+                normalize_activations="none",
+                dtype="float32",
+                device="cpu",
+            ),
+            "high_l1": StandardTrainingSAEConfig(
+                d_in=d_in,
+                d_sae=32,
+                l1_coefficient=1.0,
+                decoder_init_norm=0.1,
+                normalize_activations="none",
+                dtype="float32",
+                device="cpu",
+            ),
+        },
+        hook_names="blocks.0.hook_mlp_out",
+        output_path=str(tmp_path / "out"),
+        training_tokens=32,
+    )
+    runner = MultiSAETrainingRunner(
+        cfg, override_model=ts_model, override_dataset=dataset
+    )
+    saes = runner.run()
+
+    assert set(saes.keys()) == {"low_l1", "high_l1"}
+    # Output dirs exist with weights/cfg files per SAE
+    assert (tmp_path / "out" / "low_l1" / "sae_weights.safetensors").exists()
+    assert (tmp_path / "out" / "high_l1" / "sae_weights.safetensors").exists()
+    assert (tmp_path / "out" / "runner_cfg.json").exists()
+    # Both SAEs should have non-zero W_dec (training did something)
+    for sae in saes.values():
+        assert sae.W_dec.abs().sum().item() > 0
+
+
+def test_multi_sae_runner_trains_two_saes_at_different_hooks(
+    ts_model: HookedTransformer, dataset: Dataset
+):
+    d_in = ts_model.cfg.d_model
+    cfg = _build_cfg(
+        saes={
+            "resid": StandardTrainingSAEConfig(
+                d_in=d_in,
+                d_sae=32,
+                l1_coefficient=1e-3,
+                decoder_init_norm=0.1,
+                normalize_activations="none",
+                dtype="float32",
+                device="cpu",
+            ),
+            "topk_mlp": TopKTrainingSAEConfig(
+                d_in=d_in,
+                d_sae=32,
+                k=4,
+                normalize_activations="none",
+                decoder_init_norm=0.1,
+                dtype="float32",
+                device="cpu",
+            ),
+        },
+        hook_names={
+            "resid": "blocks.0.hook_resid_pre",
+            "topk_mlp": "blocks.0.hook_mlp_out",
+        },
+        training_tokens=32,
+    )
+    runner = MultiSAETrainingRunner(
+        cfg, override_model=ts_model, override_dataset=dataset
+    )
+    saes = runner.run()
+
+    assert set(saes.keys()) == {"resid", "topk_mlp"}
+    assert saes["resid"].cfg.metadata.hook_name == "blocks.0.hook_resid_pre"
+    assert saes["topk_mlp"].cfg.metadata.hook_name == "blocks.0.hook_mlp_out"
+
+
+def test_multi_sae_runner_resume_from_checkpoint(
+    ts_model: HookedTransformer, dataset: Dataset, tmp_path: Path
+):
+    d_in = ts_model.cfg.d_model
+    saes_cfg = {
+        "a": StandardTrainingSAEConfig(
+            d_in=d_in,
+            d_sae=32,
+            l1_coefficient=1e-3,
+            decoder_init_norm=0.1,
+            normalize_activations="none",
+            dtype="float32",
+            device="cpu",
+        ),
+        "b": StandardTrainingSAEConfig(
+            d_in=d_in,
+            d_sae=32,
+            l1_coefficient=1e-3,
+            decoder_init_norm=0.1,
+            normalize_activations="none",
+            dtype="float32",
+            device="cpu",
+        ),
+    }
+    cfg = _build_cfg(
+        saes=saes_cfg,
+        hook_names="blocks.0.hook_mlp_out",
+        checkpoint_path=str(tmp_path / "ckpt"),
+        n_checkpoints=2,
+        save_final_checkpoint=True,
+        training_tokens=64,
+    )
+    MultiSAETrainingRunner(cfg, override_model=ts_model, override_dataset=dataset).run()
+
+    # Locate the final checkpoint (suffixed with `final_<n>`)
+    base = Path(cfg.checkpoint_path)  # type: ignore[arg-type]
+    final_dirs = list(base.glob("final_*"))
+    assert final_dirs, "expected a final_<n> checkpoint dir"
+    final_dir = final_dirs[0]
+    assert (final_dir / "a" / "sae_weights.safetensors").exists()
+    assert (final_dir / "b" / "sae_weights.safetensors").exists()
+    assert (final_dir / "runner_cfg.json").exists()
+
+
+def test_multi_sae_runner_config_validates_d_in_mismatch(ts_model: HookedTransformer):
+    d_in = ts_model.cfg.d_model
+    with pytest.raises(ValueError, match="must have the same d_in"):
+        _build_cfg(
+            saes={
+                "a": StandardTrainingSAEConfig(
+                    d_in=d_in,
+                    d_sae=32,
+                    decoder_init_norm=0.1,
+                    dtype="float32",
+                    device="cpu",
+                ),
+                "b": StandardTrainingSAEConfig(
+                    d_in=d_in + 1,  # mismatched d_in at the same hook
+                    d_sae=32,
+                    decoder_init_norm=0.1,
+                    dtype="float32",
+                    device="cpu",
+                ),
+            },
+            hook_names="blocks.0.hook_mlp_out",
+        )
+
+
+def test_multi_sae_runner_config_rejects_mismatched_hook_keys():
+    with pytest.raises(ValueError, match="missing|extra"):
+        MultiSAETrainingRunnerConfig(
+            saes={
+                "a": StandardTrainingSAEConfig(
+                    d_in=64,
+                    d_sae=32,
+                    decoder_init_norm=0.1,
+                    dtype="float32",
+                    device="cpu",
+                ),
+            },
+            hook_names={"b": "blocks.0.hook_mlp_out"},  # mismatch
+            logger=LoggingConfig(log_to_wandb=False),
+        )
+
+
+def test_multi_sae_runner_smoke_loss_decreases(
+    ts_model: HookedTransformer, dataset: Dataset
+):
+    """Functional smoke: training reduces reconstruction loss for both SAEs."""
+    d_in = ts_model.cfg.d_model
+    cfg = _build_cfg(
+        saes={
+            "a": StandardTrainingSAEConfig(
+                d_in=d_in,
+                d_sae=32,
+                l1_coefficient=1e-3,
+                decoder_init_norm=0.1,
+                normalize_activations="none",
+                dtype="float32",
+                device="cpu",
+            ),
+            "b": StandardTrainingSAEConfig(
+                d_in=d_in,
+                d_sae=32,
+                l1_coefficient=1e-3,
+                decoder_init_norm=0.1,
+                normalize_activations="none",
+                dtype="float32",
+                device="cpu",
+            ),
+        },
+        hook_names="blocks.0.hook_mlp_out",
+        training_tokens=200,  # ~50 steps
+    )
+    runner = MultiSAETrainingRunner(
+        cfg, override_model=ts_model, override_dataset=dataset
+    )
+
+    # Get initial losses by running a single step manually via the trainer's helper
+    # — easier path: train for the full run and check final outputs are reasonable.
+    saes = runner.run()
+    # After ~50 steps the SAEs should be reconstructing better than pure decode of zeros.
+    multi_store = runner.activations_store
+    multi_store._dataloader = None  # reset cursor for a fresh batch
+    batch_dict = next(multi_store.get_multi_hook_data_loader())
+    batch = batch_dict["blocks.0.hook_mlp_out"]
+    for sae in saes.values():
+        recon = sae(batch)
+        per_sample_mse = (recon - batch).pow(2).sum(-1).mean()
+        # crude: trained reconstruction error should be less than the input's own variance
+        baseline = batch.pow(2).sum(-1).mean()
+        assert per_sample_mse < baseline, (
+            f"reconstruction worse than zero baseline: {per_sample_mse.item()} vs "
+            f"{baseline.item()}"
+        )

--- a/tests/training/test_activations_store_multi_hook.py
+++ b/tests/training/test_activations_store_multi_hook.py
@@ -1,0 +1,195 @@
+from typing import Any
+
+import pytest
+import torch
+from datasets import Dataset
+from transformer_lens import HookedTransformer
+
+from sae_lens.training.activations_store import ActivationsStore
+from tests.helpers import TINYSTORIES_MODEL, assert_close, load_model_cached
+
+
+def _common_kwargs(dataset: Dataset) -> dict[str, Any]:
+    return dict(
+        dataset=dataset,
+        streaming=False,
+        context_size=8,
+        n_batches_in_buffer=2,
+        total_training_tokens=10_000,
+        store_batch_size_prompts=4,
+        train_batch_size_tokens=4,
+        prepend_bos=True,
+        normalize_activations="none",
+        device=torch.device("cpu"),
+        dtype="float32",
+        seqpos_slice=(None,),
+        activations_mixing_fraction=0.0,
+    )
+
+
+@pytest.fixture
+def ts_model() -> HookedTransformer:
+    return load_model_cached(TINYSTORIES_MODEL)
+
+
+@pytest.fixture
+def dataset() -> Dataset:
+    # Each row is distinct so different positions have different activations
+    # — catches misaligned splits across hooks.
+    return Dataset.from_list(
+        [{"text": f"document number {i} the quick brown fox jumps"} for i in range(200)]
+    )
+
+
+def test_multi_hook_get_multi_hook_activations_matches_per_hook_get_activations(
+    ts_model: HookedTransformer,
+    dataset: Dataset,
+):
+    hook_a = "blocks.0.hook_resid_pre"
+    hook_b = "blocks.0.hook_mlp_out"
+    d_in = ts_model.cfg.d_model
+
+    common = _common_kwargs(dataset)
+
+    store_single_a = ActivationsStore(
+        model=ts_model, hook_name=hook_a, hook_head_index=None, d_in=d_in, **common
+    )
+    store_single_b = ActivationsStore(
+        model=ts_model, hook_name=hook_b, hook_head_index=None, d_in=d_in, **common
+    )
+    store_multi = ActivationsStore.from_config_multi_hook(
+        model=ts_model,
+        hook_names=[hook_a, hook_b],
+        hook_d_ins={hook_a: d_in, hook_b: d_in},
+        **common,
+    )
+
+    batch_tokens = store_single_a.get_batch_tokens()
+    # all stores see same dataset so independent fetches yield same tokens
+    same_tokens = store_single_b.get_batch_tokens()
+    assert torch.equal(batch_tokens, same_tokens)
+    multi_tokens = store_multi.get_batch_tokens()
+    assert torch.equal(batch_tokens, multi_tokens)
+
+    single_a = store_single_a.get_activations(batch_tokens)
+    single_b = store_single_b.get_activations(batch_tokens)
+    multi = store_multi.get_multi_hook_activations(batch_tokens)
+
+    assert set(multi.keys()) == {hook_a, hook_b}
+    assert_close(multi[hook_a], single_a)
+    assert_close(multi[hook_b], single_b)
+
+
+def test_multi_hook_data_loader_matches_single_hook_per_hook(
+    ts_model: HookedTransformer,
+    dataset: Dataset,
+):
+    hook_a = "blocks.0.hook_resid_pre"
+    hook_b = "blocks.0.hook_mlp_out"
+    d_in = ts_model.cfg.d_model
+
+    common = _common_kwargs(dataset)
+
+    store_single_a = ActivationsStore(
+        model=ts_model, hook_name=hook_a, hook_head_index=None, d_in=d_in, **common
+    )
+    store_single_b = ActivationsStore(
+        model=ts_model, hook_name=hook_b, hook_head_index=None, d_in=d_in, **common
+    )
+    store_multi = ActivationsStore.from_config_multi_hook(
+        model=ts_model,
+        hook_names=[hook_a, hook_b],
+        hook_d_ins={hook_a: d_in, hook_b: d_in},
+        **common,
+    )
+
+    multi_iter = store_multi.get_multi_hook_data_loader()
+    for _ in range(5):
+        multi_batch = next(multi_iter)
+        single_a_batch = next(store_single_a)
+        single_b_batch = next(store_single_b)
+        assert set(multi_batch.keys()) == {hook_a, hook_b}
+        assert multi_batch[hook_a].shape == single_a_batch.shape
+        assert_close(multi_batch[hook_a], single_a_batch)
+        assert_close(multi_batch[hook_b], single_b_batch)
+
+
+def test_multi_hook_supports_different_d_ins_via_attn_hook(
+    ts_model: HookedTransformer,
+    dataset: Dataset,
+):
+    # blocks.0.attn.hook_z has shape (B, C, n_heads, d_head); flattened d_in = n_heads * d_head.
+    # For tiny-stories-1M (d_model=64, n_heads varying), this differs from hook_resid_pre's d_model.
+    hook_resid = "blocks.0.hook_resid_pre"
+    hook_z = "blocks.0.attn.hook_z"
+    d_resid = ts_model.cfg.d_model
+    d_z = ts_model.cfg.n_heads * ts_model.cfg.d_head
+
+    common = _common_kwargs(dataset)
+
+    store_single_z = ActivationsStore(
+        model=ts_model, hook_name=hook_z, hook_head_index=None, d_in=d_z, **common
+    )
+    store_single_resid = ActivationsStore(
+        model=ts_model,
+        hook_name=hook_resid,
+        hook_head_index=None,
+        d_in=d_resid,
+        **common,
+    )
+    store_multi = ActivationsStore.from_config_multi_hook(
+        model=ts_model,
+        hook_names=[hook_resid, hook_z],
+        hook_d_ins={hook_resid: d_resid, hook_z: d_z},
+        **common,
+    )
+
+    multi_iter = store_multi.get_multi_hook_data_loader()
+    for _ in range(3):
+        multi_batch = next(multi_iter)
+        single_z_batch = next(store_single_z)
+        single_resid_batch = next(store_single_resid)
+        # different feature dims per hook — verifies concat-split with heterogeneous shapes
+        assert multi_batch[hook_resid].shape[-1] == d_resid
+        assert multi_batch[hook_z].shape[-1] == d_z
+        assert_close(multi_batch[hook_z], single_z_batch)
+        assert_close(multi_batch[hook_resid], single_resid_batch)
+
+
+def test_multi_hook_factory_validates_inputs(
+    ts_model: HookedTransformer, dataset: Dataset
+):
+    common = _common_kwargs(dataset)
+    common.pop("dataset")
+    with pytest.raises(ValueError, match="hook_names must be non-empty"):
+        ActivationsStore.from_config_multi_hook(
+            model=ts_model,
+            dataset=dataset,
+            hook_names=[],
+            hook_d_ins={},
+            **common,
+        )
+    with pytest.raises(ValueError, match="hook_d_ins missing entries"):
+        ActivationsStore.from_config_multi_hook(
+            model=ts_model,
+            dataset=dataset,
+            hook_names=["blocks.0.hook_mlp_out"],
+            hook_d_ins={},
+            **common,
+        )
+
+
+def test_get_multi_hook_data_loader_errors_on_single_hook_store(
+    ts_model: HookedTransformer, dataset: Dataset
+):
+    store = ActivationsStore(
+        model=ts_model,
+        hook_name="blocks.0.hook_mlp_out",
+        hook_head_index=None,
+        d_in=ts_model.cfg.d_model,
+        **_common_kwargs(dataset),
+    )
+    with pytest.raises(RuntimeError, match="from_config_multi_hook"):
+        store.get_multi_hook_data_loader()
+    with pytest.raises(RuntimeError, match="from_config_multi_hook"):
+        store.get_multi_hook_activations(torch.zeros((2, 8), dtype=torch.long))

--- a/tests/training/test_mixing_buffer.py
+++ b/tests/training/test_mixing_buffer.py
@@ -3,8 +3,11 @@ from collections.abc import Iterator
 import pytest
 import torch
 
-from sae_lens.training.mixing_buffer import mixing_buffer
-from tests.helpers import assert_not_close
+from sae_lens.training.mixing_buffer import (
+    mixing_buffer,
+    multi_hook_concat_split_iter,
+)
+from tests.helpers import assert_close, assert_not_close
 
 
 def test_mixing_buffer_yields_batches_of_correct_size_despite_loader_size_fluctuations():
@@ -184,6 +187,112 @@ def test_mixing_buffer_mix_fraction_matches_observed_mix_fraction():
 
     mean_mix_fraction = sum(observed_mix_fractions) / len(observed_mix_fractions)
     assert mean_mix_fraction == pytest.approx(target_mix_frac, abs=0.03)
+
+
+def test_multi_hook_concat_split_iter_passthrough_no_shuffle():
+    # mix_fraction=0 → no shuffling; output dict should match input order, per-hook.
+    h_a, h_b = "a", "b"
+    n_per = 16
+    a_in = torch.arange(n_per * 4, dtype=torch.float32).reshape(n_per, 4)
+    b_in = torch.arange(n_per * 7, dtype=torch.float32).reshape(n_per, 7) + 1000
+    inputs = [{h_a: a_in, h_b: b_in}]
+
+    out_batches = list(
+        multi_hook_concat_split_iter(
+            buffer_size=16,
+            batch_size=4,
+            activations_loader=iter(inputs),
+            hook_names=[h_a, h_b],
+            mix_fraction=0.0,
+        )
+    )
+    assert len(out_batches) == 4
+    assert_close(torch.cat([b[h_a] for b in out_batches]), a_in)
+    assert_close(torch.cat([b[h_b] for b in out_batches]), b_in)
+
+
+def test_multi_hook_concat_split_iter_alignment_under_shuffle():
+    # Encode the row index in both tensors so we can recover the permutation.
+    # Row i has hook_a[i] = (i, i, ...) and hook_b[i] = (i, i, i, i).
+    # If the two hooks were shuffled with different permutations, the row index
+    # encoded in hook_a wouldn't match the row index encoded in hook_b.
+    h_a, h_b = "a", "b"
+    n = 32
+    a_in = torch.arange(n, dtype=torch.float32).unsqueeze(1).expand(n, 3).contiguous()
+    b_in = torch.arange(n, dtype=torch.float32).unsqueeze(1).expand(n, 5).contiguous()
+
+    out_batches = list(
+        multi_hook_concat_split_iter(
+            buffer_size=32,
+            batch_size=4,
+            activations_loader=iter([{h_a: a_in, h_b: b_in}]),
+            hook_names=[h_a, h_b],
+            mix_fraction=0.5,
+        )
+    )
+
+    for batch in out_batches:
+        # Every row in hook_a encodes its original row index; same for hook_b.
+        a_rows = batch[h_a][:, 0]
+        b_rows = batch[h_b][:, 0]
+        assert_close(a_rows, b_rows)
+        # And every column within a single hook's row should encode the same index.
+        assert_close(batch[h_a], a_rows.unsqueeze(1).expand_as(batch[h_a]))
+        assert_close(batch[h_b], b_rows.unsqueeze(1).expand_as(batch[h_b]))
+
+
+def test_multi_hook_concat_split_iter_handles_different_d_ins():
+    h_a, h_b, h_c = "a", "b", "c"
+    n = 12
+    a_in = torch.randn(n, 2)
+    b_in = torch.randn(n, 5)
+    c_in = torch.randn(n, 3)
+
+    out_batches = list(
+        multi_hook_concat_split_iter(
+            buffer_size=12,
+            batch_size=4,
+            activations_loader=iter([{h_a: a_in, h_b: b_in, h_c: c_in}]),
+            hook_names=[h_a, h_b, h_c],
+            mix_fraction=0.0,
+        )
+    )
+    assert len(out_batches) == 3
+    for batch in out_batches:
+        assert batch[h_a].shape == (4, 2)
+        assert batch[h_b].shape == (4, 5)
+        assert batch[h_c].shape == (4, 3)
+    assert_close(torch.cat([b[h_a] for b in out_batches]), a_in)
+    assert_close(torch.cat([b[h_b] for b in out_batches]), b_in)
+    assert_close(torch.cat([b[h_c] for b in out_batches]), c_in)
+
+
+def test_multi_hook_concat_split_iter_errors_on_missing_hook():
+    h_a, h_b = "a", "b"
+    inputs = [{h_a: torch.randn(8, 4)}]  # missing h_b
+    with pytest.raises(ValueError, match="hooks"):
+        list(
+            multi_hook_concat_split_iter(
+                buffer_size=8,
+                batch_size=4,
+                activations_loader=iter(inputs),
+                hook_names=[h_a, h_b],
+                mix_fraction=0.0,
+            )
+        )
+
+
+def test_multi_hook_concat_split_iter_empty_loader():
+    out = list(
+        multi_hook_concat_split_iter(
+            buffer_size=8,
+            batch_size=4,
+            activations_loader=iter([]),
+            hook_names=["a", "b"],
+            mix_fraction=0.0,
+        )
+    )
+    assert out == []
 
 
 @pytest.mark.parametrize("mix_fraction", [0.9, 1.0])

--- a/tests/training/test_multi_sae_trainer.py
+++ b/tests/training/test_multi_sae_trainer.py
@@ -1,0 +1,432 @@
+import copy
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+from datasets import Dataset
+from transformer_lens import HookedTransformer
+
+from sae_lens.config import LoggingConfig, SAETrainerConfig
+from sae_lens.saes.standard_sae import StandardTrainingSAE, StandardTrainingSAEConfig
+from sae_lens.training.activations_store import ActivationsStore
+from sae_lens.training.multi_sae_trainer import MultiSAETrainer
+from sae_lens.training.sae_trainer import SAETrainer
+from tests.helpers import TINYSTORIES_MODEL, assert_close, load_model_cached
+
+
+@pytest.fixture
+def ts_model() -> HookedTransformer:
+    return load_model_cached(TINYSTORIES_MODEL)
+
+
+@pytest.fixture
+def dataset() -> Dataset:
+    return Dataset.from_list(
+        [{"text": f"row {i} the quick brown fox jumps"} for i in range(200)]
+    )
+
+
+def _common_store_kwargs(dataset: Dataset) -> dict[str, Any]:
+    return dict(
+        dataset=dataset,
+        streaming=False,
+        context_size=8,
+        n_batches_in_buffer=2,
+        total_training_tokens=10_000,
+        store_batch_size_prompts=4,
+        train_batch_size_tokens=4,
+        prepend_bos=True,
+        normalize_activations="none",
+        device=torch.device("cpu"),
+        dtype="float32",
+        seqpos_slice=(None,),
+        activations_mixing_fraction=0.0,
+    )
+
+
+def _make_sae(d_in: int) -> StandardTrainingSAE:
+    cfg = StandardTrainingSAEConfig(
+        d_in=d_in,
+        d_sae=32,
+        l1_coefficient=1e-3,
+        decoder_init_norm=0.1,
+        normalize_activations="none",
+        dtype="float32",
+        device="cpu",
+    )
+    return StandardTrainingSAE(cfg)
+
+
+def _trainer_cfg(total_samples: int) -> SAETrainerConfig:
+    return SAETrainerConfig(
+        total_training_samples=total_samples,
+        train_batch_size_samples=4,
+        lr=1e-3,
+        lr_end=1e-4,
+        device="cpu",
+        n_checkpoints=0,
+        save_final_checkpoint=False,
+        logger=LoggingConfig(log_to_wandb=False),
+        n_batches_for_norm_estimate=2,
+    )
+
+
+def test_multi_sae_trainer_matches_two_independent_single_trainers(
+    ts_model: HookedTransformer, dataset: Dataset
+):
+    """
+    Equivalence test: running 2 SAEs through a MultiSAETrainer must produce
+    bit-for-bit the same final weights as running 2 SAETrainers independently
+    on the same model + dataset, with shuffling disabled.
+    """
+    hook_a = "blocks.0.hook_resid_pre"
+    hook_b = "blocks.0.hook_mlp_out"
+    d_in = ts_model.cfg.d_model
+    n_steps = 5
+    common = _common_store_kwargs(dataset)
+
+    sae_a_proto = _make_sae(d_in)
+    sae_b_proto = _make_sae(d_in)
+    sae_a_single = copy.deepcopy(sae_a_proto)
+    sae_b_single = copy.deepcopy(sae_b_proto)
+    sae_a_multi = copy.deepcopy(sae_a_proto)
+    sae_b_multi = copy.deepcopy(sae_b_proto)
+
+    cfg = _trainer_cfg(total_samples=n_steps * 4)
+
+    store_a = ActivationsStore(
+        model=ts_model, hook_name=hook_a, hook_head_index=None, d_in=d_in, **common
+    )
+    store_b = ActivationsStore(
+        model=ts_model, hook_name=hook_b, hook_head_index=None, d_in=d_in, **common
+    )
+    trainer_a = SAETrainer(cfg=cfg, sae=sae_a_single, data_provider=store_a)
+    trainer_b = SAETrainer(cfg=cfg, sae=sae_b_single, data_provider=store_b)
+    trainer_a.fit()
+    trainer_b.fit()
+
+    multi_store = ActivationsStore.from_config_multi_hook(
+        model=ts_model,
+        hook_names=[hook_a, hook_b],
+        hook_d_ins={hook_a: d_in, hook_b: d_in},
+        **common,
+    )
+    multi_trainer = MultiSAETrainer(
+        cfg=cfg,
+        saes={"a": sae_a_multi, "b": sae_b_multi},
+        hook_names={"a": hook_a, "b": hook_b},
+        data_provider=multi_store.get_multi_hook_data_loader(),
+    )
+    multi_trainer.fit()
+
+    for p_single, p_multi in zip(
+        sae_a_single.parameters(), sae_a_multi.parameters(), strict=True
+    ):
+        assert_close(p_single, p_multi)
+    for p_single, p_multi in zip(
+        sae_b_single.parameters(), sae_b_multi.parameters(), strict=True
+    ):
+        assert_close(p_single, p_multi)
+
+    # Optimizer state should also match.
+    opt_single = trainer_a.optimizer.state_dict()["state"]
+    opt_multi = multi_trainer.trainers["a"].optimizer.state_dict()["state"]
+    for pid in opt_single:
+        for key, val in opt_single[pid].items():
+            mv = opt_multi[pid][key]
+            if torch.is_tensor(val):
+                assert_close(val, mv)
+            else:
+                assert val == mv
+
+    # Counters mirror correctly.
+    assert multi_trainer.n_training_samples == trainer_a.n_training_samples
+    assert multi_trainer.n_training_steps == trainer_a.n_training_steps
+
+
+def test_multi_sae_trainer_two_saes_at_same_hook_train_independently(
+    ts_model: HookedTransformer, dataset: Dataset
+):
+    """
+    Two SAEs at the same hook with different initial weights must remain
+    distinct after training (independent optimizers; no cross-contamination).
+    """
+    hook = "blocks.0.hook_mlp_out"
+    d_in = ts_model.cfg.d_model
+    n_steps = 4
+    common = _common_store_kwargs(dataset)
+
+    sae_a = _make_sae(d_in)
+    sae_b = _make_sae(d_in)
+    # Force them to have different init weights (otherwise zero-grad init coincidence).
+    with torch.no_grad():
+        for p_b in sae_b.parameters():
+            p_b.add_(torch.ones_like(p_b))
+
+    multi_store = ActivationsStore.from_config_multi_hook(
+        model=ts_model,
+        hook_names=[hook],
+        hook_d_ins={hook: d_in},
+        **common,
+    )
+    multi_trainer = MultiSAETrainer(
+        cfg=_trainer_cfg(total_samples=n_steps * 4),
+        saes={"a": sae_a, "b": sae_b},
+        hook_names={"a": hook, "b": hook},
+        data_provider=multi_store.get_multi_hook_data_loader(),
+    )
+    multi_trainer.fit()
+
+    # SAEs have independent params. They received the same activations but
+    # had different starting weights, so should still differ.
+    a_params = list(sae_a.parameters())
+    b_params = list(sae_b.parameters())
+    differs = any(
+        not torch.allclose(a, b) for a, b in zip(a_params, b_params, strict=True)
+    )
+    assert differs, "two SAEs at same hook collapsed to identical weights"
+
+
+def test_multi_sae_trainer_runs_with_normalize_activations(
+    ts_model: HookedTransformer, dataset: Dataset
+):
+    """Smoke: scaling-factor estimation runs once across SAEs and folds into weights at end."""
+    hook = "blocks.0.hook_mlp_out"
+    d_in = ts_model.cfg.d_model
+    common = _common_store_kwargs(dataset)
+
+    cfg_a = StandardTrainingSAEConfig(
+        d_in=d_in,
+        d_sae=32,
+        l1_coefficient=1e-3,
+        decoder_init_norm=0.1,
+        normalize_activations="expected_average_only_in",
+        dtype="float32",
+        device="cpu",
+    )
+    sae = StandardTrainingSAE(cfg_a)
+
+    multi_store = ActivationsStore.from_config_multi_hook(
+        model=ts_model,
+        hook_names=[hook],
+        hook_d_ins={hook: d_in},
+        **common,
+    )
+    multi_trainer = MultiSAETrainer(
+        cfg=_trainer_cfg(total_samples=4 * 4),
+        saes={"a": sae},
+        hook_names={"a": hook},
+        data_provider=multi_store.get_multi_hook_data_loader(),
+    )
+    multi_trainer.fit()
+
+    # After training, the scaling factor should be folded back to None.
+    assert multi_trainer.trainers["a"].activation_scaler.scaling_factor is None
+
+
+def test_multi_sae_trainer_save_and_load_round_trip(
+    ts_model: HookedTransformer, dataset: Dataset, tmp_path: Any
+):
+    hook_a = "blocks.0.hook_resid_pre"
+    hook_b = "blocks.0.hook_mlp_out"
+    d_in = ts_model.cfg.d_model
+    common = _common_store_kwargs(dataset)
+
+    sae_a = _make_sae(d_in)
+    sae_b = _make_sae(d_in)
+
+    multi_store = ActivationsStore.from_config_multi_hook(
+        model=ts_model,
+        hook_names=[hook_a, hook_b],
+        hook_d_ins={hook_a: d_in, hook_b: d_in},
+        **common,
+    )
+
+    cfg = _trainer_cfg(total_samples=4 * 4)
+    cfg.checkpoint_path = str(tmp_path / "ckpt")
+
+    trainer = MultiSAETrainer(
+        cfg=cfg,
+        saes={"a": sae_a, "b": sae_b},
+        hook_names={"a": hook_a, "b": hook_b},
+        data_provider=multi_store.get_multi_hook_data_loader(),
+    )
+    # Run a few real steps so optimizer/sparsity state is non-trivial.
+    trainer.fit()
+    saved_a_w_enc = sae_a.W_enc.clone()
+    saved_b_w_enc = sae_b.W_enc.clone()
+    saved_n_samples = trainer.n_training_samples
+
+    trainer.save_checkpoint(checkpoint_name="ckpt0")
+    checkpoint_dir = tmp_path / "ckpt" / "ckpt0"
+    assert (checkpoint_dir / "a" / "sae_weights.safetensors").exists()
+    assert (checkpoint_dir / "b" / "sae_weights.safetensors").exists()
+    assert (checkpoint_dir / "a" / "trainer_state.pt").exists()
+    assert (checkpoint_dir / "b" / "trainer_state.pt").exists()
+
+    # Build a fresh trainer with new SAEs, load checkpoint, verify state restored.
+    fresh_a = _make_sae(d_in)
+    fresh_b = _make_sae(d_in)
+    fresh_trainer = MultiSAETrainer(
+        cfg=cfg,
+        saes={"a": fresh_a, "b": fresh_b},
+        hook_names={"a": hook_a, "b": hook_b},
+        data_provider=multi_store.get_multi_hook_data_loader(),
+    )
+    fresh_trainer.load_checkpoint(checkpoint_dir)
+
+    assert_close(fresh_a.W_enc, saved_a_w_enc)
+    assert_close(fresh_b.W_enc, saved_b_w_enc)
+    assert fresh_trainer.n_training_samples == saved_n_samples
+
+
+def test_multi_sae_trainer_validates_hook_keys(ts_model: HookedTransformer):
+    cfg = _trainer_cfg(total_samples=4)
+    sae = _make_sae(ts_model.cfg.d_model)
+    with pytest.raises(ValueError, match="identical keys"):
+        MultiSAETrainer(
+            cfg=cfg,
+            saes={"a": sae},
+            hook_names={"b": "blocks.0.hook_mlp_out"},
+            data_provider=iter(()),  # type: ignore[arg-type]
+        )
+
+
+def test_multi_sae_trainer_per_sae_loss_decreases_over_training(
+    ts_model: HookedTransformer, dataset: Dataset
+):
+    """Functional: per-SAE losses fall when training on the same activations repeatedly."""
+    hook = "blocks.0.hook_mlp_out"
+    d_in = ts_model.cfg.d_model
+    common = _common_store_kwargs(dataset)
+
+    sae_a = _make_sae(d_in)
+    sae_b = _make_sae(d_in)
+    multi_store = ActivationsStore.from_config_multi_hook(
+        model=ts_model,
+        hook_names=[hook],
+        hook_d_ins={hook: d_in},
+        **common,
+    )
+    trainer = MultiSAETrainer(
+        cfg=_trainer_cfg(total_samples=4),  # 1 step
+        saes={"a": sae_a, "b": sae_b},
+        hook_names={"a": hook, "b": hook},
+        data_provider=multi_store.get_multi_hook_data_loader(),
+    )
+    # Pull one batch and step both SAEs on the same activations 5 times.
+    multi_batch = next(trainer.data_provider)
+    same_input = multi_batch[hook]
+    losses_a: list[float] = []
+    losses_b: list[float] = []
+    for _ in range(5):
+        out_a = trainer.trainers["a"].step(same_input.clone())
+        out_b = trainer.trainers["b"].step(same_input.clone())
+        losses_a.append(out_a.loss.item())
+        losses_b.append(out_b.loss.item())
+    for prev, nxt in zip(losses_a[:-1], losses_a[1:]):
+        assert nxt < prev
+    for prev, nxt in zip(losses_b[:-1], losses_b[1:]):
+        assert nxt < prev
+
+
+def test_multi_sae_trainer_writes_n_checkpoints_during_fit(
+    ts_model: HookedTransformer, dataset: Dataset, tmp_path: Any
+):
+    hook = "blocks.0.hook_mlp_out"
+    d_in = ts_model.cfg.d_model
+    common = _common_store_kwargs(dataset)
+    sae_a = _make_sae(d_in)
+    sae_b = _make_sae(d_in)
+
+    multi_store = ActivationsStore.from_config_multi_hook(
+        model=ts_model,
+        hook_names=[hook],
+        hook_d_ins={hook: d_in},
+        **common,
+    )
+    cfg = _trainer_cfg(total_samples=12 * 4)  # 12 steps
+    cfg.checkpoint_path = str(tmp_path / "ckpts")
+    cfg.n_checkpoints = 2
+    cfg.save_final_checkpoint = True
+
+    trainer = MultiSAETrainer(
+        cfg=cfg,
+        saes={"a": sae_a, "b": sae_b},
+        hook_names={"a": hook, "b": hook},
+        data_provider=multi_store.get_multi_hook_data_loader(),
+    )
+    trainer.fit()
+
+    base = Path(cfg.checkpoint_path)
+    sae_weight_files = list(base.glob("**/sae_weights.safetensors"))
+    # 2 intermediate + 1 final = 3 checkpoint dirs, each with 2 SAEs
+    assert (
+        len(sae_weight_files) == 3 * 2
+    ), f"expected 6 sae_weights files (3 ckpts × 2 SAEs), got {len(sae_weight_files)}"
+
+
+def test_multi_sae_trainer_skips_checkpoints_when_path_none_and_no_wandb(
+    ts_model: HookedTransformer, dataset: Dataset
+):
+    hook = "blocks.0.hook_mlp_out"
+    d_in = ts_model.cfg.d_model
+    common = _common_store_kwargs(dataset)
+    sae_a = _make_sae(d_in)
+
+    multi_store = ActivationsStore.from_config_multi_hook(
+        model=ts_model,
+        hook_names=[hook],
+        hook_d_ins={hook: d_in},
+        **common,
+    )
+    cfg = _trainer_cfg(total_samples=4 * 4)
+    cfg.checkpoint_path = None
+    cfg.n_checkpoints = 2
+    cfg.save_final_checkpoint = True
+
+    received_paths: list[Any] = []
+
+    def save_fn(checkpoint_path: Any) -> None:
+        received_paths.append(checkpoint_path)
+
+    trainer = MultiSAETrainer(
+        cfg=cfg,
+        saes={"a": sae_a},
+        hook_names={"a": hook},
+        data_provider=multi_store.get_multi_hook_data_loader(),
+        save_checkpoint_fn=save_fn,
+    )
+    trainer.fit()
+    # save_checkpoint should have been invoked but each call passes path=None
+    assert all(p is None for p in received_paths)
+    assert len(received_paths) >= 1  # at least the final-checkpoint call
+
+
+def test_multi_sae_trainer_advances_counters_in_lockstep(
+    ts_model: HookedTransformer, dataset: Dataset
+):
+    hook = "blocks.0.hook_mlp_out"
+    d_in = ts_model.cfg.d_model
+    common = _common_store_kwargs(dataset)
+    sae_a = _make_sae(d_in)
+    sae_b = _make_sae(d_in)
+
+    multi_store = ActivationsStore.from_config_multi_hook(
+        model=ts_model,
+        hook_names=[hook],
+        hook_d_ins={hook: d_in},
+        **common,
+    )
+    trainer = MultiSAETrainer(
+        cfg=_trainer_cfg(total_samples=8 * 4),
+        saes={"a": sae_a, "b": sae_b},
+        hook_names={"a": hook, "b": hook},
+        data_provider=multi_store.get_multi_hook_data_loader(),
+    )
+    trainer.fit()
+    assert trainer.trainers["a"].n_training_steps == trainer.n_training_steps
+    assert trainer.trainers["b"].n_training_steps == trainer.n_training_steps
+    assert trainer.trainers["a"].n_training_samples == trainer.n_training_samples
+    assert trainer.trainers["b"].n_training_samples == trainer.n_training_samples

--- a/tests/training/test_multi_sae_trainer.py
+++ b/tests/training/test_multi_sae_trainer.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 import torch
 from datasets import Dataset
+from tqdm.auto import tqdm
 from transformer_lens import HookedTransformer
 
 from sae_lens.config import LoggingConfig, SAETrainerConfig
@@ -282,6 +283,56 @@ def test_multi_sae_trainer_save_and_load_round_trip(
     assert_close(fresh_a.W_enc, saved_a_w_enc)
     assert_close(fresh_b.W_enc, saved_b_w_enc)
     assert fresh_trainer.n_training_samples == saved_n_samples
+
+
+def test_multi_sae_trainer_load_checkpoint_errors_on_missing_sae_subdir(
+    ts_model: HookedTransformer, dataset: Dataset, tmp_path: Path
+):
+    hook = "blocks.0.hook_mlp_out"
+    d_in = ts_model.cfg.d_model
+    multi_store = ActivationsStore.from_config_multi_hook(
+        model=ts_model,
+        hook_names=[hook],
+        hook_d_ins={hook: d_in},
+        **_common_store_kwargs(dataset),
+    )
+    trainer = MultiSAETrainer(
+        cfg=_trainer_cfg(total_samples=4),
+        saes={"a": _make_sae(d_in), "b": _make_sae(d_in)},
+        hook_names={"a": hook, "b": hook},
+        data_provider=multi_store.get_multi_hook_data_loader(),
+    )
+    # the directory exists but has no per-SAE subdirectories
+    (tmp_path / "empty_ckpt").mkdir()
+    with pytest.raises(FileNotFoundError, match="missing per-SAE subdirectories"):
+        trainer.load_checkpoint(tmp_path / "empty_ckpt")
+
+
+def test_multi_sae_trainer_update_pbar_refreshes_on_interval(
+    ts_model: HookedTransformer, dataset: Dataset
+):
+    hook = "blocks.0.hook_mlp_out"
+    d_in = ts_model.cfg.d_model
+    multi_store = ActivationsStore.from_config_multi_hook(
+        model=ts_model,
+        hook_names=[hook],
+        hook_d_ins={hook: d_in},
+        **_common_store_kwargs(dataset),
+    )
+    trainer = MultiSAETrainer(
+        cfg=_trainer_cfg(total_samples=4),
+        saes={"a": _make_sae(d_in)},
+        hook_names={"a": hook},
+        data_provider=multi_store.get_multi_hook_data_loader(),
+    )
+    multi_batch = next(trainer.data_provider)
+    step_outputs = {"a": trainer.trainers["a"].step(multi_batch[hook])}
+
+    pbar = tqdm(total=1000)
+    trainer.n_training_steps = 100  # a multiple of the 100-step refresh interval
+    trainer._update_pbar(step_outputs, pbar)  # type: ignore[reportPrivateUsage]
+    assert pbar.desc.startswith("100|")
+    pbar.close()
 
 
 def test_multi_sae_trainer_validates_hook_keys(ts_model: HookedTransformer):

--- a/tests/training/test_multi_sae_trainer.py
+++ b/tests/training/test_multi_sae_trainer.py
@@ -12,7 +12,12 @@ from sae_lens.saes.standard_sae import StandardTrainingSAE, StandardTrainingSAEC
 from sae_lens.training.activations_store import ActivationsStore
 from sae_lens.training.multi_sae_trainer import MultiSAETrainer
 from sae_lens.training.sae_trainer import SAETrainer
-from tests.helpers import TINYSTORIES_MODEL, assert_close, load_model_cached
+from tests.helpers import (
+    TINYSTORIES_MODEL,
+    assert_close,
+    load_model_cached,
+    random_params,
+)
 
 
 @pytest.fixture
@@ -55,7 +60,9 @@ def _make_sae(d_in: int) -> StandardTrainingSAE:
         dtype="float32",
         device="cpu",
     )
-    return StandardTrainingSAE(cfg)
+    sae = StandardTrainingSAE(cfg)
+    random_params(sae)
+    return sae
 
 
 def _trainer_cfg(total_samples: int) -> SAETrainerConfig:
@@ -159,10 +166,6 @@ def test_multi_sae_trainer_two_saes_at_same_hook_train_independently(
 
     sae_a = _make_sae(d_in)
     sae_b = _make_sae(d_in)
-    # Force them to have different init weights (otherwise zero-grad init coincidence).
-    with torch.no_grad():
-        for p_b in sae_b.parameters():
-            p_b.add_(torch.ones_like(p_b))
 
     multi_store = ActivationsStore.from_config_multi_hook(
         model=ts_model,

--- a/tests/training/test_multi_sae_trainer.py
+++ b/tests/training/test_multi_sae_trainer.py
@@ -83,11 +83,6 @@ def _trainer_cfg(total_samples: int) -> SAETrainerConfig:
 def test_multi_sae_trainer_matches_two_independent_single_trainers(
     ts_model: HookedTransformer, dataset: Dataset
 ):
-    """
-    Equivalence test: running 2 SAEs through a MultiSAETrainer must produce
-    bit-for-bit the same final weights as running 2 SAETrainers independently
-    on the same model + dataset, with shuffling disabled.
-    """
     hook_a = "blocks.0.hook_resid_pre"
     hook_b = "blocks.0.hook_mlp_out"
     d_in = ts_model.cfg.d_model
@@ -156,10 +151,6 @@ def test_multi_sae_trainer_matches_two_independent_single_trainers(
 def test_multi_sae_trainer_two_saes_at_same_hook_train_independently(
     ts_model: HookedTransformer, dataset: Dataset
 ):
-    """
-    Two SAEs at the same hook with different initial weights must remain
-    distinct after training (independent optimizers; no cross-contamination).
-    """
     hook = "blocks.0.hook_mlp_out"
     d_in = ts_model.cfg.d_model
     n_steps = 4
@@ -195,7 +186,6 @@ def test_multi_sae_trainer_two_saes_at_same_hook_train_independently(
 def test_multi_sae_trainer_runs_with_normalize_activations(
     ts_model: HookedTransformer, dataset: Dataset
 ):
-    """Smoke: scaling-factor estimation runs once across SAEs and folds into weights at end."""
     hook = "blocks.0.hook_mlp_out"
     d_in = ts_model.cfg.d_model
     common = _common_store_kwargs(dataset)
@@ -350,7 +340,6 @@ def test_multi_sae_trainer_validates_hook_keys(ts_model: HookedTransformer):
 def test_multi_sae_trainer_per_sae_loss_decreases_over_training(
     ts_model: HookedTransformer, dataset: Dataset
 ):
-    """Functional: per-SAE losses fall when training on the same activations repeatedly."""
     hook = "blocks.0.hook_mlp_out"
     d_in = ts_model.cfg.d_model
     common = _common_store_kwargs(dataset)

--- a/tests/training/test_multi_sae_trainer.py
+++ b/tests/training/test_multi_sae_trainer.py
@@ -220,7 +220,7 @@ def test_multi_sae_trainer_runs_with_normalize_activations(
 
 
 def test_multi_sae_trainer_save_and_load_round_trip(
-    ts_model: HookedTransformer, dataset: Dataset, tmp_path: Any
+    ts_model: HookedTransformer, dataset: Dataset, tmp_path: Path
 ):
     hook_a = "blocks.0.hook_resid_pre"
     hook_b = "blocks.0.hook_mlp_out"
@@ -375,7 +375,7 @@ def test_multi_sae_trainer_per_sae_loss_decreases_over_training(
 
 
 def test_multi_sae_trainer_writes_n_checkpoints_during_fit(
-    ts_model: HookedTransformer, dataset: Dataset, tmp_path: Any
+    ts_model: HookedTransformer, dataset: Dataset, tmp_path: Path
 ):
     hook = "blocks.0.hook_mlp_out"
     d_in = ts_model.cfg.d_model

--- a/tests/training/test_sae_trainer.py
+++ b/tests/training/test_sae_trainer.py
@@ -4,7 +4,6 @@ from typing import Any, Callable
 
 import pytest
 import torch
-import wandb
 from datasets import Dataset
 from transformer_lens import HookedTransformer
 
@@ -625,35 +624,10 @@ def test_SAETrainer_save_and_load_from_checkpoint(
             assert old_state[key] == new_state[key]
 
 
-class _FakeArtifact:
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        pass
-
-    def add_file(self, *args: Any, **kwargs: Any) -> None:
-        pass
-
-
-@pytest.fixture
-def captured_wandb_logs(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
-    """Patch wandb so trainer logging runs without a real session.
-
-    Returns the list of dicts passed to `wandb.log`.
-    """
-    logged: list[dict[str, Any]] = []
-    monkeypatch.setattr(wandb, "init", lambda *_a, **_k: None)
-    monkeypatch.setattr(wandb, "finish", lambda *_a, **_k: None)
-    monkeypatch.setattr(wandb, "log", lambda d, **_k: logged.append(d))
-    monkeypatch.setattr(wandb, "log_artifact", lambda *_a, **_k: None)
-    monkeypatch.setattr(wandb, "Histogram", lambda *_a, **_k: None)
-    monkeypatch.setattr(wandb, "Artifact", _FakeArtifact)
-    return logged
-
-
 def test_sae_trainer_fit_logs_train_eval_and_sparsity_metrics_to_wandb(
     model: HookedTransformer,
     captured_wandb_logs: list[dict[str, Any]],
 ) -> None:
-    """fit() with wandb on must emit train-step, eval, and sparsity-reset logs."""
     cfg = build_runner_cfg(
         d_in=64,
         d_sae=128,

--- a/tests/training/test_sae_trainer.py
+++ b/tests/training/test_sae_trainer.py
@@ -205,7 +205,7 @@ def test_build_train_step_log_dict(
     # we're relying on the trainer only for some of the metrics here
     # we should more / less try to break this and push
     # everything through the train step output if we can.
-    log_dict = trainer._build_train_step_log_dict(
+    log_dict = trainer.build_train_step_log_dict(
         output=train_output, n_training_samples=123
     )
     expected = {
@@ -244,7 +244,7 @@ def test_build_train_step_log_dict_callable_metrics(
         },
     )
 
-    log_dict = trainer._build_train_step_log_dict(
+    log_dict = trainer.build_train_step_log_dict(
         output=train_output, n_training_samples=100
     )
 

--- a/tests/training/test_sae_trainer.py
+++ b/tests/training/test_sae_trainer.py
@@ -4,11 +4,12 @@ from typing import Any, Callable
 
 import pytest
 import torch
+import wandb
 from datasets import Dataset
 from transformer_lens import HookedTransformer
 
 from sae_lens import __version__
-from sae_lens.config import LanguageModelSAERunnerConfig
+from sae_lens.config import LanguageModelSAERunnerConfig, LoggingConfig
 from sae_lens.llm_sae_training_runner import (
     LanguageModelSAETrainingRunner,
     LLMSaeEvaluator,
@@ -622,3 +623,73 @@ def test_SAETrainer_save_and_load_from_checkpoint(
             assert torch.allclose(old_state[key], new_state[key])
         else:
             assert old_state[key] == new_state[key]
+
+
+class _FakeArtifact:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def add_file(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+@pytest.fixture
+def captured_wandb_logs(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Patch wandb so trainer logging runs without a real session.
+
+    Returns the list of dicts passed to `wandb.log`.
+    """
+    logged: list[dict[str, Any]] = []
+    monkeypatch.setattr(wandb, "init", lambda *_a, **_k: None)
+    monkeypatch.setattr(wandb, "finish", lambda *_a, **_k: None)
+    monkeypatch.setattr(wandb, "log", lambda d, **_k: logged.append(d))
+    monkeypatch.setattr(wandb, "log_artifact", lambda *_a, **_k: None)
+    monkeypatch.setattr(wandb, "Histogram", lambda *_a, **_k: None)
+    monkeypatch.setattr(wandb, "Artifact", _FakeArtifact)
+    return logged
+
+
+def test_sae_trainer_fit_logs_train_eval_and_sparsity_metrics_to_wandb(
+    model: HookedTransformer,
+    captured_wandb_logs: list[dict[str, Any]],
+) -> None:
+    """fit() with wandb on must emit train-step, eval, and sparsity-reset logs."""
+    cfg = build_runner_cfg(
+        d_in=64,
+        d_sae=128,
+        training_tokens=16,  # 4 steps at train_batch_size_tokens=4
+        n_eval_batches=1,
+        feature_sampling_window=2,
+        logger=LoggingConfig(
+            log_to_wandb=True, wandb_log_frequency=1, eval_every_n_wandb_logs=1
+        ),
+    )
+    store = ActivationsStore.from_config(
+        model,
+        cfg,
+        override_dataset=Dataset.from_list([{"text": "hello world"}] * 2000),
+    )
+    sae = StandardTrainingSAE(cfg.sae)
+    evaluator = LLMSaeEvaluator(
+        model,
+        store,
+        eval_batch_size_prompts=cfg.eval_batch_size_prompts,
+        n_eval_batches=cfg.n_eval_batches,
+        model_kwargs=cfg.model_kwargs,
+    )
+    trainer = SAETrainer(
+        cfg=cfg.to_sae_trainer_config(),
+        sae=sae,
+        data_provider=store,
+        evaluator=evaluator,
+    )
+    trainer.fit()
+
+    assert captured_wandb_logs, "expected wandb.log to be called"
+    all_keys = {k for d in captured_wandb_logs for k in d}
+    # _log_train_step / build_train_step_log_dict
+    assert "losses/overall_loss" in all_keys
+    # _run_and_log_evals merges the evaluator output (ce loss is eval-only)
+    assert "model_performance_preservation" in all_keys
+    # the feature_sampling_window=2 sparsity reset emits its own log dict
+    assert "metrics/mean_log10_feature_sparsity" in all_keys


### PR DESCRIPTION
Train multiple SAEs from a single LLM forward pass, reusing the existing single-SAE training stack. MultiSAETrainer holds a dict of SAETrainer instances and routes per-SAE activations from a shared multi-hook ActivationsStore. The new ActivationsStore.from_config_multi_hook factory captures activations at multiple hooks in one run_with_cache and pipes them through the unmodified mixing_buffer via a concat-along-feature wrapper that guarantees a shared shuffle permutation across hooks. Bit-exact equivalence tests pin the multi path against running N independent SAETrainers/stores.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update