### PR TITLE
Fix explained_variance to measure variance relative to the mean (#659)

### DIFF
--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -381,6 +381,32 @@ def get_downstream_reconstruction_metrics(
     return metrics
 
 
+def _compute_explained_variance(
+    mean_sum_of_squares: list[torch.Tensor],
+    mean_act_per_dimension: list[torch.Tensor],
+    mean_sum_of_resid_squared: list[torch.Tensor],
+) -> float:
+    """Explained variance of the SAE reconstruction, relative to the per-dimension mean.
+
+    Uses the multi-dimensional identity ``Var(X) = E[X^2] - E[X]^2``::
+
+        total_variance = sum_d (E[x_d^2] - E[x_d]^2)
+        explained_variance = 1 - residual_variance / total_variance
+
+    Each argument holds one entry per eval batch (already reduced over the batch
+    dimension): ``mean_sum_of_squares[i]`` is the scalar ``sum_d E[x_d^2]``,
+    ``mean_act_per_dimension[i]`` is the ``[d_model]`` per-dimension mean ``E[x_d]``,
+    and ``mean_sum_of_resid_squared[i]`` is the scalar ``E[||x - x_hat||^2]``.
+    """
+    sum_of_squares = torch.stack(mean_sum_of_squares).mean(
+        dim=0
+    )  # scalar: sum_d E[x_d^2]
+    mean_act = torch.stack(mean_act_per_dimension).mean(dim=0)  # [d_model]: E[x_d]
+    total_variance = sum_of_squares - (mean_act**2).sum()  # sum_d (E[x_d^2] - E[x_d]^2)
+    residual_variance = torch.stack(mean_sum_of_resid_squared).mean(dim=0)
+    return (1 - residual_variance / total_variance).item()
+
+
 def get_sparsity_and_variance_metrics(
     sae: SAE[Any],
     model: HookedRootModule,
@@ -553,7 +579,7 @@ def get_sparsity_and_variance_metrics(
                 (flattened_sae_input).pow(2).sum(dim=-1).mean(dim=0)  # scalar
             )
             mean_act_per_dimension.append(
-                (flattened_sae_input).pow(2).mean(dim=0)  # [d_model]
+                (flattened_sae_input).mean(dim=0)  # E[x_d] per dimension, [d_model]
             )
             mean_sum_of_resid_squared.append(
                 resid_sum_of_squares.mean(dim=0)  # scalar
@@ -585,13 +611,11 @@ def get_sparsity_and_variance_metrics(
     for metric_name, metric_values in metric_dict.items():
         metrics[f"{metric_name}"] = torch.cat(metric_values).mean().item()
 
-    # calculate explained variance
+    # calculate explained variance, relative to the per-dimension mean (see GH #659)
     if compute_variance_metrics:
-        mean_sum_of_squares = torch.stack(mean_sum_of_squares).mean(dim=0)
-        mean_act_per_dimension = torch.cat(mean_act_per_dimension).mean(dim=0)
-        total_variance = mean_sum_of_squares - mean_act_per_dimension**2
-        residual_variance = torch.stack(mean_sum_of_resid_squared).mean(dim=0)
-        metrics["explained_variance"] = (1 - residual_variance / total_variance).item()
+        metrics["explained_variance"] = _compute_explained_variance(
+            mean_sum_of_squares, mean_act_per_dimension, mean_sum_of_resid_squared
+        )
 
     # Aggregate feature-wise metrics
     feature_metrics: dict[str, list[float]] = {}

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -766,3 +766,29 @@ def test_get_sparsity_and_variance_metrics_works_with_batchtopk_saes(
 
     # Check that l0 is close to k
     assert sparsity["l0"] == pytest.approx(2.0)
+
+
+def test_compute_explained_variance_is_relative_to_the_mean():
+    """Regression test for GH #659: explained variance must be measured relative to the
+    per-dimension mean, not relative to zero. Predicting the per-dimension mean therefore
+    explains 0 variance (the pre-#659 bug reported it as ~1.0)."""
+    from sae_lens.evals import _compute_explained_variance
+
+    # One eval batch, two samples, d_model=2, with a large mean component on dim 0.
+    x = torch.tensor([[10.0, 0.0], [12.0, 0.0]])
+
+    def batch_stats(x_hat: torch.Tensor):
+        resid_ss = (x - x_hat).pow(2).sum(dim=-1)
+        return (
+            [x.pow(2).sum(dim=-1).mean(dim=0)],  # sum_d E[x_d^2]
+            [x.mean(dim=0)],  # E[x_d], shape [d_model]
+            [resid_ss.mean(dim=0)],  # E[||x - x_hat||^2]
+        )
+
+    # Predicting the per-dimension mean explains none of the variance.
+    mss, mad, mrs = batch_stats(x.mean(dim=0, keepdim=True).expand_as(x))
+    assert _compute_explained_variance(mss, mad, mrs) == pytest.approx(0.0, abs=1e-6)
+
+    # Perfect reconstruction explains all of it.
+    mss, mad, mrs = batch_stats(x)
+    assert _compute_explained_variance(mss, mad, mrs) == pytest.approx(1.0, abs=1e-6)


### PR DESCRIPTION
Fixes #659.

## Problem
The `explained_variance` metric introduced in #443 measures variance relative to **zero** rather than relative to the **per-dimension mean**, which inflates it (the issue reports ~0.98 vs the legacy ~0.78). Two bugs in `get_sparsity_and_variance_metrics`:

1. the per-dimension term used `E[x_d^2]` (an extra `.pow(2)`) instead of `E[x_d]`;
2. `torch.cat` collapsed the per-dimension means `[d_model]` into a scalar, so `sum_d E[x_d]^2` was lost.

Together these make `total_variance ~= E[||x||^2]`, i.e. variance about zero rather than about the mean.

## Fix
Compute `E[x_d]` per dimension and aggregate with `torch.stack`, so `total_variance = sum_d (E[x_d^2] - E[x_d]^2)` (the intended `Var(X) = E[X^2] - E[X]^2`). The aggregation is extracted into a small `_compute_explained_variance` helper so it can be unit-tested directly.

## Test
Added a regression test: predicting the per-dimension mean must explain **0** variance (the pre-fix code reported ~1.0), and perfect reconstruction explains 1.0. `ruff check` and `ruff format` pass.

Thanks to @chanind for the detailed diagnosis in #659.
