### PR TITLE
feat: record final l0 and num dead features in SAE metadata

### DIFF
--- a/sae_lens/training/multi_sae_trainer.py
+++ b/sae_lens/training/multi_sae_trainer.py
@@ -149,6 +149,9 @@ class MultiSAETrainer:
                 )
                 trainer.activation_scaler.scaling_factor = None
 
+        for trainer in self.trainers.values():
+            trainer.set_final_sae_metadata()
+
         if self.cfg.save_final_checkpoint:
             self.save_checkpoint(checkpoint_name=f"final_{self.n_training_samples}")
 

--- a/sae_lens/training/sae_trainer.py
+++ b/sae_lens/training/sae_trainer.py
@@ -193,11 +193,31 @@ class SAETrainer(Generic[T_TRAINING_SAE, T_TRAINING_SAE_CONFIG]):
             )
             self.activation_scaler.scaling_factor = None
 
+        self.set_final_sae_metadata()
+
         if self.cfg.save_final_checkpoint:
             self.save_checkpoint(checkpoint_name=f"final_{self.n_training_samples}")
 
         pbar.close()
         return self.sae
+
+    @torch.no_grad()
+    def set_final_sae_metadata(self) -> None:
+        """
+        Record end-of-training stats in the SAE metadata so they are saved
+        along with the SAE.
+
+        Public seam used by `fit()` and external coordinators (e.g.
+        `MultiSAETrainer`) once training is complete, since these stats are
+        only known at the end of training.
+        """
+        # feature_sparsity holds per-feature firing probabilities over the
+        # current sparsity window, so its sum is the mean l0 over that window.
+        # Skip when the window is empty (training never stepped): 0/0 would
+        # store NaN, which is not valid strict JSON.
+        if self.n_frac_active_samples > 0:
+            self.sae.cfg.metadata.l0 = self.feature_sparsity.sum().item()
+            self.sae.cfg.metadata.num_dead_features = self.dead_neurons.sum().item()
 
     def save_checkpoint(
         self,

--- a/tests/test_llm_sae_training_runner.py
+++ b/tests/test_llm_sae_training_runner.py
@@ -87,6 +87,9 @@ def test_LanguageModelSAETrainingRunner_runs_and_saves_all_architectures(
         sae.cfg.metadata.training_architecture_details
         == cfg.sae.get_training_architecture_details()
     )
+    assert 0 <= sae.cfg.metadata["l0"] <= sae.cfg.d_sae
+    # far fewer steps have run than the 1000-step dead feature window
+    assert sae.cfg.metadata["num_dead_features"] == 0
 
     assert (tmp_path / "final_100").exists()
     loaded_sae = TrainingSAE.load_from_disk(tmp_path / "final_100")
@@ -716,6 +719,14 @@ def test_LanguageModelSAETrainingRunner_saves_final_output_and_checkpoints(
     assert (
         output_sae.cfg.metadata.training_architecture_details
         == checkpoint_sae.cfg.metadata.training_architecture_details
+    )
+    # batchtopk with k=10 caps the mean l0 at 10
+    assert 0 < checkpoint_sae.cfg.metadata["l0"] <= 10
+    assert checkpoint_sae.cfg.metadata["num_dead_features"] == 0
+    assert output_sae.cfg.metadata["l0"] == checkpoint_sae.cfg.metadata["l0"]
+    assert (
+        output_sae.cfg.metadata["num_dead_features"]
+        == checkpoint_sae.cfg.metadata["num_dead_features"]
     )
 
     # Models should have the same architecture and dimensions

--- a/tests/test_multi_sae_training_runner.py
+++ b/tests/test_multi_sae_training_runner.py
@@ -180,6 +180,12 @@ def test_multi_sae_runner_trains_two_saes_at_different_hooks(
         saes["topk_mlp"].cfg.metadata.training_architecture_details
         == cfg.saes["topk_mlp"].get_training_architecture_details()
     )
+    assert 0 < saes["resid"].cfg.metadata["l0"] <= 32
+    # topk with k=4 caps the mean l0 at 4
+    assert 0 < saes["topk_mlp"].cfg.metadata["l0"] <= 4
+    # far fewer steps have run than the 1000-step dead feature window
+    assert saes["resid"].cfg.metadata["num_dead_features"] == 0
+    assert saes["topk_mlp"].cfg.metadata["num_dead_features"] == 0
 
 
 def test_multi_sae_runner_resume_from_checkpoint(

--- a/tests/training/test_sae_trainer.py
+++ b/tests/training/test_sae_trainer.py
@@ -6,9 +6,14 @@ import pytest
 import torch
 from datasets import Dataset
 from transformer_lens import HookedTransformer
+from typing_extensions import override
 
 from sae_lens import __version__
-from sae_lens.config import LanguageModelSAERunnerConfig, LoggingConfig
+from sae_lens.config import (
+    LanguageModelSAERunnerConfig,
+    LoggingConfig,
+    SAETrainerConfig,
+)
 from sae_lens.llm_sae_training_runner import (
     LanguageModelSAETrainingRunner,
     LLMSaeEvaluator,
@@ -27,6 +32,7 @@ from tests.helpers import (
     TINYSTORIES_MODEL,
     assert_close,
     build_runner_cfg,
+    build_sae_training_cfg,
     load_model_cached,
 )
 
@@ -533,6 +539,56 @@ def test_set_final_sae_metadata_skips_when_no_samples_seen(
     # an empty sparsity window would make l0 a NaN, so nothing is recorded
     assert trainer.sae.cfg.metadata.l0 is None
     assert trainer.sae.cfg.metadata.num_dead_features is None
+
+
+class FixedSparsityTrainingSAE(StandardTrainingSAE):
+    """
+    Fires exactly `n_active` latents per sample, chosen at random and ignoring
+    the input entirely. The final latent is excluded, so it never fires.
+    """
+
+    n_active = 3
+
+    @override
+    def encode_with_hidden_pre(
+        self, x: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        _, hidden_pre = super().encode_with_hidden_pre(x)
+        firing_latents = torch.rand(*hidden_pre.shape[:-1], self.cfg.d_sae - 1).topk(
+            self.n_active, dim=-1
+        )
+        mask = torch.zeros_like(hidden_pre).scatter(-1, firing_latents.indices, 1.0)
+        # +1 keeps the fired latents nonzero while still passing grads to W_enc
+        feature_acts = mask * (hidden_pre.abs() + 1.0)
+        return feature_acts, hidden_pre
+
+
+def test_fit_records_l0_and_dead_latents_matching_actual_sae_firing() -> None:
+    d_in = 4
+    d_sae = 10
+    batch_size = 32
+    n_steps = 10
+    sae = FixedSparsityTrainingSAE(build_sae_training_cfg(d_in=d_in, d_sae=d_sae))
+    trainer = SAETrainer(
+        cfg=SAETrainerConfig(
+            total_training_samples=batch_size * n_steps,
+            train_batch_size_samples=batch_size,
+            lr_end=1e-4,
+            # low enough that the never-firing latent shows up as dead
+            dead_feature_window=n_steps // 2,
+            # don't reset the sparsity window partway through training
+            feature_sampling_window=n_steps * 2,
+        ),
+        sae=sae,
+        data_provider=iter(lambda: torch.randn(batch_size, d_in), None),
+    )
+
+    trainer.fit()
+
+    assert sae.cfg.metadata.l0 == pytest.approx(FixedSparsityTrainingSAE.n_active)
+    assert sae.cfg.metadata.num_dead_features == 1
+    # the dead latent is the excluded one, not a latent that got unlucky
+    assert trainer.dead_neurons.nonzero().flatten().tolist() == [d_sae - 1]
 
 
 def test_sae_trainer_skips_final_checkpoint_when_disabled(

--- a/tests/training/test_sae_trainer.py
+++ b/tests/training/test_sae_trainer.py
@@ -340,6 +340,10 @@ def test_checkpoints_save_runner_cfg(
     for checkpoint_cfg_path in checkpoint_cfg_paths:
         with open(checkpoint_cfg_path) as f:
             checkpoint_cfg = json.load(f)
+        if checkpoint_cfg_path.parent.name.startswith("final_"):
+            # the final checkpoint additionally records end-of-training stats
+            assert checkpoint_cfg["metadata"].pop("l0") >= 0
+            assert checkpoint_cfg["metadata"].pop("num_dead_features") == 0
         assert checkpoint_cfg == cfg.sae.to_dict()
 
     for checkpoint_runner_cfg_path in checkpoint_runner_cfg_paths:
@@ -494,6 +498,41 @@ def test_sae_trainer_saves_final_checkpoint_when_enabled(
     assert (final_checkpoint_dir / "sae_weights.safetensors").exists()
     assert (final_checkpoint_dir / "cfg.json").exists()
     assert (final_checkpoint_dir / "sparsity.safetensors").exists()
+
+    # fit() records end-of-training stats in the metadata before saving
+    with open(final_checkpoint_dir / "cfg.json") as f:
+        saved_metadata = json.load(f)["metadata"]
+    assert saved_metadata["l0"] == pytest.approx(trainer.feature_sparsity.sum().item())
+    assert saved_metadata["num_dead_features"] == trainer.dead_neurons.sum().item()
+
+
+def test_set_final_sae_metadata_records_l0_and_num_dead_features(
+    trainer: SAETrainer[StandardTrainingSAE, StandardTrainingSAEConfig],
+) -> None:
+    d_sae = trainer.sae.cfg.d_sae
+    trainer.act_freq_scores = torch.zeros(d_sae)
+    trainer.act_freq_scores[:3] = torch.tensor([4.0, 2.0, 2.0])
+    trainer.n_frac_active_samples = 4
+    trainer.n_forward_passes_since_fired = torch.zeros(d_sae)
+    trainer.n_forward_passes_since_fired[:2] = trainer.cfg.dead_feature_window + 1
+
+    trainer.set_final_sae_metadata()
+
+    # firing probabilities are (1.0, 0.5, 0.5), so the mean l0 is 2.0
+    assert trainer.sae.cfg.metadata.l0 == pytest.approx(2.0)
+    assert trainer.sae.cfg.metadata.num_dead_features == 2
+
+
+def test_set_final_sae_metadata_skips_when_no_samples_seen(
+    trainer: SAETrainer[StandardTrainingSAE, StandardTrainingSAEConfig],
+) -> None:
+    trainer.n_frac_active_samples = 0
+
+    trainer.set_final_sae_metadata()
+
+    # an empty sparsity window would make l0 a NaN, so nothing is recorded
+    assert trainer.sae.cfg.metadata.l0 is None
+    assert trainer.sae.cfg.metadata.num_dead_features is None
 
 
 def test_sae_trainer_skips_final_checkpoint_when_disabled(


### PR DESCRIPTION
## Summary

Records final `l0` and `num_dead_features` in the SAE metadata at the end of training, so both end up in the saved `cfg.json` of the final checkpoint and of the exported inference SAE. `MultiSAETrainer` does the same for each of its per-SAE trainers.

This finishes the remaining half of #663: #714 added the training-architecture metadata, and the follow-up comment asked for l0 and num dead latents recorded at the end of training.

Fixes #663

## Implementation notes

- Both values come from the trainer's existing sparsity tracking, no extra per-step work. `l0` is the sum of per-feature firing probabilities over the current sparsity window, i.e. the window-averaged mean l0 (same firing stats as the `metrics/l0` wandb log, which reports the per-batch value). `num_dead_features` matches the `sparsity/dead_features` log. If training never stepped, the fields are left unset rather than storing NaN.
- The metadata is set in `SAETrainer.fit()` just before the final checkpoint save rather than in each runner. That keeps the final checkpoint and the exported inference SAE consistent, and covers the LLM, multi-SAE, and synthetic runners in one place. Intermediate checkpoints don't get these fields since they're end-of-training stats.
- Named the count `num_dead_features` to match `dead_feature_window` and the `sparsity/dead_features` log key. The issue says "dead latents", happy to rename.
- Left out `num_training_samples` since the comment said not to go overboard and `runner_cfg.json` already records it.

## Compatibility

Additive metadata-only change: no training math, weights, or checkpoint tensors change. Configs without the new keys load as before (`SAEMetadata` returns `None` for missing keys). One existing test (`test_checkpoints_save_runner_cfg`) was updated to expect the new keys in the final checkpoint's metadata.

## Validation

- `pytest tests/training/test_sae_trainer.py tests/training/test_multi_sae_trainer.py tests/test_llm_sae_training_runner.py tests/test_multi_sae_training_runner.py` all pass
- `ruff format --check` and `ruff check` on the changed files
- `pyright` on the changed files, no new errors vs `main`

Like #714 I used a uv-managed Python environment locally rather than Poetry.
