### PR TITLE
Fix incorrect buffer size calculations in ActivationsStore 

### DIFF
--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -821,7 +821,7 @@ class ActivationsStore:
         Return an auto-refilling stream of filtered and mixed activations.
         """
         return mixing_buffer(
-            buffer_size=self.n_batches_in_buffer * self.training_context_size,
+            buffer_size=self.n_batches_in_buffer * self.train_batch_size_tokens,
             batch_size=self.train_batch_size_tokens,
             activations_loader=self._iterate_filtered_activations(),
             mix_fraction=self.activations_mixing_fraction,
@@ -943,7 +943,7 @@ class ActivationsStore:
                 "via from_config_multi_hook"
             )
         return multi_hook_concat_split_iter(
-            buffer_size=self.n_batches_in_buffer * self.training_context_size,
+            buffer_size=self.n_batches_in_buffer * self.train_batch_size_tokens,
             batch_size=self.train_batch_size_tokens,
             activations_loader=self._iterate_filtered_multi_hook_activations(),
             hook_names=list(self._hook_names),

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -374,7 +374,6 @@ class ActivationsStore:
         self.cached_activations_path = cached_activations_path
         self.autocast_lm = autocast_lm
         self.seqpos_slice = seqpos_slice
-        self.training_context_size = len(range(context_size)[slice(*seqpos_slice)])
         self.exclude_special_tokens = exclude_special_tokens
         self.disable_concat_sequences = disable_concat_sequences
         self.sequence_separator_token: int | Literal["bos", "eos", "sep"] | None = (

--- a/tests/training/test_activations_store.py
+++ b/tests/training/test_activations_store.py
@@ -714,17 +714,17 @@ def test_activations_next_batch_excludes_special_tokens(
     hook_name = "blocks.0.hook_resid_post"
     base_cfg = build_runner_cfg(
         exclude_special_tokens=False,
-        context_size=5,
+        context_size=4,
         store_batch_size_prompts=2,
         hook_name=hook_name,
-        train_batch_size_tokens=5,
+        train_batch_size_tokens=10,
     )
     cfg = build_runner_cfg(
         exclude_special_tokens=True,
-        context_size=5,
+        context_size=4,
         store_batch_size_prompts=2,
         hook_name=hook_name,
-        train_batch_size_tokens=5,
+        train_batch_size_tokens=10,
     )
     dataset = Dataset.from_list([{"text": "hello world"}] * 100)
     _, cache = ts_model.run_with_cache(dataset[0]["text"])
@@ -737,8 +737,8 @@ def test_activations_next_batch_excludes_special_tokens(
     )
     batch_base = store_base.next_batch()
     batch_exclude_special_tokens = store_exclude_special_tokens.next_batch()
-    assert batch_base.shape[0] == 5
-    assert batch_exclude_special_tokens.shape[0] == 5
+    assert batch_base.shape[0] == 10
+    assert batch_exclude_special_tokens.shape[0] == 10
 
     # bos act should be in the base batch, but not in the exclude special tokens batch
     assert (batch_base.squeeze() - bos_act).abs().sum(


### PR DESCRIPTION
# Description

`ActivationsStore.get_data_loader` and `.get_multi_hook_data_loader` both calculated the buffer size incorrectly, which I stumbled upon via an assertion error running `test_language_model_sae_runner_othellogpt` under `benchmark/test_language_model_sae_runner.py` - which doesn't run in CI which is probably why it went undetected.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] (Somewhat of a) Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My changes generate no new warnings
- [x] I have ~added~ modified a test to prove my fix is effective
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)

### Performance Check.

Not done; if deemed necessary, I'd appreciate some guidance, i.e., what to use for control and test groups.

If you have implemented a training change, please indicate precisely how performance changes with respect to the following metrics:
- [ ] L0
- [ ] CE Loss
- [ ] MSE Loss
- [ ] Feature Dashboard Interpretability

Please links to wandb dashboards with a control and test group. 