### PR TITLE
Add pytest-randomly to enable reproducing CI test failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ tenacity = ">=9.0.0"
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.2"
 pytest-cov = "^4.1.0"
+pytest-randomly = "^4.1.0"
 pre-commit = "^3.6.2"
 pyright = "1.1.365"
 mamba-lens = "^0.0.4"


### PR DESCRIPTION
Following #688: Going forward, the CI output will include the random seed used by pytest, so that in case of some test failure the seed can be set to reproduce the exact same test run.

pytest-randomly also shuffles tests order, so might uncover hidden dependencies between tests

## Type of change

- Tests only. Might uncover latent bugs.

# Checklist:

- [v] My changes generate no new warnings
- [v] New and existing tests pass locally with my changes
- [v] I have not rewritten tests relating to key interfaces which would affect backward compatibility
