### PR TITLE
TemporalSAE: don't apply decoding bias if weights are tied and bias wasn't applied at encoding

### DIFF
--- a/sae_lens/saes/temporal_sae.py
+++ b/sae_lens/saes/temporal_sae.py
@@ -325,7 +325,8 @@ class TemporalSAE(SAE[TemporalSAEConfig]):
         """
         # Decode novel codes
         sae_out = torch.matmul(feature_acts, self.W_dec)
-        sae_out = sae_out + self.b_dec
+        if not self.cfg.tied_weights or self.cfg.apply_b_dec_to_input:
+            sae_out = sae_out + self.b_dec
 
         # Apply hook
         sae_out = self.hook_sae_recons(sae_out)
@@ -348,7 +349,9 @@ class TemporalSAE(SAE[TemporalSAEConfig]):
         z_novel, z_pred = self.encode_with_predictions(x)
 
         # Decode the sum of predicted and novel codes.
-        x_recons = torch.matmul(z_novel + z_pred, self.W_dec) + self.b_dec
+        x_recons = torch.matmul(z_novel + z_pred, self.W_dec)
+        if not self.cfg.tied_weights or self.cfg.apply_b_dec_to_input:
+            x_recons = x_recons + self.b_dec
 
         # Apply output activation normalization (reverses input normalization)
         x_recons = self.run_time_activation_norm_fn_out(x_recons)

--- a/tests/saes/test_temporal_sae.py
+++ b/tests/saes/test_temporal_sae.py
@@ -29,8 +29,11 @@ def test_TemporalSAE_initialization():
 
 
 @pytest.mark.parametrize("tied_weights", [True, False])
-def test_TemporalSAE_forward(tied_weights: bool):
-    cfg = build_temporal_sae_cfg(tied_weights=tied_weights)
+@pytest.mark.parametrize("apply_b_dec_to_input", [True, False])
+def test_TemporalSAE_forward(tied_weights: bool, apply_b_dec_to_input: bool):
+    cfg = build_temporal_sae_cfg(
+        tied_weights=tied_weights, apply_b_dec_to_input=apply_b_dec_to_input
+    )
     sae = TemporalSAE.from_dict(cfg.to_dict())
 
     batch_size = 4
@@ -43,9 +46,13 @@ def test_TemporalSAE_forward(tied_weights: bool):
 
 
 @pytest.mark.parametrize("tied_weights", [True, False])
-def test_TemporalSAE_encode(tied_weights: bool):
+@pytest.mark.parametrize("apply_b_dec_to_input", [True, False])
+def test_TemporalSAE_encode(tied_weights: bool, apply_b_dec_to_input: bool):
     cfg = build_temporal_sae_cfg(
-        tied_weights=tied_weights, sae_diff_type="topk", kval_topk=32
+        tied_weights=tied_weights,
+        apply_b_dec_to_input=apply_b_dec_to_input,
+        sae_diff_type="topk",
+        kval_topk=32,
     )
     sae = TemporalSAE.from_dict(cfg.to_dict())
 
@@ -62,8 +69,12 @@ def test_TemporalSAE_encode(tied_weights: bool):
     assert l0 <= cfg.kval_topk
 
 
-def test_TemporalSAE_decode():
-    cfg = build_temporal_sae_cfg()
+@pytest.mark.parametrize("tied_weights", [True, False])
+@pytest.mark.parametrize("apply_b_dec_to_input", [True, False])
+def test_TemporalSAE_decode(tied_weights: bool, apply_b_dec_to_input: bool):
+    cfg = build_temporal_sae_cfg(
+        tied_weights=tied_weights, apply_b_dec_to_input=apply_b_dec_to_input
+    )
     sae = TemporalSAE.from_dict(cfg.to_dict())
 
     batch_size = 4


### PR DESCRIPTION
# Description

TemporalSAE decoding previously added the decoder bias unconditionally at decoding time. It should only be done in case the encoder/decoder weights are untied, or, if tied, in case the bias was also subtracted at encoding time.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
