### PR TITLE
fix: deploy_docs failures from HF rate limiting and lost cache progress

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -46,13 +46,19 @@ jobs:
           path: ~/.cache/huggingface
           restore-keys: |
             huggingface-${{ runner.os }}-3.11-
+      # The save step below uses a unique per-run key: GitHub caches are
+      # immutable, so re-saving under an existing key silently discards any
+      # configs fetched during this run. Restore falls back to the most recent
+      # cache via prefix match, so progress accumulates across runs even when
+      # a run fails partway through.
       - name: Restore SAE config cache
         id: cache-sae-config-restore
         uses: actions/cache/restore@v4
         with:
-          key: sae-config-cache-v1-${{ hashFiles('sae_lens/pretrained_saes.yaml') }}
+          key: sae-config-cache-v1-${{ hashFiles('sae_lens/pretrained_saes.yaml') }}-${{ github.run_id }}
           path: ~/.cache/sae_config_cache
           restore-keys: |
+            sae-config-cache-v1-${{ hashFiles('sae_lens/pretrained_saes.yaml') }}-
             sae-config-cache-v1-
       - name: Load cached Poetry installation
         id: cached-poetry

--- a/sae_lens/loading/pretrained_sae_loaders.py
+++ b/sae_lens/loading/pretrained_sae_loaders.py
@@ -1,5 +1,6 @@
 import json
 import re
+import time
 import warnings
 from pathlib import Path
 from typing import Any, Protocol
@@ -1746,6 +1747,24 @@ def mwhanna_transcoder_huggingface_loader(
     return cfg_dict, state_dict, None
 
 
+def _get_with_rate_limit_retry(
+    url: str, headers: dict[str, str | bytes], max_attempts: int = 5
+) -> requests.Response:
+    """GET a URL, retrying on HTTP 429 with backoff (honors Retry-After, capped at 60s)."""
+    for attempt in range(max_attempts):
+        response = requests.get(url, headers=headers, timeout=10)
+        if response.status_code != 429 or attempt == max_attempts - 1:
+            response.raise_for_status()
+            return response
+        retry_after = response.headers.get("Retry-After")
+        delay = min(float(retry_after) if retry_after else 2.0**attempt, 60.0)
+        logger.warning(
+            f"Rate limited (HTTP 429) fetching {url}, retrying in {delay:.0f}s"
+        )
+        time.sleep(delay)
+    raise AssertionError("unreachable")
+
+
 def get_safetensors_tensor_shapes(repo_id: str, filename: str) -> dict[str, list[int]]:
     """
     Get tensor shapes from a safetensors file on HuggingFace Hub
@@ -1767,15 +1786,13 @@ def get_safetensors_tensor_shapes(repo_id: str, filename: str) -> dict[str, list
 
     # Fetch first 8 bytes to get metadata size
     headers: dict[str, str | bytes] = {**hf_headers, "Range": "bytes=0-7"}
-    response = requests.get(url, headers=headers, timeout=10)
-    response.raise_for_status()
+    response = _get_with_rate_limit_retry(url, headers)
 
     meta_size = int.from_bytes(response.content, byteorder="little")
 
     # Fetch the metadata header
     headers = {**hf_headers, "Range": f"bytes=8-{8 + meta_size - 1}"}
-    response = requests.get(url, headers=headers, timeout=10)
-    response.raise_for_status()
+    response = _get_with_rate_limit_retry(url, headers)
 
     metadata_json = response.content.decode("utf-8").strip()
     metadata = json.loads(metadata_json)

--- a/tests/loading/test_pretrained_sae_loaders.py
+++ b/tests/loading/test_pretrained_sae_loaders.py
@@ -1,9 +1,11 @@
 import json
+import time
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 import pytest
+import requests
 import torch
 import yaml
 from huggingface_hub import hf_hub_download as real_hf_hub_download
@@ -13,6 +15,7 @@ from sparsify import SparseCoder, SparseCoderConfig
 
 from sae_lens import StandardSAE, StandardSAEConfig
 from sae_lens.loading.pretrained_sae_loaders import (
+    _get_with_rate_limit_retry,
     _infer_gemma_3_raw_cfg_dict,
     dictionary_learning_sae_huggingface_loader_1,
     gemma_2_sae_huggingface_loader,
@@ -2435,3 +2438,72 @@ def test_qwen_scope_sae_loads_via_from_pretrained(
 
     actual_acts = sae.encode(residual)
     assert_close(actual_acts, expected_acts)
+
+
+def _fake_response(
+    status_code: int, headers: dict[str, str] | None = None
+) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status_code
+    response.headers.update(headers or {})
+    return response
+
+
+def test_get_with_rate_limit_retry_retries_on_429_and_honors_retry_after(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    responses = iter(
+        [
+            _fake_response(429, {"Retry-After": "3"}),
+            _fake_response(429),
+            _fake_response(200),
+        ]
+    )
+    sleeps: list[float] = []
+
+    def fake_get(url: str, **kwargs: Any) -> requests.Response:  # noqa: ARG001
+        return next(responses)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setattr(time, "sleep", sleeps.append)
+
+    response = _get_with_rate_limit_retry("http://test/url", {})
+
+    assert response.status_code == 200
+    # First delay comes from the Retry-After header, second from exponential backoff
+    assert sleeps == [3.0, 2.0]
+
+
+def test_get_with_rate_limit_retry_raises_after_max_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: list[str] = []
+
+    def fake_get(url: str, **kwargs: Any) -> requests.Response:  # noqa: ARG001
+        calls.append(url)
+        return _fake_response(429)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+    with pytest.raises(requests.HTTPError, match="429"):
+        _get_with_rate_limit_retry("http://test/url", {}, max_attempts=3)
+
+    assert len(calls) == 3
+
+
+def test_get_with_rate_limit_retry_does_not_retry_other_errors(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: list[str] = []
+
+    def fake_get(url: str, **kwargs: Any) -> requests.Response:  # noqa: ARG001
+        calls.append(url)
+        return _fake_response(404)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    with pytest.raises(requests.HTTPError, match="404"):
+        _get_with_rate_limit_retry("http://test/url", {})
+
+    assert len(calls) == 1


### PR DESCRIPTION
## Diagnosis

`deploy_docs` keeps failing with `429 Too Many Requests` from HuggingFace while `docs/generate_sae_table.py` builds the pretrained SAE table. Three factors compound:

1. **Request volume**: the registry now has ~14k SAEs, and the ~9.8k gemma-scope-2 entries each need **two** raw HTTP range requests (`get_safetensors_tensor_shapes`) to infer their config — ~20k requests on a cold cache. The `HF_TOKEN` *is* being sent (`build_hf_headers()` picks it up from the env), but it doesn't make a 20k-request burst safe.
2. **No retry handling**: the raw `requests.get` calls have no 429 handling, so the first rate-limit response aborts the entire mkdocs build.
3. **Cache progress was being thrown away**: the workflow saves the config cache under the same key it restores (`sae-config-cache-v1-<yaml hash>`). GitHub caches are **immutable** — once the first failing run saved its partial cache, every later run's save was silently rejected, so each run restarted from the same partial state and died at roughly the same point. Worse, the one complete cache that exists was saved by a PR-triggered run and is scoped to `refs/pull/695/merge`, which main-branch runs can never restore.

## Fixes

- `get_safetensors_tensor_shapes` now retries HTTP 429 up to 5 times with backoff, honoring the `Retry-After` header (capped at 60s per wait). Other HTTP errors still raise immediately.
- The workflow saves the SAE config cache under a unique per-run key (`...-<yaml hash>-<run id>`) and restores via prefix fallback to the newest cache. Progress now accumulates across runs — even failed ones — so the cache converges to complete instead of resetting.

## Tests

Unit tests for the retry helper: honors `Retry-After` then falls back to exponential backoff, raises after max attempts (with the request made exactly `max_attempts` times), and does not retry non-429 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)