### PR TITLE
Comments tidy

### DIFF
--- a/sae_lens/saes/sae.py
+++ b/sae_lens/saes/sae.py
@@ -154,9 +154,11 @@ class SAEConfig(ABC):
     dtype: str = "float32"
     device: str = "cpu"
     apply_b_dec_to_input: bool = True
-    normalize_activations: Literal["none", "expected_average_only_in", "layer_norm"] = (
-        "none"  # none, expected_average_only_in (Anthropic April Update)
-    )
+    normalize_activations: Literal[
+        "none",
+        "expected_average_only_in",  # (Anthropic April Update)
+        "layer_norm",
+    ] = "none"
     reshape_activations: Literal["none", "hook_z"] = "none"
     metadata: SAEMetadata = field(default_factory=SAEMetadata)
 

--- a/sae_lens/saes/sae.py
+++ b/sae_lens/saes/sae.py
@@ -156,7 +156,7 @@ class SAEConfig(ABC):
     apply_b_dec_to_input: bool = True
     normalize_activations: Literal[
         "none",
-        "expected_average_only_in",  # (Anthropic April Update)
+        "expected_average_only_in",  # (Anthropic April 2024 Update)
         "layer_norm",
     ] = "none"
     reshape_activations: Literal["none", "hook_z"] = "none"

--- a/tests/_comparison/sae_lens_old/config.py
+++ b/tests/_comparison/sae_lens_old/config.py
@@ -83,8 +83,8 @@ class LanguageModelSAERunnerConfig:
         from_pretrained_path (str, optional): The path to a pretrained SAE. We can finetune an existing SAE if needed.
         apply_b_dec_to_input (bool): Whether to apply the decoder bias to the input. Not currently advised.
         decoder_orthogonal_init (bool): Whether to use orthogonal initialization for the decoder. Not currently advised.
-        decoder_heuristic_init (bool): Whether to use heuristic initialization for the decoder. See Anthropic April Update.
-        init_encoder_as_decoder_transpose (bool): Whether to initialize the encoder as the transpose of the decoder. See Anthropic April Update.
+        decoder_heuristic_init (bool): Whether to use heuristic initialization for the decoder. See Anthropic April 2024 Update.
+        init_encoder_as_decoder_transpose (bool): Whether to initialize the encoder as the transpose of the decoder. See Anthropic April 2024 Update.
         n_batches_in_buffer (int): The number of batches in the buffer. When not using cached activations, a buffer in ram is used. The larger it is, the better shuffled the activations will be.
         training_tokens (int): The number of training tokens.
         finetuning_tokens (int): The number of finetuning tokens. See [here](https://www.lesswrong.com/posts/3JuSjTZyMzaSeTxKk/addressing-feature-suppression-in-saes)
@@ -184,7 +184,7 @@ class LanguageModelSAERunnerConfig:
     training_tokens: int = 2_000_000
     finetuning_tokens: int = 0
     store_batch_size_prompts: int = 32
-    normalize_activations: str = "none"  # none, expected_average_only_in (Anthropic April Update), constant_norm_rescale (Anthropic Feb Update)
+    normalize_activations: str = "none"  # none, expected_average_only_in (Anthropic April 2024 Update), constant_norm_rescale (Anthropic Feb 2024 Update)
     seqpos_slice: tuple[int | None, ...] = (None,)
 
     # Misc


### PR DESCRIPTION
Comments/docstrings only

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
