### PR TITLE
Add pytest-profiling dependency, required by some tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ tenacity = ">=9.0.0"
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.2"
 pytest-cov = "^4.1.0"
+pytest-profiling = "^1.8.1"
 pre-commit = "^3.6.2"
 pyright = "1.1.365"
 mamba-lens = "^0.0.4"


### PR DESCRIPTION
Required for pytest --profile-svg to work, as instructed for example in benchmark/test_cache_activations_runner.py
