### PR TITLE
make compile_llm actually engage dynamo: propagate compile, compile run_with_cache, prune HookedProxyLM hooks

### DIFF
--- a/sae_lens/llm_sae_training_runner.py
+++ b/sae_lens/llm_sae_training_runner.py
@@ -138,6 +138,7 @@ class LanguageModelSAETrainingRunner:
                 self.cfg.model_name,
                 device=llm_device,
                 model_from_pretrained_kwargs=self.cfg.model_from_pretrained_kwargs,
+                hook_names=[self.cfg.hook_name],
             )
         else:
             self.model = override_model
@@ -289,11 +290,16 @@ class LanguageModelSAETrainingRunner:
         # (b) can't be used on both SAE and LM (some issue with cudagraphs), and
         # (c) takes some time to compile.
         # Optimal settings: max-autotune on SAE, max-autotune-no-cudagraphs on LM.
+        #
+        # We compile `run_with_cache` rather than the module itself.
+        # ActivationsStore and the evaluator call `model.run_with_cache(...)`,
+        # not `model(...)`. `torch.compile` only intercepts `__call__`/forward,
+        # so wrapping the module leaves the cache path entirely uncompiled.
         if self.cfg.compile_llm:
-            self.model = torch.compile(
-                self.model,
+            self.model.run_with_cache = torch.compile(  # type: ignore[method-assign]
+                self.model.run_with_cache,
                 mode=self.cfg.llm_compilation_mode,
-            )  # type: ignore
+            )
 
     def _compile_sae_if_needed(self):
         if self.cfg.compile_sae:

--- a/sae_lens/llm_sae_training_runner.py
+++ b/sae_lens/llm_sae_training_runner.py
@@ -108,6 +108,7 @@ class LanguageModelSAETrainingRunner:
     model: HookedRootModule
     sae: TrainingSAE[Any]
     activations_store: ActivationsStore
+    evaluator: "LLMSaeEvaluator[Any]"
 
     def __init__(
         self,
@@ -141,6 +142,12 @@ class LanguageModelSAETrainingRunner:
         else:
             self.model = override_model
 
+        # Compile the LLM before constructing anything that captures a model
+        # reference (activations store, evaluator). Otherwise compile_llm is a
+        # no-op because the store / evaluator keep pointing at the uncompiled
+        # module after `self.model` is rebound.
+        self._compile_llm_if_needed()
+
         self.activations_store = ActivationsStore.from_config(
             self.model,
             self.cfg,
@@ -163,6 +170,14 @@ class LanguageModelSAETrainingRunner:
 
         self.sae.to(self.cfg.device)
 
+        self.evaluator = LLMSaeEvaluator(
+            model=self.model,
+            activations_store=self.activations_store,
+            eval_batch_size_prompts=self.cfg.eval_batch_size_prompts,
+            n_eval_batches=self.cfg.n_eval_batches,
+            model_kwargs=self.cfg.model_kwargs,
+        )
+
     def run(self):
         """
         Run the training of the SAE.
@@ -176,14 +191,6 @@ class LanguageModelSAETrainingRunner:
                 name=self.cfg.logger.run_name,
                 id=self.cfg.logger.wandb_id,
             )
-
-        evaluator = LLMSaeEvaluator(
-            model=self.model,
-            activations_store=self.activations_store,
-            eval_batch_size_prompts=self.cfg.eval_batch_size_prompts,
-            n_eval_batches=self.cfg.n_eval_batches,
-            model_kwargs=self.cfg.model_kwargs,
-        )
 
         data_provider: DataProvider = self.activations_store
         if self.cfg.prefetch_llm_batches:
@@ -200,7 +207,7 @@ class LanguageModelSAETrainingRunner:
         trainer = SAETrainer(
             sae=self.sae,
             data_provider=data_provider,
-            evaluator=evaluator,
+            evaluator=self.evaluator,
             save_checkpoint_fn=self.save_checkpoint,
             cfg=self.cfg.to_sae_trainer_config(),
         )
@@ -211,7 +218,7 @@ class LanguageModelSAETrainingRunner:
             self.sae.load_weights_from_checkpoint(self.cfg.resume_from_checkpoint)
             self.activations_store.load_from_checkpoint(self.cfg.resume_from_checkpoint)
 
-        self._compile_if_needed()
+        self._compile_sae_if_needed()
         sae = self.run_trainer_with_interruption_handling(trainer)
 
         if self.cfg.output_path is not None:
@@ -275,22 +282,20 @@ class LanguageModelSAETrainingRunner:
             self.cfg.disable_concat_sequences
         )
 
-    def _compile_if_needed(self):
-        # Compile model and SAE
-        #  torch.compile can provide significant speedups (10-20% in testing)
-        # using max-autotune gives the best speedups but:
+    def _compile_llm_if_needed(self):
+        # torch.compile can provide significant speedups (10-20% in testing).
+        # Using max-autotune gives the best speedups but:
         # (a) increases VRAM usage,
         # (b) can't be used on both SAE and LM (some issue with cudagraphs), and
-        # (c) takes some time to compile
-        # optimal settings seem to be:
-        # use max-autotune on SAE and max-autotune-no-cudagraphs on LM
-        # (also pylance seems to really hate this)
+        # (c) takes some time to compile.
+        # Optimal settings: max-autotune on SAE, max-autotune-no-cudagraphs on LM.
         if self.cfg.compile_llm:
             self.model = torch.compile(
                 self.model,
                 mode=self.cfg.llm_compilation_mode,
             )  # type: ignore
 
+    def _compile_sae_if_needed(self):
         if self.cfg.compile_sae:
             backend = "aot_eager" if self.cfg.device == "mps" else "inductor"
 

--- a/sae_lens/load_model.py
+++ b/sae_lens/load_model.py
@@ -19,7 +19,21 @@ def load_model(
     model_name: str,
     device: str | torch.device | None = None,
     model_from_pretrained_kwargs: dict[str, Any] | None = None,
+    hook_names: list[str] | None = None,
 ) -> HookedRootModule:
+    """
+    Load a model and wrap it in the appropriate HookedRootModule.
+
+    `hook_names` restricts which submodules `HookedProxyLM` instruments with
+    forward hooks. Hooking every submodule is the default but inserts a graph
+    break at each hook under `torch.compile`, so for a large HF model that's
+    hundreds of fragments. Pass the hook names you actually need (typically
+    the SAE's `hook_name`) to keep compile fragments large.
+
+    The param is a no-op for `HookedTransformer` and `HookedMamba`, whose
+    hook points are part of the architecture rather than `register_forward_hook`
+    calls.
+    """
     model_from_pretrained_kwargs = model_from_pretrained_kwargs or {}
 
     if "n_devices" in model_from_pretrained_kwargs:
@@ -60,7 +74,7 @@ def load_model(
         if model_from_pretrained_kwargs.get("device_map") is None:
             hf_model = hf_model.to(device)  # type: ignore
         tokenizer = AutoTokenizer.from_pretrained(model_name)
-        return HookedProxyLM(hf_model, tokenizer)
+        return HookedProxyLM(hf_model, tokenizer, hook_names=hook_names)
 
     # pragma: no cover
     raise ValueError(f"Unknown model class: {model_class_name}")
@@ -69,15 +83,27 @@ def load_model(
 class HookedProxyLM(HookedRootModule):
     """
     A HookedRootModule that wraps a Huggingface AutoModelForCausalLM.
+
+    If `hook_names` is provided, only those submodules get a forward hook.
+    Otherwise every submodule is hooked (default; matches historical
+    behaviour). Restricting hooks is important for `torch.compile`: each
+    forward hook becomes a graph break, so hooking every submodule of a
+    large model fragments compilation into hundreds of tiny graphs.
     """
 
     tokenizer: PreTrainedTokenizerBase
     model: torch.nn.Module
 
-    def __init__(self, model: torch.nn.Module, tokenizer: PreTrainedTokenizerBase):
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        tokenizer: PreTrainedTokenizerBase,
+        hook_names: list[str] | None = None,
+    ):
         super().__init__()
         self.model = model
         self.tokenizer = tokenizer
+        self._allowed_hook_names = None if hook_names is None else set(hook_names)
         self.setup()
 
     # copied and modified from base HookedRootModule
@@ -85,8 +111,11 @@ class HookedProxyLM(HookedRootModule):
         self.mod_dict = {}
         self.named_modules_dict = {}
         self.hook_dict: dict[str, HookPoint] = {}
+        allowed = self._allowed_hook_names
         for name, module in self.model.named_modules():
             if name == "":
+                continue
+            if allowed is not None and name not in allowed:
                 continue
 
             hook_point = HookPoint()
@@ -97,6 +126,13 @@ class HookedProxyLM(HookedRootModule):
             self.hook_dict[name] = hook_point
             self.mod_dict[name] = hook_point
             self.named_modules_dict[name] = module
+
+        if allowed is not None:
+            missing = allowed - set(self.hook_dict)
+            if missing:
+                raise ValueError(
+                    f"hook_names not found as submodules of the model: {sorted(missing)}"
+                )
 
     def run_with_cache(self, *args: Any, **kwargs: Any):  # type: ignore
         if "names_filter" in kwargs:

--- a/sae_lens/multi_sae_training_runner.py
+++ b/sae_lens/multi_sae_training_runner.py
@@ -411,6 +411,7 @@ class MultiSAETrainingRunner:
     model: HookedRootModule
     saes: dict[str, TrainingSAE[Any]]
     activations_store: ActivationsStore
+    evaluator: MultiSAEEvaluator
 
     def __init__(
         self,
@@ -445,6 +446,13 @@ class MultiSAETrainingRunner:
                 model_from_pretrained_kwargs=cfg.model_from_pretrained_kwargs,
             )
         )
+
+        # Compile the LLM before constructing anything that captures a model
+        # reference (activations store, evaluator). Otherwise compile_llm is a
+        # no-op because the store / evaluator keep pointing at the uncompiled
+        # module after `self.model` is rebound.
+        if cfg.compile_llm:
+            self.model = torch.compile(self.model, mode=cfg.llm_compilation_mode)  # type: ignore[assignment]
 
         unique_hooks = list(dict.fromkeys(cfg.hook_names_per_sae.values()))
         hook_d_ins: dict[str, int] = {}
@@ -508,6 +516,15 @@ class MultiSAETrainingRunner:
         for sae in self.saes.values():
             sae.to(cfg.device)
 
+        self.evaluator = MultiSAEEvaluator(
+            model=self.model,
+            activations_store=self.activations_store,
+            eval_batch_size_prompts=cfg.eval_batch_size_prompts,
+            n_eval_batches=cfg.n_eval_batches,
+            model_kwargs=cfg.model_kwargs,
+            user_evaluator=cfg.evaluator,
+        )
+
     def run(self) -> dict[str, TrainingSAE[Any]]:
         self._set_sae_metadata()
         if self.cfg.logger.log_to_wandb:
@@ -518,15 +535,6 @@ class MultiSAETrainingRunner:
                 name=self.cfg.logger.run_name,
                 id=self.cfg.logger.wandb_id,
             )
-
-        evaluator = MultiSAEEvaluator(
-            model=self.model,
-            activations_store=self.activations_store,
-            eval_batch_size_prompts=self.cfg.eval_batch_size_prompts,
-            n_eval_batches=self.cfg.n_eval_batches,
-            model_kwargs=self.cfg.model_kwargs,
-            user_evaluator=self.cfg.evaluator,
-        )
 
         data_provider: MultiHookDataProvider = (
             self.activations_store.get_multi_hook_data_loader()
@@ -539,15 +547,12 @@ class MultiSAETrainingRunner:
             )
             data_provider = PrefetchingIterator(data_provider, prefetch=prefetch_size)
 
-        if self.cfg.compile_llm:
-            self.model = torch.compile(self.model, mode=self.cfg.llm_compilation_mode)  # type: ignore[assignment]
-
         trainer = MultiSAETrainer(
             cfg=self.cfg.to_sae_trainer_config(),
             saes=self.saes,
             hook_names=self.cfg.hook_names_per_sae,
             data_provider=data_provider,
-            evaluator=evaluator,
+            evaluator=self.evaluator,
             save_checkpoint_fn=self._save_runner_checkpoint_files,
         )
 

--- a/sae_lens/multi_sae_training_runner.py
+++ b/sae_lens/multi_sae_training_runner.py
@@ -444,15 +444,19 @@ class MultiSAETrainingRunner:
                 cfg.model_name,
                 device=llm_device,
                 model_from_pretrained_kwargs=cfg.model_from_pretrained_kwargs,
+                hook_names=list(dict.fromkeys(cfg.hook_names_per_sae.values())),
             )
         )
 
-        # Compile the LLM before constructing anything that captures a model
-        # reference (activations store, evaluator). Otherwise compile_llm is a
-        # no-op because the store / evaluator keep pointing at the uncompiled
-        # module after `self.model` is rebound.
+        # We compile `run_with_cache` rather than the module itself.
+        # ActivationsStore and the evaluator call `model.run_with_cache(...)`,
+        # not `model(...)`. `torch.compile` only intercepts `__call__`/forward,
+        # so wrapping the module leaves the cache path entirely uncompiled.
         if cfg.compile_llm:
-            self.model = torch.compile(self.model, mode=cfg.llm_compilation_mode)  # type: ignore[assignment]
+            self.model.run_with_cache = torch.compile(  # type: ignore[method-assign]
+                self.model.run_with_cache,
+                mode=cfg.llm_compilation_mode,
+            )
 
         unique_hooks = list(dict.fromkeys(cfg.hook_names_per_sae.values()))
         hook_d_ins: dict[str, int] = {}

--- a/tests/test_llm_sae_training_runner.py
+++ b/tests/test_llm_sae_training_runner.py
@@ -143,6 +143,81 @@ def test_LanguageModelSAETrainingRunner_runs_with_prefetch_llm_batches(
     assert sae.cfg.architecture() == "standard"
 
 
+class _CompiledMarker(torch.nn.Module):
+    """Test stand-in for `torch._dynamo.eval_frame.OptimizedModule`."""
+
+    def __init__(self, orig: torch.nn.Module):
+        super().__init__()
+        self._orig_mod = orig
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        return self._orig_mod(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            return getattr(self._orig_mod, name)
+
+
+def test_LanguageModelSAETrainingRunner_compile_llm_propagates_to_store_and_evaluator(
+    monkeypatch: pytest.MonkeyPatch, ts_model: HookedTransformer
+):
+    # Regression: if compile_llm runs after the ActivationsStore and evaluator
+    # are constructed, both keep pointing at the uncompiled module and the
+    # compile is a no-op. They must receive the compiled wrapper.
+    monkeypatch.setattr(torch, "compile", lambda m, **_: _CompiledMarker(m))
+
+    cfg = build_runner_cfg_for_arch(
+        d_in=64,
+        d_sae=128,
+        architecture="standard",
+        training_tokens=4,
+        store_batch_size_prompts=2,
+        train_batch_size_tokens=4,
+        context_size=10,
+        n_batches_in_buffer=2,
+        dataset_path=NEEL_NANDA_C4_10K_DATASET,
+        hook_name="blocks.0.hook_resid_post",
+        model_name=TINYSTORIES_MODEL,
+        compile_llm=True,
+    )
+    runner = LanguageModelSAETrainingRunner(cfg, override_model=ts_model)
+
+    assert isinstance(runner.model, _CompiledMarker)
+    assert runner.activations_store.model is runner.model
+    assert runner.evaluator.model is runner.model
+
+
+def test_LanguageModelSAETrainingRunner_no_compile_when_compile_llm_false(
+    monkeypatch: pytest.MonkeyPatch, ts_model: HookedTransformer
+):
+    compile_calls: list[Any] = []
+    monkeypatch.setattr(torch, "compile", lambda m, **_: compile_calls.append(m) or m)
+
+    cfg = build_runner_cfg_for_arch(
+        d_in=64,
+        d_sae=128,
+        architecture="standard",
+        training_tokens=4,
+        store_batch_size_prompts=2,
+        train_batch_size_tokens=4,
+        context_size=10,
+        n_batches_in_buffer=2,
+        dataset_path=NEEL_NANDA_C4_10K_DATASET,
+        hook_name="blocks.0.hook_resid_post",
+        model_name=TINYSTORIES_MODEL,
+        compile_llm=False,
+        compile_sae=False,
+    )
+    runner = LanguageModelSAETrainingRunner(cfg, override_model=ts_model)
+
+    assert compile_calls == []
+    assert runner.model is ts_model
+    assert runner.activations_store.model is ts_model
+    assert runner.evaluator.model is ts_model
+
+
 def test_parse_cfg_args_raises_system_exit_on_empty_args():
     with pytest.raises(SystemExit):
         _parse_cfg_args([])

--- a/tests/test_llm_sae_training_runner.py
+++ b/tests/test_llm_sae_training_runner.py
@@ -143,30 +143,24 @@ def test_LanguageModelSAETrainingRunner_runs_with_prefetch_llm_batches(
     assert sae.cfg.architecture() == "standard"
 
 
-class _CompiledMarker(torch.nn.Module):
-    """Test stand-in for `torch._dynamo.eval_frame.OptimizedModule`."""
+class _CompiledCallable:
+    """Test stand-in for the callable that `torch.compile` returns for a function/method."""
 
-    def __init__(self, orig: torch.nn.Module):
-        super().__init__()
-        self._orig_mod = orig
+    def __init__(self, fn: Any):
+        self._sael_orig_fn = fn
 
-    def forward(self, *args: Any, **kwargs: Any) -> Any:
-        return self._orig_mod(*args, **kwargs)
-
-    def __getattr__(self, name: str) -> Any:
-        try:
-            return super().__getattr__(name)
-        except AttributeError:
-            return getattr(self._orig_mod, name)
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self._sael_orig_fn(*args, **kwargs)
 
 
-def test_LanguageModelSAETrainingRunner_compile_llm_propagates_to_store_and_evaluator(
+def test_LanguageModelSAETrainingRunner_compile_llm_compiles_run_with_cache(
     monkeypatch: pytest.MonkeyPatch, ts_model: HookedTransformer
 ):
-    # Regression: if compile_llm runs after the ActivationsStore and evaluator
-    # are constructed, both keep pointing at the uncompiled module and the
-    # compile is a no-op. They must receive the compiled wrapper.
-    monkeypatch.setattr(torch, "compile", lambda m, **_: _CompiledMarker(m))
+    # `torch.compile` only intercepts __call__; ActivationsStore and the
+    # evaluator call `model.run_with_cache(...)`, so compile_llm replaces that
+    # bound method (not the whole module). The store and evaluator share the
+    # same model object, so they see the same compiled callable.
+    monkeypatch.setattr(torch, "compile", lambda fn, **_: _CompiledCallable(fn))
 
     cfg = build_runner_cfg_for_arch(
         d_in=64,
@@ -184,16 +178,19 @@ def test_LanguageModelSAETrainingRunner_compile_llm_propagates_to_store_and_eval
     )
     runner = LanguageModelSAETrainingRunner(cfg, override_model=ts_model)
 
-    assert isinstance(runner.model, _CompiledMarker)
+    assert isinstance(runner.model.run_with_cache, _CompiledCallable)
     assert runner.activations_store.model is runner.model
     assert runner.evaluator.model is runner.model
+    assert runner.activations_store.model.run_with_cache is runner.model.run_with_cache
 
 
 def test_LanguageModelSAETrainingRunner_no_compile_when_compile_llm_false(
     monkeypatch: pytest.MonkeyPatch, ts_model: HookedTransformer
 ):
     compile_calls: list[Any] = []
-    monkeypatch.setattr(torch, "compile", lambda m, **_: compile_calls.append(m) or m)
+    monkeypatch.setattr(
+        torch, "compile", lambda fn, **_: compile_calls.append(fn) or fn
+    )
 
     cfg = build_runner_cfg_for_arch(
         d_in=64,

--- a/tests/test_multi_sae_training_runner.py
+++ b/tests/test_multi_sae_training_runner.py
@@ -450,3 +450,64 @@ def test_multi_sae_runner_saves_checkpoint_on_interruption(
     assert cfg.checkpoint_path is not None
     saved = list(Path(cfg.checkpoint_path).glob("*/a/sae_weights.safetensors"))
     assert saved, "expected an interrupt checkpoint with the SAE's weights"
+
+
+class _CompiledMarker(torch.nn.Module):
+    """Test stand-in for `torch._dynamo.eval_frame.OptimizedModule`."""
+
+    def __init__(self, orig: torch.nn.Module):
+        super().__init__()
+        self._orig_mod = orig
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        return self._orig_mod(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            return getattr(self._orig_mod, name)
+
+
+def test_multi_sae_runner_compile_llm_propagates_to_store_and_evaluator(
+    monkeypatch: pytest.MonkeyPatch, ts_model: HookedTransformer, dataset: Dataset
+):
+    # Regression: if compile_llm runs after the ActivationsStore and evaluator
+    # are constructed, both keep pointing at the uncompiled module and the
+    # compile is a no-op. They must receive the compiled wrapper.
+    monkeypatch.setattr(torch, "compile", lambda m, **_: _CompiledMarker(m))
+
+    d_in = ts_model.cfg.d_model
+    cfg = _build_cfg(
+        saes={"a": _std_sae_cfg(d_in)},
+        hook_names="blocks.0.hook_mlp_out",
+    )
+    cfg.compile_llm = True
+    runner = MultiSAETrainingRunner(
+        cfg, override_model=ts_model, override_dataset=dataset
+    )
+
+    assert isinstance(runner.model, _CompiledMarker)
+    assert runner.activations_store.model is runner.model
+    assert runner.evaluator.model is runner.model
+
+
+def test_multi_sae_runner_no_compile_when_compile_llm_false(
+    monkeypatch: pytest.MonkeyPatch, ts_model: HookedTransformer, dataset: Dataset
+):
+    compile_calls: list[Any] = []
+    monkeypatch.setattr(torch, "compile", lambda m, **_: compile_calls.append(m) or m)
+
+    d_in = ts_model.cfg.d_model
+    cfg = _build_cfg(
+        saes={"a": _std_sae_cfg(d_in)},
+        hook_names="blocks.0.hook_mlp_out",
+    )
+    runner = MultiSAETrainingRunner(
+        cfg, override_model=ts_model, override_dataset=dataset
+    )
+
+    assert compile_calls == []
+    assert runner.model is ts_model
+    assert runner.activations_store.model is ts_model
+    assert runner.evaluator.model is ts_model

--- a/tests/test_multi_sae_training_runner.py
+++ b/tests/test_multi_sae_training_runner.py
@@ -452,30 +452,24 @@ def test_multi_sae_runner_saves_checkpoint_on_interruption(
     assert saved, "expected an interrupt checkpoint with the SAE's weights"
 
 
-class _CompiledMarker(torch.nn.Module):
-    """Test stand-in for `torch._dynamo.eval_frame.OptimizedModule`."""
+class _CompiledCallable:
+    """Test stand-in for the callable that `torch.compile` returns for a function/method."""
 
-    def __init__(self, orig: torch.nn.Module):
-        super().__init__()
-        self._orig_mod = orig
+    def __init__(self, fn: Any):
+        self._sael_orig_fn = fn
 
-    def forward(self, *args: Any, **kwargs: Any) -> Any:
-        return self._orig_mod(*args, **kwargs)
-
-    def __getattr__(self, name: str) -> Any:
-        try:
-            return super().__getattr__(name)
-        except AttributeError:
-            return getattr(self._orig_mod, name)
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self._sael_orig_fn(*args, **kwargs)
 
 
-def test_multi_sae_runner_compile_llm_propagates_to_store_and_evaluator(
+def test_multi_sae_runner_compile_llm_compiles_run_with_cache(
     monkeypatch: pytest.MonkeyPatch, ts_model: HookedTransformer, dataset: Dataset
 ):
-    # Regression: if compile_llm runs after the ActivationsStore and evaluator
-    # are constructed, both keep pointing at the uncompiled module and the
-    # compile is a no-op. They must receive the compiled wrapper.
-    monkeypatch.setattr(torch, "compile", lambda m, **_: _CompiledMarker(m))
+    # `torch.compile` only intercepts __call__; ActivationsStore and the
+    # evaluator call `model.run_with_cache(...)`, so compile_llm replaces that
+    # bound method (not the whole module). The store and evaluator share the
+    # same model object, so they see the same compiled callable.
+    monkeypatch.setattr(torch, "compile", lambda fn, **_: _CompiledCallable(fn))
 
     d_in = ts_model.cfg.d_model
     cfg = _build_cfg(
@@ -487,16 +481,19 @@ def test_multi_sae_runner_compile_llm_propagates_to_store_and_evaluator(
         cfg, override_model=ts_model, override_dataset=dataset
     )
 
-    assert isinstance(runner.model, _CompiledMarker)
+    assert isinstance(runner.model.run_with_cache, _CompiledCallable)
     assert runner.activations_store.model is runner.model
     assert runner.evaluator.model is runner.model
+    assert runner.activations_store.model.run_with_cache is runner.model.run_with_cache
 
 
 def test_multi_sae_runner_no_compile_when_compile_llm_false(
     monkeypatch: pytest.MonkeyPatch, ts_model: HookedTransformer, dataset: Dataset
 ):
     compile_calls: list[Any] = []
-    monkeypatch.setattr(torch, "compile", lambda m, **_: compile_calls.append(m) or m)
+    monkeypatch.setattr(
+        torch, "compile", lambda fn, **_: compile_calls.append(fn) or fn
+    )
 
     d_in = ts_model.cfg.d_model
     cfg = _build_cfg(

--- a/tests/training/test_load_model.py
+++ b/tests/training/test_load_model.py
@@ -353,3 +353,52 @@ def test_extract_logits_from_output_returns_none_when_object_logits_is_none():
 
     result = _extract_logits_from_output(FakeModelOutput())
     assert result is None
+
+
+def test_HookedProxyLM_hook_names_filters_registered_hooks():
+    # Only the requested submodules should be in hook_dict and have a forward
+    # hook registered. This keeps `torch.compile` from inserting a graph break
+    # at every submodule of a large HF model.
+    hf_model = AutoModelForCausalLM.from_pretrained("gpt2")
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    requested = ["transformer.h.0", "transformer.h.5"]
+
+    hooked = HookedProxyLM(hf_model, tokenizer, hook_names=requested)
+
+    assert set(hooked.hook_dict) == set(requested)
+    # The requested modules have one extra forward hook; non-requested ones don't.
+    for name in requested:
+        assert len(hf_model.get_submodule(name)._forward_hooks) == 1
+    for unrequested in ["transformer.h.1", "transformer.h.11", "transformer.wte"]:
+        assert len(hf_model.get_submodule(unrequested)._forward_hooks) == 0
+
+
+def test_HookedProxyLM_hook_names_raises_on_unknown_name():
+    hf_model = AutoModelForCausalLM.from_pretrained("gpt2")
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+
+    with pytest.raises(ValueError, match="hook_names not found as submodules"):
+        HookedProxyLM(hf_model, tokenizer, hook_names=["transformer.h.0", "nope"])
+
+
+def test_HookedProxyLM_no_hook_names_hooks_everything():
+    # Default behavior (hook_names=None): every named submodule is hooked.
+    hf_model = AutoModelForCausalLM.from_pretrained("gpt2")
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    expected_count = sum(1 for name, _ in hf_model.named_modules() if name != "")
+
+    hooked = HookedProxyLM(hf_model, tokenizer)
+
+    assert len(hooked.hook_dict) == expected_count
+
+
+def test_load_model_passes_hook_names_to_HookedProxyLM():
+    requested = ["transformer.h.3"]
+    model = load_model(
+        model_class_name="AutoModelForCausalLM",
+        model_name="gpt2",
+        device="cpu",
+        hook_names=requested,
+    )
+    assert isinstance(model, HookedProxyLM)
+    assert set(model.hook_dict) == set(requested)


### PR DESCRIPTION
## Summary

Fixes three related bugs that, together, made `compile_llm=True` a complete no-op in both `LanguageModelSAETrainingRunner` and `MultiSAETrainingRunner`.

### 1. Compile was happening too late (propagation bug)

`torch.compile(self.model, ...)` was called in `run()` **after** the `ActivationsStore` and evaluator already captured a reference to the uncompiled model. Rebinding `self.model` afterward had no downstream effect.

Fix: move the LLM compile into `__init__` right after `load_model(...)`, before any consumer captures `self.model`. Construct the evaluator in `__init__` as well so tests can inspect it without running training.

### 2. Wrapping the module didn't help — `run_with_cache` bypasses the wrapper

`torch.compile` only intercepts `__call__` / `forward`. But `ActivationsStore` and `LLMSaeEvaluator` call `model.run_with_cache(...)`, which falls through `OptimizedModule.__getattr__` straight to the uncompiled `_orig_mod.run_with_cache`. Dynamo never engages.

Fix: switch `compile_llm` to compile the `run_with_cache` bound method instead of the module:

```python
self.model.run_with_cache = torch.compile(self.model.run_with_cache, mode=...)
```

### 3. `HookedProxyLM` hooks every submodule, fragmenting compile into hundreds of graphs

`HookedProxyLM.setup()` registered a `register_forward_hook` on **every** named submodule of the HF model. Each forward hook is a graph break, so a Gemma-class model compiled into hundreds of tiny graphs — usually no faster than eager.

Fix: add an optional `hook_names: list[str] | None` parameter to `load_model` and `HookedProxyLM`. When provided, only those submodules get a hook (with validation: a missing name raises at load time). Wire the runners to pass:

- single-SAE: `[cfg.hook_name]`
- multi-SAE: `list(dict.fromkeys(cfg.hook_names_per_sae.values()))`

No-op for `HookedTransformer` and `HookedMamba` (their hook points are part of the architecture).

## Test plan

- [x] `test_LanguageModelSAETrainingRunner_compile_llm_compiles_run_with_cache` — monkeypatches `torch.compile` to return a recognizable callable and asserts `runner.model.run_with_cache` is the compiled wrapper, and that the store and evaluator share the same model object.
- [x] `test_multi_sae_runner_compile_llm_compiles_run_with_cache` — same for multi-SAE runner.
- [x] `*_no_compile_when_compile_llm_false` for both runners — confirms `torch.compile` is not called when the flag is off.
- [x] `test_HookedProxyLM_hook_names_filters_registered_hooks` — only the requested submodules end up in `hook_dict` and have a `_forward_hooks` entry.
- [x] `test_HookedProxyLM_hook_names_raises_on_unknown_name` — invalid hook name fails loudly at construction.
- [x] `test_HookedProxyLM_no_hook_names_hooks_everything` — backwards compat: `hook_names=None` keeps historical behavior.
- [x] `test_load_model_passes_hook_names_to_HookedProxyLM` — the `load_model` parameter is plumbed through.
- [x] All 72 existing tests in the affected test files continue to pass.
- [x] `ruff check`, `ruff format --check`, and `pyright` are clean on the modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)