### PR TITLE
feat: add exclude_special_tokens to HookedSAETransformer

### DIFF
--- a/sae_lens/analysis/hooked_sae_transformer.py
+++ b/sae_lens/analysis/hooked_sae_transformer.py
@@ -11,6 +11,7 @@ from transformer_lens.HookedTransformer import HookedTransformer
 
 from sae_lens import logger
 from sae_lens.saes.sae import SAE, _disable_hooks
+from sae_lens.util import get_special_token_ids
 
 SingleLoss = torch.Tensor  # Type alias for a single element tensor
 LossPerToken = torch.Tensor
@@ -72,8 +73,8 @@ class _SAEWrapper(nn.Module):
         """
         self._captured_input = x
 
-    def set_token_mask(self, mask: torch.Tensor) -> None:
-        """Set a boolean mask [batch, seq] where True = bypass SAE at that position."""
+    def set_token_mask(self, mask: torch.Tensor | None) -> None:
+        """Set a boolean mask (batch, seq) where True = bypass SAE at that position."""
         self._token_mask = mask
 
     def forward(self, original_output: torch.Tensor) -> torch.Tensor:
@@ -85,6 +86,11 @@ class _SAEWrapper(nn.Module):
             if self._captured_input is not None
             else original_output
         )
+
+        mask = self._token_mask
+        if mask is not None:
+            for _ in range(original_output.dim() - mask.dim()):
+                mask = mask.unsqueeze(-1)
 
         try:
             # Call encode and decode directly so we can control hook_sae_output
@@ -98,21 +104,23 @@ class _SAEWrapper(nn.Module):
                     with _disable_hooks(self.sae):
                         feature_acts_clean = self.sae.encode(sae_input)
                         sae_out_clean = self.sae.decode(feature_acts_clean)
-                    sae_error = self.hook_sae_error(original_output - sae_out_clean)
+                    sae_error = original_output - sae_out_clean
+                    # Excluded positions bypass the SAE entirely, so their error is 0
+                    if mask is not None:
+                        sae_error = torch.where(
+                            mask, torch.zeros_like(sae_error), sae_error
+                        )
+                    sae_error = self.hook_sae_error(sae_error)
                 sae_out = sae_out + sae_error
 
             # Restore original activations at excluded token positions before firing
             # hook_sae_output, so the cache reflects what actually flows forward.
-            if self._token_mask is not None:
-                mask = self._token_mask
-                for _ in range(sae_out.dim() - mask.dim()):
-                    mask = mask.unsqueeze(-1)
-                sae_out = torch.where(mask.expand_as(sae_out), original_output, sae_out)
+            if mask is not None:
+                sae_out = torch.where(mask, original_output, sae_out)
 
             return self.hook_sae_output(sae_out)
         finally:
             self._captured_input = None
-            self._token_mask = None
 
 
 def get_deep_attr(obj: Any, path: str):
@@ -205,10 +213,11 @@ class HookedSAETransformer(HookedTransformer):
                 model would have produced without the SAE. This works for both SAEs
                 (where input==output hook) and transcoders (where they differ).
                 Defaults to None (uses SAE's existing setting).
-            exclude_special_tokens: If True, special tokens (BOS, EOS, PAD, SEP, CLS)
-                are identified from the model tokenizer and the SAE is bypassed at those
-                positions. Pass a list of token IDs to specify custom tokens to exclude.
-                Defaults to False (SAE applied at all positions).
+            exclude_special_tokens: If True, special tokens (BOS, EOS, PAD, SEP,
+                decoder-start) are identified from the model tokenizer and the SAE
+                is bypassed at those positions. Pass a list of token IDs to specify
+                custom tokens to exclude. Defaults to False (SAE applied at all
+                positions).
         """
         input_hook = sae.cfg.metadata.hook_name
         output_hook = sae.cfg.metadata.hook_name_out or input_hook
@@ -322,66 +331,61 @@ class HookedSAETransformer(HookedTransformer):
 
         self.setup()
 
-    def _get_special_token_ids(self) -> list[int]:
-        """Return BOS, EOS, PAD, SEP, and CLS token IDs from the model tokenizer."""
-        if self.tokenizer is None:
-            logger.warning(
-                "exclude_special_tokens=True but no tokenizer is attached to the model. "
-                "Pass a list of token IDs to exclude_special_tokens instead."
-            )
-            return []
-        ids = []
-        for attr in (
-            "bos_token_id",
-            "eos_token_id",
-            "pad_token_id",
-            "sep_token_id",
-            "cls_token_id",
-        ):
-            token_id = getattr(self.tokenizer, attr, None)
-            if token_id is not None:
-                ids.append(int(token_id))
-        return list(set(ids))
-
     def _compute_exclusion_mask(
         self,
         tokens: torch.Tensor,
         exclude_special_tokens: bool | list[int],
     ) -> torch.Tensor:
-        """Build a boolean mask [batch, seq] where True = bypass the SAE at that position."""
+        """Build a boolean mask (batch, seq) where True = bypass the SAE at that position."""
         if isinstance(exclude_special_tokens, list):
             token_ids = exclude_special_tokens
+        elif self.tokenizer is None:
+            logger.warning(
+                "exclude_special_tokens=True but no tokenizer is attached to the model. "
+                "Pass a list of token IDs to exclude_special_tokens instead."
+            )
+            token_ids = []
         else:
-            token_ids = self._get_special_token_ids()
+            token_ids = get_special_token_ids(self.tokenizer)
 
         mask = torch.zeros(tokens.shape, dtype=torch.bool, device=tokens.device)
         for token_id in token_ids:
             mask = mask | (tokens == token_id)
         return mask
 
-    def forward(self, input: Any, **kwargs: Any) -> Any:  # type: ignore[override]
-        """Override to inject token exclusion masks into wrappers before the forward pass."""
+    @contextmanager
+    def _token_masks(self, input: Any, kwargs: dict[str, Any]):
+        """Set exclusion masks on wrappers for one forward pass, clearing them on exit."""
         wrappers_needing_mask = [
             w
             for w in self._acts_to_saes.values()
             if w.exclude_special_tokens is not False
         ]
         if wrappers_needing_mask:
-            prepend_bos = kwargs.get("prepend_bos")
-            padding_side = kwargs.get("padding_side")
-            tokens = self.to_tokens(
-                input,
-                prepend_bos=prepend_bos,
-                padding_side=padding_side,
-                move_to_device=True,
-                truncate=True,
-            )
-            for wrapper in wrappers_needing_mask:
-                mask = self._compute_exclusion_mask(
-                    tokens, wrapper.exclude_special_tokens
+            if isinstance(input, torch.Tensor):
+                tokens = input
+            else:
+                tokens = self.to_tokens(
+                    input,
+                    prepend_bos=kwargs.get("prepend_bos"),
+                    padding_side=kwargs.get("padding_side"),
+                    move_to_device=True,
+                    truncate=True,
                 )
-                wrapper.set_token_mask(mask)
-        return super().forward(input, **kwargs)
+            for wrapper in wrappers_needing_mask:
+                wrapper.set_token_mask(
+                    self._compute_exclusion_mask(tokens, wrapper.exclude_special_tokens)
+                )
+        try:
+            yield
+        finally:
+            for wrapper in wrappers_needing_mask:
+                wrapper.set_token_mask(None)
+
+    def forward(self, input: Any, **kwargs: Any) -> Any:  # type: ignore[override]
+        """Override to inject token exclusion masks into wrappers before the forward pass."""
+        with self._token_masks(input, kwargs):
+            return super().forward(input, **kwargs)
 
     def run_with_saes(
         self,
@@ -401,7 +405,7 @@ class HookedSAETransformer(HookedTransformer):
             saes: (SAE | list[SAE]) The SAEs to be attached for this forward pass
             reset_saes_end (bool): If True, all SAEs added during this run are removed at the end, and previously attached SAEs are restored to their original state. Default is True.
             use_error_term: (bool | None) If provided, will set the use_error_term attribute of all SAEs attached during this run to this value. Defaults to None.
-            exclude_special_tokens: (bool | list[int]) If True, bypasses the SAE at BOS/EOS/PAD/SEP/CLS positions using the model tokenizer. Pass a list of token IDs to specify custom exclusions. Defaults to False.
+            exclude_special_tokens: (bool | list[int]) If True, bypasses the SAE at special token positions (BOS, EOS, PAD, SEP, decoder-start) using the model tokenizer. Pass a list of token IDs to specify custom exclusions. Defaults to False.
             **model_kwargs: Keyword arguments for the model forward pass
         """
         with self.saes(
@@ -436,7 +440,7 @@ class HookedSAETransformer(HookedTransformer):
             saes: (SAE | list[SAE]) The SAEs to be attached for this forward pass
             reset_saes_end: (bool) If True, all SAEs added during this run are removed at the end, and previously attached SAEs are restored to their original state. Default is True.
             use_error_term: (bool | None) If provided, will set the use_error_term attribute of all SAEs attached during this run to this value. Determines whether the SAE returns input or reconstruction. Defaults to None.
-            exclude_special_tokens: (bool | list[int]) If True, bypasses the SAE at BOS/EOS/PAD/SEP/CLS positions using the model tokenizer. Pass a list of token IDs to specify custom exclusions. Defaults to False.
+            exclude_special_tokens: (bool | list[int]) If True, bypasses the SAE at special token positions (BOS, EOS, PAD, SEP, decoder-start) using the model tokenizer. Pass a list of token IDs to specify custom exclusions. Defaults to False.
             return_cache_object: (bool) if True, this will return an ActivationCache object, with a bunch of
                 useful HookedTransformer specific methods, otherwise it will return a dictionary of
                 activations as in HookedRootModule.
@@ -477,7 +481,7 @@ class HookedSAETransformer(HookedTransformer):
             *model_args: Positional arguments for the model forward pass
             saes: (SAE | list[SAE]) The SAEs to be attached for this forward pass
             reset_saes_end: (bool) If True, all SAEs added during this run are removed at the end, and previously attached SAEs are restored to their original state. (default: True)
-            exclude_special_tokens: (bool | list[int]) If True, bypasses the SAE at BOS/EOS/PAD/SEP/CLS positions using the model tokenizer. Pass a list of token IDs to specify custom exclusions. Defaults to False.
+            exclude_special_tokens: (bool | list[int]) If True, bypasses the SAE at special token positions (BOS, EOS, PAD, SEP, decoder-start) using the model tokenizer. Pass a list of token IDs to specify custom exclusions. Defaults to False.
             fwd_hooks: (list[tuple[str | Callable, Callable]]) List of forward hooks to apply
             bwd_hooks: (list[tuple[str | Callable, Callable]]) List of backward hooks to apply
             reset_hooks_end: (bool) Whether to reset the hooks at the end of the forward pass (default: True)
@@ -519,9 +523,10 @@ class HookedSAETransformer(HookedTransformer):
                 attached SAEs to their original state.
             use_error_term: If provided, will set the use_error_term attribute
                 of all SAEs attached during this run to this value.
-            exclude_special_tokens: If True, bypasses the SAE at BOS/EOS/PAD/SEP/CLS
-                positions using the model tokenizer. Pass a list of token IDs to
-                specify custom exclusions. Defaults to False.
+            exclude_special_tokens: If True, bypasses the SAE at special token
+                positions (BOS, EOS, PAD, SEP, decoder-start) using the model
+                tokenizer. Pass a list of token IDs to specify custom exclusions.
+                Defaults to False.
         """
         saes_to_restore: list[tuple[str, _SAEWrapper | None]] = []
         if isinstance(saes, SAE):

--- a/sae_lens/analysis/hooked_sae_transformer.py
+++ b/sae_lens/analysis/hooked_sae_transformer.py
@@ -359,7 +359,7 @@ class HookedSAETransformer(HookedTransformer):
             mask = mask | (tokens == token_id)
         return mask
 
-    def forward(self, input: Any, **kwargs: Any) -> Any:
+    def forward(self, input: Any, **kwargs: Any) -> Any:  # type: ignore[override]
         """Override to inject token exclusion masks into wrappers before the forward pass."""
         wrappers_needing_mask = [
             w

--- a/sae_lens/analysis/hooked_sae_transformer.py
+++ b/sae_lens/analysis/hooked_sae_transformer.py
@@ -383,7 +383,7 @@ class HookedSAETransformer(HookedTransformer):
                 wrapper.set_token_mask(None)
 
     def forward(self, input: Any, **kwargs: Any) -> Any:  # type: ignore[override]
-        """Override to inject token exclusion masks into wrappers before the forward pass."""
+        # Inject token exclusion masks into wrappers before the forward pass
         with self._token_masks(input, kwargs):
             return super().forward(input, **kwargs)
 

--- a/sae_lens/analysis/hooked_sae_transformer.py
+++ b/sae_lens/analysis/hooked_sae_transformer.py
@@ -36,7 +36,12 @@ class _SAEWrapper(nn.Module):
         computation and needs to call these hooks with the correct values.
     """
 
-    def __init__(self, sae: SAE[Any], use_error_term: bool = False):
+    def __init__(
+        self,
+        sae: SAE[Any],
+        use_error_term: bool = False,
+        exclude_special_tokens: bool | list[int] = False,
+    ):
         super().__init__()
         # Store SAE in __dict__ to avoid registering as submodule. This keeps cache
         # paths clean by avoiding a ".sae." prefix on hook names. See class docstring.
@@ -50,7 +55,9 @@ class _SAEWrapper(nn.Module):
         self.hook_sae_error = HookPoint()
         self.hook_sae_output = HookPoint()
         self.use_error_term = use_error_term
+        self.exclude_special_tokens = exclude_special_tokens
         self._captured_input: torch.Tensor | None = None
+        self._token_mask: torch.Tensor | None = None
 
     @property
     def sae(self) -> SAE[Any]:
@@ -63,6 +70,10 @@ class _SAEWrapper(nn.Module):
         in-place between capture and use, and avoiding clone preserves memory.
         """
         self._captured_input = x
+
+    def set_token_mask(self, mask: torch.Tensor) -> None:
+        """Set a boolean mask [batch, seq] where True = bypass SAE at that position."""
+        self._token_mask = mask
 
     def forward(self, original_output: torch.Tensor) -> torch.Tensor:
         """Run SAE/transcoder at output hook location."""
@@ -89,9 +100,18 @@ class _SAEWrapper(nn.Module):
                     sae_error = self.hook_sae_error(original_output - sae_out_clean)
                 sae_out = sae_out + sae_error
 
+            # Restore original activations at excluded token positions before firing
+            # hook_sae_output, so the cache reflects what actually flows forward.
+            if self._token_mask is not None:
+                mask = self._token_mask
+                for _ in range(sae_out.dim() - mask.dim()):
+                    mask = mask.unsqueeze(-1)
+                sae_out = torch.where(mask.expand_as(sae_out), original_output, sae_out)
+
             return self.hook_sae_output(sae_out)
         finally:
             self._captured_input = None
+            self._token_mask = None
 
 
 def get_deep_attr(obj: Any, path: str):
@@ -166,7 +186,12 @@ class HookedSAETransformer(HookedTransformer):
         """Returns a dict mapping hook names to attached SAEs."""
         return {name: wrapper.sae for name, wrapper in self._acts_to_saes.items()}
 
-    def add_sae(self, sae: SAE[Any], use_error_term: bool | None = None):
+    def add_sae(
+        self,
+        sae: SAE[Any],
+        use_error_term: bool | None = None,
+        exclude_special_tokens: bool | list[int] = False,
+    ):
         """Attaches an SAE or Transcoder to the model.
 
         WARNING: This SAE will be permanently attached until you remove it with
@@ -179,6 +204,10 @@ class HookedSAETransformer(HookedTransformer):
                 model would have produced without the SAE. This works for both SAEs
                 (where input==output hook) and transcoders (where they differ).
                 Defaults to None (uses SAE's existing setting).
+            exclude_special_tokens: If True, special tokens (BOS, EOS, PAD, SEP, CLS)
+                are identified from the model tokenizer and the SAE is bypassed at those
+                positions. Pass a list of token IDs to specify custom tokens to exclude.
+                Defaults to False (SAE applied at all positions).
         """
         input_hook = sae.cfg.metadata.hook_name
         output_hook = sae.cfg.metadata.hook_name_out or input_hook
@@ -206,7 +235,11 @@ class HookedSAETransformer(HookedTransformer):
         effective_use_error_term = (
             use_error_term if use_error_term is not None else sae.use_error_term
         )
-        wrapper = _SAEWrapper(sae, use_error_term=effective_use_error_term)
+        wrapper = _SAEWrapper(
+            sae,
+            use_error_term=effective_use_error_term,
+            exclude_special_tokens=exclude_special_tokens,
+        )
 
         # For transcoders (input != output), capture input at input hook
         if input_hook != output_hook:
@@ -259,7 +292,11 @@ class HookedSAETransformer(HookedTransformer):
         if prev_wrapper is not None:
             # Rebuild hook_dict before adding new SAE
             self.setup()
-            self.add_sae(prev_wrapper.sae, use_error_term=prev_wrapper.use_error_term)
+            self.add_sae(
+                prev_wrapper.sae,
+                use_error_term=prev_wrapper.use_error_term,
+                exclude_special_tokens=prev_wrapper.exclude_special_tokens,
+            )
 
     def reset_saes(
         self,
@@ -284,12 +321,65 @@ class HookedSAETransformer(HookedTransformer):
 
         self.setup()
 
+    def _get_special_token_ids(self) -> list[int]:
+        """Return BOS, EOS, PAD, SEP, and CLS token IDs from the model tokenizer."""
+        if self.tokenizer is None:
+            logger.warning(
+                "exclude_special_tokens=True but no tokenizer is attached to the model. "
+                "Pass a list of token IDs to exclude_special_tokens instead."
+            )
+            return []
+        ids = []
+        for attr in ("bos_token_id", "eos_token_id", "pad_token_id", "sep_token_id", "cls_token_id"):
+            token_id = getattr(self.tokenizer, attr, None)
+            if token_id is not None:
+                ids.append(int(token_id))
+        return list(set(ids))
+
+    def _compute_exclusion_mask(
+        self,
+        tokens: torch.Tensor,
+        exclude_special_tokens: bool | list[int],
+    ) -> torch.Tensor:
+        """Build a boolean mask [batch, seq] where True = bypass the SAE at that position."""
+        if isinstance(exclude_special_tokens, list):
+            token_ids = exclude_special_tokens
+        else:
+            token_ids = self._get_special_token_ids()
+
+        mask = torch.zeros(tokens.shape, dtype=torch.bool, device=tokens.device)
+        for token_id in token_ids:
+            mask = mask | (tokens == token_id)
+        return mask
+
+    def forward(self, input: Any, **kwargs: Any) -> Any:
+        """Override to inject token exclusion masks into wrappers before the forward pass."""
+        wrappers_needing_mask = [
+            w for w in self._acts_to_saes.values()
+            if w.exclude_special_tokens is not False
+        ]
+        if wrappers_needing_mask:
+            prepend_bos = kwargs.get("prepend_bos", None)
+            padding_side = kwargs.get("padding_side", None)
+            tokens = self.to_tokens(
+                input,
+                prepend_bos=prepend_bos,
+                padding_side=padding_side,
+                move_to_device=True,
+                truncate=True,
+            )
+            for wrapper in wrappers_needing_mask:
+                mask = self._compute_exclusion_mask(tokens, wrapper.exclude_special_tokens)
+                wrapper.set_token_mask(mask)
+        return super().forward(input, **kwargs)
+
     def run_with_saes(
         self,
         *model_args: Any,
         saes: SAE[Any] | list[SAE[Any]] = [],
         reset_saes_end: bool = True,
         use_error_term: bool | None = None,
+        exclude_special_tokens: bool | list[int] = False,
         **model_kwargs: Any,
     ) -> None | torch.Tensor | Loss | tuple[torch.Tensor, Loss]:
         """Wrapper around HookedTransformer forward pass.
@@ -301,10 +391,14 @@ class HookedSAETransformer(HookedTransformer):
             saes: (SAE | list[SAE]) The SAEs to be attached for this forward pass
             reset_saes_end (bool): If True, all SAEs added during this run are removed at the end, and previously attached SAEs are restored to their original state. Default is True.
             use_error_term: (bool | None) If provided, will set the use_error_term attribute of all SAEs attached during this run to this value. Defaults to None.
+            exclude_special_tokens: (bool | list[int]) If True, bypasses the SAE at BOS/EOS/PAD/SEP/CLS positions using the model tokenizer. Pass a list of token IDs to specify custom exclusions. Defaults to False.
             **model_kwargs: Keyword arguments for the model forward pass
         """
         with self.saes(
-            saes=saes, reset_saes_end=reset_saes_end, use_error_term=use_error_term
+            saes=saes,
+            reset_saes_end=reset_saes_end,
+            use_error_term=use_error_term,
+            exclude_special_tokens=exclude_special_tokens,
         ):
             return self(*model_args, **model_kwargs)
 
@@ -314,6 +408,7 @@ class HookedSAETransformer(HookedTransformer):
         saes: SAE[Any] | list[SAE[Any]] = [],
         reset_saes_end: bool = True,
         use_error_term: bool | None = None,
+        exclude_special_tokens: bool | list[int] = False,
         return_cache_object: bool = True,
         remove_batch_dim: bool = False,
         **kwargs: Any,
@@ -331,6 +426,7 @@ class HookedSAETransformer(HookedTransformer):
             saes: (SAE | list[SAE]) The SAEs to be attached for this forward pass
             reset_saes_end: (bool) If True, all SAEs added during this run are removed at the end, and previously attached SAEs are restored to their original state. Default is True.
             use_error_term: (bool | None) If provided, will set the use_error_term attribute of all SAEs attached during this run to this value. Determines whether the SAE returns input or reconstruction. Defaults to None.
+            exclude_special_tokens: (bool | list[int]) If True, bypasses the SAE at BOS/EOS/PAD/SEP/CLS positions using the model tokenizer. Pass a list of token IDs to specify custom exclusions. Defaults to False.
             return_cache_object: (bool) if True, this will return an ActivationCache object, with a bunch of
                 useful HookedTransformer specific methods, otherwise it will return a dictionary of
                 activations as in HookedRootModule.
@@ -338,7 +434,10 @@ class HookedSAETransformer(HookedTransformer):
             **kwargs: Keyword arguments for the model forward pass
         """
         with self.saes(
-            saes=saes, reset_saes_end=reset_saes_end, use_error_term=use_error_term
+            saes=saes,
+            reset_saes_end=reset_saes_end,
+            use_error_term=use_error_term,
+            exclude_special_tokens=exclude_special_tokens,
         ):
             return self.run_with_cache(  # type: ignore
                 *model_args,
@@ -352,6 +451,7 @@ class HookedSAETransformer(HookedTransformer):
         *model_args: Any,
         saes: SAE[Any] | list[SAE[Any]] = [],
         reset_saes_end: bool = True,
+        exclude_special_tokens: bool | list[int] = False,
         fwd_hooks: list[tuple[str | Callable, Callable]] = [],  # type: ignore
         bwd_hooks: list[tuple[str | Callable, Callable]] = [],  # type: ignore
         reset_hooks_end: bool = True,
@@ -367,13 +467,14 @@ class HookedSAETransformer(HookedTransformer):
             *model_args: Positional arguments for the model forward pass
             saes: (SAE | list[SAE]) The SAEs to be attached for this forward pass
             reset_saes_end: (bool) If True, all SAEs added during this run are removed at the end, and previously attached SAEs are restored to their original state. (default: True)
+            exclude_special_tokens: (bool | list[int]) If True, bypasses the SAE at BOS/EOS/PAD/SEP/CLS positions using the model tokenizer. Pass a list of token IDs to specify custom exclusions. Defaults to False.
             fwd_hooks: (list[tuple[str | Callable, Callable]]) List of forward hooks to apply
             bwd_hooks: (list[tuple[str | Callable, Callable]]) List of backward hooks to apply
             reset_hooks_end: (bool) Whether to reset the hooks at the end of the forward pass (default: True)
             clear_contexts: (bool) Whether to clear the contexts at the end of the forward pass (default: False)
             **model_kwargs: Keyword arguments for the model forward pass
         """
-        with self.saes(saes=saes, reset_saes_end=reset_saes_end):
+        with self.saes(saes=saes, reset_saes_end=reset_saes_end, exclude_special_tokens=exclude_special_tokens):
             return self.run_with_hooks(
                 *model_args,
                 fwd_hooks=fwd_hooks,
@@ -389,6 +490,7 @@ class HookedSAETransformer(HookedTransformer):
         saes: SAE[Any] | list[SAE[Any]] = [],
         reset_saes_end: bool = True,
         use_error_term: bool | None = None,
+        exclude_special_tokens: bool | list[int] = False,
     ):
         """A context manager for adding temporary SAEs to the model.
 
@@ -403,6 +505,9 @@ class HookedSAETransformer(HookedTransformer):
                 attached SAEs to their original state.
             use_error_term: If provided, will set the use_error_term attribute
                 of all SAEs attached during this run to this value.
+            exclude_special_tokens: If True, bypasses the SAE at BOS/EOS/PAD/SEP/CLS
+                positions using the model tokenizer. Pass a list of token IDs to
+                specify custom exclusions. Defaults to False.
         """
         saes_to_restore: list[tuple[str, _SAEWrapper | None]] = []
         if isinstance(saes, SAE):
@@ -412,7 +517,11 @@ class HookedSAETransformer(HookedTransformer):
                 act_name = sae.cfg.metadata.hook_name
                 prev_wrapper = self._acts_to_saes.get(act_name, None)
                 saes_to_restore.append((act_name, prev_wrapper))
-                self.add_sae(sae, use_error_term=use_error_term)
+                self.add_sae(
+                    sae,
+                    use_error_term=use_error_term,
+                    exclude_special_tokens=exclude_special_tokens,
+                )
             yield self
         finally:
             if reset_saes_end:

--- a/sae_lens/analysis/hooked_sae_transformer.py
+++ b/sae_lens/analysis/hooked_sae_transformer.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from contextlib import contextmanager
-from typing import Any, Callable
+from typing import Any
 
 import torch
 from torch import nn
@@ -330,7 +331,13 @@ class HookedSAETransformer(HookedTransformer):
             )
             return []
         ids = []
-        for attr in ("bos_token_id", "eos_token_id", "pad_token_id", "sep_token_id", "cls_token_id"):
+        for attr in (
+            "bos_token_id",
+            "eos_token_id",
+            "pad_token_id",
+            "sep_token_id",
+            "cls_token_id",
+        ):
             token_id = getattr(self.tokenizer, attr, None)
             if token_id is not None:
                 ids.append(int(token_id))
@@ -355,12 +362,13 @@ class HookedSAETransformer(HookedTransformer):
     def forward(self, input: Any, **kwargs: Any) -> Any:
         """Override to inject token exclusion masks into wrappers before the forward pass."""
         wrappers_needing_mask = [
-            w for w in self._acts_to_saes.values()
+            w
+            for w in self._acts_to_saes.values()
             if w.exclude_special_tokens is not False
         ]
         if wrappers_needing_mask:
-            prepend_bos = kwargs.get("prepend_bos", None)
-            padding_side = kwargs.get("padding_side", None)
+            prepend_bos = kwargs.get("prepend_bos")
+            padding_side = kwargs.get("padding_side")
             tokens = self.to_tokens(
                 input,
                 prepend_bos=prepend_bos,
@@ -369,7 +377,9 @@ class HookedSAETransformer(HookedTransformer):
                 truncate=True,
             )
             for wrapper in wrappers_needing_mask:
-                mask = self._compute_exclusion_mask(tokens, wrapper.exclude_special_tokens)
+                mask = self._compute_exclusion_mask(
+                    tokens, wrapper.exclude_special_tokens
+                )
                 wrapper.set_token_mask(mask)
         return super().forward(input, **kwargs)
 
@@ -474,7 +484,11 @@ class HookedSAETransformer(HookedTransformer):
             clear_contexts: (bool) Whether to clear the contexts at the end of the forward pass (default: False)
             **model_kwargs: Keyword arguments for the model forward pass
         """
-        with self.saes(saes=saes, reset_saes_end=reset_saes_end, exclude_special_tokens=exclude_special_tokens):
+        with self.saes(
+            saes=saes,
+            reset_saes_end=reset_saes_end,
+            exclude_special_tokens=exclude_special_tokens,
+        ):
             return self.run_with_hooks(
                 *model_args,
                 fwd_hooks=fwd_hooks,

--- a/tests/analysis/test_hooked_sae_transformer.py
+++ b/tests/analysis/test_hooked_sae_transformer.py
@@ -1122,3 +1122,190 @@ def test_error_term_unchanged_when_latents_ablated():
 
     # Verify outputs changed (ablation had an effect on reconstruction)
     assert not torch.allclose(output_ablated, output_baseline, atol=1e-5)
+
+
+# ============================================================================
+# exclude_special_tokens Tests
+# ============================================================================
+
+
+def test_exclude_special_tokens_stored_on_wrapper(
+    model: HookedSAETransformer, hooked_sae: SAE
+):
+    act_name = hooked_sae.cfg.metadata.hook_name
+
+    model.add_sae(hooked_sae, exclude_special_tokens=True)
+    wrapper = get_deep_attr(model, act_name)
+    assert isinstance(wrapper, _SAEWrapper)
+    assert wrapper.exclude_special_tokens is True
+    model.reset_saes()
+
+    model.add_sae(hooked_sae, exclude_special_tokens=[1, 2, 3])
+    wrapper = get_deep_attr(model, act_name)
+    assert wrapper.exclude_special_tokens == [1, 2, 3]
+    model.reset_saes()
+
+    model.add_sae(hooked_sae, exclude_special_tokens=False)
+    wrapper = get_deep_attr(model, act_name)
+    assert wrapper.exclude_special_tokens is False
+    model.reset_saes()
+
+
+def test_exclude_special_tokens_context_manager_stores_setting(
+    model: HookedSAETransformer, hooked_sae: SAE
+):
+    act_name = hooked_sae.cfg.metadata.hook_name
+    with model.saes(saes=[hooked_sae], exclude_special_tokens=True):
+        wrapper = get_deep_attr(model, act_name)
+        assert isinstance(wrapper, _SAEWrapper)
+        assert wrapper.exclude_special_tokens is True
+    assert len(model._acts_to_saes) == 0
+
+
+def test_exclude_special_tokens_bypasses_bos_position(
+    model: HookedSAETransformer, hooked_sae: SAE
+):
+    act_name = hooked_sae.cfg.metadata.hook_name
+
+    _, cache_no_sae = model.run_with_cache(prompt, prepend_bos=True)
+    _, cache_with_exclusion = model.run_with_cache_with_saes(
+        prompt,
+        saes=[hooked_sae],
+        use_error_term=False,
+        exclude_special_tokens=True,
+        prepend_bos=True,
+    )
+
+    # hook_sae_output at BOS (position 0) must equal the original activation
+    # because BOS is excluded and the wrapper restores original_output there
+    sae_out_at_bos = cache_with_exclusion[act_name + ".hook_sae_output"][:, 0, ...]
+    original_at_bos = cache_no_sae[act_name][:, 0, ...]
+    assert_close(sae_out_at_bos, original_at_bos, atol=1e-5)
+
+
+def test_exclude_special_tokens_false_applies_sae_at_bos(
+    model: HookedSAETransformer, hooked_sae: SAE
+):
+    act_name = hooked_sae.cfg.metadata.hook_name
+
+    _, cache_no_sae = model.run_with_cache(prompt, prepend_bos=True)
+    _, cache_with_sae = model.run_with_cache_with_saes(
+        prompt,
+        saes=[hooked_sae],
+        use_error_term=False,
+        exclude_special_tokens=False,
+        prepend_bos=True,
+    )
+
+    # With no exclusion, BOS position is also reconstructed by the SAE
+    sae_out_at_bos = cache_with_sae[act_name + ".hook_sae_output"][:, 0, ...]
+    original_at_bos = cache_no_sae[act_name][:, 0, ...]
+    assert_not_close(sae_out_at_bos, original_at_bos)
+
+
+def test_exclude_specific_token_ids_bypasses_those_positions(
+    model: HookedSAETransformer, hooked_sae: SAE
+):
+    act_name = hooked_sae.cfg.metadata.hook_name
+
+    tokens = model.to_tokens(prompt, prepend_bos=True)
+    target_token_id = int(tokens[0, 1].item())
+
+    _, cache_no_sae = model.run_with_cache(prompt, prepend_bos=True)
+    _, cache_with_exclusion = model.run_with_cache_with_saes(
+        prompt,
+        saes=[hooked_sae],
+        use_error_term=False,
+        exclude_special_tokens=[target_token_id],
+        prepend_bos=True,
+    )
+
+    # Position 1 has the excluded token — must match original
+    assert_close(
+        cache_with_exclusion[act_name + ".hook_sae_output"][:, 1, ...],
+        cache_no_sae[act_name][:, 1, ...],
+        atol=1e-5,
+    )
+
+
+def test_exclude_special_tokens_run_with_saes(
+    model: HookedSAETransformer, hooked_sae: SAE
+):
+    logits = model.run_with_saes(
+        prompt, saes=[hooked_sae], use_error_term=True, exclude_special_tokens=True
+    )
+    assert logits is not None
+    assert len(model._acts_to_saes) == 0
+
+
+def test_exclude_special_tokens_run_with_cache_with_saes(
+    model: HookedSAETransformer, hooked_sae: SAE
+):
+    logits, cache = model.run_with_cache_with_saes(
+        prompt, saes=[hooked_sae], use_error_term=True, exclude_special_tokens=True
+    )
+    assert logits is not None
+    act_name = hooked_sae.cfg.metadata.hook_name
+    assert act_name + ".hook_sae_acts_post" in cache
+    assert len(model._acts_to_saes) == 0
+
+
+def test_exclude_special_tokens_run_with_hooks_with_saes(
+    model: HookedSAETransformer, hooked_sae: SAE
+):
+    c = Counter()
+    act_name = hooked_sae.cfg.metadata.hook_name
+    logits = model.run_with_hooks_with_saes(
+        prompt,
+        saes=[hooked_sae],
+        fwd_hooks=[(act_name + ".hook_sae_acts_post", c.inc)],
+        exclude_special_tokens=True,
+    )
+    assert logits is not None
+    assert c.count == 1
+    assert len(model._acts_to_saes) == 0
+
+
+def test_exclude_special_tokens_restored_after_context_exit(
+    model: HookedSAETransformer, hooked_sae: SAE
+):
+    act_name = hooked_sae.cfg.metadata.hook_name
+
+    model.add_sae(hooked_sae, exclude_special_tokens=True)
+    assert model._acts_to_saes[act_name].exclude_special_tokens is True
+
+    second_sae = SAE.from_dict(hooked_sae.cfg.to_dict())  # type: ignore
+    with model.saes(saes=[second_sae], exclude_special_tokens=False):
+        assert model._acts_to_saes[act_name].exclude_special_tokens is False
+
+    # Original wrapper (exclude_special_tokens=True) should be restored
+    assert model._acts_to_saes[act_name].exclude_special_tokens is True
+    model.reset_saes()
+
+
+def test_exclude_special_tokens_empty_list_applies_sae_everywhere(
+    model: HookedSAETransformer, hooked_sae: SAE
+):
+    act_name = hooked_sae.cfg.metadata.hook_name
+
+    _, cache_empty_exclude = model.run_with_cache_with_saes(
+        prompt,
+        saes=[hooked_sae],
+        use_error_term=False,
+        exclude_special_tokens=[],
+        prepend_bos=True,
+    )
+    _, cache_no_exclude = model.run_with_cache_with_saes(
+        prompt,
+        saes=[hooked_sae],
+        use_error_term=False,
+        exclude_special_tokens=False,
+        prepend_bos=True,
+    )
+
+    # Both empty-list and False should produce identical SAE outputs
+    assert_close(
+        cache_empty_exclude[act_name + ".hook_sae_output"],
+        cache_no_exclude[act_name + ".hook_sae_output"],
+        atol=1e-6,
+    )

--- a/tests/analysis/test_hooked_sae_transformer.py
+++ b/tests/analysis/test_hooked_sae_transformer.py
@@ -1309,3 +1309,78 @@ def test_exclude_special_tokens_empty_list_applies_sae_everywhere(
         cache_no_exclude[act_name + ".hook_sae_output"],
         atol=1e-6,
     )
+
+
+def test_exclude_special_tokens_zeroes_sae_error_at_excluded_positions(
+    model: HookedSAETransformer, hooked_sae: SAE
+):
+    act_name = hooked_sae.cfg.metadata.hook_name
+
+    _, cache = model.run_with_cache_with_saes(
+        prompt,
+        saes=[hooked_sae],
+        use_error_term=True,
+        exclude_special_tokens=True,
+        prepend_bos=True,
+    )
+
+    error = cache[act_name + ".hook_sae_error"]
+    # BOS (position 0) is excluded, so it has no SAE error
+    assert torch.all(error[:, 0, ...] == 0)
+    # Non-excluded positions still have a real error term
+    assert error[:, 1:, ...].abs().sum() > 0
+
+
+def test_exclude_special_tokens_mask_cleared_after_forward(
+    model: HookedSAETransformer, hooked_sae: SAE
+):
+    act_name = hooked_sae.cfg.metadata.hook_name
+    model.add_sae(hooked_sae, exclude_special_tokens=True)
+    wrapper = model._acts_to_saes[act_name]
+
+    model(prompt)
+
+    assert wrapper._token_mask is None
+    model.reset_saes()
+
+
+def test_exclude_special_tokens_mask_cleared_when_forward_raises(
+    model: HookedSAETransformer, hooked_sae: SAE
+):
+    act_name = hooked_sae.cfg.metadata.hook_name
+    model.add_sae(hooked_sae, exclude_special_tokens=True)
+    wrapper = model._acts_to_saes[act_name]
+
+    def raise_error(tensor: torch.Tensor, hook: HookPoint) -> torch.Tensor:  # noqa: ARG001
+        raise RuntimeError("boom")
+
+    # hook_embed fires before any SAE wrapper, so the wrapper never runs and
+    # only the context manager can clean up the mask
+    with pytest.raises(RuntimeError, match="boom"):
+        model.run_with_hooks(prompt, fwd_hooks=[("hook_embed", raise_error)])
+
+    assert wrapper._token_mask is None
+    model.reset_saes()
+
+
+def test_exclude_special_tokens_with_token_tensor_input(
+    model: HookedSAETransformer, hooked_sae: SAE
+):
+    act_name = hooked_sae.cfg.metadata.hook_name
+    tokens = model.to_tokens(prompt, prepend_bos=True)
+
+    _, cache_no_sae = model.run_with_cache(tokens)
+    _, cache_with_exclusion = model.run_with_cache_with_saes(
+        tokens,
+        saes=[hooked_sae],
+        use_error_term=False,
+        exclude_special_tokens=True,
+    )
+
+    # BOS position must match the original activation even when the input is
+    # already a token tensor rather than a string
+    assert_close(
+        cache_with_exclusion[act_name + ".hook_sae_output"][:, 0, ...],
+        cache_no_sae[act_name][:, 0, ...],
+        atol=1e-5,
+    )


### PR DESCRIPTION
## Summary

- Adds `exclude_special_tokens: bool | list[int] = False` to `add_sae()`, `run_with_saes()`, `run_with_cache_with_saes()`, `run_with_hooks_with_saes()`, and the `saes()` context manager
- When `True`, bypasses SAE processing at BOS/EOS/PAD/SEP/CLS positions using token IDs from the model tokenizer; pass a list of ints for custom token IDs
- Excluded positions return the original activation unchanged
- `exclude_special_tokens` is preserved when `saes()` context manager restores a prior wrapper

## Implementation

`_SAEWrapper` stores a `_token_mask` set per-forward-pass via a `HookedSAETransformer.forward()` override, consumed in `_SAEWrapper.forward()` via `torch.where`. Propagates through all public entry points and preserved across context manager nesting.

All 145 existing tests continue to pass + 10 new tests added.

Closes #350