### PR TITLE
fix: use canonical HookedRootModule import to resolve pyright unknown-type errors

### DIFF
--- a/sae_lens/multi_sae_training_runner.py
+++ b/sae_lens/multi_sae_training_runner.py
@@ -33,7 +33,7 @@ from typing import Any, Literal
 import torch
 import wandb
 from safetensors.torch import save_file
-from transformer_lens.hook_points import HookedRootModule
+from transformer_lens import HookedRootModule
 
 from sae_lens import __version__, logger
 from sae_lens.config import HfDataset, LoggingConfig, SAETrainerConfig

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -15,7 +15,7 @@ from huggingface_hub.utils import HfHubHTTPError
 from requests import HTTPError
 from safetensors.torch import load_file, save_file
 from tqdm.auto import tqdm
-from transformer_lens.hook_points import HookedRootModule
+from transformer_lens import HookedRootModule
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from sae_lens import logger

--- a/tests/_comparison/sae_lens_old/training/activations_store.py
+++ b/tests/_comparison/sae_lens_old/training/activations_store.py
@@ -17,7 +17,7 @@ from requests import HTTPError
 from safetensors.torch import save_file
 from torch.utils.data import DataLoader
 from tqdm import tqdm
-from transformer_lens.hook_points import HookedRootModule
+from transformer_lens import HookedRootModule
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from tests._comparison.sae_lens_old import logger


### PR DESCRIPTION
Fixes #684

## Type of change

- Bug fix (non-breaking change which fixes an issue)

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)