### PR TITLE
fix: extract_layer_from_tlens_hook_name handles trailing-int hook names

### DIFF
--- a/sae_lens/util.py
+++ b/sae_lens/util.py
@@ -47,11 +47,16 @@ def extract_stop_at_layer_from_tlens_hook_name(hook_name: str) -> int | None:
 
 
 def extract_layer_from_tlens_hook_name(hook_name: str) -> int | None:
-    """Extract the layer from a HookedTransformer hook name.
+    """Extract the layer from a HookedTransformer or HF-style hook name.
 
-    Returns None if the hook name is not a valid HookedTransformer hook name.
+    Matches the first `.<int>` segment that is followed by either another `.`
+    or the end of the string, so both TransformerLens names like
+    `blocks.30.hook_resid_post` and HF named-module paths like
+    `model.language_model.layers.30` are recognised.
+
+    Returns None if the hook name has no layer segment.
     """
-    hook_match = re.search(r"\.(\d+)\.", hook_name)
+    hook_match = re.search(r"\.(\d+)(?:\.|$)", hook_name)
     return None if hook_match is None else int(hook_match.group(1))
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -20,10 +20,15 @@ from sae_lens.util import (
 @pytest.mark.parametrize(
     "hook_name,expected_layer",
     [
+        # TransformerLens hook names: layer index is followed by another `.`
         ("blocks.0.attn.hook_q", 1),
         ("blocks.12.attn.hook_k", 13),
         ("blocks.999.attn.hook_v", 1000),
         ("blocks.42.mlp.hook_pre", 43),
+        # HF-style named-module paths: layer index is the final segment
+        ("model.layers.30", 31),
+        ("model.language_model.layers.0", 1),
+        ("transformer.h.11", 12),
     ],
 )
 def test_extract_stop_at_layer_from_tlens_hook_name_valid(


### PR DESCRIPTION
## Summary

`extract_layer_from_tlens_hook_name` required a trailing `.` after the layer index (regex `\.(\d+)\.`), so HF-style named-module paths like `model.language_model.layers.30` — where the index is the final segment — returned `None`.

`ActivationsStore.get_activations` passes the result as `stop_at_layer` to `model.run_with_cache(...)`. When it's `None`, `HookedProxyLM` runs every layer in the model, even when the SAE only needs activations from layer 30. For a 48-layer Gemma 4 hooked at layer 30, that's 17 layers of wasted FLOPs and KV-cache memory per batch.

Loosen the regex to `\.(\d+)(?:\.|$)` so both forms work:
- TransformerLens: `blocks.30.hook_resid_post` → 30
- HF named-module: `model.language_model.layers.30` → 30

## Test plan

- [x] Added parametrized cases for HF-style paths: `model.layers.30`, `model.language_model.layers.0`, `transformer.h.11`.
- [x] Existing parametrized TL cases (`blocks.X.attn.hook_q` etc.) still pass.
- [x] Existing invalid-input cases (missing/non-numeric layer, empty string) still return `None`.
- [x] `ruff check`, `ruff format --check`, `pyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)