### PR TITLE
Training CLI fixes

### DIFF
--- a/docs/training_saes.md
+++ b/docs/training_saes.md
@@ -426,10 +426,10 @@ Resume by passing `resume_from_checkpoint=<checkpoint_dir>`. The per-SAE keys in
 
 ## CLI Runner
 
-The SAE training runner can also be run from the command line via the `sae_lens.sae_training_runner` module. This can be useful for quickly testing different hyperparameters or running training on a remote server. The command line interface is shown below. All options to the CLI are the same as the [LanguageModelSAERunnerConfig][sae_lens.LanguageModelSAERunnerConfig] with a `--` prefix. E.g., `--model_name` is the same as `model_name` in the config.
+The SAE training runner can also be run from the command line via the `sae_lens.llm_sae_training_runner` module. This can be useful for quickly testing different hyperparameters or running training on a remote server. The command line interface is shown below. All options to the CLI are the same as the [LanguageModelSAERunnerConfig][sae_lens.LanguageModelSAERunnerConfig] with a `--` prefix. E.g., `--model_name` is the same as `model_name` in the config.
 
 ```bash
-python -m sae_lens.sae_training_runner --help
+python -m sae_lens.llm_sae_training_runner --help
 ```
 
 ## Logging to Weights and Biases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ mamba-lens = { version = "^0.0.4", optional = true }
 python-dotenv = ">=1.0.1"
 pyyaml = "^6.0.1"
 typing-extensions = "^4.10.0"
-simple-parsing = "^0.1.6"
+simple-parsing = "^0.1.8"
 tenacity = ">=9.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/sae_lens/config.py
+++ b/sae_lens/config.py
@@ -140,6 +140,7 @@ class LanguageModelSAERunnerConfig(Generic[T_TRAINING_SAE_CONFIG]):
         dataset_trust_remote_code (bool): Whether to trust remote code when loading datasets from Huggingface.
         streaming (bool): Whether to stream the dataset. Streaming large datasets is usually practical.
         is_dataset_tokenized (bool): Whether the dataset is already tokenized.
+        use_chat_formatting (bool): Tokenize using a chat template.
         context_size (int): The context size to use when generating activations on which to train the SAE.
         use_cached_activations (bool): Whether to use cached activations. This is useful when doing sweeps over the same activations.
         cached_activations_path (str, optional): The path to the cached activations. Defaults to "activations/{dataset_path}/{model_name}/{hook_name}_{hook_head_index}".

--- a/sae_lens/llm_sae_training_runner.py
+++ b/sae_lens/llm_sae_training_runner.py
@@ -370,7 +370,7 @@ def _parse_cfg_args(
     architecture_parser.add_argument(
         "--architecture",
         type=str,
-        choices=["standard", "gated", "jumprelu", "topk", "batchtopk"],
+        choices=SAE_TRAINING_CLASS_REGISTRY.keys(),
         default="standard",
         help="SAE architecture to use",
     )

--- a/sae_lens/llm_sae_training_runner.py
+++ b/sae_lens/llm_sae_training_runner.py
@@ -1,6 +1,8 @@
+import dataclasses
 import json
 import signal
 import sys
+from argparse import Namespace
 from collections.abc import Sequence
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
@@ -12,7 +14,7 @@ import wandb
 from safetensors.torch import save_file
 from simple_parsing import ArgumentParser
 from transformer_lens.hook_points import HookedRootModule
-from typing_extensions import deprecated
+from typing_extensions import deprecated, override
 
 from sae_lens import logger
 from sae_lens.config import HfDataset, LanguageModelSAERunnerConfig
@@ -358,11 +360,36 @@ def _parse_cfg_args(
     concrete SAE config class to use, then parses the full configuration
     with that concrete type.
     """
+
+    # Generate help strings only from docstrings, not from comments.
+    # From https://github.com/lebrice/SimpleParsing/issues/352#issuecomment-4654285752
+    class CustomParser(ArgumentParser):
+        @override
+        def _resolve_subgroups(
+            self,
+            wrappers: list[Any],
+            args: list[str],
+            namespace: Namespace | None = None,
+        ) -> tuple[list[Any], dict[str, str]]:
+            resolved_wrappers, chosen_subgroups = super()._resolve_subgroups(
+                wrappers, args, namespace
+            )
+            for root_wrapper in resolved_wrappers:
+                for dc_wrapper in [root_wrapper, *root_wrapper.descendants]:
+                    for field_wrapper in dc_wrapper.fields:
+                        field_wrapper._docstring = dataclasses.replace(
+                            field_wrapper._docstring,
+                            comment_above="",
+                            comment_inline="",
+                            docstring_below="",
+                        )
+            return resolved_wrappers, chosen_subgroups
+
     if len(args) == 0:
         args = ["--help"]
 
     # First, parse only the architecture to determine which concrete class to use
-    architecture_parser = ArgumentParser(
+    architecture_parser = CustomParser(
         description="Parse architecture to determine SAE config class",
         exit_on_error=False,
         add_help=False,  # Don't add help to avoid conflicts
@@ -434,7 +461,7 @@ def _parse_cfg_args(
     concrete_config_class = create_config_class(sae_config_type)
 
     # Now parse the full configuration with the concrete type
-    parser = ArgumentParser(exit_on_error=False)
+    parser = CustomParser(exit_on_error=False)
     parser.add_arguments(concrete_config_class, dest="cfg")
 
     # Parse the filtered arguments (without --architecture)

--- a/sae_lens/llm_sae_training_runner.py
+++ b/sae_lens/llm_sae_training_runner.py
@@ -5,14 +5,15 @@ import sys
 from argparse import Namespace
 from collections.abc import Sequence
 from contextlib import AbstractContextManager, nullcontext
-from dataclasses import dataclass
+from dataclasses import dataclass, make_dataclass
+from functools import partial
 from pathlib import Path
 from typing import Any, Generic
 
 import torch
 import wandb
 from safetensors.torch import save_file
-from simple_parsing import ArgumentParser
+from simple_parsing import ArgumentParser, subgroups
 from transformer_lens.hook_points import HookedRootModule
 from typing_extensions import deprecated, override
 
@@ -356,9 +357,10 @@ def _parse_cfg_args(
     """
     Parse command line arguments into a LanguageModelSAERunnerConfig.
 
-    This function first parses the architecture argument to determine which
-    concrete SAE config class to use, then parses the full configuration
-    with that concrete type.
+    ``--architecture`` selects which concrete ``TrainingSAEConfig`` subclass the
+    config is built around (and therefore which SAE-specific flags exist), via
+    ``simple_parsing`` subgroups. The choices are taken from the training-SAE
+    registry.
     """
 
     # Generate help strings only from docstrings, not from comments.
@@ -388,87 +390,27 @@ def _parse_cfg_args(
     if len(args) == 0:
         args = ["--help"]
 
-    # First, parse only the architecture to determine which concrete class to use
-    architecture_parser = CustomParser(
-        description="Parse architecture to determine SAE config class",
-        exit_on_error=False,
-        add_help=False,  # Don't add help to avoid conflicts
-    )
-    architecture_parser.add_argument(
-        "--architecture",
-        type=str,
-        choices=SAE_TRAINING_CLASS_REGISTRY.keys(),
-        default="standard",
-        help="SAE architecture to use",
-    )
-
-    # Parse known args to extract architecture, ignore unknown args for now
-    arch_args, remaining_args = architecture_parser.parse_known_args(args)
-    architecture = arch_args.architecture
-
-    # Remove architecture from remaining args if it exists
-    filtered_args = []
-    skip_next = False
-    for arg in remaining_args:
-        if skip_next:
-            skip_next = False
-            continue
-        if arg == "--architecture":
-            skip_next = True  # Skip the next argument (the architecture value)
-            continue
-        filtered_args.append(arg)
-
-    # Create a custom wrapper class that simple_parsing can handle
-    def create_config_class(
-        sae_config_type: type[TrainingSAEConfig],
-    ) -> type[LanguageModelSAERunnerConfig[TrainingSAEConfig]]:
-        """Create a concrete config class for the given SAE config type."""
-
-        # Create the base config without the sae field
-        from dataclasses import field as dataclass_field
-        from dataclasses import fields, make_dataclass
-
-        # Get all fields from LanguageModelSAERunnerConfig except the generic sae field
-        base_fields = []
-        for field_obj in fields(LanguageModelSAERunnerConfig):
-            if field_obj.name != "sae":
-                base_fields.append((field_obj.name, field_obj.type, field_obj))
-
-        # Add the concrete sae field
-        base_fields.append(
+    sae_subgroups: dict[
+        str, TrainingSAEConfig | type[TrainingSAEConfig] | partial[TrainingSAEConfig]
+    ] = {
+        name: partial(config_class, d_in=512, d_sae=1024)
+        for name, (_, config_class) in SAE_TRAINING_CLASS_REGISTRY.items()
+    }
+    cli_config_class = make_dataclass(
+        "CommandLineRunnerConfig",
+        [
             (
                 "sae",
-                sae_config_type,
-                dataclass_field(
-                    default_factory=lambda: sae_config_type(d_in=512, d_sae=1024)
-                ),
+                TrainingSAEConfig,
+                subgroups(sae_subgroups, default="standard", alias="--architecture"),
             )
-        )
+        ],
+        bases=(LanguageModelSAERunnerConfig,),
+    )
 
-        # Create the concrete class
-        return make_dataclass(
-            f"{sae_config_type.__name__}RunnerConfig",
-            base_fields,
-            bases=(LanguageModelSAERunnerConfig,),
-        )
-
-    # Map architecture to concrete config class
-    sae_config_map: dict[str, type[TrainingSAEConfig]] = {
-        name: cfg for name, (_, cfg) in SAE_TRAINING_CLASS_REGISTRY.items()
-    }
-
-    sae_config_type = sae_config_map[architecture]
-    concrete_config_class = create_config_class(sae_config_type)
-
-    # Now parse the full configuration with the concrete type
     parser = CustomParser(exit_on_error=False)
-    parser.add_arguments(concrete_config_class, dest="cfg")
-
-    # Parse the filtered arguments (without --architecture)
-    parsed_args = parser.parse_args(filtered_args)
-
-    # Return the parsed configuration
-    return parsed_args.cfg
+    parser.add_arguments(cli_config_class, dest="cfg")
+    return parser.parse_args(args).cfg
 
 
 # moved into its own function to make it easier to test

--- a/sae_lens/saes/batchtopk_sae.py
+++ b/sae_lens/saes/batchtopk_sae.py
@@ -47,25 +47,22 @@ class BatchTopKTrainingSAEConfig(TopKTrainingSAEConfig):
         k (float): Average number of features to keep active across the batch. Unlike
             standard TopK SAEs where k is an integer per sample, this is a float
             representing the average number of active features across all samples in
-            the batch. Defaults to 100.
+            the batch.
         topk_threshold_lr (float): Learning rate for updating the global topk threshold.
             The threshold is updated using an exponential moving average of the minimum
-            positive activation value. Defaults to 0.01.
+            positive activation value.
         aux_loss_coefficient (float): Coefficient for the auxiliary loss that encourages
             dead neurons to learn useful features. Inherited from TopKTrainingSAEConfig.
-            Defaults to 1.0.
         rescale_acts_by_decoder_norm (bool): Treat the decoder as if it was already normalized.
-            Inherited from TopKTrainingSAEConfig. Defaults to True.
+            Inherited from TopKTrainingSAEConfig.
         decoder_init_norm (float | None): Norm to initialize decoder weights to.
-            Inherited from TrainingSAEConfig. Defaults to 0.1.
+            Inherited from TrainingSAEConfig.
         d_in (int): Input dimension (dimensionality of the activations being encoded).
             Inherited from SAEConfig.
         d_sae (int): SAE latent dimension (number of features in the SAE).
             Inherited from SAEConfig.
         dtype (str): Data type for the SAE parameters. Inherited from SAEConfig.
-            Defaults to "float32".
         device (str): Device to place the SAE on. Inherited from SAEConfig.
-            Defaults to "cpu".
     """
 
     k: float = 100  # type: ignore[assignment]

--- a/sae_lens/saes/jumprelu_sae.py
+++ b/sae_lens/saes/jumprelu_sae.py
@@ -193,8 +193,8 @@ class JumpReLUTrainingSAEConfig(TrainingSAEConfig):
         jumprelu_sparsity_loss_mode: mode for the sparsity loss, either "step" or "tanh". "step" is Google Deepmind's L0 loss, "tanh" is Anthropic's sparsity loss.
         l0_coefficient: coefficient for the l0 sparsity loss
         l0_warm_up_steps: number of warm-up steps for the l0 sparsity loss
-        pre_act_loss_coefficient: coefficient for the pre-activation loss. Set to None to disable. Set to 3e-6 to match Anthropic's setup. Default is None.
-        jumprelu_tanh_scale: scale for the tanh sparsity loss. Only relevant for "tanh" sparsity loss mode. Default is 4.0.
+        pre_act_loss_coefficient: coefficient for the pre-activation loss. Set to None to disable. Set to 3e-6 to match Anthropic's setup.
+        jumprelu_tanh_scale: scale for the tanh sparsity loss. Only relevant for "tanh" sparsity loss mode.
     """
 
     jumprelu_init_threshold: float = 0.01

--- a/sae_lens/saes/jumprelu_sae.py
+++ b/sae_lens/saes/jumprelu_sae.py
@@ -187,13 +187,14 @@ class JumpReLUTrainingSAEConfig(TrainingSAEConfig):
     """
     Configuration class for training a JumpReLUTrainingSAE.
 
-    - jumprelu_init_threshold: initial threshold for the JumpReLU activation
-    - jumprelu_bandwidth: bandwidth for the JumpReLU activation
-    - jumprelu_sparsity_loss_mode: mode for the sparsity loss, either "step" or "tanh". "step" is Google Deepmind's L0 loss, "tanh" is Anthropic's sparsity loss.
-    - l0_coefficient: coefficient for the l0 sparsity loss
-    - l0_warm_up_steps: number of warm-up steps for the l0 sparsity loss
-    - pre_act_loss_coefficient: coefficient for the pre-activation loss. Set to None to disable. Set to 3e-6 to match Anthropic's setup. Default is None.
-    - jumprelu_tanh_scale: scale for the tanh sparsity loss. Only relevant for "tanh" sparsity loss mode. Default is 4.0.
+    Args:
+        jumprelu_init_threshold: initial threshold for the JumpReLU activation
+        jumprelu_bandwidth: bandwidth for the JumpReLU activation
+        jumprelu_sparsity_loss_mode: mode for the sparsity loss, either "step" or "tanh". "step" is Google Deepmind's L0 loss, "tanh" is Anthropic's sparsity loss.
+        l0_coefficient: coefficient for the l0 sparsity loss
+        l0_warm_up_steps: number of warm-up steps for the l0 sparsity loss
+        pre_act_loss_coefficient: coefficient for the pre-activation loss. Set to None to disable. Set to 3e-6 to match Anthropic's setup. Default is None.
+        jumprelu_tanh_scale: scale for the tanh sparsity loss. Only relevant for "tanh" sparsity loss mode. Default is 4.0.
     """
 
     jumprelu_init_threshold: float = 0.01

--- a/sae_lens/saes/matching_pursuit_sae.py
+++ b/sae_lens/saes/matching_pursuit_sae.py
@@ -26,26 +26,21 @@ class MatchingPursuitSAEConfig(SAEConfig):
     Configuration class for MatchingPursuitSAE inference.
 
     Args:
-        residual_threshold (float): residual error at which to stop selecting latents. Default 1e-2.
+        residual_threshold (float): residual error at which to stop selecting latents.
         max_iterations (int | None): Maximum iterations (default: d_in if set to None).
-            Defaults to None.
-        stop_on_duplicate_support (bool): Whether to stop selecting latents if the support set has not changed from the previous iteration. Defaults to True.
+        stop_on_duplicate_support (bool): Whether to stop selecting latents if the support set has not changed from the previous iteration.
         d_in (int): Input dimension (dimensionality of the activations being encoded).
             Inherited from SAEConfig.
         d_sae (int): SAE latent dimension (number of features in the SAE).
             Inherited from SAEConfig.
         dtype (str): Data type for the SAE parameters. Inherited from SAEConfig.
-            Defaults to "float32".
         device (str): Device to place the SAE on. Inherited from SAEConfig.
-            Defaults to "cpu".
         apply_b_dec_to_input (bool): Whether to apply decoder bias to the input
-            before encoding. Inherited from SAEConfig. Defaults to True.
+            before encoding. Inherited from SAEConfig.
         normalize_activations (Literal["none", "expected_average_only_in", "constant_norm_rescale", "layer_norm"]):
             Normalization strategy for input activations. Inherited from SAEConfig.
-            Defaults to "none".
         reshape_activations (Literal["none", "hook_z"]): How to reshape activations
             (useful for attention head outputs). Inherited from SAEConfig.
-            Defaults to "none".
         metadata (SAEMetadata): Metadata about the SAE (model name, hook name, etc.).
             Inherited from SAEConfig.
     """
@@ -123,29 +118,24 @@ class MatchingPursuitTrainingSAEConfig(TrainingSAEConfig):
     Configuration class for training a MatchingPursuitTrainingSAE.
 
     Args:
-        residual_threshold (float): residual error at which to stop selecting latents. Default 1e-2.
+        residual_threshold (float): residual error at which to stop selecting latents.
         max_iterations (int | None): Maximum iterations (default: d_in if set to None).
-            Defaults to None.
-        stop_on_duplicate_support (bool): Whether to stop selecting latents if the support set has not changed from the previous iteration. Defaults to True.
+        stop_on_duplicate_support (bool): Whether to stop selecting latents if the support set has not changed from the previous iteration.
         decoder_init_norm (float | None): Norm to initialize decoder weights to.
             0.1 corresponds to the "heuristic" initialization from Anthropic's April update.
-            Use None to disable. Inherited from TrainingSAEConfig. Defaults to 0.1.
+            Use None to disable. Inherited from TrainingSAEConfig.
         d_in (int): Input dimension (dimensionality of the activations being encoded).
             Inherited from SAEConfig.
         d_sae (int): SAE latent dimension (number of features in the SAE).
             Inherited from SAEConfig.
         dtype (str): Data type for the SAE parameters. Inherited from SAEConfig.
-            Defaults to "float32".
         device (str): Device to place the SAE on. Inherited from SAEConfig.
-            Defaults to "cpu".
         apply_b_dec_to_input (bool): Whether to apply decoder bias to the input
-            before encoding. Inherited from SAEConfig. Defaults to True.
+            before encoding. Inherited from SAEConfig.
         normalize_activations (Literal["none", "expected_average_only_in", "constant_norm_rescale", "layer_norm"]):
             Normalization strategy for input activations. Inherited from SAEConfig.
-            Defaults to "none".
         reshape_activations (Literal["none", "hook_z"]): How to reshape activations
             (useful for attention head outputs). Inherited from SAEConfig.
-            Defaults to "none".
         metadata (SAEMetadata): Metadata about the SAE training (model name, hook name, etc.).
             Inherited from SAEConfig.
     """

--- a/sae_lens/saes/matryoshka_batchtopk_sae.py
+++ b/sae_lens/saes/matryoshka_batchtopk_sae.py
@@ -31,30 +31,26 @@ class MatryoshkaBatchTopKTrainingSAEConfig(BatchTopKTrainingSAEConfig):
     After training, MatryoshkaBatchTopK SAEs are saved as JumpReLU SAEs.
 
     Args:
-        matryoshka_widths (list[int]): The widths of the matryoshka levels. Defaults to an empty list.
+        matryoshka_widths (list[int]): The widths of the matryoshka levels.
         k (float): The number of features to keep active. Inherited from BatchTopKTrainingSAEConfig.
-            Defaults to 100.
         topk_threshold_lr (float): Learning rate for updating the global topk threshold.
             The threshold is updated using an exponential moving average of the minimum
-            positive activation value. Defaults to 0.01.
+            positive activation value.
         use_matryoshka_aux_loss (bool): Whether to encourage dead latents to reconstruct the error
             of just their own level rather than the error of the entire SAE. This should result in
-            better feature revival, but is slower to train. Defaults to False.
+            better feature revival, but is slower to train.
         aux_loss_coefficient (float): Coefficient for the auxiliary loss that encourages
             dead neurons to learn useful features. Inherited from TopKTrainingSAEConfig.
-            Defaults to 1.0.
         rescale_acts_by_decoder_norm (bool): Treat the decoder as if it was already normalized.
-            Inherited from TopKTrainingSAEConfig. Defaults to True.
+            Inherited from TopKTrainingSAEConfig.
         decoder_init_norm (float | None): Norm to initialize decoder weights to.
-            Inherited from TrainingSAEConfig. Defaults to 0.1.
+            Inherited from TrainingSAEConfig.
         d_in (int): Input dimension (dimensionality of the activations being encoded).
             Inherited from SAEConfig.
         d_sae (int): SAE latent dimension (number of features in the SAE).
             Inherited from SAEConfig.
         dtype (str): Data type for the SAE parameters. Inherited from SAEConfig.
-            Defaults to "float32".
         device (str): Device to place the SAE on. Inherited from SAEConfig.
-            Defaults to "cpu".
     """
 
     matryoshka_widths: list[int] = field(default_factory=list)

--- a/sae_lens/saes/sae.py
+++ b/sae_lens/saes/sae.py
@@ -815,8 +815,13 @@ class SAE(HookedRootModule, Generic[T_SAE_CONFIG], ABC):
 
 @dataclass(kw_only=True)
 class TrainingSAEConfig(SAEConfig, ABC):
-    # https://transformer-circuits.pub/2024/april-update/index.html#training-saes
-    # 0.1 corresponds to the "heuristic" initialization, use None to disable
+    """
+    Configuration base class for training all SAE architectures.
+
+    Args:
+        decoder_init_norm (float | None): "heuristic" initialization, see Anthropic 2024 Circuits Update. None to disable
+    """
+
     decoder_init_norm: float | None = 0.1
 
     @classmethod

--- a/sae_lens/saes/topk_sae.py
+++ b/sae_lens/saes/topk_sae.py
@@ -121,26 +121,22 @@ class TopKSAEConfig(SAEConfig):
 
     Args:
         k (int): Number of top features to keep active during inference. Only the top k
-            features with the highest pre-activations will be non-zero. Defaults to 100.
+            features with the highest pre-activations will be non-zero.
         rescale_acts_by_decoder_norm (bool): Whether to treat the decoder as if it was
             already normalized. This affects the topk selection by rescaling pre-activations
-            by decoder norms. Requires that the SAE was trained this way. Defaults to False.
+            by decoder norms. Requires that the SAE was trained this way.
         d_in (int): Input dimension (dimensionality of the activations being encoded).
             Inherited from SAEConfig.
         d_sae (int): SAE latent dimension (number of features in the SAE).
             Inherited from SAEConfig.
         dtype (str): Data type for the SAE parameters. Inherited from SAEConfig.
-            Defaults to "float32".
         device (str): Device to place the SAE on. Inherited from SAEConfig.
-            Defaults to "cpu".
         apply_b_dec_to_input (bool): Whether to apply decoder bias to the input
-            before encoding. Inherited from SAEConfig. Defaults to True.
+            before encoding. Inherited from SAEConfig.
         normalize_activations (Literal["none", "expected_average_only_in", "constant_norm_rescale", "layer_norm"]):
             Normalization strategy for input activations. Inherited from SAEConfig.
-            Defaults to "none".
         reshape_activations (Literal["none", "hook_z"]): How to reshape activations
             (useful for attention head outputs). Inherited from SAEConfig.
-            Defaults to "none".
         metadata (SAEMetadata): Metadata about the SAE (model name, hook name, etc.).
             Inherited from SAEConfig.
     """
@@ -305,37 +301,33 @@ class TopKTrainingSAEConfig(TrainingSAEConfig):
 
     Args:
         k (int): Number of top features to keep active. Only the top k features
-            with the highest pre-activations will be non-zero. Defaults to 100.
+            with the highest pre-activations will be non-zero.
         use_sparse_activations (bool): Whether to use sparse tensor representations
             for activations during training. This can reduce memory usage and improve
             performance when k is small relative to d_sae, but is only worthwhile if
-            using float32 and not using autocast. Defaults to False.
+            using float32 and not using autocast.
         aux_loss_coefficient (float): Coefficient for the auxiliary loss that encourages
             dead neurons to learn useful features. This loss helps prevent neuron death
             in TopK SAEs by having dead neurons reconstruct the residual error from
-            live neurons. Defaults to 1.0.
+            live neurons.
         rescale_acts_by_decoder_norm (bool): Treat the decoder as if it was already normalized.
             This is a good idea since decoder norm can randomly drift during training, and this
-            affects what the topk activations will be. Defaults to True.
+            affects what the topk activations will be.
         decoder_init_norm (float | None): Norm to initialize decoder weights to.
             0.1 corresponds to the "heuristic" initialization from Anthropic's April update.
-            Use None to disable. Inherited from TrainingSAEConfig. Defaults to 0.1.
+            Use None to disable. Inherited from TrainingSAEConfig.
         d_in (int): Input dimension (dimensionality of the activations being encoded).
             Inherited from SAEConfig.
         d_sae (int): SAE latent dimension (number of features in the SAE).
             Inherited from SAEConfig.
         dtype (str): Data type for the SAE parameters. Inherited from SAEConfig.
-            Defaults to "float32".
         device (str): Device to place the SAE on. Inherited from SAEConfig.
-            Defaults to "cpu".
         apply_b_dec_to_input (bool): Whether to apply decoder bias to the input
-            before encoding. Inherited from SAEConfig. Defaults to True.
+            before encoding. Inherited from SAEConfig.
         normalize_activations (Literal["none", "expected_average_only_in", "constant_norm_rescale", "layer_norm"]):
             Normalization strategy for input activations. Inherited from SAEConfig.
-            Defaults to "none".
         reshape_activations (Literal["none", "hook_z"]): How to reshape activations
             (useful for attention head outputs). Inherited from SAEConfig.
-            Defaults to "none".
         metadata (SAEMetadata): Metadata about the SAE training (model name, hook name, etc.).
             Inherited from SAEConfig.
     """

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,6 +7,7 @@ import torch
 from transformer_lens import HookedTransformer
 
 from sae_lens.config import LanguageModelSAERunnerConfig, LoggingConfig
+from sae_lens.registry import SAE_TRAINING_CLASS_REGISTRY
 from sae_lens.saes.batchtopk_sae import BatchTopKTrainingSAEConfig
 from sae_lens.saes.gated_sae import GatedSAEConfig, GatedTrainingSAEConfig
 from sae_lens.saes.jumprelu_sae import JumpReLUSAEConfig, JumpReLUTrainingSAEConfig
@@ -36,15 +37,7 @@ ALL_FOLDABLE_ARCHITECTURES = [
     "gated",
     "jumprelu",
 ]  # Architectures with fold W_dec to unit norm implementation
-ALL_TRAINING_ARCHITECTURES = [
-    "standard",
-    "gated",
-    "jumprelu",
-    "topk",
-    "batchtopk",
-    "matryoshka_batchtopk",
-    "matching_pursuit",
-]
+ALL_TRAINING_ARCHITECTURES = list(SAE_TRAINING_CLASS_REGISTRY.keys())
 
 
 def to_sparse(tensor: torch.Tensor) -> torch.Tensor:

--- a/tests/test_llm_sae_training_runner.py
+++ b/tests/test_llm_sae_training_runner.py
@@ -825,9 +825,12 @@ class TestResumeFromCheckpoint:
         activations_store_path = checkpoint_dirs[0] / ACTIVATIONS_STORE_STATE_FILENAME
         assert activations_store_path.exists(), "Activations store state wasn't saved"
 
-    def test_cli_args_parsing_with_resume(self):
+    @pytest.mark.parametrize("architecture", ALL_TRAINING_ARCHITECTURES)
+    def test_cli_args_parsing_with_resume(self, architecture: str):
         """Test that CLI args parsing works with --resume_from_checkpoint."""
         args = [
+            "--architecture",
+            architecture,
             "--model_name",
             "test-model",
             "--dataset_path",

--- a/tests/test_llm_sae_training_runner.py
+++ b/tests/test_llm_sae_training_runner.py
@@ -840,6 +840,7 @@ class TestResumeFromCheckpoint:
         ]
         cfg = _parse_cfg_args(args)
 
+        assert cfg.sae.architecture() == architecture
         assert cfg.model_name == "test-model"
         assert cfg.dataset_path == "test-dataset"
         assert cfg.resume_from_checkpoint == "/path/to/checkpoint"

--- a/tests/test_llm_sae_training_runner.py
+++ b/tests/test_llm_sae_training_runner.py
@@ -220,6 +220,15 @@ def test_parse_cfg_args_raises_system_exit_on_empty_args():
         _parse_cfg_args([])
 
 
+def test_parse_cfg_args_shows_architecture_in_help(capfd: pytest.CaptureFixture[str]):
+    with pytest.raises(SystemExit):
+        _parse_cfg_args(["--help"])
+    out = capfd.readouterr().out
+    assert "--architecture" in out
+    for architecture in ALL_TRAINING_ARCHITECTURES:
+        assert architecture in out
+
+
 def test_parse_cfg_args_raises_exception_on_invalid_args():
     with pytest.raises((SystemExit, Exception)):
         _parse_cfg_args(["--invalid-argument", "value"])


### PR DESCRIPTION
# Description

- Add support for missing architectures in training CLI, list was hard-coded and out-of-date
- Fixes to training CLI help, fixes #699
- As part of the help fixes (adding missing --architecture flag), the CLI code was also simplified by using the existing subgroups feature of simple-parsing

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility


### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
