### PR TITLE
SAE overrides tidy

### DIFF
--- a/sae_lens/saes/batchtopk_sae.py
+++ b/sae_lens/saes/batchtopk_sae.py
@@ -102,6 +102,7 @@ class BatchTopKTrainingSAE(TopKTrainingSAE):
             torch.tensor(0.0, dtype=torch.double, device=self.W_dec.device),
         )
 
+    @override
     def get_activation_fn(self) -> Callable[[torch.Tensor], torch.Tensor]:
         return BatchTopK(self.cfg.k)
 

--- a/sae_lens/saes/gated_sae.py
+++ b/sae_lens/saes/gated_sae.py
@@ -48,6 +48,7 @@ class GatedSAE(SAE[GatedSAEConfig]):
         super().initialize_weights()
         _init_weights_gated(self)
 
+    @override
     def encode(self, x: torch.Tensor) -> torch.Tensor:
         """
         Encode the input tensor into the feature space using a gated encoder.
@@ -69,6 +70,7 @@ class GatedSAE(SAE[GatedSAEConfig]):
         # Combine gating and magnitudes
         return self.hook_sae_acts_post(active_features * feature_magnitudes)
 
+    @override
     def decode(self, feature_acts: torch.Tensor) -> torch.Tensor:
         """
         Decode the feature activations back into the input space:
@@ -86,6 +88,7 @@ class GatedSAE(SAE[GatedSAEConfig]):
         # 4) reshape if needed (hook_z)
         return self.reshape_fn_out(sae_out_pre, self.d_head)
 
+    @override
     @torch.no_grad()
     def fold_W_dec_norm(self):
         """Override to handle gated-specific parameters."""
@@ -138,10 +141,12 @@ class GatedTrainingSAE(TrainingSAE[GatedTrainingSAEConfig]):
             )
         super().__init__(cfg, use_error_term)
 
+    @override
     def initialize_weights(self) -> None:
         super().initialize_weights()
         _init_weights_gated(self)
 
+    @override
     def encode_with_hidden_pre(
         self, x: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -166,6 +171,7 @@ class GatedTrainingSAE(TrainingSAE[GatedTrainingSAEConfig]):
         # Return both the final feature activations and the pre-activation (for logging or penalty)
         return feature_acts, magnitude_pre_activation
 
+    @override
     def calculate_aux_loss(
         self,
         step_input: TrainStepInput,
@@ -207,6 +213,7 @@ class GatedTrainingSAE(TrainingSAE[GatedTrainingSAEConfig]):
             "weights/b_mag": b_mag_dist,
         }
 
+    @override
     def get_coefficients(self) -> dict[str, float | TrainCoefficientConfig]:
         return {
             "l1": TrainCoefficientConfig(
@@ -215,6 +222,7 @@ class GatedTrainingSAE(TrainingSAE[GatedTrainingSAEConfig]):
             ),
         }
 
+    @override
     @torch.no_grad()
     def fold_W_dec_norm(self):
         """Override to handle gated-specific parameters."""

--- a/sae_lens/saes/jumprelu_sae.py
+++ b/sae_lens/saes/jumprelu_sae.py
@@ -130,6 +130,7 @@ class JumpReLUSAE(SAE[JumpReLUSAEConfig]):
             torch.zeros(self.cfg.d_sae, dtype=self.dtype, device=self.device)
         )
 
+    @override
     def encode(self, x: torch.Tensor) -> torch.Tensor:
         """
         Encode the input tensor into the feature space using JumpReLU.
@@ -148,6 +149,7 @@ class JumpReLUSAE(SAE[JumpReLUSAEConfig]):
         # 3) Multiply the normally activated units by that mask.
         return self.hook_sae_acts_post(base_acts * jump_relu_mask)
 
+    @override
     def decode(self, feature_acts: torch.Tensor) -> torch.Tensor:
         """
         Decode the feature activations back to the input space.
@@ -158,6 +160,7 @@ class JumpReLUSAE(SAE[JumpReLUSAEConfig]):
         sae_out_pre = self.run_time_activation_norm_fn_out(sae_out_pre)
         return self.reshape_fn_out(sae_out_pre, self.d_head)
 
+    @override
     @torch.no_grad()
     def fold_W_dec_norm(self):
         """
@@ -262,6 +265,7 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
         """
         return torch.exp(self.log_threshold)
 
+    @override
     def encode_with_hidden_pre(
         self, x: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -320,6 +324,7 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
             ),
         }
 
+    @override
     @torch.no_grad()
     def fold_W_dec_norm(self):
         """
@@ -337,6 +342,7 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
         # Fix: Use squeeze() instead of squeeze(-1) to match old behavior
         self.log_threshold.data = torch.log(current_thresh * W_dec_norms.squeeze())
 
+    @override
     def process_state_dict_for_saving(self, state_dict: dict[str, Any]) -> None:
         """Convert log_threshold to threshold for saving"""
         if "log_threshold" in state_dict:
@@ -344,6 +350,7 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
             del state_dict["log_threshold"]
             state_dict["threshold"] = threshold
 
+    @override
     def process_state_dict_for_loading(self, state_dict: dict[str, Any]) -> None:
         """Convert threshold to log_threshold for loading"""
         if "threshold" in state_dict:

--- a/sae_lens/saes/sae.py
+++ b/sae_lens/saes/sae.py
@@ -914,6 +914,7 @@ class TrainingSAE(SAE[T_TRAINING_SAE_CONFIG], ABC):
         """Encode with access to pre-activation values for training."""
         ...
 
+    @override
     def encode(self, x: torch.Tensor) -> torch.Tensor:
         """
         For inference, just encode without returning hidden_pre.
@@ -922,6 +923,7 @@ class TrainingSAE(SAE[T_TRAINING_SAE_CONFIG], ABC):
         feature_acts, _ = self.encode_with_hidden_pre(x)
         return feature_acts
 
+    @override
     def decode(self, feature_acts: torch.Tensor) -> torch.Tensor:
         """
         Decodes feature activations back into input space,

--- a/sae_lens/saes/sae.py
+++ b/sae_lens/saes/sae.py
@@ -496,11 +496,11 @@ class SAE(HookedRootModule, Generic[T_SAE_CONFIG], ABC):
 
         return self.hook_sae_output(sae_out)
 
-    # overwrite this in subclasses to modify the state_dict in-place before saving
+    # override this in subclasses to modify the state_dict in-place before saving
     def process_state_dict_for_saving(self, state_dict: dict[str, Any]) -> None:
         pass
 
-    # overwrite this in subclasses to modify the state_dict in-place after loading
+    # override this in subclasses to modify the state_dict in-place after loading
     def process_state_dict_for_loading(self, state_dict: dict[str, Any]) -> None:
         pass
 

--- a/sae_lens/saes/standard_sae.py
+++ b/sae_lens/saes/standard_sae.py
@@ -54,6 +54,7 @@ class StandardSAE(SAE[StandardSAEConfig]):
         super().initialize_weights()
         _init_weights_standard(self)
 
+    @override
     def encode(self, x: torch.Tensor) -> torch.Tensor:
         """
         Encode the input tensor into the feature space.
@@ -65,6 +66,7 @@ class StandardSAE(SAE[StandardSAEConfig]):
         # Apply the activation function (e.g., ReLU, depending on config)
         return self.hook_sae_acts_post(self.activation_fn(hidden_pre))
 
+    @override
     def decode(self, feature_acts: torch.Tensor) -> torch.Tensor:
         """
         Decode the feature activations back to the input space.
@@ -110,6 +112,7 @@ class StandardTrainingSAE(TrainingSAE[StandardTrainingSAEConfig]):
 
     b_enc: nn.Parameter
 
+    @override
     def initialize_weights(self) -> None:
         super().initialize_weights()
         _init_weights_standard(self)
@@ -123,6 +126,7 @@ class StandardTrainingSAE(TrainingSAE[StandardTrainingSAEConfig]):
             ),
         }
 
+    @override
     def encode_with_hidden_pre(
         self, x: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -134,6 +138,7 @@ class StandardTrainingSAE(TrainingSAE[StandardTrainingSAEConfig]):
         feature_acts = self.hook_sae_acts_post(self.activation_fn(hidden_pre))
         return feature_acts, hidden_pre
 
+    @override
     def calculate_aux_loss(
         self,
         step_input: TrainStepInput,

--- a/sae_lens/saes/temporal_sae.py
+++ b/sae_lens/saes/temporal_sae.py
@@ -312,9 +312,11 @@ class TemporalSAE(SAE[TemporalSAEConfig]):
         # Return only novel codes (these are the interpretable features)
         return z_novel, z_pred
 
+    @override
     def encode(self, x: torch.Tensor) -> torch.Tensor:
         return self.encode_with_predictions(x)[0]
 
+    @override
     def decode(self, feature_acts: torch.Tensor) -> torch.Tensor:
         """Decode novel codes to reconstruction.
 

--- a/sae_lens/saes/topk_sae.py
+++ b/sae_lens/saes/topk_sae.py
@@ -251,6 +251,7 @@ class TopKSAE(SAE[TopKSAEConfig]):
         super().initialize_weights()
         _init_weights_topk(self)
 
+    @override
     def encode(self, x: torch.Tensor) -> torch.Tensor:
         """
         Converts input x into feature activations.
@@ -263,6 +264,7 @@ class TopKSAE(SAE[TopKSAEConfig]):
         # The BaseSAE already sets self.activation_fn to TopK(...) if config requests topk.
         return self.hook_sae_acts_post(self.activation_fn(hidden_pre))
 
+    @override
     def decode(
         self,
         feature_acts: torch.Tensor,
@@ -366,6 +368,7 @@ class TopKTrainingSAE(TrainingSAE[TopKTrainingSAEConfig]):
         super().initialize_weights()
         _init_weights_topk(self)
 
+    @override
     def encode_with_hidden_pre(
         self, x: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor]:

--- a/sae_lens/saes/transcoder.py
+++ b/sae_lens/saes/transcoder.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import torch
 from torch import nn
+from typing_extensions import override
 
 from sae_lens.saes.sae import (
     SAE,
@@ -22,6 +23,7 @@ class TranscoderConfig(SAEConfig):
     # hook_layer_out: int = 0
     # hook_head_index_out: int | None = None
 
+    @override
     @classmethod
     def architecture(cls) -> str:
         """Return the architecture name for this config."""
@@ -75,6 +77,7 @@ class Transcoder(SAE[TranscoderConfig]):
         super().__init__(cfg)
         self.cfg = cfg
 
+    @override
     def initialize_weights(self):
         """Initialize transcoder weights with proper dimensions."""
         # Initialize b_dec with output dimension
@@ -101,6 +104,7 @@ class Transcoder(SAE[TranscoderConfig]):
             torch.zeros(self.cfg.d_sae, dtype=self.dtype, device=self.device)
         )
 
+    @override
     def process_sae_in(self, sae_in: torch.Tensor) -> torch.Tensor:
         """
         Process input without applying decoder bias (which has wrong dimension
@@ -115,6 +119,7 @@ class Transcoder(SAE[TranscoderConfig]):
         sae_in = self.hook_sae_input(sae_in)
         return self.run_time_activation_norm_fn_in(sae_in)
 
+    @override
     def encode(self, x: torch.Tensor) -> torch.Tensor:
         """
         Encode the input tensor into the feature space.
@@ -126,6 +131,7 @@ class Transcoder(SAE[TranscoderConfig]):
         # Apply the activation function (e.g., ReLU)
         return self.hook_sae_acts_post(self.activation_fn(hidden_pre))
 
+    @override
     def decode(self, feature_acts: torch.Tensor) -> torch.Tensor:
         """Decode to output dimension."""
         # W_dec has shape [d_sae, d_out], feature_acts has shape
@@ -136,6 +142,7 @@ class Transcoder(SAE[TranscoderConfig]):
         # output dimension is different from the input dimension
         return self.hook_sae_recons(sae_out)
 
+    @override
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Forward pass for transcoder.
@@ -182,6 +189,7 @@ class Transcoder(SAE[TranscoderConfig]):
 
 @dataclass
 class SkipTranscoderConfig(TranscoderConfig):
+    @override
     @classmethod
     def architecture(cls) -> str:
         """Return the architecture name for this config."""
@@ -222,6 +230,7 @@ class SkipTranscoder(Transcoder):
         # Shape: [d_out, d_in] to map from input to output dimension
         self.W_skip = nn.Parameter(torch.zeros(self.cfg.d_out, self.cfg.d_in))
 
+    @override
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Forward pass for skip transcoder.
@@ -241,6 +250,7 @@ class SkipTranscoder(Transcoder):
         skip_out = x @ self.W_skip.T.to(x.device)
         return sae_out + skip_out
 
+    @override
     def forward_with_activations(
         self,
         x: torch.Tensor,
@@ -277,6 +287,7 @@ class SkipTranscoder(Transcoder):
 class JumpReLUTranscoderConfig(TranscoderConfig):
     """Configuration for JumpReLU transcoder."""
 
+    @override
     @classmethod
     def architecture(cls) -> str:
         """Return the architecture name for this config."""
@@ -314,6 +325,7 @@ class JumpReLUTranscoder(Transcoder):
         super().__init__(cfg)
         self.cfg = cfg
 
+    @override
     def initialize_weights(self):
         """Initialize transcoder weights including threshold parameter."""
         super().initialize_weights()
@@ -323,6 +335,7 @@ class JumpReLUTranscoder(Transcoder):
             torch.zeros(self.cfg.d_sae, dtype=self.dtype, device=self.device)
         )
 
+    @override
     def encode(self, x: torch.Tensor) -> torch.Tensor:
         """
         Encode using JumpReLU activation.
@@ -346,6 +359,7 @@ class JumpReLUTranscoder(Transcoder):
         # Apply mask and hook
         return self.hook_sae_acts_post(feature_acts * jump_relu_mask)
 
+    @override
     def fold_W_dec_norm(self) -> None:
         """
         Fold the decoder weight norm into the threshold parameter.
@@ -374,6 +388,7 @@ class JumpReLUTranscoder(Transcoder):
 class JumpReLUSkipTranscoderConfig(JumpReLUTranscoderConfig):
     """Configuration for JumpReLU transcoder."""
 
+    @override
     @classmethod
     def architecture(cls) -> str:
         """Return the architecture name for this config."""

--- a/tests/_comparison/sae_lens_old/sae.py
+++ b/tests/_comparison/sae_lens_old/sae.py
@@ -517,11 +517,11 @@ class SAE(HookedRootModule):
 
         return model_weights_path, cfg_path
 
-    # overwrite this in subclasses to modify the state_dict in-place before saving
+    # override this in subclasses to modify the state_dict in-place before saving
     def process_state_dict_for_saving(self, state_dict: dict[str, Any]) -> None:
         pass
 
-    # overwrite this in subclasses to modify the state_dict in-place after loading
+    # override this in subclasses to modify the state_dict in-place after loading
     def process_state_dict_for_loading(self, state_dict: dict[str, Any]) -> None:
         pass
 


### PR DESCRIPTION
Add overrides decorators consistently in SAE/SAE config classes.
Also fix overwrite->override in a couple of docstrings.