### PR TITLE
Fix HookedRootModule type imports

### DIFF
--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -17,7 +17,8 @@ import einops
 import pandas as pd
 import torch
 from tqdm.auto import tqdm
-from transformer_lens import HookedRootModule, HookedTransformer
+from transformer_lens import HookedTransformer
+from transformer_lens.HookedRootModule import HookedRootModule
 
 from sae_lens.loading.pretrained_saes_directory import get_pretrained_saes_directory
 from sae_lens.saes.sae import SAE, SAEConfig

--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -18,7 +18,7 @@ import pandas as pd
 import torch
 from tqdm.auto import tqdm
 from transformer_lens import HookedTransformer
-from transformer_lens.HookedRootModule import HookedRootModule
+from transformer_lens.HookedTransformer import HookedRootModule
 
 from sae_lens.loading.pretrained_saes_directory import get_pretrained_saes_directory
 from sae_lens.saes.sae import SAE, SAEConfig

--- a/sae_lens/evals.py
+++ b/sae_lens/evals.py
@@ -17,8 +17,7 @@ import einops
 import pandas as pd
 import torch
 from tqdm.auto import tqdm
-from transformer_lens import HookedTransformer
-from transformer_lens.hook_points import HookedRootModule
+from transformer_lens import HookedRootModule, HookedTransformer
 
 from sae_lens.loading.pretrained_saes_directory import get_pretrained_saes_directory
 from sae_lens.saes.sae import SAE, SAEConfig

--- a/sae_lens/llm_sae_training_runner.py
+++ b/sae_lens/llm_sae_training_runner.py
@@ -14,7 +14,7 @@ import torch
 import wandb
 from safetensors.torch import save_file
 from simple_parsing import ArgumentParser, subgroups
-from transformer_lens import HookedRootModule
+from transformer_lens.HookedRootModule import HookedRootModule
 from typing_extensions import deprecated, override
 
 from sae_lens import logger

--- a/sae_lens/llm_sae_training_runner.py
+++ b/sae_lens/llm_sae_training_runner.py
@@ -14,7 +14,7 @@ import torch
 import wandb
 from safetensors.torch import save_file
 from simple_parsing import ArgumentParser, subgroups
-from transformer_lens.HookedRootModule import HookedRootModule
+from transformer_lens.HookedTransformer import HookedRootModule
 from typing_extensions import deprecated, override
 
 from sae_lens import logger

--- a/sae_lens/llm_sae_training_runner.py
+++ b/sae_lens/llm_sae_training_runner.py
@@ -14,7 +14,7 @@ import torch
 import wandb
 from safetensors.torch import save_file
 from simple_parsing import ArgumentParser, subgroups
-from transformer_lens.hook_points import HookedRootModule
+from transformer_lens import HookedRootModule
 from typing_extensions import deprecated, override
 
 from sae_lens import logger

--- a/sae_lens/load_model.py
+++ b/sae_lens/load_model.py
@@ -3,8 +3,7 @@ from typing import Any, Callable, Literal, cast
 import torch
 from transformer_lens import HookedTransformer
 from transformer_lens.hook_points import HookPoint
-from transformer_lens.HookedRootModule import HookedRootModule
-from transformer_lens.HookedTransformer import Loss, Output
+from transformer_lens.HookedTransformer import HookedRootModule, Loss, Output
 from transformer_lens.utils import (
     USE_DEFAULT_VALUE,
     get_tokens_with_bos_removed,

--- a/sae_lens/load_model.py
+++ b/sae_lens/load_model.py
@@ -1,8 +1,9 @@
 from typing import Any, Callable, Literal, cast
 
 import torch
-from transformer_lens import HookedRootModule, HookedTransformer
+from transformer_lens import HookedTransformer
 from transformer_lens.hook_points import HookPoint
+from transformer_lens.HookedRootModule import HookedRootModule
 from transformer_lens.HookedTransformer import Loss, Output
 from transformer_lens.utils import (
     USE_DEFAULT_VALUE,

--- a/sae_lens/load_model.py
+++ b/sae_lens/load_model.py
@@ -1,8 +1,8 @@
 from typing import Any, Callable, Literal, cast
 
 import torch
-from transformer_lens import HookedTransformer
-from transformer_lens.hook_points import HookedRootModule, HookPoint
+from transformer_lens import HookedRootModule, HookedTransformer
+from transformer_lens.hook_points import HookPoint
 from transformer_lens.HookedTransformer import Loss, Output
 from transformer_lens.utils import (
     USE_DEFAULT_VALUE,

--- a/sae_lens/multi_sae_training_runner.py
+++ b/sae_lens/multi_sae_training_runner.py
@@ -33,7 +33,7 @@ from typing import Any, Literal
 import torch
 import wandb
 from safetensors.torch import save_file
-from transformer_lens.HookedRootModule import HookedRootModule
+from transformer_lens.HookedTransformer import HookedRootModule
 
 from sae_lens import __version__, logger
 from sae_lens.config import HfDataset, LoggingConfig, SAETrainerConfig

--- a/sae_lens/multi_sae_training_runner.py
+++ b/sae_lens/multi_sae_training_runner.py
@@ -33,7 +33,7 @@ from typing import Any, Literal
 import torch
 import wandb
 from safetensors.torch import save_file
-from transformer_lens.hook_points import HookedRootModule
+from transformer_lens import HookedRootModule
 
 from sae_lens import __version__, logger
 from sae_lens.config import HfDataset, LoggingConfig, SAETrainerConfig

--- a/sae_lens/multi_sae_training_runner.py
+++ b/sae_lens/multi_sae_training_runner.py
@@ -33,7 +33,7 @@ from typing import Any, Literal
 import torch
 import wandb
 from safetensors.torch import save_file
-from transformer_lens import HookedRootModule
+from transformer_lens.HookedRootModule import HookedRootModule
 
 from sae_lens import __version__, logger
 from sae_lens.config import HfDataset, LoggingConfig, SAETrainerConfig

--- a/sae_lens/saes/sae.py
+++ b/sae_lens/saes/sae.py
@@ -22,8 +22,8 @@ import torch
 from numpy.typing import NDArray
 from safetensors.torch import load_file, save_file
 from torch import nn
-from transformer_lens import HookedRootModule
 from transformer_lens.hook_points import HookPoint
+from transformer_lens.HookedRootModule import HookedRootModule
 from typing_extensions import deprecated, overload, override
 
 from sae_lens import __version__

--- a/sae_lens/saes/sae.py
+++ b/sae_lens/saes/sae.py
@@ -22,7 +22,8 @@ import torch
 from numpy.typing import NDArray
 from safetensors.torch import load_file, save_file
 from torch import nn
-from transformer_lens.hook_points import HookedRootModule, HookPoint
+from transformer_lens import HookedRootModule
+from transformer_lens.hook_points import HookPoint
 from typing_extensions import deprecated, overload, override
 
 from sae_lens import __version__

--- a/sae_lens/saes/sae.py
+++ b/sae_lens/saes/sae.py
@@ -23,7 +23,7 @@ from numpy.typing import NDArray
 from safetensors.torch import load_file, save_file
 from torch import nn
 from transformer_lens.hook_points import HookPoint
-from transformer_lens.HookedRootModule import HookedRootModule
+from transformer_lens.HookedTransformer import HookedRootModule
 from typing_extensions import deprecated, overload, override
 
 from sae_lens import __version__

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -15,7 +15,7 @@ from huggingface_hub.utils import HfHubHTTPError
 from requests import HTTPError
 from safetensors.torch import load_file, save_file
 from tqdm.auto import tqdm
-from transformer_lens import HookedRootModule
+from transformer_lens.HookedRootModule import HookedRootModule
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from sae_lens import logger

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -15,7 +15,7 @@ from huggingface_hub.utils import HfHubHTTPError
 from requests import HTTPError
 from safetensors.torch import load_file, save_file
 from tqdm.auto import tqdm
-from transformer_lens.HookedRootModule import HookedRootModule
+from transformer_lens.HookedTransformer import HookedRootModule
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from sae_lens import logger

--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -15,7 +15,7 @@ from huggingface_hub.utils import HfHubHTTPError
 from requests import HTTPError
 from safetensors.torch import load_file, save_file
 from tqdm.auto import tqdm
-from transformer_lens.hook_points import HookedRootModule
+from transformer_lens import HookedRootModule
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from sae_lens import logger

--- a/tests/_comparison/sae_lens_old/evals.py
+++ b/tests/_comparison/sae_lens_old/evals.py
@@ -16,8 +16,7 @@ import einops
 import pandas as pd
 import torch
 from tqdm import tqdm
-from transformer_lens import HookedTransformer
-from transformer_lens.hook_points import HookedRootModule
+from transformer_lens import HookedRootModule, HookedTransformer
 
 from tests._comparison.sae_lens_old.sae import SAE
 from tests._comparison.sae_lens_old.toolkit.pretrained_saes_directory import (

--- a/tests/_comparison/sae_lens_old/evals.py
+++ b/tests/_comparison/sae_lens_old/evals.py
@@ -17,7 +17,7 @@ import pandas as pd
 import torch
 from tqdm import tqdm
 from transformer_lens import HookedTransformer
-from transformer_lens.HookedRootModule import HookedRootModule
+from transformer_lens.HookedTransformer import HookedRootModule
 
 from tests._comparison.sae_lens_old.sae import SAE
 from tests._comparison.sae_lens_old.toolkit.pretrained_saes_directory import (

--- a/tests/_comparison/sae_lens_old/evals.py
+++ b/tests/_comparison/sae_lens_old/evals.py
@@ -16,7 +16,8 @@ import einops
 import pandas as pd
 import torch
 from tqdm import tqdm
-from transformer_lens import HookedRootModule, HookedTransformer
+from transformer_lens import HookedTransformer
+from transformer_lens.HookedRootModule import HookedRootModule
 
 from tests._comparison.sae_lens_old.sae import SAE
 from tests._comparison.sae_lens_old.toolkit.pretrained_saes_directory import (

--- a/tests/_comparison/sae_lens_old/load_model.py
+++ b/tests/_comparison/sae_lens_old/load_model.py
@@ -1,8 +1,8 @@
 from typing import Any, Literal, cast
 
 import torch
-from transformer_lens import HookedTransformer
-from transformer_lens.hook_points import HookedRootModule, HookPoint
+from transformer_lens import HookedRootModule, HookedTransformer
+from transformer_lens.hook_points import HookPoint
 from transformer_lens.HookedTransformer import Loss, Output
 from transformer_lens.utils import (
     USE_DEFAULT_VALUE,

--- a/tests/_comparison/sae_lens_old/load_model.py
+++ b/tests/_comparison/sae_lens_old/load_model.py
@@ -3,8 +3,7 @@ from typing import Any, Literal, cast
 import torch
 from transformer_lens import HookedTransformer
 from transformer_lens.hook_points import HookPoint
-from transformer_lens.HookedRootModule import HookedRootModule
-from transformer_lens.HookedTransformer import Loss, Output
+from transformer_lens.HookedTransformer import HookedRootModule, Loss, Output
 from transformer_lens.utils import (
     USE_DEFAULT_VALUE,
     get_tokens_with_bos_removed,

--- a/tests/_comparison/sae_lens_old/load_model.py
+++ b/tests/_comparison/sae_lens_old/load_model.py
@@ -1,8 +1,9 @@
 from typing import Any, Literal, cast
 
 import torch
-from transformer_lens import HookedRootModule, HookedTransformer
+from transformer_lens import HookedTransformer
 from transformer_lens.hook_points import HookPoint
+from transformer_lens.HookedRootModule import HookedRootModule
 from transformer_lens.HookedTransformer import Loss, Output
 from transformer_lens.utils import (
     USE_DEFAULT_VALUE,

--- a/tests/_comparison/sae_lens_old/sae.py
+++ b/tests/_comparison/sae_lens_old/sae.py
@@ -13,8 +13,8 @@ import einops
 import torch
 from safetensors.torch import save_file
 from torch import nn
-from transformer_lens import HookedRootModule
 from transformer_lens.hook_points import HookPoint
+from transformer_lens.HookedRootModule import HookedRootModule
 from typing_extensions import deprecated
 
 from tests._comparison.sae_lens_old.config import (

--- a/tests/_comparison/sae_lens_old/sae.py
+++ b/tests/_comparison/sae_lens_old/sae.py
@@ -14,7 +14,7 @@ import torch
 from safetensors.torch import save_file
 from torch import nn
 from transformer_lens.hook_points import HookPoint
-from transformer_lens.HookedRootModule import HookedRootModule
+from transformer_lens.HookedTransformer import HookedRootModule
 from typing_extensions import deprecated
 
 from tests._comparison.sae_lens_old.config import (

--- a/tests/_comparison/sae_lens_old/sae.py
+++ b/tests/_comparison/sae_lens_old/sae.py
@@ -13,7 +13,8 @@ import einops
 import torch
 from safetensors.torch import save_file
 from torch import nn
-from transformer_lens.hook_points import HookedRootModule, HookPoint
+from transformer_lens import HookedRootModule
+from transformer_lens.hook_points import HookPoint
 from typing_extensions import deprecated
 
 from tests._comparison.sae_lens_old.config import (

--- a/tests/_comparison/sae_lens_old/sae_training_runner.py
+++ b/tests/_comparison/sae_lens_old/sae_training_runner.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 import torch
 import wandb
 from simple_parsing import ArgumentParser
-from transformer_lens import HookedRootModule
+from transformer_lens.HookedRootModule import HookedRootModule
 
 from tests._comparison.sae_lens_old import logger
 from tests._comparison.sae_lens_old.config import (

--- a/tests/_comparison/sae_lens_old/sae_training_runner.py
+++ b/tests/_comparison/sae_lens_old/sae_training_runner.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 import torch
 import wandb
 from simple_parsing import ArgumentParser
-from transformer_lens.hook_points import HookedRootModule
+from transformer_lens import HookedRootModule
 
 from tests._comparison.sae_lens_old import logger
 from tests._comparison.sae_lens_old.config import (

--- a/tests/_comparison/sae_lens_old/sae_training_runner.py
+++ b/tests/_comparison/sae_lens_old/sae_training_runner.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 import torch
 import wandb
 from simple_parsing import ArgumentParser
-from transformer_lens.HookedRootModule import HookedRootModule
+from transformer_lens.HookedTransformer import HookedRootModule
 
 from tests._comparison.sae_lens_old import logger
 from tests._comparison.sae_lens_old.config import (

--- a/tests/_comparison/sae_lens_old/training/activations_store.py
+++ b/tests/_comparison/sae_lens_old/training/activations_store.py
@@ -17,7 +17,7 @@ from requests import HTTPError
 from safetensors.torch import save_file
 from torch.utils.data import DataLoader
 from tqdm import tqdm
-from transformer_lens.HookedRootModule import HookedRootModule
+from transformer_lens.HookedTransformer import HookedRootModule
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from tests._comparison.sae_lens_old import logger

--- a/tests/_comparison/sae_lens_old/training/activations_store.py
+++ b/tests/_comparison/sae_lens_old/training/activations_store.py
@@ -17,7 +17,7 @@ from requests import HTTPError
 from safetensors.torch import save_file
 from torch.utils.data import DataLoader
 from tqdm import tqdm
-from transformer_lens import HookedRootModule
+from transformer_lens.HookedRootModule import HookedRootModule
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from tests._comparison.sae_lens_old import logger

--- a/tests/_comparison/sae_lens_old/training/activations_store.py
+++ b/tests/_comparison/sae_lens_old/training/activations_store.py
@@ -17,7 +17,7 @@ from requests import HTTPError
 from safetensors.torch import save_file
 from torch.utils.data import DataLoader
 from tqdm import tqdm
-from transformer_lens.hook_points import HookedRootModule
+from transformer_lens import HookedRootModule
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from tests._comparison.sae_lens_old import logger

--- a/tests/_comparison/sae_lens_old/training/sae_trainer.py
+++ b/tests/_comparison/sae_lens_old/training/sae_trainer.py
@@ -5,7 +5,7 @@ import torch
 import wandb
 from torch.optim import Adam
 from tqdm import tqdm
-from transformer_lens import HookedRootModule
+from transformer_lens.HookedRootModule import HookedRootModule
 
 from tests._comparison.sae_lens_old import __version__
 from tests._comparison.sae_lens_old.config import LanguageModelSAERunnerConfig

--- a/tests/_comparison/sae_lens_old/training/sae_trainer.py
+++ b/tests/_comparison/sae_lens_old/training/sae_trainer.py
@@ -5,7 +5,7 @@ import torch
 import wandb
 from torch.optim import Adam
 from tqdm import tqdm
-from transformer_lens.hook_points import HookedRootModule
+from transformer_lens import HookedRootModule
 
 from tests._comparison.sae_lens_old import __version__
 from tests._comparison.sae_lens_old.config import LanguageModelSAERunnerConfig

--- a/tests/_comparison/sae_lens_old/training/sae_trainer.py
+++ b/tests/_comparison/sae_lens_old/training/sae_trainer.py
@@ -5,7 +5,7 @@ import torch
 import wandb
 from torch.optim import Adam
 from tqdm import tqdm
-from transformer_lens.HookedRootModule import HookedRootModule
+from transformer_lens.HookedTransformer import HookedRootModule
 
 from tests._comparison.sae_lens_old import __version__
 from tests._comparison.sae_lens_old.config import LanguageModelSAERunnerConfig


### PR DESCRIPTION
## Summary

- Import `HookedRootModule` from `transformer_lens.HookedTransformer` instead of `transformer_lens.hook_points`.
- Apply the same import cleanup to comparison fixtures so Pyright sees a concrete type throughout the checked surface.
- Keep `HookPoint` imports from `transformer_lens.hook_points`, where that symbol still lives.

Fixes #684.

## Relationship to #685 and cross-platform regression proof

This supersedes #685. That PR imported `HookedRootModule` from the `transformer_lens` package root: it fixed the macOS errors but was closed after Linux CI reported unknown types. This PR instead uses `transformer_lens.HookedTransformer`, which is compatible with the project's supported TransformerLens range.

Using the same Python 3.10 / Pyright command on the 12 affected files:

- current `main`: 13 errors (`reportUnknownParameterType`)
- this PR: 0 errors

The Linux `build` workflow and docs workflow pass.

## Validation

- `.venv/bin/ruff format --check sae_lens/training/activations_store.py sae_lens/multi_sae_training_runner.py sae_lens/llm_sae_training_runner.py sae_lens/evals.py sae_lens/saes/sae.py sae_lens/load_model.py tests/_comparison/sae_lens_old/training/activations_store.py tests/_comparison/sae_lens_old/evals.py tests/_comparison/sae_lens_old/training/sae_trainer.py tests/_comparison/sae_lens_old/sae_training_runner.py tests/_comparison/sae_lens_old/sae.py tests/_comparison/sae_lens_old/load_model.py`
- `.venv/bin/ruff check sae_lens/training/activations_store.py sae_lens/multi_sae_training_runner.py sae_lens/llm_sae_training_runner.py sae_lens/evals.py sae_lens/saes/sae.py sae_lens/load_model.py tests/_comparison/sae_lens_old/training/activations_store.py tests/_comparison/sae_lens_old/evals.py tests/_comparison/sae_lens_old/training/sae_trainer.py tests/_comparison/sae_lens_old/sae_training_runner.py tests/_comparison/sae_lens_old/sae.py tests/_comparison/sae_lens_old/load_model.py`
- `.venv/bin/pyright --pythonpath .venv/bin/python --pythonversion 3.10 sae_lens/multi_sae_training_runner.py sae_lens/training/activations_store.py tests/_comparison/sae_lens_old/training/activations_store.py sae_lens/llm_sae_training_runner.py sae_lens/evals.py sae_lens/saes/sae.py sae_lens/load_model.py tests/_comparison/sae_lens_old/evals.py tests/_comparison/sae_lens_old/training/sae_trainer.py tests/_comparison/sae_lens_old/sae_training_runner.py tests/_comparison/sae_lens_old/sae.py tests/_comparison/sae_lens_old/load_model.py`
- `.venv/bin/python -m pytest tests/training/test_activations_store.py tests/training/test_activations_store_multi_hook.py tests/test_multi_sae_training_runner.py -q`
- `.venv/bin/python -m pytest tests/training/test_load_model.py -q`
- `git diff --check`
