### PR TITLE
Add missing calls to reshape_fn_out() in TemporalSAE

### DIFF
--- a/sae_lens/saes/temporal_sae.py
+++ b/sae_lens/saes/temporal_sae.py
@@ -342,6 +342,8 @@ class TemporalSAE(SAE[TemporalSAEConfig]):
         # Apply output activation normalization (reverses input normalization)
         sae_out = self.run_time_activation_norm_fn_out(sae_out)
 
+        sae_out = self.reshape_fn_out(sae_out, self.d_head)
+
         logger.warning(
             "NOTE this only decodes x_novel. The x_pred is missing, so we're not reconstructing the full x."
         )
@@ -363,6 +365,8 @@ class TemporalSAE(SAE[TemporalSAEConfig]):
 
         # Apply output activation normalization (reverses input normalization)
         x_recons = self.run_time_activation_norm_fn_out(x_recons)
+
+        x_recons = self.reshape_fn_out(x_recons, self.d_head)
 
         return self.hook_sae_output(x_recons)
 

--- a/tests/saes/test_temporal_sae.py
+++ b/tests/saes/test_temporal_sae.py
@@ -153,6 +153,43 @@ def test_TemporalSAE_forward_applies_b_dec_only_when_appropriate(
     assert_close(sae.forward(x), expected)
 
 
+def test_TemporalSAE_decode_reverses_hook_z_reshaping():
+    n_heads = 4
+    d_head = 8
+    cfg = build_temporal_sae_cfg(d_in=n_heads * d_head, reshape_activations="hook_z")
+    sae = TemporalSAE.from_dict(cfg.to_dict())
+    assert sae.hook_z_reshaping_mode
+
+    batch_size = 2
+    seq_len = 6
+    x = torch.randn(
+        batch_size, seq_len, n_heads, d_head, dtype=DTYPE_MAP[sae.cfg.dtype]
+    )
+
+    novel_codes = sae.encode(x)
+    reconstruction = sae.decode(novel_codes)
+
+    assert reconstruction.shape == x.shape
+
+
+def test_TemporalSAE_forward_reverses_hook_z_reshaping():
+    n_heads = 4
+    d_head = 8
+    cfg = build_temporal_sae_cfg(d_in=n_heads * d_head, reshape_activations="hook_z")
+    sae = TemporalSAE.from_dict(cfg.to_dict())
+    assert sae.hook_z_reshaping_mode
+
+    batch_size = 2
+    seq_len = 6
+    x = torch.randn(
+        batch_size, seq_len, n_heads, d_head, dtype=DTYPE_MAP[sae.cfg.dtype]
+    )
+
+    reconstruction = sae(x)
+
+    assert reconstruction.shape == x.shape
+
+
 @pytest.mark.parametrize("sae_diff_type", ["relu", "topk"])
 def test_TemporalSAE_sae_diff_type(sae_diff_type: str):
     cfg = build_temporal_sae_cfg(


### PR DESCRIPTION
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
