### PR TITLE
fix: don't load the dataset when reading cached activations

### DIFF
--- a/sae_lens/training/activations_store.py
+++ b/sae_lens/training/activations_store.py
@@ -50,7 +50,7 @@ class ActivationsStore:
     """
 
     model: HookedRootModule
-    dataset: HfDataset
+    dataset: HfDataset | None
     cached_activations_path: str | None
     cached_activation_dataset: Dataset | None = None
     tokens_column: Literal[
@@ -101,7 +101,7 @@ class ActivationsStore:
             # NOOP
             prepend_bos=False,
             hook_head_index=None,
-            dataset=cfg.dataset_path,
+            dataset=None,
             streaming=False,
             model=model,
             normalize_activations="none",
@@ -310,7 +310,7 @@ class ActivationsStore:
     def __init__(
         self,
         model: HookedRootModule,
-        dataset: HfDataset | str,
+        dataset: HfDataset | str | None,
         streaming: bool,
         hook_name: str,
         hook_head_index: int | None,
@@ -385,6 +385,16 @@ class ActivationsStore:
         self._hook_head_indices = {}
 
         self.n_dataset_processed = 0
+
+        # Cached activations are read straight from disk, so there is no dataset to
+        # inspect or iterate and the tokenization checks below don't apply.
+        if self.dataset is None:
+            if self.cached_activations_path is None:
+                raise ValueError(
+                    "Either dataset or cached_activations_path must be provided."
+                )
+            self.cached_activation_dataset = self.load_cached_activation_dataset()
+            return
 
         # Check if dataset is tokenized
         dataset_sample = next(iter(self.dataset))
@@ -468,6 +478,7 @@ class ActivationsStore:
         """
         Helper to iterate over the dataset while incrementing n_dataset_processed
         """
+        assert self.dataset is not None
         for row in self.dataset:
             # typing datasets is difficult
             yield row[self.tokens_column]  # type: ignore
@@ -601,6 +612,7 @@ class ActivationsStore:
         The default buffer_size of 1 means that only the shard will be shuffled; larger buffer sizes will
         additionally shuffle individual elements within the shard.
         """
+        assert self.dataset is not None
         if isinstance(self.dataset, IterableDataset):
             self.dataset = self.dataset.shuffle(seed=seed, buffer_size=buffer_size)
         else:
@@ -611,6 +623,7 @@ class ActivationsStore:
         """
         Resets the input dataset iterator to the beginning.
         """
+        assert self.dataset is not None
         self.iterable_dataset = iter(self.dataset)
 
     def get_batch_tokens(

--- a/tests/test_cache_activations_runner.py
+++ b/tests/test_cache_activations_runner.py
@@ -124,6 +124,58 @@ def test_load_cached_activations(tmp_path: Path):
         )
 
 
+def test_load_cached_activations_does_not_load_the_dataset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    cfg = _default_cfg(tmp_path)
+    runner = CacheActivationsRunner(cfg)
+    runner.run()
+
+    model = HookedTransformer.from_pretrained(cfg.model_name)
+
+    def fail_if_called(*_a: Any, **_k: Any) -> Any:
+        raise AssertionError(
+            "load_dataset should not be called when reading cached activations"
+        )
+
+    monkeypatch.setattr(
+        "sae_lens.training.activations_store.load_dataset", fail_if_called
+    )
+
+    activations_store = ActivationsStore.from_config(model, cfg)
+
+    assert activations_store.dataset is None
+    buffer = activations_store.get_raw_llm_batch()
+    assert buffer[0].shape == (
+        activations_store.store_batch_size_prompts * cfg.context_size,
+        cfg.d_in,
+    )
+
+
+def test_activations_store_requires_dataset_or_cache_path():
+    with pytest.raises(
+        ValueError, match="Either dataset or cached_activations_path must be provided"
+    ):
+        ActivationsStore(
+            model=HookedTransformer.from_pretrained("gelu-1l"),
+            dataset=None,
+            cached_activations_path=None,
+            streaming=False,
+            hook_name="blocks.0.hook_mlp_out",
+            hook_head_index=None,
+            context_size=8,
+            d_in=512,
+            n_batches_in_buffer=2,
+            total_training_tokens=16,
+            store_batch_size_prompts=8,
+            train_batch_size_tokens=8,
+            prepend_bos=False,
+            normalize_activations="none",
+            device=torch.device("cpu"),
+            dtype="float32",
+        )
+
+
 def test_cache_activations_runner_to_string():
     cfg = _default_cfg(Path("tmp_path"))
     runner = CacheActivationsRunner(cfg)


### PR DESCRIPTION
# Description

`ActivationsStore.from_cache_activations` passes the training dataset through to `__init__`, which loads it from HuggingFace even though nothing on the cached-activations path ever reads it.

The dataset is already marked as a no-op there. In `from_cache_activations` it sits under the `# NOOP` comment next to the other arguments that path doesn't use:

```python
# NOOP
prepend_bos=False,
hook_head_index=None,
dataset=cfg.dataset_path,
streaming=False,
```

But `__init__` still loads it. Instrumenting `load_dataset` and building a store through `from_cache_activations` shows a full dataset load before the cache is touched:

```
load_dataset called with 'monology/pile-uncopyrighted'
```

If you're reading activations off disk you end up spending the time and memory to load a dataset you never touch. Issue #551 asks for a way to load an existing `ActivationsStore` without the dataset for exactly this reason, and this PR implements that.

I found two places in `__init__` that touch the dataset up front. One is the `load_dataset` call and the other is the `next(iter(self.dataset))` sample probe that derives `is_dataset_tokenized` and `tokens_column`. Everything after that only reads the dataset when it's actually iterated, since `iterable_sequences` is a generator and the cache path reads `cached_activation_dataset` instead, so those two were the only blockers.

I made `dataset` optional and returned early from the tokenization probe when it's None, then passed `None` from `from_cache_activations`. Guarding `load_dataset` itself was not needed, since `isinstance(None, str)` is already False.

One thing I want to flag is that `dataset_path` isn't unused at the config level. `CacheActivationsRunnerConfig.__post_init__` still uses it to build the default `cached_activations_path`, so I've only changed `ActivationsStore.__init__`, which doesn't need it on the cache path.

I also added a guard so that constructing with neither a dataset nor a `cached_activations_path` raises a clear `ValueError` instead of failing later with a missing attribute, and asserted the dataset is present in the three internal methods that iterate it so the optional type stays sound.

Fixes #551

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have not rewritten tests relating to key interfaces which would affect backward compatibility

### You have tested formatting, typing and tests

- [x] I have run `make check-ci` to check format and linting. (you can run `make format` to format code if needed.)
