### PR TITLE
fix: mse eval metric scaled inversely with eval batch token count

### DIFF
--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -579,7 +579,6 @@ def get_sparsity_and_variance_metrics(
                 (flattened_sae_input - flattened_sae_out).pow(2).sum(dim=-1)
             )
 
-            mse = resid_sum_of_squares / flattened_mask.sum()
             # Explained variance (old, incorrect, formula)
             batched_variance_sum = (
                 (flattened_sae_input - flattened_sae_input.mean(dim=0))
@@ -600,7 +599,10 @@ def get_sparsity_and_variance_metrics(
             )
             cossim = (x_normed * x_hat_normed).sum(dim=-1)
 
-            metric_dict["mse"].append(mse)
+            # Per-token squared reconstruction error ||x - x_hat||^2, averaged
+            # over all tokens after the eval loop. Matches the training MSE
+            # convention of sum over dimensions, mean over tokens.
+            metric_dict["mse"].append(resid_sum_of_squares)
             metric_dict["cossim"].append(cossim)
 
         if compute_featurewise_density_statistics:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -645,6 +645,104 @@ def test_get_sparsity_and_variance_metrics_identity_sae_perfect_reconstruction(
     assert metrics["mse"] == pytest.approx(0.0, abs=1e-5)
 
 
+def test_get_sparsity_and_variance_metrics_mse_matches_mean_squared_reconstruction_error(
+    model: HookedTransformer,
+    example_dataset: Dataset,
+):
+    d_in = 64
+    hook_name = "blocks.1.hook_resid_pre"
+    cfg = build_runner_cfg(d_in=d_in, d_sae=2 * d_in, hook_name=hook_name)
+
+    training_sae = StandardTrainingSAE.from_dict(cfg.get_training_sae_cfg_dict())
+    sae = StandardSAE.from_dict(training_sae.cfg.get_inference_sae_cfg_dict())
+    random_params(sae)
+
+    eval_batch_size_prompts = 4
+    activation_store = ActivationsStore.from_config(
+        model, cfg, override_dataset=example_dataset
+    )
+    metrics, _ = get_sparsity_and_variance_metrics(
+        sae=sae,
+        model=model,
+        activation_store=activation_store,
+        activation_scaler=ActivationScaler(None),
+        n_batches=1,
+        compute_l2_norms=False,
+        compute_sparsity_metrics=False,
+        compute_variance_metrics=True,
+        compute_featurewise_density_statistics=True,
+        eval_batch_size_prompts=eval_batch_size_prompts,
+        model_kwargs={},
+    )
+
+    # Recompute the expected MSE by hand on the same batch of tokens: mean over
+    # tokens of ||x - x_hat||^2, matching the training MSE convention.
+    fresh_store = ActivationsStore.from_config(
+        model, cfg, override_dataset=example_dataset
+    )
+    batch_tokens = fresh_store.get_batch_tokens(eval_batch_size_prompts)
+    _, cache = model.run_with_cache(
+        batch_tokens, prepend_bos=False, names_filter=[hook_name]
+    )
+    acts = cache[hook_name].flatten(0, 1)
+    sae_out = sae.decode(sae.encode(acts))
+    expected_mse = (acts - sae_out).pow(2).sum(dim=-1).mean().item()
+
+    assert metrics["mse"] == pytest.approx(expected_mse, rel=1e-4)
+
+
+def test_get_sparsity_and_variance_metrics_mse_is_invariant_to_batch_size(
+    model: HookedTransformer,
+    example_dataset: Dataset,
+):
+    d_in = 64
+    hook_name = "blocks.1.hook_resid_pre"
+    cfg = build_runner_cfg(d_in=d_in, d_sae=2 * d_in, hook_name=hook_name)
+
+    training_sae = StandardTrainingSAE.from_dict(cfg.get_training_sae_cfg_dict())
+    sae = StandardSAE.from_dict(training_sae.cfg.get_inference_sae_cfg_dict())
+    random_params(sae)
+
+    eval_kwargs: dict[str, Any] = dict(
+        sae=sae,
+        model=model,
+        activation_scaler=ActivationScaler(None),
+        compute_l2_norms=False,
+        compute_sparsity_metrics=False,
+        compute_variance_metrics=True,
+        compute_featurewise_density_statistics=True,
+        model_kwargs={},
+    )
+
+    # Evaluate the same 4 prompts as one batch of 4 and as two batches of 2.
+    store_one_batch = ActivationsStore.from_config(
+        model, cfg, override_dataset=example_dataset
+    )
+    metrics_one_batch, _ = get_sparsity_and_variance_metrics(
+        activation_store=store_one_batch,
+        n_batches=1,
+        eval_batch_size_prompts=4,
+        **eval_kwargs,
+    )
+
+    store_two_batches = ActivationsStore.from_config(
+        model, cfg, override_dataset=example_dataset
+    )
+    metrics_two_batches, _ = get_sparsity_and_variance_metrics(
+        activation_store=store_two_batches,
+        n_batches=2,
+        eval_batch_size_prompts=2,
+        **eval_kwargs,
+    )
+
+    assert metrics_two_batches["mse"] == pytest.approx(
+        metrics_one_batch["mse"], rel=1e-4
+    )
+    assert metrics_two_batches["explained_variance"] == pytest.approx(
+        metrics_one_batch["explained_variance"], rel=1e-4
+    )
+
+
 def test_explained_variance_invariant_to_activation_shift(
     model: HookedTransformer,
     example_dataset: Dataset,


### PR DESCRIPTION
## Summary

`get_sparsity_and_variance_metrics` computed the `mse` metric as:

```python
mse = resid_sum_of_squares / flattened_mask.sum()
```

`resid_sum_of_squares` is already a **per-token** quantity (`||x - x_hat||²` for each token), and `flattened_mask.sum()` is the total number of unmasked tokens in the eval batch. Dividing one by the other and then averaging per token means the reported "mse" is `E[||x - x_hat||²] / n_tokens_per_batch` — it scales inversely with `eval_batch_size_prompts × context_size` instead of measuring reconstruction quality alone. This has been present since #285 (Sep 2024).

## Fix

Report the mean over tokens of `||x - x_hat||²`, i.e. append the per-token `resid_sum_of_squares` directly and let the existing per-token aggregation average it. This matches the training MSE convention (`.sum(dim=-1).mean()` in `TrainingSAE.training_forward_pass`) and the residual term of `ExplainedVarianceCalculator`.

Note that reported `mse` values will be larger than before by a factor of the eval batch token count — the old values were not comparable across eval configurations anyway.

## Tests

Both new tests fail on `main` and pass with the fix:

- `test_get_sparsity_and_variance_metrics_mse_matches_mean_squared_reconstruction_error`: recomputes the expected MSE by hand on the same token batch (model forward + SAE encode/decode) and pins `metrics["mse"]` to it. On `main` the reported value is smaller by a factor of the batch token count.
- `test_get_sparsity_and_variance_metrics_mse_is_invariant_to_batch_size`: evaluates the same 4 prompts as 1×4 and 2×2 batches and asserts `mse` (and `explained_variance`) agree. On `main` the two `mse` values differ by ~2×.

Found while auditing the explained-variance calculation for #659 / #665.

🤖 Generated with [Claude Code](https://claude.com/claude-code)