### PR TITLE
Add missing hooks

### DIFF
--- a/sae_lens/saes/jumprelu_sae.py
+++ b/sae_lens/saes/jumprelu_sae.py
@@ -271,8 +271,10 @@ class JumpReLUTrainingSAE(TrainingSAE[JumpReLUTrainingSAEConfig]):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         sae_in = self.process_sae_in(x)
 
-        hidden_pre = sae_in @ self.W_enc + self.b_enc
-        feature_acts = JumpReLU.apply(hidden_pre, self.threshold, self.bandwidth)
+        hidden_pre = self.hook_sae_acts_pre(sae_in @ self.W_enc + self.b_enc)
+        feature_acts = self.hook_sae_acts_post(
+            JumpReLU.apply(hidden_pre, self.threshold, self.bandwidth)
+        )
 
         return feature_acts, hidden_pre  # type: ignore
 

--- a/sae_lens/saes/temporal_sae.py
+++ b/sae_lens/saes/temporal_sae.py
@@ -300,7 +300,8 @@ class TemporalSAE(SAE[TemporalSAEConfig]):
             x_residual = x_residual - proj_scale * Dz_pred_
 
         # Encode residual (novel part) with sparse SAE
-        z_novel = F.relu(torch.matmul(x_residual * self.lam, W_enc))
+        hidden_pre = self.hook_sae_acts_pre(torch.matmul(x_residual * self.lam, W_enc))
+        z_novel = F.relu(hidden_pre)
         if self.cfg.sae_diff_type == "topk":
             kval = self.cfg.kval_topk
             if kval is not None:
@@ -308,6 +309,7 @@ class TemporalSAE(SAE[TemporalSAEConfig]):
                 mask = torch.zeros_like(z_novel)
                 mask.scatter_(-1, topk_indices, 1)
                 z_novel = z_novel * mask
+        z_novel = self.hook_sae_acts_post(z_novel)
 
         # Return only novel codes (these are the interpretable features)
         return z_novel, z_pred

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -15,7 +15,14 @@ from sae_lens.saes.matching_pursuit_sae import (
     MatchingPursuitTrainingSAEConfig,
 )
 from sae_lens.saes.matryoshka_batchtopk_sae import MatryoshkaBatchTopKTrainingSAEConfig
-from sae_lens.saes.sae import T_TRAINING_SAE_CONFIG, SAEConfig, TrainingSAEConfig
+from sae_lens.saes.sae import (
+    T_TRAINING_SAE_CONFIG,
+    SAEConfig,
+    TrainingSAE,
+    TrainingSAEConfig,
+    TrainStepInput,
+    TrainStepOutput,
+)
 from sae_lens.saes.standard_sae import StandardSAEConfig, StandardTrainingSAEConfig
 from sae_lens.saes.temporal_sae import TemporalSAEConfig
 from sae_lens.saes.topk_sae import TopKSAEConfig, TopKTrainingSAEConfig
@@ -725,6 +732,21 @@ def random_params(model: torch.nn.Module) -> None:
         param.data = torch.rand_like(param)
     for buffer in model.buffers():
         buffer.data = torch.rand_like(buffer)
+
+
+def run_training_forward_pass_with_cache(
+    sae: TrainingSAE[Any], step_input: TrainStepInput
+) -> tuple[TrainStepOutput, dict[str, torch.Tensor]]:
+    """
+    Like ``run_with_cache``, but captures the values flowing through each SAE hook
+    point during ``training_forward_pass`` rather than during ``forward``. Returns the
+    train step output alongside a hook-name -> activation cache, so tests can verify
+    the hooks actually fire during the training forward pass itself.
+    """
+    cache, fwd_hooks, _ = sae.get_caching_hooks()
+    with sae.hooks(fwd_hooks=fwd_hooks):
+        step_output = sae.training_forward_pass(step_input)
+    return step_output, cache
 
 
 SAE_TRAINING_CONFIG_BUILDERS = {

--- a/tests/saes/test_batchtopk_sae.py
+++ b/tests/saes/test_batchtopk_sae.py
@@ -17,6 +17,7 @@ from tests.helpers import (
     assert_not_close,
     build_batchtopk_sae_training_cfg,
     random_params,
+    run_training_forward_pass_with_cache,
 )
 
 
@@ -516,3 +517,34 @@ def test_BatchTopKTrainingSAE_gives_same_output_despite_rescale_acts_by_decoder_
 
     assert_not_close(enhanced_acts, topk_acts, rtol=1e-2)
     assert_close(enhanced_output, topk_output, rtol=1e-2)
+
+
+def test_BatchTopKTrainingSAE_training_forward_pass_hooks():
+    sae = BatchTopKTrainingSAE(build_batchtopk_sae_training_cfg())
+    x = torch.randn(32, sae.cfg.d_in)
+    step_input = TrainStepInput(
+        sae_in=x,
+        coefficients={},
+        dead_neuron_mask=None,
+        n_training_steps=0,
+        is_logging_step=False,
+    )
+    # topk rescales hidden_pre by the decoder norm after hook_sae_acts_pre fires,
+    # so the hook captures the raw pre-activation, not train_step_output.hidden_pre
+    raw_hidden_pre = sae.process_sae_in(x) @ sae.W_enc + sae.b_enc
+
+    train_step_output, train_cache = run_training_forward_pass_with_cache(
+        sae, step_input
+    )
+    assert train_cache["hook_sae_input"].equal(x)
+    assert train_cache["hook_sae_acts_pre"].equal(raw_hidden_pre)
+    assert train_cache["hook_sae_acts_post"].equal(train_step_output.feature_acts)
+    assert train_cache["hook_sae_recons"].equal(train_step_output.sae_out)
+
+    # Verify training output matches a regular run_with_cache forward pass
+    _, cache = sae.run_with_cache(x)
+    assert train_cache["hook_sae_input"].equal(cache["hook_sae_input"])
+    assert train_cache["hook_sae_acts_pre"].equal(cache["hook_sae_acts_pre"])
+    assert train_cache["hook_sae_acts_post"].equal(cache["hook_sae_acts_post"])
+    assert train_cache["hook_sae_recons"].equal(cache["hook_sae_recons"])
+    assert train_cache["hook_sae_recons"].equal(cache["hook_sae_output"])

--- a/tests/saes/test_gated_sae.py
+++ b/tests/saes/test_gated_sae.py
@@ -12,6 +12,7 @@ from tests.helpers import (
     assert_not_close,
     build_gated_sae_cfg,
     build_gated_sae_training_cfg,
+    run_training_forward_pass_with_cache,
 )
 
 
@@ -326,3 +327,31 @@ def test_GatedTrainingSAE_save_and_load_inference_sae(tmp_path: Path) -> None:
     training_full_out = training_sae(sae_in)
     inference_full_out = inference_sae(sae_in)
     assert_close(training_full_out, inference_full_out)
+
+
+def test_GatedTrainingSAE_training_forward_pass_hooks():
+    sae = GatedTrainingSAE(build_gated_sae_training_cfg())
+    x = torch.randn(32, sae.cfg.d_in)
+    step_input = TrainStepInput(
+        sae_in=x,
+        coefficients={"l1": sae.cfg.l1_coefficient},
+        dead_neuron_mask=None,
+        n_training_steps=0,
+        is_logging_step=False,
+    )
+
+    train_step_output, train_cache = run_training_forward_pass_with_cache(
+        sae, step_input
+    )
+    assert train_cache["hook_sae_input"].equal(x)
+    assert train_cache["hook_sae_acts_pre"].equal(train_step_output.hidden_pre)
+    assert train_cache["hook_sae_acts_post"].equal(train_step_output.feature_acts)
+    assert train_cache["hook_sae_recons"].equal(train_step_output.sae_out)
+
+    # Verify training output matches a regular run_with_cache forward pass
+    _, cache = sae.run_with_cache(x)
+    assert train_cache["hook_sae_input"].equal(cache["hook_sae_input"])
+    assert train_cache["hook_sae_acts_pre"].equal(cache["hook_sae_acts_pre"])
+    assert train_cache["hook_sae_acts_post"].equal(cache["hook_sae_acts_post"])
+    assert train_cache["hook_sae_recons"].equal(cache["hook_sae_recons"])
+    assert train_cache["hook_sae_recons"].equal(cache["hook_sae_output"])

--- a/tests/saes/test_jumprelu_sae.py
+++ b/tests/saes/test_jumprelu_sae.py
@@ -17,6 +17,7 @@ from tests.helpers import (
     assert_not_close,
     build_jumprelu_sae_cfg,
     build_jumprelu_sae_training_cfg,
+    run_training_forward_pass_with_cache,
 )
 
 
@@ -51,14 +52,15 @@ def test_JumpReLUTrainingSAE_training_forward_pass():
     d_in = sae.cfg.d_in
 
     x = torch.randn(batch_size, d_in)
-    train_step_output = sae.training_forward_pass(
-        step_input=TrainStepInput(
-            sae_in=x,
-            coefficients={"l0": sae.cfg.l0_coefficient},
-            dead_neuron_mask=None,
-            n_training_steps=0,
-            is_logging_step=False,
-        ),
+    step_input = TrainStepInput(
+        sae_in=x,
+        coefficients={"l0": sae.cfg.l0_coefficient},
+        dead_neuron_mask=None,
+        n_training_steps=0,
+        is_logging_step=False,
+    )
+    train_step_output, train_cache = run_training_forward_pass_with_cache(
+        sae, step_input
     )
 
     assert train_step_output.sae_out.shape == (batch_size, d_in)
@@ -81,6 +83,19 @@ def test_JumpReLUTrainingSAE_training_forward_pass():
     assert (
         pytest.approx(train_step_output.losses["mse_loss"].item()) == expected_mse_loss  # type: ignore
     )
+
+    assert train_cache["hook_sae_input"].equal(x)
+    assert train_cache["hook_sae_acts_pre"].equal(train_step_output.hidden_pre)
+    assert train_cache["hook_sae_acts_post"].equal(train_step_output.feature_acts)
+    assert train_cache["hook_sae_recons"].equal(train_step_output.sae_out)
+
+    # Verify training output matches a regular run_with_cache forward pass
+    _, cache = sae.run_with_cache(x)
+    assert train_cache["hook_sae_input"].equal(cache["hook_sae_input"])
+    assert train_cache["hook_sae_acts_pre"].equal(cache["hook_sae_acts_pre"])
+    assert train_cache["hook_sae_acts_post"].equal(cache["hook_sae_acts_post"])
+    assert train_cache["hook_sae_recons"].equal(cache["hook_sae_recons"])
+    assert train_cache["hook_sae_recons"].equal(cache["hook_sae_output"])
 
 
 def test_JumpReLUSAE_initialization():

--- a/tests/saes/test_matryoshka_batchtopk_sae.py
+++ b/tests/saes/test_matryoshka_batchtopk_sae.py
@@ -23,6 +23,7 @@ from tests.helpers import (
     build_batchtopk_sae_training_cfg,
     build_matryoshka_batchtopk_sae_training_cfg,
     random_params,
+    run_training_forward_pass_with_cache,
 )
 
 
@@ -786,3 +787,34 @@ def test_aux_loss_rescale_acts_matches_fold_W_dec_norm(use_matryoshka_aux_loss: 
     assert_close(output_rescale.loss, output_folded.loss)
     for key in output_rescale.losses:
         assert_close(output_rescale.losses[key], output_folded.losses[key])
+
+
+def test_MatryoshkaBatchTopKTrainingSAE_training_forward_pass_hooks():
+    sae = MatryoshkaBatchTopKTrainingSAE(build_matryoshka_batchtopk_sae_training_cfg())
+    x = torch.randn(32, sae.cfg.d_in)
+    step_input = TrainStepInput(
+        sae_in=x,
+        coefficients={},
+        dead_neuron_mask=None,
+        n_training_steps=0,
+        is_logging_step=False,
+    )
+    # topk rescales hidden_pre by the decoder norm after hook_sae_acts_pre fires,
+    # so the hook captures the raw pre-activation, not train_step_output.hidden_pre
+    raw_hidden_pre = sae.process_sae_in(x) @ sae.W_enc + sae.b_enc
+
+    train_step_output, train_cache = run_training_forward_pass_with_cache(
+        sae, step_input
+    )
+    assert train_cache["hook_sae_input"].equal(x)
+    assert train_cache["hook_sae_acts_pre"].equal(raw_hidden_pre)
+    assert train_cache["hook_sae_acts_post"].equal(train_step_output.feature_acts)
+    assert train_cache["hook_sae_recons"].equal(train_step_output.sae_out)
+
+    # Verify training output matches a regular run_with_cache forward pass
+    _, cache = sae.run_with_cache(x)
+    assert train_cache["hook_sae_input"].equal(cache["hook_sae_input"])
+    assert train_cache["hook_sae_acts_pre"].equal(cache["hook_sae_acts_pre"])
+    assert train_cache["hook_sae_acts_post"].equal(cache["hook_sae_acts_post"])
+    assert train_cache["hook_sae_recons"].equal(cache["hook_sae_recons"])
+    assert train_cache["hook_sae_recons"].equal(cache["hook_sae_output"])

--- a/tests/saes/test_standard_sae.py
+++ b/tests/saes/test_standard_sae.py
@@ -11,7 +11,7 @@ from safetensors import safe_open
 from transformer_lens.hook_points import HookPoint
 
 from sae_lens.config import LanguageModelSAERunnerConfig
-from sae_lens.saes.sae import SAE, TrainingSAE, _disable_hooks
+from sae_lens.saes.sae import SAE, TrainingSAE, TrainStepInput, _disable_hooks
 from sae_lens.saes.standard_sae import (
     StandardSAE,
     StandardTrainingSAE,
@@ -29,6 +29,7 @@ from tests.helpers import (
     build_sae_cfg_for_arch,
     build_sae_training_cfg,
     build_sae_training_cfg_for_arch,
+    run_training_forward_pass_with_cache,
 )
 
 
@@ -890,3 +891,44 @@ def test_StandardTrainingSAE_save_and_load_inference_sae(tmp_path: Path) -> None
     training_full_out = training_sae(sae_in)
     inference_full_out = inference_sae(sae_in)
     assert_close(training_full_out, inference_full_out)
+
+
+def test_StandardTrainingSAE_training_forward_pass_hooks():
+    sae = StandardTrainingSAE(build_sae_training_cfg())
+    x = torch.randn(32, sae.cfg.d_in)
+    step_input = TrainStepInput(
+        sae_in=x,
+        coefficients={"l1": sae.cfg.l1_coefficient},
+        dead_neuron_mask=None,
+        n_training_steps=0,
+        is_logging_step=False,
+    )
+
+    train_step_output, train_cache = run_training_forward_pass_with_cache(
+        sae, step_input
+    )
+    assert train_cache["hook_sae_input"].equal(x)
+    assert train_cache["hook_sae_acts_pre"].equal(train_step_output.hidden_pre)
+    assert train_cache["hook_sae_acts_post"].equal(train_step_output.feature_acts)
+    assert train_cache["hook_sae_recons"].equal(train_step_output.sae_out)
+
+    # Verify training output matches a regular run_with_cache forward pass
+    _, cache = sae.run_with_cache(x)
+    assert train_cache["hook_sae_input"].equal(cache["hook_sae_input"])
+    assert train_cache["hook_sae_acts_pre"].equal(cache["hook_sae_acts_pre"])
+    assert train_cache["hook_sae_acts_post"].equal(cache["hook_sae_acts_post"])
+    assert train_cache["hook_sae_recons"].equal(cache["hook_sae_recons"])
+    assert train_cache["hook_sae_recons"].equal(cache["hook_sae_output"])
+
+
+def test_StandardSAE_forward_hooks():
+    sae = StandardSAE(build_sae_cfg())
+    x = torch.randn(32, sae.cfg.d_in)
+    out, cache = sae.run_with_cache(x)
+    assert cache["hook_sae_input"].equal(x)
+    assert cache["hook_sae_acts_pre"].equal(
+        sae.process_sae_in(x) @ sae.W_enc + sae.b_enc
+    )
+    assert cache["hook_sae_acts_post"].equal(sae.encode(x))
+    assert cache["hook_sae_recons"].equal(out)
+    assert cache["hook_sae_output"].equal(out)

--- a/tests/saes/test_temporal_sae.py
+++ b/tests/saes/test_temporal_sae.py
@@ -6,7 +6,7 @@ import torch
 from sae_lens.constants import DTYPE_MAP
 from sae_lens.saes.sae import SAE
 from sae_lens.saes.temporal_sae import ManualAttention, TemporalSAE
-from tests.helpers import build_temporal_sae_cfg
+from tests.helpers import assert_close, build_temporal_sae_cfg
 
 
 def test_TemporalSAE_initialization():
@@ -40,6 +40,16 @@ def test_TemporalSAE_forward(tied_weights: bool):
     reconstruction = sae.forward(x)
 
     assert reconstruction.shape == x.shape
+
+
+def test_TemporalSAE_forward_pass_calls_hooks():
+    sae = TemporalSAE(build_temporal_sae_cfg(dtype="float32"))
+    x = torch.randn(4, 16, sae.cfg.d_in)
+    out, cache = sae.run_with_cache(x)
+    assert_close(cache["hook_sae_input"], x)
+    assert "hook_sae_acts_pre" in cache
+    assert_close(cache["hook_sae_acts_post"], sae.encode(x))
+    assert_close(cache["hook_sae_output"], out)
 
 
 @pytest.mark.parametrize("tied_weights", [True, False])

--- a/tests/saes/test_topk_sae.py
+++ b/tests/saes/test_topk_sae.py
@@ -15,6 +15,7 @@ from tests.helpers import (
     build_topk_sae_cfg,
     build_topk_sae_training_cfg,
     random_params,
+    run_training_forward_pass_with_cache,
 )
 
 
@@ -477,3 +478,47 @@ def test_TopKSAE_fold_W_dec_norm_errors_when_rescale_acts_by_decoder_norm_is_Fal
 
     with pytest.raises(NotImplementedError):
         sae.fold_W_dec_norm()
+
+
+def test_TopKTrainingSAE_training_forward_pass_hooks():
+    sae = TopKTrainingSAE(build_topk_sae_training_cfg())
+    x = torch.randn(32, sae.cfg.d_in)
+    step_input = TrainStepInput(
+        sae_in=x,
+        coefficients={},
+        dead_neuron_mask=None,
+        n_training_steps=0,
+        is_logging_step=False,
+    )
+    # topk rescales hidden_pre by the decoder norm after hook_sae_acts_pre fires,
+    # so the hook captures the raw pre-activation, not train_step_output.hidden_pre
+    raw_hidden_pre = sae.process_sae_in(x) @ sae.W_enc + sae.b_enc
+
+    train_step_output, train_cache = run_training_forward_pass_with_cache(
+        sae, step_input
+    )
+    assert train_cache["hook_sae_input"].equal(x)
+    assert train_cache["hook_sae_acts_pre"].equal(raw_hidden_pre)
+    assert train_cache["hook_sae_acts_post"].equal(train_step_output.feature_acts)
+    assert train_cache["hook_sae_recons"].equal(train_step_output.sae_out)
+
+    # Verify training output matches a regular run_with_cache forward pass
+    _, cache = sae.run_with_cache(x)
+    assert train_cache["hook_sae_input"].equal(cache["hook_sae_input"])
+    assert train_cache["hook_sae_acts_pre"].equal(cache["hook_sae_acts_pre"])
+    assert train_cache["hook_sae_acts_post"].equal(cache["hook_sae_acts_post"])
+    assert train_cache["hook_sae_recons"].equal(cache["hook_sae_recons"])
+    assert train_cache["hook_sae_recons"].equal(cache["hook_sae_output"])
+
+
+def test_TopKSAE_forward_hooks():
+    sae = TopKSAE(build_topk_sae_cfg())
+    x = torch.randn(32, sae.cfg.d_in)
+    out, cache = sae.run_with_cache(x)
+    assert cache["hook_sae_input"].equal(x)
+    assert cache["hook_sae_acts_pre"].equal(
+        sae.process_sae_in(x) @ sae.W_enc + sae.b_enc
+    )
+    assert cache["hook_sae_acts_post"].equal(sae.encode(x))
+    assert cache["hook_sae_recons"].equal(out)
+    assert cache["hook_sae_output"].equal(out)

--- a/tests/saes/test_transcoder.py
+++ b/tests/saes/test_transcoder.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Any
+from typing import Any, Callable
 
 import pytest
 import torch
@@ -694,3 +694,26 @@ class TestTranscoderIntegration:
         out2, feat2 = transcoder2.forward_with_activations(x)
         assert_close(out1, out2)
         assert_close(feat1, feat2)
+
+
+@pytest.mark.parametrize(
+    "build_cfg, sae_class",
+    [
+        (build_transcoder_cfg, Transcoder),
+        (build_skip_transcoder_cfg, SkipTranscoder),
+        (build_jumprelu_transcoder_cfg, JumpReLUTranscoder),
+        (build_jumprelu_skip_transcoder_cfg, JumpReLUSkipTranscoder),
+    ],
+)
+def test_transcoder_forward_pass_calls_hooks(
+    build_cfg: Callable[[], TranscoderConfig], sae_class: type[Transcoder]
+):
+    sae = sae_class(build_cfg())
+    x = torch.randn(8, sae.cfg.d_in)
+    _, cache = sae.run_with_cache(x)
+    assert_close(cache["hook_sae_input"], x)
+    assert_close(
+        cache["hook_sae_acts_pre"], sae.process_sae_in(x) @ sae.W_enc + sae.b_enc
+    )
+    assert_close(cache["hook_sae_acts_post"], sae.encode(x))
+    assert "hook_sae_recons" in cache


### PR DESCRIPTION
Add missing `hook_sae_acts_pre`/`post` in `JumpReLUTrainingSAE` and `TemporalSAE`

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
