### PR TITLE
fix: _validate_seqpos rejects valid step_size of 1 in seqpos_slice

### DIFF
--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -669,7 +669,7 @@ def _validate_seqpos(seqpos: tuple[int | None, ...], context_size: int) -> None:
     # Ensure that the step-size is larger or equal to 1
     if len(seqpos) == 3:
         step_size = seqpos[2] or 1
-        if step_size <= 1:
+        if step_size < 1:
             raise ValueError(
                 f"Ensure the step_size={seqpos[2]} for sequence slicing is at least 1."
             )

--- a/tests/training/test_config.py
+++ b/tests/training/test_config.py
@@ -19,6 +19,15 @@ test_cases_for_seqpos = [
     ((6, 3, None), ValueError),
 ]
 
+valid_seqpos_slices = [
+    (0, 5, 1),
+    (None, 5, None),
+    (None, None, 1),
+    (1, None, 1),
+    (None,),
+    (2, 8),
+]
+
 
 @pytest.mark.parametrize("seqpos_slice, expected_error", test_cases_for_seqpos)
 def test_sae_training_runner_config_seqpos(
@@ -31,6 +40,35 @@ def test_sae_training_runner_config_seqpos(
             seqpos_slice=seqpos_slice,
             context_size=context_size,
         )
+
+
+@pytest.mark.parametrize("seqpos_slice", valid_seqpos_slices)
+def test_sae_training_runner_config_seqpos_accepts_valid_slices(
+    seqpos_slice: tuple[int | None, ...],
+):
+    cfg = LanguageModelSAERunnerConfig(
+        sae=StandardTrainingSAEConfig(d_in=10, d_sae=10),
+        seqpos_slice=seqpos_slice,
+        context_size=10,
+    )
+    assert cfg.seqpos_slice == seqpos_slice
+
+
+@pytest.mark.parametrize("seqpos_slice", valid_seqpos_slices)
+def test_cache_activations_runner_config_seqpos_accepts_valid_slices(
+    seqpos_slice: tuple[int | None, ...],
+):
+    cfg = CacheActivationsRunnerConfig(
+        dataset_path="",
+        model_name="",
+        model_batch_size=1,
+        hook_name="",
+        d_in=1,
+        training_tokens=100,
+        context_size=10,
+        seqpos_slice=seqpos_slice,
+    )
+    assert cfg.seqpos_slice == seqpos_slice
 
 
 def test_LanguageModelSAERunnerConfig_hook_eval_deprecated_usage():


### PR DESCRIPTION
`_validate_seqpos` in `sae_lens/config.py` validates the step component of a
  3-tuple `seqpos_slice`. The intent (per the comment "Ensure that the step-size
  is larger or equal to 1" and the error message "is at least 1") is to reject
  steps below 1. But the guard was written as `step_size <= 1`, which also
  rejects a step of exactly `1` — the most common case.

  Because the step defaults to `1` when omitted (`step_size = seqpos[2] or 1`),
  this made every natural 3-tuple usage crash at config-construction time:

  - `seqpos_slice=(0, 5, 1)` — explicit step of 1
  - `seqpos_slice=(None, 5, None)` — step omitted, defaults to 1
  - `seqpos_slice=(1, None, 1)` — e.g. drop the BOS position, keep the rest

  All raised `ValueError: Ensure the step_size=1 for sequence slicing is at
  least 1.` — a self-contradictory message, since 1 *is* at least 1.

  ## Fix

  Relax the guard so that a step of `1` is accepted — an omitted or `None` step
  defaults to 1 as well — while `0` and negative values are still rejected as
  before. It is a one-character change in `sae_lens/config.py`, replacing the
  comparison `step_size <= 1` with `step_size < 1`.

  ## Testing

  The existing parametrized tests only covered error cases (steps of 0, -1, and
  empty/reversed ranges); the valid `step == 1` path was untested. This PR adds
  parametrized tests for both `LanguageModelSAERunnerConfig` and
  `CacheActivationsRunnerConfig` asserting that valid slices such as `(0, 5,
  1)`, `(None, 5, None)`, `(None, None, 1)`, and `(1, None, 1)` are accepted and
  round-trip correctly.

  Reverting only the one-character fix makes 8 of the new tests fail; restoring
  it makes all pass. `ruff check`, `ruff format --check`, and `pyright` are all
  clean.