### PR TITLE
Preserve training architecture in SAE metadata

### DIFF
--- a/sae_lens/saes/matching_pursuit_sae.py
+++ b/sae_lens/saes/matching_pursuit_sae.py
@@ -151,12 +151,12 @@ class MatchingPursuitTrainingSAEConfig(TrainingSAEConfig):
 
     @override
     def __post_init__(self):
-        super().__post_init__()
         if self.decoder_init_norm != 1.0:
             self.decoder_init_norm = 1.0
             warnings.warn(
                 "decoder_init_norm must be set to 1.0 for MatchingPursuitTrainingSAE, setting to 1.0"
             )
+        super().__post_init__()
 
 
 class MatchingPursuitTrainingSAE(TrainingSAE[MatchingPursuitTrainingSAEConfig]):

--- a/sae_lens/saes/sae.py
+++ b/sae_lens/saes/sae.py
@@ -884,7 +884,7 @@ class TrainingSAEConfig(SAEConfig, ABC):
         return {
             **super().to_dict(),
             **asdict(self),
-            "metadata": self.metadata.to_dict(),
+            "metadata": self._metadata_with_training_info(),
             "architecture": self.architecture(),
         }
 
@@ -893,6 +893,35 @@ class TrainingSAEConfig(SAEConfig, ABC):
         Get the architecture for inference.
         """
         return get_sae_class(self.architecture())[1]
+
+    def get_training_architecture_details(self) -> dict[str, Any]:
+        """
+        Return config fields that describe training behavior but are not needed
+        by the inference SAE architecture.
+        """
+        inference_config_field_names = {
+            field.name for field in fields(self.get_inference_config_class())
+        }
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if field.name not in inference_config_field_names
+            and field.name != "metadata"
+        }
+
+    def _metadata_with_training_info(self) -> dict[str, Any]:
+        metadata = self.metadata.to_dict()
+        metadata["training_architecture"] = self.architecture()
+        metadata["training_architecture_details"] = (
+            self.get_training_architecture_details()
+        )
+        return metadata
+
+    def add_training_info_to_metadata(self) -> None:
+        self.metadata.training_architecture = self.architecture()
+        self.metadata.training_architecture_details = (
+            self.get_training_architecture_details()
+        )
 
     # this needs to exist so we can initialize the parent sae cfg without the training specific
     # parameters. Maybe there's a cleaner way to do this
@@ -908,7 +937,7 @@ class TrainingSAEConfig(SAEConfig, ABC):
             for field_name in base_config_field_names
         }
         result_dict["architecture"] = base_sae_cfg_class.architecture()
-        result_dict["metadata"] = self.metadata.to_dict()
+        result_dict["metadata"] = self._metadata_with_training_info()
         return result_dict
 
 
@@ -916,6 +945,7 @@ class TrainingSAE(SAE[T_TRAINING_SAE_CONFIG], ABC):
     """Abstract base class for training versions of SAEs."""
 
     def __init__(self, cfg: T_TRAINING_SAE_CONFIG, use_error_term: bool = False):
+        cfg.add_training_info_to_metadata()
         super().__init__(cfg, use_error_term)
 
         # Turn off hook_z reshaping for training mode - the activation store

--- a/sae_lens/saes/sae.py
+++ b/sae_lens/saes/sae.py
@@ -842,6 +842,10 @@ class TrainingSAEConfig(SAEConfig, ABC):
     @abstractmethod
     def architecture(cls) -> str: ...
 
+    def __post_init__(self):
+        super().__post_init__()
+        self.add_training_info_to_metadata()
+
     @classmethod
     def from_sae_runner_config(
         cls: type[T_TRAINING_SAE_CONFIG],

--- a/tests/saes/test_sae.py
+++ b/tests/saes/test_sae.py
@@ -37,6 +37,34 @@ def test_TrainingSAEConfig_to_and_from_dict_all_architectures(architecture: str)
     assert reloaded_cfg.to_dict() == cfg.to_dict()
     assert reloaded_cfg.__class__ == cfg.__class__
     assert reloaded_cfg.__class__ == get_sae_training_class(architecture)[1]
+    assert cfg.to_dict()["metadata"]["training_architecture"] == architecture
+
+
+def test_TrainingSAEConfig_serializes_training_architecture_details():
+    cfg = build_sae_training_cfg_for_arch(
+        architecture="matryoshka_batchtopk",
+        d_sae=128,
+        k=8,
+        rescale_acts_by_decoder_norm=False,
+        topk_threshold_lr=0.03,
+        matryoshka_widths=[32, 64, 128],
+        use_matryoshka_aux_loss=True,
+    )
+
+    cfg_dict = cfg.to_dict()
+    metadata = cfg_dict["metadata"]
+
+    assert metadata["training_architecture"] == "matryoshka_batchtopk"
+    assert metadata["training_architecture_details"] == {
+        "decoder_init_norm": 0.1,
+        "aux_loss_coefficient": 1.0,
+        "use_sparse_activations": False,
+        "k": 8,
+        "rescale_acts_by_decoder_norm": False,
+        "topk_threshold_lr": 0.03,
+        "matryoshka_widths": [32, 64, 128],
+        "use_matryoshka_aux_loss": True,
+    }
 
 
 @pytest.mark.parametrize("architecture", ALL_TRAINING_ARCHITECTURES)

--- a/tests/test_llm_sae_training_runner.py
+++ b/tests/test_llm_sae_training_runner.py
@@ -82,6 +82,11 @@ def test_LanguageModelSAETrainingRunner_runs_and_saves_all_architectures(
     assert sae.cfg.metadata.exclude_special_tokens is True
     assert sae.cfg.metadata.sae_lens_version == __version__
     assert sae.cfg.metadata.sae_lens_training_version == __version__
+    assert sae.cfg.metadata.training_architecture == architecture
+    assert (
+        sae.cfg.metadata.training_architecture_details
+        == cfg.sae.get_training_architecture_details()
+    )
 
     assert (tmp_path / "final_100").exists()
     loaded_sae = TrainingSAE.load_from_disk(tmp_path / "final_100")
@@ -698,6 +703,20 @@ def test_LanguageModelSAETrainingRunner_saves_final_output_and_checkpoints(
     # we should save the inference model in the final output, not the training model
     assert sae.cfg.architecture() == "batchtopk"
     assert output_sae.cfg.architecture() == "jumprelu"
+    assert checkpoint_sae.cfg.metadata.training_architecture == "batchtopk"
+    assert output_sae.cfg.metadata.training_architecture == "batchtopk"
+    assert checkpoint_sae.cfg.metadata.training_architecture_details == {
+        "decoder_init_norm": 0.1,
+        "aux_loss_coefficient": 1.0,
+        "use_sparse_activations": False,
+        "k": 10,
+        "rescale_acts_by_decoder_norm": False,
+        "topk_threshold_lr": 0.02,
+    }
+    assert (
+        output_sae.cfg.metadata.training_architecture_details
+        == checkpoint_sae.cfg.metadata.training_architecture_details
+    )
 
     # Models should have the same architecture and dimensions
     assert output_sae.cfg.d_in == checkpoint_sae.cfg.d_in

--- a/tests/test_multi_sae_training_runner.py
+++ b/tests/test_multi_sae_training_runner.py
@@ -174,6 +174,12 @@ def test_multi_sae_runner_trains_two_saes_at_different_hooks(
     assert set(saes.keys()) == {"resid", "topk_mlp"}
     assert saes["resid"].cfg.metadata.hook_name == "blocks.0.hook_resid_pre"
     assert saes["topk_mlp"].cfg.metadata.hook_name == "blocks.0.hook_mlp_out"
+    assert saes["resid"].cfg.metadata.training_architecture == "standard"
+    assert saes["topk_mlp"].cfg.metadata.training_architecture == "topk"
+    assert (
+        saes["topk_mlp"].cfg.metadata.training_architecture_details
+        == cfg.saes["topk_mlp"].get_training_architecture_details()
+    )
 
 
 def test_multi_sae_runner_resume_from_checkpoint(


### PR DESCRIPTION
## Summary

- Add deterministic `training_architecture` and `training_architecture_details` metadata to training SAE configs.
- Preserve that provenance when converting training configs into inference SAE configs, including BatchTopK/MatryoshkaBatchTopK saves that load as JumpReLU inference SAEs.
- Cover config serialization, single-SAE training runner saves, checkpoints, and multi-SAE training saves with regression tests.

## Motivation

Issue #663 points out that saved configs can lose the training architecture once a training-only architecture is represented by its inference architecture. This records the original training architecture and the training-only config fields in metadata so downstream users can inspect how the SAE was trained even when the runtime inference architecture differs.

This PR addresses the training-architecture provenance part of #663. It intentionally does not add final l0 or dead-latent counts to config metadata, since those are run/evaluation artifacts rather than deterministic config fields.

## Compatibility and performance

This is an additive metadata-only change. Existing configs that do not contain these metadata keys remain loadable. It does not change model weights, forward or inference behavior, training losses, optimization, or checkpoint tensors.

Performance metrics (L0, CE loss, MSE loss, and feature-dashboard interpretability) are therefore unchanged / not applicable. Final L0 and dead-latent counts remain excluded because they are run/evaluation outputs rather than deterministic configuration.

## Validation

- `.venv/bin/python -m pytest tests/saes/test_sae.py -q`
- `.venv/bin/python -m pytest tests/training/test_config.py::test_LanguageModelSAERunnerConfig_to_dict_and_from_dict -q`
- `.venv/bin/python -m pytest tests/test_llm_sae_training_runner.py::test_LanguageModelSAETrainingRunner_runs_and_saves_all_architectures tests/test_llm_sae_training_runner.py::test_LanguageModelSAETrainingRunner_saves_final_output_and_checkpoints tests/test_multi_sae_training_runner.py::test_multi_sae_runner_trains_two_saes_at_different_hooks -q`
- `.venv/bin/ruff format --check sae_lens/saes/sae.py tests/saes/test_sae.py tests/test_llm_sae_training_runner.py tests/test_multi_sae_training_runner.py`
- `.venv/bin/ruff check sae_lens/saes/sae.py tests/saes/test_sae.py tests/test_llm_sae_training_runner.py tests/test_multi_sae_training_runner.py`
- `.venv/bin/pyright --pythonpath .venv/bin/python --pythonversion 3.10 sae_lens/saes/sae.py tests/saes/test_sae.py tests/test_llm_sae_training_runner.py tests/test_multi_sae_training_runner.py`
- `git diff --check`

Note: I used a uv-managed Python 3.10 environment locally because Poetry was not installed in this environment.
