### PR TITLE
Document fine tuning existing SAEs

### DIFF
--- a/docs/training_saes.md
+++ b/docs/training_saes.md
@@ -111,6 +111,84 @@ sparse_autoencoder.save_inference_model("path/to/save/dir")
 
 As you can see, the training setup provides a large number of options to explore. The full list of options can be found by inspecting the `LanguageModelSAERunnerConfig` class and the specific SAE configuration class you intend to use (e.g., `StandardTrainingSAEConfig`, `TopKTrainingSAEConfig`, etc.).
 
+## Fine tuning an existing SAE
+
+SAELens supports two different ways to load prior training outputs, depending on
+whether you want a new fine-tuning run or an exact continuation of an existing
+run.
+
+Use `from_pretrained_path` when you want to initialize a new training run from a
+saved training SAE. The path should point to a directory that can be loaded by
+`TrainingSAE.load_from_disk`, such as a directory containing `cfg.json` and
+`sae_weights.safetensors`. The runner loads the SAE weights and SAE config from
+disk, then creates a fresh activation store, optimizer, scheduler, and trainer
+state from the current `LanguageModelSAERunnerConfig`. The nested `sae` field is
+still required when you build `LanguageModelSAERunnerConfig`, so keep it
+consistent with the saved SAE.
+
+```python
+from sae_lens import (
+    LanguageModelSAERunnerConfig,
+    LanguageModelSAETrainingRunner,
+    LoggingConfig,
+    StandardTrainingSAEConfig,
+)
+
+cfg = LanguageModelSAERunnerConfig(
+    model_name="tiny-stories-1L-21M",
+    hook_name="blocks.0.hook_mlp_out",
+    dataset_path="apollo-research/roneneldan-TinyStories-tokenizer-gpt2",
+    is_dataset_tokenized=True,
+    streaming=True,
+    sae=StandardTrainingSAEConfig(
+        d_in=1024,
+        d_sae=16 * 1024,
+        apply_b_dec_to_input=True,
+        normalize_activations="expected_average_only_in",
+        l1_coefficient=5,
+    ),
+    from_pretrained_path="path/to/existing/training_sae",
+    training_tokens=50_000_000,
+    train_batch_size_tokens=4096,
+    logger=LoggingConfig(log_to_wandb=False),
+    device=device,
+)
+
+fine_tuned_sae = LanguageModelSAETrainingRunner(cfg).run()
+fine_tuned_sae.save_inference_model("path/to/fine_tuned_sae")
+```
+
+Use `resume_from_checkpoint` when you want to continue the same training run.
+The checkpoint directory should contain `sae_weights.safetensors`,
+`trainer_state.pt`, and `activations_store_state.safetensors`. This restores the
+SAE weights, optimizer state, scheduler state, activation store progress, and
+training counters.
+
+```python
+cfg = LanguageModelSAERunnerConfig(
+    model_name="tiny-stories-1L-21M",
+    hook_name="blocks.0.hook_mlp_out",
+    dataset_path="apollo-research/roneneldan-TinyStories-tokenizer-gpt2",
+    is_dataset_tokenized=True,
+    streaming=True,
+    sae=StandardTrainingSAEConfig(
+        d_in=1024,
+        d_sae=16 * 1024,
+        apply_b_dec_to_input=True,
+        normalize_activations="expected_average_only_in",
+        l1_coefficient=5,
+    ),
+    checkpoint_path="checkpoints",
+    resume_from_checkpoint="checkpoints/run_id/final_100000000",
+    training_tokens=150_000_000,
+    train_batch_size_tokens=4096,
+    logger=LoggingConfig(log_to_wandb=False),
+    device=device,
+)
+
+resumed_sae = LanguageModelSAETrainingRunner(cfg).run()
+```
+
 ### Training BatchTopk SAEs
 
 <!-- prettier-ignore-start -->

--- a/docs/training_saes.md
+++ b/docs/training_saes.md
@@ -111,84 +111,6 @@ sparse_autoencoder.save_inference_model("path/to/save/dir")
 
 As you can see, the training setup provides a large number of options to explore. The full list of options can be found by inspecting the `LanguageModelSAERunnerConfig` class and the specific SAE configuration class you intend to use (e.g., `StandardTrainingSAEConfig`, `TopKTrainingSAEConfig`, etc.).
 
-## Fine tuning an existing SAE
-
-SAELens supports two different ways to load prior training outputs, depending on
-whether you want a new fine-tuning run or an exact continuation of an existing
-run.
-
-Use `from_pretrained_path` when you want to initialize a new training run from a
-saved training SAE. The path should point to a directory that can be loaded by
-`TrainingSAE.load_from_disk`, such as a directory containing `cfg.json` and
-`sae_weights.safetensors`. The runner loads the SAE weights and SAE config from
-disk, then creates a fresh activation store, optimizer, scheduler, and trainer
-state from the current `LanguageModelSAERunnerConfig`. The nested `sae` field is
-still required when you build `LanguageModelSAERunnerConfig`, so keep it
-consistent with the saved SAE.
-
-```python
-from sae_lens import (
-    LanguageModelSAERunnerConfig,
-    LanguageModelSAETrainingRunner,
-    LoggingConfig,
-    StandardTrainingSAEConfig,
-)
-
-cfg = LanguageModelSAERunnerConfig(
-    model_name="tiny-stories-1L-21M",
-    hook_name="blocks.0.hook_mlp_out",
-    dataset_path="apollo-research/roneneldan-TinyStories-tokenizer-gpt2",
-    is_dataset_tokenized=True,
-    streaming=True,
-    sae=StandardTrainingSAEConfig(
-        d_in=1024,
-        d_sae=16 * 1024,
-        apply_b_dec_to_input=True,
-        normalize_activations="expected_average_only_in",
-        l1_coefficient=5,
-    ),
-    from_pretrained_path="path/to/existing/training_sae",
-    training_tokens=50_000_000,
-    train_batch_size_tokens=4096,
-    logger=LoggingConfig(log_to_wandb=False),
-    device=device,
-)
-
-fine_tuned_sae = LanguageModelSAETrainingRunner(cfg).run()
-fine_tuned_sae.save_inference_model("path/to/fine_tuned_sae")
-```
-
-Use `resume_from_checkpoint` when you want to continue the same training run.
-The checkpoint directory should contain `sae_weights.safetensors`,
-`trainer_state.pt`, and `activations_store_state.safetensors`. This restores the
-SAE weights, optimizer state, scheduler state, activation store progress, and
-training counters.
-
-```python
-cfg = LanguageModelSAERunnerConfig(
-    model_name="tiny-stories-1L-21M",
-    hook_name="blocks.0.hook_mlp_out",
-    dataset_path="apollo-research/roneneldan-TinyStories-tokenizer-gpt2",
-    is_dataset_tokenized=True,
-    streaming=True,
-    sae=StandardTrainingSAEConfig(
-        d_in=1024,
-        d_sae=16 * 1024,
-        apply_b_dec_to_input=True,
-        normalize_activations="expected_average_only_in",
-        l1_coefficient=5,
-    ),
-    checkpoint_path="checkpoints",
-    resume_from_checkpoint="checkpoints/run_id/final_100000000",
-    training_tokens=150_000_000,
-    train_batch_size_tokens=4096,
-    logger=LoggingConfig(log_to_wandb=False),
-    device=device,
-)
-
-resumed_sae = LanguageModelSAETrainingRunner(cfg).run()
-```
-
 ### Training BatchTopk SAEs
 
 <!-- prettier-ignore-start -->
@@ -437,6 +359,57 @@ cfg = LanguageModelSAERunnerConfig( # Full config would be defined here
 sparse_autoencoder = LanguageModelSAETrainingRunner(cfg).run()
 ```
 
+## Fine-tuning an existing SAE
+
+Use `from_pretrained_path` to initialize a new training run from a saved
+training SAE. The path should point to a directory that can be loaded by
+`TrainingSAE.load_from_disk`, such as a directory containing `cfg.json` and
+`sae_weights.safetensors`. The runner loads the SAE weights and SAE config from
+disk, then creates a fresh activation store, optimizer, scheduler, and trainer
+state from the current `LanguageModelSAERunnerConfig`. The nested `sae` field is
+still required when you build `LanguageModelSAERunnerConfig`, so keep it
+consistent with the saved SAE.
+
+```python
+import torch
+
+from sae_lens import (
+    LanguageModelSAERunnerConfig,
+    LanguageModelSAETrainingRunner,
+    LoggingConfig,
+    StandardTrainingSAEConfig,
+)
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
+cfg = LanguageModelSAERunnerConfig(
+    model_name="tiny-stories-1L-21M",
+    hook_name="blocks.0.hook_mlp_out",
+    dataset_path="apollo-research/roneneldan-TinyStories-tokenizer-gpt2",
+    is_dataset_tokenized=True,
+    streaming=True,
+    sae=StandardTrainingSAEConfig(
+        d_in=1024,
+        d_sae=16 * 1024,
+        apply_b_dec_to_input=True,
+        normalize_activations="expected_average_only_in",
+        l1_coefficient=5,
+    ),
+    from_pretrained_path="path/to/existing/training_sae",
+    training_tokens=50_000_000,
+    train_batch_size_tokens=4096,
+    logger=LoggingConfig(log_to_wandb=False),
+    device=device,
+)
+
+fine_tuned_sae = LanguageModelSAETrainingRunner(cfg).run()
+fine_tuned_sae.save_inference_model("path/to/fine_tuned_sae")
+```
+
+Note that `from_pretrained_path` starts a brand new training run from the saved
+weights. To continue an existing run exactly where it left off, use
+`resume_from_checkpoint` instead — see [Checkpoints](#checkpoints).
+
 ## Training multiple SAEs in parallel (experimental)
 
 <!-- prettier-ignore-start -->
@@ -534,18 +507,22 @@ Some general performance tips:
 
 Checkpoints allow you to save a snapshot of the SAE and sparsitity statistics during training. To enable checkpointing, set `n_checkpoints` to a value larger than 0. If WandB logging is enabled, checkpoints will be uploaded as WandB artifacts. To save checkpoints locally, the `checkpoint_path` parameter can be set to a local directory. You can also set `save_final_checkpoint=True` to save a final checkpoint after training is finished.
 
-To resume training from a saved checkpoint, set `resume_from_checkpoint` to the path of the checkpoint when creating a `LanguageModelSAETrainingRunner`, or set `--resume_from_checkpoint` when running the CLI.
+To resume training from a saved checkpoint, set `resume_from_checkpoint` to the path of the checkpoint when creating a `LanguageModelSAETrainingRunner`, or set `--resume_from_checkpoint` when running the CLI. This restores the SAE weights, optimizer state, scheduler state, activation store progress, and training counters, so the run continues exactly where it left off.
+
+Checkpoint directories are saved under `checkpoint_path` as `<checkpoint_path>/<run_id>/<checkpoint_name>`, and contain `sae_weights.safetensors`, `trainer_state.pt`, `activations_store_state.safetensors`, and `activation_scaler.json`, all of which are required to resume.
 
 ```python
 
 cfg = LanguageModelSAERunnerConfig(
     # ... other LanguageModelSAERunnerConfig parameters ...
-    resume_from_checkpoint="path/to/checkpoint"
+    resume_from_checkpoint="checkpoints/run_id/final_100000000"
 )
 runner = LanguageModelSAETrainingRunner(cfg)
 runner.run()
 
 ```
+
+To instead start a fresh fine-tuning run from saved SAE weights, use `from_pretrained_path` — see [Fine-tuning an existing SAE](#fine-tuning-an-existing-sae).
 
 ## Optimizers and Schedulers
 


### PR DESCRIPTION
Summary
- Document from_pretrained_path for starting a fresh run from saved training SAE weights
- Document resume_from_checkpoint for exact continuation with trainer and activation store state
- Include expected checkpoint files and minimal examples

Verification
- /Users/joyyang/Projects/open-source/.venv/saelens/bin/python -m pytest tests/test_util.py -q
- Markdown code fence count is balanced

Addresses #426